### PR TITLE
Detect language from URL and browser

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,6 +7,7 @@ describe("App", () => {
   afterEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
+    window.history.replaceState({}, "", "/");
   });
 
   it("renders the learning path before the challenge", () => {
@@ -240,5 +241,16 @@ describe("App", () => {
 
     expect(screen.getByRole("button", { name: "Learn" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Challenge" })).toBeInTheDocument();
+  });
+
+  it("loads a supported language from the URL and stores the preference", () => {
+    localStorage.setItem("jabiko.language", "en");
+    window.history.replaceState({}, "", "/?lang=ko");
+
+    render(<App />);
+
+    expect(screen.getByRole("button", { name: "학습" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "도전" })).toBeInTheDocument();
+    expect(localStorage.getItem("jabiko.language")).toBe("ko");
   });
 });

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getInitialLanguage, LANGUAGE_STORAGE_KEY } from "./i18n";
+
+describe("getInitialLanguage", () => {
+  afterEach(() => {
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+    vi.restoreAllMocks();
+  });
+
+  it("uses lang from the URL and stores it for later visits", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en");
+    window.history.replaceState({}, "", "/?lang=ko");
+
+    expect(getInitialLanguage()).toBe("ko");
+    expect(localStorage.getItem(LANGUAGE_STORAGE_KEY)).toBe("ko");
+  });
+
+  it("falls back to stored preference when the URL has no supported lang", () => {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, "en");
+    window.history.replaceState({}, "", "/?lang=fr");
+
+    expect(getInitialLanguage()).toBe("en");
+  });
+
+  it("uses browser languages when no URL or stored preference exists", () => {
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["ko-KR", "en-US"]);
+
+    expect(getInitialLanguage()).toBe("ko");
+  });
+
+  it("maps Traditional Chinese browser locales to zh-Hant", () => {
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["zh-TW", "en-US"]);
+
+    expect(getInitialLanguage()).toBe("zh-Hant");
+  });
+
+  it("falls back to zh-Hant when no source matches", () => {
+    vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["fr-FR"]);
+
+    expect(getInitialLanguage()).toBe("zh-Hant");
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -458,14 +458,65 @@ export const copy: Record<Language, Copy> = {
   }
 };
 
+function isSupportedLanguage(value: string | null | undefined): value is Language {
+  return value === "zh-Hant" || value === "en" || value === "ko";
+}
+
+function languageFromLocale(locale: string): Language | null {
+  const normalizedLocale = locale.toLowerCase();
+
+  if (normalizedLocale === "ko" || normalizedLocale.startsWith("ko-")) {
+    return "ko";
+  }
+
+  if (normalizedLocale === "en" || normalizedLocale.startsWith("en-")) {
+    return "en";
+  }
+
+  if (
+    normalizedLocale === "zh" ||
+    normalizedLocale === "zh-hant" ||
+    normalizedLocale.startsWith("zh-hant-") ||
+    normalizedLocale.startsWith("zh-tw") ||
+    normalizedLocale.startsWith("zh-hk") ||
+    normalizedLocale.startsWith("zh-mo")
+  ) {
+    return "zh-Hant";
+  }
+
+  return null;
+}
+
+function languageFromBrowser(): Language | null {
+  const browserLocales =
+    navigator.languages.length > 0 ? navigator.languages : [navigator.language];
+
+  for (const locale of browserLocales) {
+    const language = languageFromLocale(locale);
+
+    if (language) {
+      return language;
+    }
+  }
+
+  return null;
+}
+
 export function getInitialLanguage(): Language {
+  const urlLanguage = new URLSearchParams(window.location.search).get("lang");
+
+  if (isSupportedLanguage(urlLanguage)) {
+    storeLanguage(urlLanguage);
+    return urlLanguage;
+  }
+
   const storedLanguage = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
 
-  if (storedLanguage === "en" || storedLanguage === "ko" || storedLanguage === "zh-Hant") {
+  if (isSupportedLanguage(storedLanguage)) {
     return storedLanguage;
   }
 
-  return "zh-Hant";
+  return languageFromBrowser() ?? "zh-Hant";
 }
 
 export function storeLanguage(language: Language) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+
+import { beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+  vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["zh-TW"]);
+});


### PR DESCRIPTION
## Summary
- Add URL `?lang=` language override for `zh-Hant`, `en`, and `ko`.
- Persist supported URL language overrides to localStorage.
- Fall back to stored preference, browser language, then Traditional Chinese.

## Test Plan
- `rtk pnpm test`
- `rtk pnpm run build`
- `rtk git --no-optional-locks diff --check`