### PR TITLE
fix: generate choice distractors from same-verb rule variants

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -141,7 +141,7 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
     await user.click(screen.getByRole("button", { name: "選擇題" }));
-    await user.click(screen.getByRole("button", { name: "聞いて" }));
+    await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByText("再想一下")).toBeInTheDocument();
     expect(screen.getByText("正解：書いて")).toBeInTheDocument();
@@ -154,7 +154,7 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
     await user.click(screen.getByRole("button", { name: "選擇題" }));
-    await user.click(screen.getByRole("button", { name: "聞いて" }));
+    await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByRole("heading", { name: "錯題複習" })).toBeInTheDocument();
     expect(screen.getByText("書く -> て形")).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,13 @@ import {
   validateAnswer,
   VERB_FORMS
 } from "./domain/conjugation";
-import { buildQuestionPool, getMistakeQuestions, scoreAttempt, selectQuestion } from "./domain/practice";
+import {
+  buildChoiceOptions,
+  buildQuestionPool,
+  getMistakeQuestions,
+  scoreAttempt,
+  selectQuestion
+} from "./domain/practice";
 import { createAttemptStore } from "./domain/storage";
 import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
 import { vocabulary } from "./domain/vocabulary";
@@ -1066,29 +1072,6 @@ function getInitialTheme(): Theme {
 
 function storeTheme(theme: Theme) {
   window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-}
-
-function buildChoiceOptions(
-  currentQuestion: PracticeQuestion,
-  questions: PracticeQuestion[],
-  questionIndex: number
-): string[] {
-  const correctAnswer = currentQuestion.expectedAnswers[0];
-  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
-  const distractors = uniqueAnswers(
-    questions
-      .filter((question) => question.id !== currentQuestion.id)
-      .flatMap((question) => question.expectedAnswers)
-      .filter((answer) => !acceptedAnswers.has(answer))
-  );
-  const options = [correctAnswer, ...distractors.slice(0, 3)];
-  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
-
-  return [...options.slice(offset), ...options.slice(0, offset)];
-}
-
-function uniqueAnswers(answers: string[]): string[] {
-  return Array.from(new Set(answers));
 }
 
 function uniqueForms(forms: TargetForm[]): TargetForm[] {

--- a/src/domain/conjugation.ts
+++ b/src/domain/conjugation.ts
@@ -89,6 +89,64 @@ export const ADJECTIVE_FORMS: TargetForm[] = [
   "obligationPast"
 ];
 
+const NAI_DERIVED_SUFFIX: Partial<Record<TargetForm, string>> = {
+  negativeTe: "ないで",
+  negativeContinuative: "なくて",
+  plainPastNegative: "なかった",
+  obligationPast: "なければならなかった"
+};
+
+export function generateVerbRuleCandidates(surface: string, targetForm: TargetForm): string[] {
+  if (targetForm === "plainPresentNegative") {
+    return generateVerbRuleCandidates(surface, "nai");
+  }
+
+  if (targetForm === "plainPastAffirmative") {
+    return generateVerbRuleCandidates(surface, "ta");
+  }
+
+  if (targetForm === "dictionary" || targetForm === "plainPresentAffirmative") {
+    return [surface];
+  }
+
+  const stem = surface.slice(0, -1);
+  const candidates: string[] = [];
+
+  if (targetForm === "te") {
+    pushRuleCandidates(candidates, stem, GODAN_TE_ENDINGS, "て");
+  } else if (targetForm === "ta") {
+    pushRuleCandidates(candidates, stem, GODAN_TA_ENDINGS, "た");
+  } else if (targetForm === "masu") {
+    pushRuleCandidates(candidates, stem, GODAN_MASU_ENDINGS, "ます");
+  } else if (targetForm === "nai") {
+    pushRuleCandidates(candidates, stem, GODAN_NAI_ENDINGS, "ない");
+  } else {
+    const suffix = NAI_DERIVED_SUFFIX[targetForm];
+    if (!suffix) {
+      return [];
+    }
+
+    candidates.push(stem + suffix);
+    for (const transform of Object.values(GODAN_NAI_ENDINGS)) {
+      candidates.push(stem + transform.replace(/ない$/, suffix));
+    }
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+function pushRuleCandidates(
+  out: string[],
+  stem: string,
+  endings: Record<string, string>,
+  ichidanSuffix: string
+): void {
+  out.push(stem + ichidanSuffix);
+  for (const transform of Object.values(endings)) {
+    out.push(stem + transform);
+  }
+}
+
 export function conjugate(item: VocabularyItem, targetForm: TargetForm): ConjugationResult {
   if (item.partOfSpeech === "verb") {
     return conjugateVerb(item, targetForm);

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { vocabulary } from "./vocabulary";
-import { buildQuestionPool, getMistakeQuestions, scoreAttempt } from "./practice";
+import { buildChoiceOptions, buildQuestionPool, getMistakeQuestions, scoreAttempt } from "./practice";
 
 describe("buildQuestionPool", () => {
   it("filters questions by part of speech, verb group, and selected forms", () => {
@@ -69,6 +69,107 @@ describe("scoreAttempt", () => {
       isCorrect: true,
       responseTimeMs: 1400
     });
+  });
+});
+
+describe("buildChoiceOptions", () => {
+  it("uses other te-form rules of the same verb as distractors", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "帰る");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("帰って");
+    expect(options).toHaveLength(4);
+    expect(options.every((option) => option.startsWith("帰"))).toBe(true);
+    expect(options.filter((option) => option !== "帰って").every((option) => /[てで]$/.test(option))).toBe(true);
+  });
+
+  it("includes the classic ichidan mistake when testing te-form of る-ending godan verbs", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "帰る");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+    const distractors = options.filter((option) => option !== "帰って");
+
+    // expect rule-based wrong attempts to dominate (not other words' answers)
+    expect(distractors.every((option) => option.startsWith("帰"))).toBe(true);
+  });
+
+  it("uses ta-form rule variants as distractors", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["ta"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "読む");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("読んだ");
+    expect(options.every((option) => option.startsWith("読"))).toBe(true);
+    expect(options.filter((option) => option !== "読んだ").every((option) => /[ただ]$/.test(option))).toBe(true);
+  });
+
+  it("falls back to same-word other-form distractors for irregular verbs", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "irregular",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "勉強する");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("勉強して");
+    expect(options.every((option) => option.startsWith("勉強"))).toBe(true);
+  });
+
+  it("does not duplicate the prompt word in choice options", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "聞く");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).not.toContain("聞く");
+  });
+
+  it("uses same-word distractors for adjective practice", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "i_adjective",
+      verbGroup: "all",
+      targetForms: ["plainPresentNegative"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "高い");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("高くない");
+    expect(options.every((option) => option.startsWith("高"))).toBe(true);
   });
 });
 

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -1,5 +1,13 @@
-import { ADJECTIVE_FORMS, conjugate, validateAnswer, VERB_FORMS } from "./conjugation";
+import {
+  ADJECTIVE_FORMS,
+  conjugate,
+  generateVerbRuleCandidates,
+  validateAnswer,
+  VERB_FORMS
+} from "./conjugation";
 import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup, VocabularyItem } from "./types";
+
+export const CHOICE_COUNT = 4;
 
 export interface QuestionOptions {
   partOfSpeech: PartOfSpeech | "mixed";
@@ -59,6 +67,76 @@ export function selectQuestion(questions: PracticeQuestion[], index: number): Pr
   }
 
   return questions[index % questions.length];
+}
+
+export function buildChoiceOptions(
+  currentQuestion: PracticeQuestion,
+  questions: PracticeQuestion[],
+  questionIndex: number
+): string[] {
+  const correctAnswer = currentQuestion.expectedAnswers[0];
+  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
+  const vocab = currentQuestion.vocabulary;
+  const targetForm = currentQuestion.targetForm;
+
+  const ruleDistractors = buildRuleVariantDistractors(vocab, targetForm, acceptedAnswers);
+  const sameWordDistractors = buildSameWordDistractors(vocab, targetForm, acceptedAnswers);
+  const fallbackDistractors = uniqueAnswers(
+    questions
+      .filter(
+        (question) =>
+          question.vocabulary.id !== vocab.id && question.vocabulary.partOfSpeech === vocab.partOfSpeech
+      )
+      .flatMap((question) => question.expectedAnswers)
+      .filter((answer) => !acceptedAnswers.has(answer) && answer !== vocab.surface)
+  );
+
+  const distractors = uniqueAnswers([...ruleDistractors, ...sameWordDistractors, ...fallbackDistractors]);
+  const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
+  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
+
+  return [...options.slice(offset), ...options.slice(0, offset)];
+}
+
+function buildRuleVariantDistractors(
+  vocab: VocabularyItem,
+  targetForm: TargetForm,
+  acceptedAnswers: Set<string>
+): string[] {
+  if (vocab.partOfSpeech !== "verb" || vocab.group === "irregular") {
+    return [];
+  }
+
+  return generateVerbRuleCandidates(vocab.surface, targetForm).filter(
+    (candidate) => !acceptedAnswers.has(candidate) && candidate !== vocab.surface
+  );
+}
+
+function buildSameWordDistractors(
+  vocab: VocabularyItem,
+  targetForm: TargetForm,
+  acceptedAnswers: Set<string>
+): string[] {
+  const forms = vocab.partOfSpeech === "verb" ? VERB_FORMS : ADJECTIVE_FORMS;
+  const distractors: string[] = [];
+
+  for (const form of forms) {
+    if (form === targetForm) continue;
+
+    const result = conjugate(vocab, form);
+
+    for (const answer of result.answers) {
+      if (!answer || acceptedAnswers.has(answer) || distractors.includes(answer)) continue;
+      if (answer === vocab.surface) continue;
+      distractors.push(answer);
+    }
+  }
+
+  return distractors;
+}
+
+function uniqueAnswers(answers: string[]): string[] {
+  return Array.from(new Set(answers));
 }
 
 function isFormCompatible(item: VocabularyItem, targetForm: TargetForm): boolean {


### PR DESCRIPTION
## Summary

Multiple-choice distractors previously pulled answers from unrelated words in the question pool. For 帰る → て形, the choices ended up being 書いた / 聞いて / 帰って / 書いて — learners could just pick the option whose kanji matched the prompt without ever testing the conjugation rule.

Distractors now come from three sources, in priority order:

1. **Same verb, wrong conjugation rule applied** — e.g. 帰る → て形 distractors: 帰て (ichidan rule), 帰いて (く rule), 帰いで (ぐ rule). All same kanji, all look like te-form attempts, so the only way to answer is to know the actual rule.
2. **Same word, other conjugation forms** — fallback for when wrong-rule candidates run out (e.g. 帰ります, 帰らない).
3. **Other words** — last resort, almost never reached.

Ichidan-style attempts (e.g. 帰て) are placed first so godan exceptions like 帰る always surface the classic ｢treat as ichidan｣ mistake as a distractor.

Irregular verbs (する, 来る, compound する) skip rule variants since godan rules do not produce meaningful candidates for them — they go straight to same-word distractors.

## Changes

- New \`generateVerbRuleCandidates(surface, targetForm)\` in \`src/domain/conjugation.ts\` produces all candidates for a given target form by applying every godan rule + ichidan rule to the verb's stem.
- New \`buildChoiceOptions\` in \`src/domain/practice.ts\` consumes rule variants first, then same-word other-forms, then cross-word.
- Moved choice-option logic from \`App.tsx\` to the domain layer so it can be unit-tested.

## Test plan

- [x] \`pnpm test\` — 46 tests pass (6 new tests for buildChoiceOptions).
- [x] \`pnpm build\` — tsc + vite both clean.
- [ ] Manual UI check: launch \`pnpm dev\`, start challenge, confirm 帰る → て形 shows rule-variant distractors and not other words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced multiple-choice options with intelligent distractor selection incorporating verb conjugation variants, same-word conjugated forms, and fallback answer options.

* **Tests**
  * Added comprehensive test coverage for choice option generation across verb patterns, adjective forms, and irregular verbs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/Jabiko/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->