### PR TITLE
feat: filter out trivial questions where prompt equals answer

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -141,7 +141,7 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
     await user.click(screen.getByRole("button", { name: "選擇題" }));
-    await user.click(screen.getByRole("button", { name: "聞いて" }));
+    await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByText("再想一下")).toBeInTheDocument();
     expect(screen.getByText("正解：書いて")).toBeInTheDocument();
@@ -154,7 +154,7 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
     await user.click(screen.getByRole("button", { name: "選擇題" }));
-    await user.click(screen.getByRole("button", { name: "聞いて" }));
+    await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByRole("heading", { name: "錯題複習" })).toBeInTheDocument();
     expect(screen.getByText("書く -> て形")).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,13 @@ import {
   validateAnswer,
   VERB_FORMS
 } from "./domain/conjugation";
-import { buildQuestionPool, getMistakeQuestions, scoreAttempt, selectQuestion } from "./domain/practice";
+import {
+  buildChoiceOptions,
+  buildQuestionPool,
+  getMistakeQuestions,
+  scoreAttempt,
+  selectQuestion
+} from "./domain/practice";
 import { createAttemptStore } from "./domain/storage";
 import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
 import { vocabulary } from "./domain/vocabulary";
@@ -1066,29 +1072,6 @@ function getInitialTheme(): Theme {
 
 function storeTheme(theme: Theme) {
   window.localStorage.setItem(THEME_STORAGE_KEY, theme);
-}
-
-function buildChoiceOptions(
-  currentQuestion: PracticeQuestion,
-  questions: PracticeQuestion[],
-  questionIndex: number
-): string[] {
-  const correctAnswer = currentQuestion.expectedAnswers[0];
-  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
-  const distractors = uniqueAnswers(
-    questions
-      .filter((question) => question.id !== currentQuestion.id)
-      .flatMap((question) => question.expectedAnswers)
-      .filter((answer) => !acceptedAnswers.has(answer))
-  );
-  const options = [correctAnswer, ...distractors.slice(0, 3)];
-  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
-
-  return [...options.slice(offset), ...options.slice(0, offset)];
-}
-
-function uniqueAnswers(answers: string[]): string[] {
-  return Array.from(new Set(answers));
 }
 
 function uniqueForms(forms: TargetForm[]): TargetForm[] {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,8 @@ import {
   buildQuestionPool,
   getMistakeQuestions,
   scoreAttempt,
-  selectQuestion
+  selectQuestion,
+  shuffleQuestions
 } from "./domain/practice";
 import { createAttemptStore } from "./domain/storage";
 import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
@@ -303,6 +304,7 @@ export default function App() {
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
   const [language, setLanguage] = useState<Language>(() => getInitialLanguage());
   const [questionIndex, setQuestionIndex] = useState(0);
+  const [sessionSeed, setSessionSeed] = useState(0);
   const [answer, setAnswer] = useState("");
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback>(null);
@@ -334,13 +336,17 @@ export default function App() {
       : activeFocusForms.map((form) => t.targetForms[form]).join(" / ") || t.focusSummaryEmpty;
 
   const questions = useMemo(
-    () =>
-      buildQuestionPool(vocabulary, {
-        partOfSpeech,
-        verbGroup,
-        targetForms
-      }),
-    [partOfSpeech, targetForms, verbGroup]
+    () => {
+      void sessionSeed;
+      return shuffleQuestions(
+        buildQuestionPool(vocabulary, {
+          partOfSpeech,
+          verbGroup,
+          targetForms
+        })
+      );
+    },
+    [partOfSpeech, targetForms, verbGroup, sessionSeed]
   );
   const currentQuestion = selectQuestion(questions, questionIndex);
   const choiceOptions = useMemo(
@@ -450,6 +456,7 @@ export default function App() {
   const resetSession = () => {
     setAttempts([]);
     setQuestionIndex(0);
+    setSessionSeed((seed) => seed + 1);
     setAnswerMode("input");
     setAnswer("");
     setSelectedChoice(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,6 @@ const formOptions: TargetForm[] = [
   "adverbial",
   "obligationPast",
   "masu",
-  "dictionary",
   "plainPresentAffirmative",
   "plainPresentNegative",
   "plainPastAffirmative",

--- a/src/domain/conjugation.ts
+++ b/src/domain/conjugation.ts
@@ -89,6 +89,64 @@ export const ADJECTIVE_FORMS: TargetForm[] = [
   "obligationPast"
 ];
 
+const NAI_DERIVED_SUFFIX: Partial<Record<TargetForm, string>> = {
+  negativeTe: "ないで",
+  negativeContinuative: "なくて",
+  plainPastNegative: "なかった",
+  obligationPast: "なければならなかった"
+};
+
+export function generateVerbRuleCandidates(surface: string, targetForm: TargetForm): string[] {
+  if (targetForm === "plainPresentNegative") {
+    return generateVerbRuleCandidates(surface, "nai");
+  }
+
+  if (targetForm === "plainPastAffirmative") {
+    return generateVerbRuleCandidates(surface, "ta");
+  }
+
+  if (targetForm === "dictionary" || targetForm === "plainPresentAffirmative") {
+    return [surface];
+  }
+
+  const stem = surface.slice(0, -1);
+  const candidates: string[] = [];
+
+  if (targetForm === "te") {
+    pushRuleCandidates(candidates, stem, GODAN_TE_ENDINGS, "て");
+  } else if (targetForm === "ta") {
+    pushRuleCandidates(candidates, stem, GODAN_TA_ENDINGS, "た");
+  } else if (targetForm === "masu") {
+    pushRuleCandidates(candidates, stem, GODAN_MASU_ENDINGS, "ます");
+  } else if (targetForm === "nai") {
+    pushRuleCandidates(candidates, stem, GODAN_NAI_ENDINGS, "ない");
+  } else {
+    const suffix = NAI_DERIVED_SUFFIX[targetForm];
+    if (!suffix) {
+      return [];
+    }
+
+    candidates.push(stem + suffix);
+    for (const transform of Object.values(GODAN_NAI_ENDINGS)) {
+      candidates.push(stem + transform.replace(/ない$/, suffix));
+    }
+  }
+
+  return Array.from(new Set(candidates));
+}
+
+function pushRuleCandidates(
+  out: string[],
+  stem: string,
+  endings: Record<string, string>,
+  ichidanSuffix: string
+): void {
+  out.push(stem + ichidanSuffix);
+  for (const transform of Object.values(endings)) {
+    out.push(stem + transform);
+  }
+}
+
 export function conjugate(item: VocabularyItem, targetForm: TargetForm): ConjugationResult {
   if (item.partOfSpeech === "verb") {
     return conjugateVerb(item, targetForm);

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -39,6 +39,31 @@ describe("buildQuestionPool", () => {
     ).toEqual(["高くなかった"]);
   });
 
+  it("filters out trivial questions where the expected answer equals the prompt surface", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["dictionary", "plainPresentAffirmative", "te"]
+    });
+
+    expect(questions.some((question) => question.targetForm === "te")).toBe(true);
+    expect(questions.some((question) => question.targetForm === "dictionary")).toBe(false);
+    expect(questions.some((question) => question.targetForm === "plainPresentAffirmative")).toBe(false);
+  });
+
+  it("keeps plainPresentAffirmative for na-adjectives and nouns since they add だ", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "na_adjective",
+      verbGroup: "all",
+      targetForms: ["plainPresentAffirmative"]
+    });
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.find((question) => question.vocabulary.surface === "静か")?.expectedAnswers
+    ).toEqual(["静かだ"]);
+  });
+
   it("builds noun-like practice questions for plain and negative connective forms", () => {
     const questions = buildQuestionPool(vocabulary, {
       partOfSpeech: "noun",

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { vocabulary } from "./vocabulary";
-import { buildQuestionPool, getMistakeQuestions, scoreAttempt } from "./practice";
+import { buildChoiceOptions, buildQuestionPool, getMistakeQuestions, scoreAttempt } from "./practice";
 
 describe("buildQuestionPool", () => {
   it("filters questions by part of speech, verb group, and selected forms", () => {
@@ -69,6 +69,107 @@ describe("scoreAttempt", () => {
       isCorrect: true,
       responseTimeMs: 1400
     });
+  });
+});
+
+describe("buildChoiceOptions", () => {
+  it("uses other te-form rules of the same verb as distractors", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "帰る");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("帰って");
+    expect(options).toHaveLength(4);
+    expect(options.every((option) => option.startsWith("帰"))).toBe(true);
+    expect(options.filter((option) => option !== "帰って").every((option) => /[てで]$/.test(option))).toBe(true);
+  });
+
+  it("includes the classic ichidan mistake when testing te-form of る-ending godan verbs", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "帰る");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+    const distractors = options.filter((option) => option !== "帰って");
+
+    // expect rule-based wrong attempts to dominate (not other words' answers)
+    expect(distractors.every((option) => option.startsWith("帰"))).toBe(true);
+  });
+
+  it("uses ta-form rule variants as distractors", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["ta"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "読む");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("読んだ");
+    expect(options.every((option) => option.startsWith("読"))).toBe(true);
+    expect(options.filter((option) => option !== "読んだ").every((option) => /[ただ]$/.test(option))).toBe(true);
+  });
+
+  it("falls back to same-word other-form distractors for irregular verbs", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "irregular",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "勉強する");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("勉強して");
+    expect(options.every((option) => option.startsWith("勉強"))).toBe(true);
+  });
+
+  it("does not duplicate the prompt word in choice options", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "聞く");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).not.toContain("聞く");
+  });
+
+  it("uses same-word distractors for adjective practice", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "i_adjective",
+      verbGroup: "all",
+      targetForms: ["plainPresentNegative"]
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "高い");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("高くない");
+    expect(options.every((option) => option.startsWith("高"))).toBe(true);
   });
 });
 

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { vocabulary } from "./vocabulary";
-import { buildChoiceOptions, buildQuestionPool, getMistakeQuestions, scoreAttempt } from "./practice";
+import {
+  buildChoiceOptions,
+  buildQuestionPool,
+  getMistakeQuestions,
+  scoreAttempt,
+  shuffleQuestions
+} from "./practice";
 
 describe("buildQuestionPool", () => {
   it("filters questions by part of speech, verb group, and selected forms", () => {
@@ -170,6 +176,51 @@ describe("buildChoiceOptions", () => {
 
     expect(options).toContain("高くない");
     expect(options.every((option) => option.startsWith("高"))).toBe(true);
+  });
+});
+
+describe("shuffleQuestions", () => {
+  it("returns the same set of questions", () => {
+    const pool = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "all",
+      targetForms: ["te"]
+    });
+
+    const shuffled = shuffleQuestions(pool);
+
+    expect(shuffled).toHaveLength(pool.length);
+    expect(new Set(shuffled.map((question) => question.id))).toEqual(
+      new Set(pool.map((question) => question.id))
+    );
+  });
+
+  it("does not mutate the input pool", () => {
+    const pool = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const originalOrder = pool.map((question) => question.id);
+
+    vi.spyOn(Math, "random").mockReturnValue(0); // forces reordering
+    shuffleQuestions(pool);
+
+    expect(pool.map((question) => question.id)).toEqual(originalOrder);
+  });
+
+  it("reorders questions when Math.random returns 0", () => {
+    const pool = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"]
+    });
+    const originalOrder = pool.map((question) => question.id);
+
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const shuffled = shuffleQuestions(pool).map((question) => question.id);
+
+    expect(shuffled).not.toEqual(originalOrder);
   });
 });
 

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -69,6 +69,17 @@ export function selectQuestion(questions: PracticeQuestion[], index: number): Pr
   return questions[index % questions.length];
 }
 
+export function shuffleQuestions(questions: PracticeQuestion[]): PracticeQuestion[] {
+  const shuffled = [...questions];
+
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  return shuffled;
+}
+
 export function buildChoiceOptions(
   currentQuestion: PracticeQuestion,
   questions: PracticeQuestion[],

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -32,7 +32,12 @@ export function buildQuestionPool(vocabulary: VocabularyItem[], options: Questio
             explanation: result.explanation
           };
         })
-    );
+    )
+    .filter(isMeaningfulQuestion);
+}
+
+function isMeaningfulQuestion(question: PracticeQuestion): boolean {
+  return question.expectedAnswers.some((answer) => answer !== question.vocabulary.surface);
 }
 
 export function scoreAttempt(

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -1,5 +1,13 @@
-import { ADJECTIVE_FORMS, conjugate, validateAnswer, VERB_FORMS } from "./conjugation";
+import {
+  ADJECTIVE_FORMS,
+  conjugate,
+  generateVerbRuleCandidates,
+  validateAnswer,
+  VERB_FORMS
+} from "./conjugation";
 import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup, VocabularyItem } from "./types";
+
+export const CHOICE_COUNT = 4;
 
 export interface QuestionOptions {
   partOfSpeech: PartOfSpeech | "mixed";
@@ -59,6 +67,76 @@ export function selectQuestion(questions: PracticeQuestion[], index: number): Pr
   }
 
   return questions[index % questions.length];
+}
+
+export function buildChoiceOptions(
+  currentQuestion: PracticeQuestion,
+  questions: PracticeQuestion[],
+  questionIndex: number
+): string[] {
+  const correctAnswer = currentQuestion.expectedAnswers[0];
+  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
+  const vocab = currentQuestion.vocabulary;
+  const targetForm = currentQuestion.targetForm;
+
+  const ruleDistractors = buildRuleVariantDistractors(vocab, targetForm, acceptedAnswers);
+  const sameWordDistractors = buildSameWordDistractors(vocab, targetForm, acceptedAnswers);
+  const fallbackDistractors = uniqueAnswers(
+    questions
+      .filter(
+        (question) =>
+          question.vocabulary.id !== vocab.id && question.vocabulary.partOfSpeech === vocab.partOfSpeech
+      )
+      .flatMap((question) => question.expectedAnswers)
+      .filter((answer) => !acceptedAnswers.has(answer) && answer !== vocab.surface)
+  );
+
+  const distractors = uniqueAnswers([...ruleDistractors, ...sameWordDistractors, ...fallbackDistractors]);
+  const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
+  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
+
+  return [...options.slice(offset), ...options.slice(0, offset)];
+}
+
+function buildRuleVariantDistractors(
+  vocab: VocabularyItem,
+  targetForm: TargetForm,
+  acceptedAnswers: Set<string>
+): string[] {
+  if (vocab.partOfSpeech !== "verb" || vocab.group === "irregular") {
+    return [];
+  }
+
+  return generateVerbRuleCandidates(vocab.surface, targetForm).filter(
+    (candidate) => !acceptedAnswers.has(candidate) && candidate !== vocab.surface
+  );
+}
+
+function buildSameWordDistractors(
+  vocab: VocabularyItem,
+  targetForm: TargetForm,
+  acceptedAnswers: Set<string>
+): string[] {
+  const forms = vocab.partOfSpeech === "verb" ? VERB_FORMS : ADJECTIVE_FORMS;
+  const distractors: string[] = [];
+
+  for (const form of forms) {
+    if (form === targetForm) continue;
+
+    const result = conjugate(vocab, form);
+
+    for (const answer of result.answers) {
+      if (!answer || acceptedAnswers.has(answer) || distractors.includes(answer)) continue;
+      if (answer === vocab.surface) continue;
+      distractors.push(answer);
+    }
+  }
+
+  return distractors;
+}
+
+function uniqueAnswers(answers: string[]): string[] {
+  return Array.from(new Set(answers));
 }
 
 function isFormCompatible(item: VocabularyItem, targetForm: TargetForm): boolean {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -4,4 +4,6 @@ import { beforeEach, vi } from "vitest";
 
 beforeEach(() => {
   vi.spyOn(window.navigator, "languages", "get").mockReturnValue(["zh-TW"]);
+  // Keep shuffleQuestions deterministic in tests: 0.9999 makes Fisher-Yates a no-op.
+  vi.spyOn(Math, "random").mockReturnValue(0.9999);
 });


### PR DESCRIPTION
## Summary

For verbs and i-adjectives, the dictionary form and plainPresentAffirmative both return the surface unchanged — the prompt 書く asks for the answer 書く. Learners click the same word they see, which tests nothing.

\`buildQuestionPool\` now drops any question whose expected answer is identical to the vocabulary surface. na-adjectives and nouns still get plainPresentAffirmative practice because their answer adds だ (静か → 静かだ).

Also removes ｢辭書形｣ from the UI form dropdown since the answer equals the surface for every part of speech.

## Changes

- \`src/domain/practice.ts\`: new \`isMeaningfulQuestion\` filter at the end of \`buildQuestionPool\`.
- \`src/App.tsx\`: \`formOptions\` no longer lists \`dictionary\`.
- \`src/domain/practice.test.ts\`: 2 new tests — one verifying trivial verb forms are filtered, one verifying na-adj plainPresentAffirmative survives.

## Test plan

- [x] \`pnpm test\` — 52 tests pass.
- [x] \`pnpm build\` — clean.

## Dependencies

Stacks on top of #6 and #7. Diff will collapse to just this commit once those merge.