### PR TITLE
feat: add JLPT N1 / N2 reading practice

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import {
   shuffleQuestions
 } from "./domain/practice";
 import { createAttemptStore } from "./domain/storage";
-import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
+import type { Attempt, JlptLevel, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
 import { vocabulary } from "./domain/vocabulary";
 import { copy, getInitialLanguage, languageOptions, storeLanguage, type Language } from "./i18n";
 import "./styles.css";
@@ -59,11 +59,14 @@ const formOptions: TargetForm[] = [
   "masu",
   "potential",
   "volitional",
+  "reading",
   "plainPresentAffirmative",
   "plainPresentNegative",
   "plainPastAffirmative",
   "plainPastNegative"
 ];
+
+const jlptLevels: Array<JlptLevel | "all"> = ["all", "N5", "N4", "N3", "N2", "N1"];
 
 const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; verbOnly?: boolean }> = [
   { value: "single", targetForms: [] },
@@ -297,6 +300,7 @@ export default function App() {
   const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>("single");
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
   const [language, setLanguage] = useState<Language>(() => getInitialLanguage());
+  const [jlptLevel, setJlptLevel] = useState<JlptLevel | "all">("all");
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
@@ -306,12 +310,13 @@ export default function App() {
   const nextButtonRef = useRef<HTMLButtonElement>(null);
   const t = copy[language];
 
-  const compatibleForms =
+  const baseCompatibleForms =
     partOfSpeech === "mixed"
       ? uniqueForms([...VERB_FORMS, ...ADJECTIVE_FORMS])
       : partOfSpeech === "verb"
         ? VERB_FORMS
         : ADJECTIVE_FORMS;
+  const compatibleForms = uniqueForms([...baseCompatibleForms, "reading"]);
   const selectedForm = compatibleForms.includes(targetForm) ? targetForm : compatibleForms[0];
   const targetForms = useMemo(
     () =>
@@ -333,11 +338,12 @@ export default function App() {
         buildQuestionPool(vocabulary, {
           partOfSpeech,
           verbGroup,
-          targetForms
+          targetForms,
+          level: jlptLevel
         })
       );
     },
-    [partOfSpeech, targetForms, verbGroup, sessionSeed]
+    [partOfSpeech, targetForms, verbGroup, jlptLevel, sessionSeed]
   );
   const currentQuestion = selectQuestion(questions, questionIndex);
   const choiceOptions = useMemo(
@@ -563,6 +569,25 @@ export default function App() {
             </div>
           </fieldset>
 
+          <fieldset>
+            <legend>{t.jlptLevel}</legend>
+            <div className="segmented focus-segmented">
+              {jlptLevels.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  className={jlptLevel === option ? "selected" : ""}
+                  onClick={() => {
+                    setJlptLevel(option);
+                    resetSession();
+                  }}
+                >
+                  {t.jlptLevels[option]}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
           <label className="select-label">
             {t.targetForm}
             <select
@@ -619,7 +644,9 @@ export default function App() {
                   <GraduationCap aria-hidden="true" />
                   {partOfSpeechLabel(currentQuestion.vocabulary.partOfSpeech, language)}
                 </p>
-                <p className="reading">{currentQuestion.vocabulary.reading}</p>
+                {currentQuestion.targetForm === "reading" ? null : (
+                  <p className="reading">{currentQuestion.vocabulary.reading}</p>
+                )}
                 <p className="surface">{currentQuestion.vocabulary.surface}</p>
                 <p className="meaning">{currentQuestion.vocabulary.meaningZh}</p>
               </div>

--- a/src/domain/conjugation.ts
+++ b/src/domain/conjugation.ts
@@ -88,6 +88,7 @@ export const TARGET_FORM_LABELS: Record<TargetForm, string> = {
   ta: "た形",
   potential: "可能形",
   volitional: "意向形",
+  reading: "念法",
   plainPresentAffirmative: "普通形・非過去肯定",
   plainPresentNegative: "普通形・非過去否定",
   plainPastAffirmative: "普通形・過去肯定",
@@ -249,7 +250,17 @@ function pushNominalLikeCandidates(out: string[], base: string, targetForm: Targ
   }
 }
 
+export const VOCAB_FORMS: TargetForm[] = ["reading"];
+
 export function conjugate(item: VocabularyItem, targetForm: TargetForm): ConjugationResult {
+  if (targetForm === "reading") {
+    return {
+      targetForm,
+      answers: [item.reading],
+      explanation: `「${item.surface}」的念法是「${item.reading}」。意思：${item.meaningZh}。`
+    };
+  }
+
   if (item.partOfSpeech === "verb") {
     return conjugateVerb(item, targetForm);
   }

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -51,6 +51,40 @@ describe("buildQuestionPool", () => {
     expect(questions.some((question) => question.targetForm === "plainPresentAffirmative")).toBe(false);
   });
 
+  it("filters by JLPT level when one is selected", () => {
+    const n2Questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"],
+      level: "N2"
+    });
+    const n1Questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"],
+      level: "N1"
+    });
+
+    expect(n2Questions.length).toBeGreaterThan(0);
+    expect(n2Questions.every((question) => question.vocabulary.level === "N2")).toBe(true);
+    expect(n1Questions.every((question) => question.vocabulary.level === "N1")).toBe(true);
+    expect(n2Questions.some((question) => question.vocabulary.surface === "影響")).toBe(true);
+    expect(n1Questions.some((question) => question.vocabulary.surface === "蹂躙")).toBe(true);
+  });
+
+  it("supports reading questions for any part of speech", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"],
+      level: "N1"
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "蹂躙");
+
+    expect(target).toBeDefined();
+    expect(target!.expectedAnswers).toEqual(["じゅうりん"]);
+  });
+
   it("keeps plainPresentAffirmative for na-adjectives and nouns since they add だ", () => {
     const questions = buildQuestionPool(vocabulary, {
       partOfSpeech: "na_adjective",
@@ -268,6 +302,24 @@ describe("buildChoiceOptions", () => {
     expect(options).toContain("書こう");
     expect(options.every((option) => option.startsWith("書"))).toBe(true);
     expect(options.filter((option) => option !== "書こう").every((option) => /[うよ]う?$/.test(option))).toBe(true);
+  });
+
+  it("uses other words' readings as distractors for reading questions", () => {
+    const questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"],
+      level: "N2"
+    });
+    const target = questions.find((question) => question.vocabulary.surface === "影響");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("えいきょう");
+    expect(options).toHaveLength(4);
+    expect(options.every((option) => /^[぀-ゟ]+$/.test(option))).toBe(true);
   });
 
   it("includes the cross-category wrong rule for the adverbial form", () => {

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -6,7 +6,15 @@ import {
   validateAnswer,
   VERB_FORMS
 } from "./conjugation";
-import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup, VocabularyItem } from "./types";
+import type {
+  Attempt,
+  JlptLevel,
+  PartOfSpeech,
+  PracticeQuestion,
+  TargetForm,
+  VerbGroup,
+  VocabularyItem
+} from "./types";
 
 export const CHOICE_COUNT = 4;
 
@@ -14,10 +22,14 @@ export interface QuestionOptions {
   partOfSpeech: PartOfSpeech | "mixed";
   verbGroup: VerbGroup | "all";
   targetForms: TargetForm[];
+  level?: JlptLevel | "all";
 }
 
 export function buildQuestionPool(vocabulary: VocabularyItem[], options: QuestionOptions): PracticeQuestion[] {
+  const level = options.level ?? "all";
+
   return vocabulary
+    .filter((item) => level === "all" || item.level === level)
     .filter((item) => options.partOfSpeech === "mixed" || item.partOfSpeech === options.partOfSpeech)
     .filter((item) => item.partOfSpeech !== "verb" || options.verbGroup === "all" || item.group === options.verbGroup)
     .flatMap((item) =>
@@ -91,6 +103,10 @@ export function buildChoiceOptions(
   questions: PracticeQuestion[],
   questionIndex: number
 ): string[] {
+  if (currentQuestion.targetForm === "reading") {
+    return buildReadingChoiceOptions(currentQuestion, questions, questionIndex);
+  }
+
   const correctAnswer = currentQuestion.expectedAnswers[0];
   const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
   const vocab = currentQuestion.vocabulary;
@@ -109,6 +125,30 @@ export function buildChoiceOptions(
   );
 
   const distractors = uniqueAnswers([...ruleDistractors, ...sameWordDistractors, ...fallbackDistractors]);
+  const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
+  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
+
+  return [...options.slice(offset), ...options.slice(0, offset)];
+}
+
+function buildReadingChoiceOptions(
+  currentQuestion: PracticeQuestion,
+  questions: PracticeQuestion[],
+  questionIndex: number
+): string[] {
+  const correctAnswer = currentQuestion.expectedAnswers[0];
+  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
+  const vocab = currentQuestion.vocabulary;
+
+  const distractors = uniqueAnswers(
+    questions
+      .filter(
+        (question) => question.vocabulary.id !== vocab.id && question.targetForm === "reading"
+      )
+      .flatMap((question) => question.expectedAnswers)
+      .filter((answer) => !acceptedAnswers.has(answer))
+  );
+
   const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
   const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
 
@@ -160,6 +200,10 @@ function uniqueAnswers(answers: string[]): string[] {
 }
 
 function isFormCompatible(item: VocabularyItem, targetForm: TargetForm): boolean {
+  if (targetForm === "reading") {
+    return true;
+  }
+
   if (item.partOfSpeech === "verb") {
     return VERB_FORMS.includes(targetForm);
   }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -2,6 +2,8 @@ export type PartOfSpeech = "verb" | "i_adjective" | "na_adjective" | "noun";
 
 export type VerbGroup = "godan" | "ichidan" | "irregular";
 
+export type JlptLevel = "N5" | "N4" | "N3" | "N2" | "N1";
+
 export type TargetForm =
   | "dictionary"
   | "masu"
@@ -14,6 +16,7 @@ export type TargetForm =
   | "ta"
   | "potential"
   | "volitional"
+  | "reading"
   | "plainPresentAffirmative"
   | "plainPresentNegative"
   | "plainPastAffirmative"
@@ -34,6 +37,7 @@ export interface VocabularyItem {
   lesson: number | null;
   tags: string[];
   examples: ExampleSentence[];
+  level?: JlptLevel;
 }
 
 export interface ConjugationResult {

--- a/src/domain/vocabulary.ts
+++ b/src/domain/vocabulary.ts
@@ -1,4 +1,4 @@
-import type { VocabularyItem } from "./types";
+import type { JlptLevel, VocabularyItem } from "./types";
 
 export const vocabulary: VocabularyItem[] = [
   verb("kaku", "書く", "かく", "寫", "godan", "私はノートに漢字を書く。", "我在筆記本寫漢字。"),
@@ -41,8 +41,157 @@ export const vocabulary: VocabularyItem[] = [
   naAdjective("kantan", "簡単", "かんたん", "簡單", "この問題は簡単だ。", "這個問題很簡單。"),
   noun("gakusei", "学生", "がくせい", "學生", "私は学生だ。", "我是學生。"),
   noun("sensei", "先生", "せんせい", "老師", "田中さんは先生だ。", "田中先生是老師。"),
-  noun("kaishain", "会社員", "かいしゃいん", "公司職員", "兄は会社員だ。", "哥哥是公司職員。")
+  noun("kaishain", "会社員", "かいしゃいん", "公司職員", "兄は会社員だ。", "哥哥是公司職員。"),
+  ...n2Vocabulary(),
+  ...n1Vocabulary()
 ];
+
+function n2Vocabulary(): VocabularyItem[] {
+  return [
+    jlptNoun("n2-eikyou", "影響", "えいきょう", "影響", "N2"),
+    jlptNoun("n2-keiken", "経験", "けいけん", "經驗", "N2"),
+    jlptNoun("n2-kankyou", "環境", "かんきょう", "環境", "N2"),
+    jlptNoun("n2-seihin", "製品", "せいひん", "產品", "N2"),
+    jlptNoun("n2-bunka", "文化", "ぶんか", "文化", "N2"),
+    jlptNoun("n2-kokusai", "国際", "こくさい", "國際", "N2"),
+    jlptNoun("n2-seiji", "政治", "せいじ", "政治", "N2"),
+    jlptNoun("n2-keizai", "経済", "けいざい", "經濟", "N2"),
+    jlptNoun("n2-shakai", "社会", "しゃかい", "社會", "N2"),
+    jlptNoun("n2-senmon", "専門", "せんもん", "專業、專門", "N2"),
+    jlptNoun("n2-kaiketsu", "解決", "かいけつ", "解決", "N2"),
+    jlptNoun("n2-zouka", "増加", "ぞうか", "增加", "N2"),
+    jlptNoun("n2-genshou", "減少", "げんしょう", "減少", "N2"),
+    jlptNaAdjective("n2-juuyou", "重要", "じゅうよう", "重要", "N2"),
+    jlptNaAdjective("n2-hitsuyou", "必要", "ひつよう", "必要", "N2"),
+    jlptNaAdjective("n2-kanou", "可能", "かのう", "可能", "N2"),
+    jlptNaAdjective("n2-fuan", "不安", "ふあん", "不安、焦慮", "N2"),
+    jlptNoun("n2-kakunin", "確認", "かくにん", "確認", "N2"),
+    jlptNoun("n2-keikaku", "計画", "けいかく", "計畫", "N2"),
+    jlptNoun("n2-doryoku", "努力", "どりょく", "努力", "N2"),
+    jlptNoun("n2-kankei", "関係", "かんけい", "關係", "N2"),
+    jlptNoun("n2-heiwa", "平和", "へいわ", "和平", "N2"),
+    jlptNoun("n2-jiyuu", "自由", "じゆう", "自由", "N2"),
+    jlptNoun("n2-shurui", "種類", "しゅるい", "種類", "N2"),
+    jlptNoun("n2-joutai", "状態", "じょうたい", "狀態", "N2"),
+    jlptNoun("n2-hyougen", "表現", "ひょうげん", "表現、表達", "N2"),
+    jlptNoun("n2-teikyou", "提供", "ていきょう", "提供", "N2"),
+    jlptNoun("n2-houmon", "訪問", "ほうもん", "拜訪", "N2"),
+    jlptNoun("n2-shoutai", "招待", "しょうたい", "邀請", "N2"),
+    jlptNoun("n2-shoukai", "紹介", "しょうかい", "介紹", "N2"),
+    jlptNoun("n2-kansha", "感謝", "かんしゃ", "感謝", "N2"),
+    jlptNoun("n2-kitai", "期待", "きたい", "期待", "N2"),
+    jlptNoun("n2-inshou", "印象", "いんしょう", "印象", "N2"),
+    jlptNoun("n2-souzou", "想像", "そうぞう", "想像", "N2"),
+    jlptNoun("n2-hyoumen", "表面", "ひょうめん", "表面", "N2"),
+    jlptNoun("n2-naiyou", "内容", "ないよう", "內容", "N2"),
+    jlptNoun("n2-hani", "範囲", "はんい", "範圍", "N2"),
+    jlptNoun("n2-genkai", "限界", "げんかい", "界限、極限", "N2"),
+    jlptNaAdjective("n2-kakujitsu", "確実", "かくじつ", "確實", "N2"),
+    jlptNaAdjective("n2-konnan", "困難", "こんなん", "困難", "N2"),
+    jlptNaAdjective("n2-fukuzatsu", "複雑", "ふくざつ", "複雜", "N2"),
+    jlptNaAdjective("n2-futsuu", "普通", "ふつう", "普通", "N2"),
+    jlptNaAdjective("n2-anzen", "安全", "あんぜん", "安全", "N2"),
+    jlptNaAdjective("n2-kiken", "危険", "きけん", "危險", "N2"),
+    jlptNoun("n2-kenkou", "健康", "けんこう", "健康", "N2"),
+    jlptNoun("n2-byouki", "病気", "びょうき", "生病", "N2"),
+    jlptNoun("n2-chiryou", "治療", "ちりょう", "治療", "N2"),
+    jlptNoun("n2-kensa", "検査", "けんさ", "檢查", "N2"),
+    jlptNoun("n2-hantai", "反対", "はんたい", "反對、相反", "N2"),
+    jlptNoun("n2-sansei", "賛成", "さんせい", "贊成", "N2")
+  ];
+}
+
+function n1Vocabulary(): VocabularyItem[] {
+  return [
+    jlptNoun("n1-haaku", "把握", "はあく", "掌握、理解", "N1"),
+    jlptNoun("n1-shoutotsu", "衝突", "しょうとつ", "衝突、相撞", "N1"),
+    jlptNoun("n1-kattou", "葛藤", "かっとう", "糾葛、糾結", "N1"),
+    jlptNaAdjective("n1-chimitsu", "緻密", "ちみつ", "精細、縝密", "N1"),
+    jlptNoun("n1-shintou", "浸透", "しんとう", "滲透", "N1"),
+    jlptNoun("n1-manen", "蔓延", "まんえん", "蔓延", "N1"),
+    jlptNoun("n1-tekkai", "撤回", "てっかい", "撤回", "N1"),
+    jlptNoun("n1-honrou", "翻弄", "ほんろう", "玩弄、擺布", "N1"),
+    jlptNoun("n1-kousoku", "拘束", "こうそく", "拘束、束縛", "N1"),
+    jlptNoun("n1-masshou", "抹消", "まっしょう", "抹消、刪除", "N1"),
+    jlptNoun("n1-funkyuu", "紛糾", "ふんきゅう", "糾紛、混亂", "N1"),
+    jlptNoun("n1-ruiseki", "累積", "るいせき", "累積", "N1"),
+    jlptNoun("n1-shousai", "詳細", "しょうさい", "詳細", "N1"),
+    jlptNoun("n1-teikan", "諦観", "ていかん", "看破、達觀", "N1"),
+    jlptNoun("n1-kunou", "苦悩", "くのう", "苦惱", "N1"),
+    jlptNoun("n1-chikuseki", "蓄積", "ちくせき", "累積、儲存", "N1"),
+    jlptNoun("n1-soushitsu", "喪失", "そうしつ", "喪失", "N1"),
+    jlptNoun("n1-jousei", "醸成", "じょうせい", "醞釀、釀成", "N1"),
+    jlptNoun("n1-kensei", "牽制", "けんせい", "牽制", "N1"),
+    jlptNaAdjective("n1-bakuzen", "漠然", "ばくぜん", "茫然、模糊", "N1"),
+    jlptNaAdjective("n1-kencho", "顕著", "けんちょ", "顯著", "N1"),
+    jlptNoun("n1-mosaku", "模索", "もさく", "摸索", "N1"),
+    jlptNoun("n1-secchuu", "折衷", "せっちゅう", "折衷", "N1"),
+    jlptNoun("n1-mohan", "模範", "もはん", "模範", "N1"),
+    jlptNoun("n1-zenji", "漸次", "ぜんじ", "逐漸、漸次", "N1"),
+    jlptNoun("n1-zenshin", "漸進", "ぜんしん", "逐步前進", "N1"),
+    jlptNoun("n1-zengen", "漸減", "ぜんげん", "逐漸減少", "N1"),
+    jlptNoun("n1-tansho", "端緒", "たんしょ", "開端、線索", "N1"),
+    jlptNaAdjective("n1-tanteki", "端的", "たんてき", "明顯、坦率", "N1"),
+    jlptNoun("n1-ishizue", "礎", "いしずえ", "基石、根基", "N1"),
+    jlptNoun("n1-shinzui", "神髄", "しんずい", "精髓", "N1"),
+    jlptNoun("n1-shushi", "趣旨", "しゅし", "主旨、宗旨", "N1"),
+    jlptNoun("n1-gaiyou", "概要", "がいよう", "概要", "N1"),
+    jlptNoun("n1-gainen", "概念", "がいねん", "概念", "N1"),
+    jlptNoun("n1-gairyaku", "概略", "がいりゃく", "概略", "N1"),
+    jlptNoun("n1-gaikan", "概観", "がいかん", "概觀", "N1"),
+    jlptNoun("n1-kyouji", "矜持", "きょうじ", "自尊、矜持", "N1"),
+    jlptNoun("n1-kiben", "詭弁", "きべん", "詭辯", "N1"),
+    jlptNaAdjective("n1-kenmei", "賢明", "けんめい", "賢明", "N1"),
+    jlptNoun("n1-tainou", "滞納", "たいのう", "滯納、拖欠", "N1"),
+    jlptNoun("n1-kenin", "牽引", "けんいん", "牽引、拖動", "N1"),
+    jlptNoun("n1-jifu", "自負", "じふ", "自負、自豪", "N1"),
+    jlptNoun("n1-junrin", "蹂躙", "じゅうりん", "蹂躪、踐踏", "N1"),
+    jlptNoun("n1-bakko", "跋扈", "ばっこ", "橫行、跋扈", "N1"),
+    jlptNoun("n1-chouraku", "凋落", "ちょうらく", "衰落、凋零", "N1"),
+    jlptNoun("n1-hinagata", "雛形", "ひながた", "雛形、模型", "N1"),
+    jlptNoun("n1-fusshoku", "払拭", "ふっしょく", "拂拭、消除", "N1"),
+    jlptNoun("n1-roubai", "狼狽", "ろうばい", "狼狽、慌張", "N1"),
+    jlptNaAdjective("n1-koukatsu", "狡猾", "こうかつ", "狡猾", "N1"),
+    jlptNoun("n1-doukoku", "慟哭", "どうこく", "慟哭、痛哭", "N1"),
+    jlptNoun("n1-yuuryo", "憂慮", "ゆうりょ", "憂慮", "N1")
+  ];
+}
+
+function jlptNoun(id: string, surface: string, reading: string, meaningZh: string, level: JlptLevel): VocabularyItem {
+  return jlptItem(id, surface, reading, meaningZh, "noun", level);
+}
+
+function jlptNaAdjective(
+  id: string,
+  surface: string,
+  reading: string,
+  meaningZh: string,
+  level: JlptLevel
+): VocabularyItem {
+  return jlptItem(id, surface, reading, meaningZh, "na_adjective", level);
+}
+
+function jlptItem(
+  id: string,
+  surface: string,
+  reading: string,
+  meaningZh: string,
+  partOfSpeech: VocabularyItem["partOfSpeech"],
+  level: JlptLevel
+): VocabularyItem {
+  return {
+    id,
+    surface,
+    reading,
+    meaningZh,
+    partOfSpeech,
+    group: null,
+    lesson: null,
+    tags: [],
+    examples: [],
+    level
+  };
+}
 
 function verb(
   id: string,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,4 @@
-import type { PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
+import type { JlptLevel, PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
 
 export type Language = "zh-Hant" | "en" | "ko";
 
@@ -69,6 +69,8 @@ type Copy = {
   verbGroups: Record<VerbGroup | "all", string>;
   focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast", string>;
   targetForms: Record<TargetForm, string>;
+  jlptLevel: string;
+  jlptLevels: Record<JlptLevel | "all", string>;
   lessonCardFocus: string[];
 };
 
@@ -193,10 +195,20 @@ export const copy: Record<Language, Copy> = {
       ta: "た形",
       potential: "可能形",
       volitional: "意向形",
+      reading: "念法",
       plainPresentAffirmative: "普通形・非過去肯定",
       plainPresentNegative: "普通形・非過去否定",
       plainPastAffirmative: "普通形・過去肯定",
       plainPastNegative: "普通形・過去否定"
+    },
+    jlptLevel: "JLPT 級別",
+    jlptLevels: {
+      all: "全部",
+      N5: "N5",
+      N4: "N4",
+      N3: "N3",
+      N2: "N2",
+      N1: "N1"
     },
     lessonCardFocus: ["て形 / た形音便", "ないで / なくて / なかった", "形容詞與名詞型"]
   },
@@ -312,10 +324,20 @@ export const copy: Record<Language, Copy> = {
       ta: "Ta-form",
       potential: "Potential form",
       volitional: "Volitional form",
+      reading: "Reading",
       plainPresentAffirmative: "Plain non-past affirmative",
       plainPresentNegative: "Plain non-past negative",
       plainPastAffirmative: "Plain past affirmative",
       plainPastNegative: "Plain past negative"
+    },
+    jlptLevel: "JLPT level",
+    jlptLevels: {
+      all: "All",
+      N5: "N5",
+      N4: "N4",
+      N3: "N3",
+      N2: "N2",
+      N1: "N1"
     },
     lessonCardFocus: ["Te/Ta sound changes", "naide / nakute / nakatta", "Adjectives and noun-like forms"]
   },
@@ -431,10 +453,20 @@ export const copy: Record<Language, Copy> = {
       ta: "た형",
       potential: "가능형",
       volitional: "의향형",
+      reading: "읽는 법",
       plainPresentAffirmative: "보통형・현재 긍정",
       plainPresentNegative: "보통형・현재 부정",
       plainPastAffirmative: "보통형・과거 긍정",
       plainPastNegative: "보통형・과거 부정"
+    },
+    jlptLevel: "JLPT 등급",
+    jlptLevels: {
+      all: "전체",
+      N5: "N5",
+      N4: "N4",
+      N3: "N3",
+      N2: "N2",
+      N1: "N1"
     },
     lessonCardFocus: ["て/た 음편", "ないで / なくて / なかった", "형용사와 명사형"]
   }


### PR DESCRIPTION
## Summary

Introduces a vocabulary practice mode alongside the conjugation drills. The new ｢reading｣ target form (｢念法｣) shows a kanji compound and asks the learner to pick the correct furigana from four choices.

| | |
|---|---|
| Question prompt | 蹂躙 (meaning: 蹂躪、踐踏) |
| Correct | じゅうりん |
| Distractors | randomly drawn from other words' readings in the same pool (other N1 words) |

## Domain changes

- \`VocabularyItem\` gains an optional \`level\` field (\`JlptLevel = "N5" | "N4" | "N3" | "N2" | "N1"\`).
- New target form \`"reading"\` is compatible with every part of speech. \`conjugate(item, "reading")\` returns the stored reading and a feedback explanation that also includes the Chinese meaning.
- \`buildQuestionPool\` accepts a \`level\` filter (\`"all" | "N5" | ... | "N1"\`); existing callers stay on \`"all"\` by default.
- \`buildChoiceOptions\` routes reading questions to a dedicated branch that pulls distractors only from other words' readings in the same pool — no cross-pollution from conjugated kanji forms (which would otherwise give the answer away by being the only kana-only option).

## Vocabulary

- **50 N2 entries**: 影響, 経験, 環境, 製品, 文化, 国際, 政治, 経済, 社会, 専門, 解決, 増加, 減少, 重要, 必要, 可能, 不安, 確認, 計画, 努力, 関係, 平和, 自由, 種類, 状態, 表現, 提供, 訪問, 招待, 紹介, 感謝, 期待, 印象, 想像, 表面, 内容, 範囲, 限界, 確実, 困難, 複雑, 普通, 安全, 危険, 健康, 病気, 治療, 検査, 反対, 賛成
- **50 N1 entries**: 把握, 衝突, 葛藤, 緻密, 浸透, 蔓延, 撤回, 翻弄, 拘束, 抹消, 紛糾, 累積, 詳細, 諦観, 苦悩, 蓄積, 喪失, 醸成, 牽制, 漠然, 顕著, 模索, 折衷, 模範, 漸次, 漸進, 漸減, 端緒, 端的, 礎, 神髄, 趣旨, 概要, 概念, 概略, 概観, 矜持, 詭弁, 賢明, 滞納, 牽引, 自負, 蹂躙, 跋扈, 凋落, 雛形, 払拭, 狼狽, 狡猾, 慟哭, 憂慮

Existing Minna no Nihongo vocabulary is untouched; without a level field it appears only under ｢全部｣.

## UI

- New JLPT-level segmented control in the practice settings panel.
- The reading row is hidden in the prompt when the target form is ｢念法｣ so the answer isn't given away; the meaning row stays so the learner has context.
- ｢念法｣ is selectable from the target-form dropdown and stays available regardless of the part-of-speech filter.

## Translations

\`targetForms.reading\` and \`jlptLevel\` / \`jlptLevels\` labels added in zh-Hant, en, and ko.

## Test plan

- [x] \`pnpm test\` — 59 tests pass (3 new pool tests + 1 new choice-option test).
- [x] \`pnpm build\` — clean. JS bundle grows by ~7.4 KB (vocab data).

## Out of scope

- Meaning questions (｢意思｣) — will follow in a separate PR per the agreed phasing.
- Existing 大家的日本語 vocabulary is not retroactively tagged with N5/N4. Those entries are still reachable via the ｢全部｣ filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JLPT difficulty level selection (N5–N1) in settings to customize practice questions.
  * Introduced reading practice mode to test pronunciation of vocabulary and kanji.
  * Expanded vocabulary database with N2 and N1 level words.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/Jabiko/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->