### PR TITLE
fix: make JLPT level filter actually usable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -579,6 +579,11 @@ export default function App() {
                   className={jlptLevel === option ? "selected" : ""}
                   onClick={() => {
                     setJlptLevel(option);
+                    if (option === "N1" || option === "N2") {
+                      setPartOfSpeech("mixed");
+                      setPracticeFocus("single");
+                      setTargetForm("reading");
+                    }
                     resetSession();
                   }}
                 >

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -51,6 +51,19 @@ describe("buildQuestionPool", () => {
     expect(questions.some((question) => question.targetForm === "plainPresentAffirmative")).toBe(false);
   });
 
+  it("returns a populated pool for the N5 filter (existing Minna no Nihongo vocabulary)", () => {
+    const n5Questions = buildQuestionPool(vocabulary, {
+      partOfSpeech: "verb",
+      verbGroup: "godan",
+      targetForms: ["te"],
+      level: "N5"
+    });
+
+    expect(n5Questions.length).toBeGreaterThan(0);
+    expect(n5Questions.every((question) => question.vocabulary.level === "N5")).toBe(true);
+    expect(n5Questions.some((question) => question.vocabulary.surface === "書く")).toBe(true);
+  });
+
   it("filters by JLPT level when one is selected", () => {
     const n2Questions = buildQuestionPool(vocabulary, {
       partOfSpeech: "mixed",

--- a/src/domain/vocabulary.ts
+++ b/src/domain/vocabulary.ts
@@ -152,7 +152,8 @@ function extraVerb(group: VerbGroup, surface: string, reading: string, meaningZh
     group,
     lesson: null,
     tags: [],
-    examples: []
+    examples: [],
+    level: "N5"
   };
 }
 
@@ -220,6 +221,7 @@ function item(
     group,
     lesson: null,
     tags: [],
-    examples: [{ japanese, meaningZh: exampleZh }]
+    examples: [{ japanese, meaningZh: exampleZh }],
+    level: "N5"
   };
 }


### PR DESCRIPTION
## Reported

Tapping any of N5 / N4 / N3 / N2 / N1 leaves the challenge with an empty pool.

## Root cause — two layers

1. The existing Minna no Nihongo vocabulary (#12 shipped only N1 / N2 data alongside it) never carried a level tag, so it dropped out of every non-｢全部｣ filter.
2. The default challenge state is \`partOfSpeech=verb\` + \`verbGroup=godan\`, but the N1 / N2 vocabulary is entirely nouns and na-adjectives. Even after picking N1 or N2, the intersection was empty unless the learner manually changed two other selectors.

## Fix

- **Tag existing vocabulary with N5**: the original Minna no Nihongo entries (and the verb expansion from #13) now carry \`level: "N5"\`, so the N5 filter returns the basic verb / adjective / noun pool learners expect.
- **Smart switch on N1 / N2**: when a learner picks N1 or N2 — the two levels actually backed by vocab data — the click also sets \`partOfSpeech="mixed"\` and \`targetForm="reading"\`, so JLPT vocabulary appears immediately. The reset button still reverts everything if they want conjugation drills back.

| Level | Before | After |
|---|---|---|
| 全部 | works (all vocab) | works (all vocab) |
| N5 | **empty** | basic Minna verbs / adjectives / nouns |
| N4 | empty | empty (no data yet — follow-up) |
| N3 | empty | empty (no data yet — follow-up) |
| N2 | empty unless user changes 2 selectors | 200 noun / na-adj reading questions |
| N1 | empty unless user changes 2 selectors | 200 noun / na-adj reading questions |

## Test plan

- [x] \`pnpm test\` — 60 pass (added a pool test that asserts the N5 filter returns Minna verbs including 書く).
- [x] \`pnpm build\` — clean.

## Follow-ups (separate PRs)

- Backfill N4 / N3 vocabulary
- Consider tagging Minna L13+ as N4 once the pool grows (the existing entries are roughly N5 by frequency)