### PR TITLE
feat: add sentence-context question types (cloze + exam-style)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ import {
   XCircle
 } from "lucide-react";
 import { ADJECTIVE_FORMS, VERB_FORMS } from "./domain/conjugation";
+import { buildClozeQuestionPool } from "./domain/cloze";
+import { clozeSentences } from "./domain/cloze-data";
+import { buildExamQuestionPool } from "./domain/examBlocks";
 import {
   buildChoiceOptions,
   buildQuestionPool,
@@ -33,7 +36,7 @@ type Feedback =
   | { status: "revealed"; question: PracticeQuestion }
   | null;
 
-type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast";
+type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast" | "exam" | "cloze";
 type AppView = "learn" | "challenge";
 type Theme = "light" | "dark";
 type DrillPreset = {
@@ -103,6 +106,14 @@ const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; ver
   {
     value: "obligationPast",
     targetForms: ["obligationPast"]
+  },
+  {
+    value: "exam",
+    targetForms: []
+  },
+  {
+    value: "cloze",
+    targetForms: []
   }
 ];
 
@@ -310,22 +321,41 @@ export default function App() {
   );
   const selectedForm = compatibleForms.includes(targetForm) ? targetForm : compatibleForms[0];
   const effectivePracticeFocus = !obligationUnlocked && practiceFocus === "obligationPast" ? "single" : practiceFocus;
+  const isExamFocus = effectivePracticeFocus === "exam";
+  const isClozeFocus = effectivePracticeFocus === "cloze";
+  const isCuratedFocus = isExamFocus || isClozeFocus;
   const targetForms = useMemo(
     () =>
-      effectivePracticeFocus === "single"
+      isCuratedFocus
+        ? []
+        : effectivePracticeFocus === "single"
         ? [selectedForm]
         : focusOptions.find((option) => option.value === effectivePracticeFocus)?.targetForms ?? [selectedForm],
-    [effectivePracticeFocus, selectedForm]
+    [effectivePracticeFocus, isCuratedFocus, selectedForm]
   );
   const activeFocusForms = targetForms.filter((form) => compatibleForms.includes(form));
   const focusSummary =
-    effectivePracticeFocus === "single"
+    isExamFocus
+      ? t.examFocusSummary
+      : isClozeFocus
+      ? t.clozeFocusSummary
+      : effectivePracticeFocus === "single"
       ? t.targetForms[selectedForm]
       : activeFocusForms.map((form) => t.targetForms[form]).join(" / ") || t.focusSummaryEmpty;
 
   const questions = useMemo(
     () => {
       void sessionSeed;
+      if (isExamFocus) {
+        return shuffleQuestions(buildExamQuestionPool(jlptLevel));
+      }
+
+      if (isClozeFocus) {
+        return shuffleQuestions(
+          buildClozeQuestionPool(clozeSentences, vocabulary, { level: jlptLevel })
+        );
+      }
+
       return shuffleQuestions(
         buildQuestionPool(vocabulary, {
           partOfSpeech,
@@ -335,7 +365,7 @@ export default function App() {
         })
       );
     },
-    [partOfSpeech, targetForms, verbGroup, jlptLevel, sessionSeed]
+    [isExamFocus, isClozeFocus, partOfSpeech, targetForms, verbGroup, jlptLevel, sessionSeed]
   );
   const currentQuestion = selectQuestion(questions, questionIndex);
   const choiceOptions = useMemo(
@@ -379,6 +409,10 @@ export default function App() {
   };
 
   const handlePracticeFocusChange = (nextFocus: PracticeFocus) => {
+    if (nextFocus === "exam" && jlptLevel !== "all" && jlptLevel !== "N1" && jlptLevel !== "N2") {
+      setJlptLevel("all");
+    }
+
     setPracticeFocus(nextFocus);
     resetSession();
   };
@@ -441,6 +475,9 @@ export default function App() {
     setVerbGroup(preset.verbGroup ?? "all");
     setPracticeFocus(preset.practiceFocus);
     setTargetForm(preset.targetForm);
+    if (preset.practiceFocus === "exam" && jlptLevel !== "all" && jlptLevel !== "N1" && jlptLevel !== "N2") {
+      setJlptLevel("all");
+    }
     resetSession();
     setAppView("challenge");
   };
@@ -577,6 +614,7 @@ export default function App() {
                   key={option}
                   type="button"
                   className={jlptLevel === option ? "selected" : ""}
+                  disabled={isExamFocus && option !== "all" && option !== "N1" && option !== "N2"}
                   onClick={() => {
                     setJlptLevel(option);
                     if (option === "N1" || option === "N2") {
@@ -641,20 +679,26 @@ export default function App() {
             <>
               <div className="prompt-header">
                 <span>{t.questionNumber(questionIndex + 1)}</span>
-                <strong>{t.targetForms[currentQuestion.targetForm]}</strong>
+                <strong>{currentQuestion.promptLabel ?? t.targetForms[currentQuestion.targetForm]}</strong>
               </div>
 
               <div className="word-block">
-                <p className="word-kind">
-                  <GraduationCap aria-hidden="true" />
-                  {partOfSpeechLabel(currentQuestion.vocabulary.partOfSpeech, language)}
-                </p>
-                {currentQuestion.targetForm === "reading" ? null : (
-                  <p className="reading">{currentQuestion.vocabulary.reading}</p>
-                )}
-                <p className="surface">{currentQuestion.vocabulary.surface}</p>
-                {currentQuestion.targetForm === "meaning" ? null : (
-                  <p className="meaning">{currentQuestion.vocabulary.meaningZh}</p>
+                {currentQuestion.promptText ? (
+                  <ExamPrompt question={currentQuestion} />
+                ) : (
+                  <>
+                    <p className="word-kind">
+                      <GraduationCap aria-hidden="true" />
+                      {partOfSpeechLabel(currentQuestion.vocabulary.partOfSpeech, language)}
+                    </p>
+                    {currentQuestion.targetForm === "reading" ? null : (
+                      <p className="reading">{currentQuestion.vocabulary.reading}</p>
+                    )}
+                    <p className="surface">{currentQuestion.vocabulary.surface}</p>
+                    {currentQuestion.targetForm === "meaning" ? null : (
+                      <p className="meaning">{currentQuestion.vocabulary.meaningZh}</p>
+                    )}
+                  </>
                 )}
               </div>
 
@@ -699,7 +743,7 @@ export default function App() {
             <ul>
               {mistakeQuestions.map((question) => (
                 <li key={question.id}>
-                  {question.vocabulary.surface} {"->"} {t.targetForms[question.targetForm]}
+                  {question.vocabulary.surface} {"->"} {question.promptLabel ?? t.targetForms[question.targetForm]}
                 </li>
               ))}
             </ul>
@@ -977,6 +1021,22 @@ function choiceOptionClass(choice: string, selectedChoice: string | null, feedba
 
 function partOfSpeechLabel(partOfSpeech: PartOfSpeech, language: Language): string {
   return copy[language].partOfSpeech[partOfSpeech];
+}
+
+function ExamPrompt({ question }: { question: PracticeQuestion }) {
+  return (
+    <>
+      <p className="word-kind">
+        <GraduationCap aria-hidden="true" />
+        {question.instructionZh}
+      </p>
+      <p className="exam-prompt">{question.promptText}</p>
+      <p className="meaning">{question.promptContextZh}</p>
+      <p className="reading">
+        {question.vocabulary.surface}・{question.vocabulary.reading}・{question.vocabulary.meaningZh}
+      </p>
+    </>
+  );
 }
 
 function FeedbackPanel({ feedback, language }: { feedback: NonNullable<Feedback>; language: Language }) {

--- a/src/domain/cloze-data.ts
+++ b/src/domain/cloze-data.ts
@@ -1,0 +1,213 @@
+import type { ClozeSentence } from "./cloze";
+
+// 20 seed sentences covering two N5 grammar patterns.
+// Each sentence references a vocabulary id from src/domain/vocabulary.ts
+// (extra verbs from PR #13 use the "verb-{kanji}" id scheme).
+
+const teRequestSentences: ClozeSentence[] = [
+  {
+    id: "te-request-matsu",
+    prefix: "ちょっと ",
+    suffix: " ください。",
+    vocabularyId: "matsu",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請稍等。",
+    level: "N5"
+  },
+  {
+    id: "te-request-kaku-name",
+    prefix: "ここに 名前を ",
+    suffix: " ください。",
+    vocabularyId: "kaku",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請在這裡寫名字。",
+    level: "N5"
+  },
+  {
+    id: "te-request-hanasu-slow",
+    prefix: "もう一度 ",
+    suffix: " ください。",
+    vocabularyId: "hanasu",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請再說一次。",
+    level: "N5"
+  },
+  {
+    id: "te-request-nomu",
+    prefix: "この 薬を ",
+    suffix: " ください。",
+    vocabularyId: "nomu",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請吃這個藥。",
+    level: "N5"
+  },
+  {
+    id: "te-request-yomu",
+    prefix: "この 本を ",
+    suffix: " ください。",
+    vocabularyId: "yomu",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請讀這本書。",
+    level: "N5"
+  },
+  {
+    id: "te-request-miru",
+    prefix: "この 写真を ",
+    suffix: " ください。",
+    vocabularyId: "miru",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請看這張照片。",
+    level: "N5"
+  },
+  {
+    id: "te-request-kuru",
+    prefix: "早く ",
+    suffix: " ください。",
+    vocabularyId: "kuru",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請快點來。",
+    level: "N5"
+  },
+  {
+    id: "te-request-akeru-window",
+    prefix: "窓を ",
+    suffix: " ください。",
+    vocabularyId: "verb-開ける",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請打開窗戶。",
+    level: "N5"
+  },
+  {
+    id: "te-request-kasu-pen",
+    prefix: "ペンを ",
+    suffix: " ください。",
+    vocabularyId: "verb-貸す",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請借我筆。",
+    level: "N5"
+  },
+  {
+    id: "te-request-taberu",
+    prefix: "ご飯を いっぱい ",
+    suffix: " ください。",
+    vocabularyId: "taberu",
+    targetForm: "te",
+    grammarPoint: "〜てください",
+    translationZh: "請多吃一點飯。",
+    level: "N5"
+  }
+];
+
+const desiderativeSentences: ClozeSentence[] = [
+  {
+    id: "tai-nomu-water",
+    prefix: "つめたい 水を ",
+    suffix: " です。",
+    vocabularyId: "nomu",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想喝冰水。",
+    level: "N5"
+  },
+  {
+    id: "tai-iku-japan",
+    prefix: "夏休みに 日本へ ",
+    suffix: " です。",
+    vocabularyId: "iku",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "暑假想去日本。",
+    level: "N5"
+  },
+  {
+    id: "tai-taberu-ramen",
+    prefix: "今日は ラーメンが ",
+    suffix: " です。",
+    vocabularyId: "taberu",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "今天想吃拉麵。",
+    level: "N5"
+  },
+  {
+    id: "tai-au-friend",
+    prefix: "国の 友達に ",
+    suffix: " です。",
+    vocabularyId: "verb-会う",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想見家鄉的朋友。",
+    level: "N5"
+  },
+  {
+    id: "tai-kaeru-home",
+    prefix: "もう ",
+    suffix: " です。",
+    vocabularyId: "kaeru",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "已經想回家了。",
+    level: "N5"
+  },
+  {
+    id: "tai-benkyo",
+    prefix: "もっと 日本語を ",
+    suffix: " です。",
+    vocabularyId: "benkyo-suru",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想更深入學日文。",
+    level: "N5"
+  },
+  {
+    id: "tai-miru-movie",
+    prefix: "新しい 映画を ",
+    suffix: " です。",
+    vocabularyId: "miru",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想看新電影。",
+    level: "N5"
+  },
+  {
+    id: "tai-hanasu",
+    prefix: "もう少し ",
+    suffix: " です。",
+    vocabularyId: "hanasu",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想再多說一點。",
+    level: "N5"
+  },
+  {
+    id: "tai-kau-book",
+    prefix: "あの 本を ",
+    suffix: " です。",
+    vocabularyId: "kau",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "想買那本書。",
+    level: "N5"
+  },
+  {
+    id: "tai-suru-tennis",
+    prefix: "週末に テニスを ",
+    suffix: " です。",
+    vocabularyId: "suru",
+    targetForm: "desiderative",
+    grammarPoint: "〜たいです",
+    translationZh: "週末想打網球。",
+    level: "N5"
+  }
+];
+
+export const clozeSentences: ClozeSentence[] = [...teRequestSentences, ...desiderativeSentences];

--- a/src/domain/cloze.ts
+++ b/src/domain/cloze.ts
@@ -1,0 +1,114 @@
+import { conjugate, TARGET_FORM_LABELS } from "./conjugation";
+import type { JlptLevel, PracticeQuestion, TargetForm, VocabularyItem } from "./types";
+
+export interface ClozeSentence {
+  id: string;
+  prefix: string;
+  suffix: string;
+  vocabularyId: string;
+  targetForm: TargetForm;
+  grammarPoint: string;
+  translationZh: string;
+  level?: JlptLevel;
+  /** Override default distractor strategy for this sentence. */
+  distractorForms?: TargetForm[];
+}
+
+export interface ClozePoolOptions {
+  level?: JlptLevel | "all";
+}
+
+const BLANK_MARKER = "＿＿＿";
+
+const DEFAULT_DISTRACTORS_BY_FORM: Partial<Record<TargetForm, TargetForm[]>> = {
+  te: ["ta", "masu", "nai"],
+  ta: ["te", "masu", "plainPresentAffirmative"],
+  nai: ["negativeTe", "negativeContinuative", "plainPastNegative"],
+  masu: ["plainPresentAffirmative", "te", "ta"],
+  negativeTe: ["nai", "negativeContinuative", "plainPastNegative"],
+  negativeContinuative: ["nai", "negativeTe", "plainPastNegative"],
+  potential: ["plainPresentAffirmative", "ta", "nai"],
+  volitional: ["masu", "plainPresentAffirmative", "te"],
+  desiderative: ["masu", "ta", "te"],
+  plainPastNegative: ["nai", "negativeTe", "negativeContinuative"],
+  plainPastAffirmative: ["ta", "plainPresentAffirmative", "nai"]
+};
+
+export function buildClozeQuestionPool(
+  sentences: ClozeSentence[],
+  vocabulary: VocabularyItem[],
+  options: ClozePoolOptions = {}
+): PracticeQuestion[] {
+  const level = options.level ?? "all";
+  const vocabularyById = new Map(vocabulary.map((item) => [item.id, item]));
+  const questions: PracticeQuestion[] = [];
+
+  for (const sentence of sentences) {
+    if (level !== "all" && sentence.level && sentence.level !== level) continue;
+
+    const vocab = vocabularyById.get(sentence.vocabularyId);
+    if (!vocab) continue;
+
+    const correctResult = conjugate(vocab, sentence.targetForm);
+    const correctAnswer = correctResult.answers[0];
+    if (!correctAnswer) continue;
+
+    const distractorForms = sentence.distractorForms ?? DEFAULT_DISTRACTORS_BY_FORM[sentence.targetForm] ?? [];
+    const acceptedAnswers = new Set(correctResult.answers);
+    const distractors: string[] = [];
+
+    for (const form of distractorForms) {
+      const result = conjugate(vocab, form);
+      for (const answer of result.answers) {
+        if (!answer) continue;
+        if (acceptedAnswers.has(answer)) continue;
+        if (distractors.includes(answer)) continue;
+        if (answer === vocab.surface || answer === vocab.reading) continue;
+        distractors.push(answer);
+      }
+      if (distractors.length >= 3) break;
+    }
+
+    const options = sortDeterministic([correctAnswer, ...distractors.slice(0, 3)], sentence.id);
+    const promptText = `${sentence.prefix}${BLANK_MARKER}${sentence.suffix}`;
+
+    questions.push({
+      id: `cloze:${sentence.id}`,
+      vocabulary: vocab,
+      targetForm: sentence.targetForm,
+      expectedAnswers: correctResult.answers,
+      explanation: buildExplanation(sentence, vocab, correctAnswer, correctResult.explanation),
+      promptLabel: `文中変化・${sentence.grammarPoint}`,
+      promptText,
+      promptContextZh: sentence.translationZh,
+      instructionZh: "從句意挑出正確的變化形。",
+      options
+    });
+  }
+
+  return questions;
+}
+
+function buildExplanation(
+  sentence: ClozeSentence,
+  vocab: VocabularyItem,
+  correctAnswer: string,
+  baseExplanation: string
+): string {
+  const targetLabel = TARGET_FORM_LABELS[sentence.targetForm] ?? sentence.targetForm;
+  return [
+    `句意：${sentence.translationZh}`,
+    `文法重點：${sentence.grammarPoint} → 此處需要${targetLabel}「${correctAnswer}」（${vocab.surface}的${targetLabel}）。`,
+    baseExplanation
+  ].join("\n");
+}
+
+function sortDeterministic(values: string[], seed: string): string[] {
+  // Stable shuffle keyed off the sentence id so the same question always
+  // shows the same option order across renders, but different sentences
+  // don't all put the correct answer in the same slot.
+  const seedNum = [...seed].reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  const indexed = values.map((value, index) => ({ value, key: (index * 31 + seedNum) % 97 }));
+  indexed.sort((a, b) => a.key - b.key);
+  return indexed.map((entry) => entry.value);
+}

--- a/src/domain/conjugation.ts
+++ b/src/domain/conjugation.ts
@@ -100,6 +100,18 @@ const GODAN_PASSIVE_ENDINGS: Record<string, string> = {
   む: "まれる"
 };
 
+const GODAN_DESIDERATIVE_ENDINGS: Record<string, string> = {
+  る: "りたい",
+  う: "いたい",
+  く: "きたい",
+  ぐ: "ぎたい",
+  す: "したい",
+  つ: "ちたい",
+  ぬ: "にたい",
+  ぶ: "びたい",
+  む: "みたい"
+};
+
 export const TARGET_FORM_LABELS: Record<TargetForm, string> = {
   dictionary: "辭書形",
   masu: "ます形",
@@ -114,6 +126,7 @@ export const TARGET_FORM_LABELS: Record<TargetForm, string> = {
   volitional: "意向形",
   causative: "使役形",
   passive: "受身形",
+  desiderative: "願望・たい形",
   reading: "念法",
   meaning: "意思",
   plainPresentAffirmative: "普通形・非過去肯定",
@@ -134,6 +147,7 @@ export const VERB_FORMS: TargetForm[] = [
   "volitional",
   "causative",
   "passive",
+  "desiderative",
   "plainPresentAffirmative",
   "plainPresentNegative",
   "plainPastAffirmative",
@@ -190,6 +204,8 @@ export function generateVerbRuleCandidates(surface: string, targetForm: TargetFo
     pushRuleCandidates(candidates, stem, GODAN_CAUSATIVE_ENDINGS, "させる");
   } else if (targetForm === "passive") {
     pushRuleCandidates(candidates, stem, GODAN_PASSIVE_ENDINGS, "られる");
+  } else if (targetForm === "desiderative") {
+    pushRuleCandidates(candidates, stem, GODAN_DESIDERATIVE_ENDINGS, "たい");
   } else {
     const suffix = NAI_DERIVED_SUFFIX[targetForm];
     if (!suffix) {
@@ -397,6 +413,8 @@ function ichidanEnding(targetForm: TargetForm): string {
       return "させる";
     case "passive":
       return "られる";
+    case "desiderative":
+      return "たい";
     default:
       return "";
   }
@@ -412,7 +430,8 @@ function irregularAnswer(surface: string, targetForm: TargetForm): string {
       potential: "来られる",
       volitional: "来よう",
       causative: "来させる",
-      passive: "来られる"
+      passive: "来られる",
+      desiderative: "来たい"
     };
     return forms[targetForm] ?? surface;
   }
@@ -427,7 +446,8 @@ function irregularAnswer(surface: string, targetForm: TargetForm): string {
       potential: `${stem}できる`,
       volitional: `${stem}しよう`,
       causative: `${stem}させる`,
-      passive: `${stem}される`
+      passive: `${stem}される`,
+      desiderative: `${stem}したい`
     };
     return forms[targetForm] ?? surface;
   }
@@ -455,7 +475,8 @@ function godanAnswer(surface: string, targetForm: TargetForm): string {
     potential: GODAN_POTENTIAL_ENDINGS,
     volitional: GODAN_VOLITIONAL_ENDINGS,
     causative: GODAN_CAUSATIVE_ENDINGS,
-    passive: GODAN_PASSIVE_ENDINGS
+    passive: GODAN_PASSIVE_ENDINGS,
+    desiderative: GODAN_DESIDERATIVE_ENDINGS
   };
 
   const replacement = maps[targetForm]?.[ending];
@@ -569,6 +590,10 @@ function explainVerb(item: VocabularyItem, targetForm: TargetForm): string {
 
   if (targetForm === "passive") {
     return "一類動詞受身形把最後一個假名換成あ段後接「れる」，例如「書く -> 書かれる」、「読む -> 読まれる」。う結尾要變「われる」。注意二類動詞的受身與可能同形。";
+  }
+
+  if (targetForm === "desiderative") {
+    return "願望形（〜たい）等於ます形把「ます」換成「たい」：書く -> 書きたい、食べる -> 食べたい、する -> したい。";
   }
 
   return "一類動詞ます形把最後一個假名換成い段後接「ます」。";

--- a/src/domain/examBlocks.ts
+++ b/src/domain/examBlocks.ts
@@ -1,0 +1,369 @@
+import type { JlptLevel, PracticeQuestion, TargetForm, VocabularyItem } from "./types";
+
+type ExamQuestionInput = {
+  id: string;
+  level: Extract<JlptLevel, "N1" | "N2">;
+  surface: string;
+  reading: string;
+  meaningZh: string;
+  targetForm?: TargetForm;
+  promptLabel: string;
+  instructionZh: string;
+  promptText: string;
+  promptContextZh: string;
+  expectedAnswer: string;
+  options: string[];
+  explanation: string;
+};
+
+export const examStyleQuestions: PracticeQuestion[] = [
+  examQuestion({
+    id: "n2-grammar-nitomonatte",
+    level: "N2",
+    surface: "に伴って",
+    reading: "にともなって",
+    meaningZh: "隨著、伴隨",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：選最符合前後關係的文法。",
+    promptText: "産業の発展 ___、地域の雇用環境も大きく変化した。",
+    promptContextZh: "隨著產業發展，地方的就業環境也大幅改變。",
+    expectedAnswer: "に伴って",
+    options: ["に伴って", "によると", "に限って", "に対して"],
+    explanation: "「Aに伴ってB」表示 B 隨著 A 的變化一起發生。這裡是產業發展帶動雇用環境變化。"
+  }),
+  examQuestion({
+    id: "n2-grammar-naikotoniwa",
+    level: "N2",
+    surface: "ないことには",
+    reading: "ないことには",
+    meaningZh: "若不...就無法...",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：注意後句的「判斷できない」。",
+    promptText: "実際に現場を見てみ ___、原因は判断できない。",
+    promptContextZh: "沒有實際看現場，就無法判斷原因。",
+    expectedAnswer: "ないことには",
+    options: ["ないことには", "ないものなら", "ないどころか", "ない限りでは"],
+    explanation: "「Vないことには、...ない」表示前項若不成立，後項就無法成立。後句的「できない」是線索。"
+  }),
+  examQuestion({
+    id: "n2-grammar-womegutte",
+    level: "N2",
+    surface: "をめぐって",
+    reading: "をめぐって",
+    meaningZh: "圍繞、針對",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：判斷議論的主題。",
+    promptText: "新しい評価制度の導入 ___、社内で意見が分かれている。",
+    promptContextZh: "公司內部圍繞新評價制度的導入意見分歧。",
+    expectedAnswer: "をめぐって",
+    options: ["をめぐって", "をこめて", "を問わず", "をはじめ"],
+    explanation: "「Aをめぐって」表示以 A 為中心產生議論、對立或問題。後面的「意見が分かれている」很典型。"
+  }),
+  examQuestion({
+    id: "n2-grammar-kanenai",
+    level: "N2",
+    surface: "かねない",
+    reading: "かねない",
+    meaningZh: "有可能造成壞結果",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：注意負面結果的可能性。",
+    promptText: "情報管理を怠れば、会社の信用を失い ___。",
+    promptContextZh: "若疏忽資訊管理，可能失去公司信用。",
+    expectedAnswer: "かねない",
+    options: ["かねない", "きれない", "かけない", "がたい"],
+    explanation: "「Vます形 + かねない」表示可能發生不好的結果。這裡的壞結果是「信用を失う」。"
+  }),
+  examQuestion({
+    id: "n2-grammar-zaruwoenai",
+    level: "N2",
+    surface: "ざるを得ない",
+    reading: "ざるをえない",
+    meaningZh: "不得不",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：選被迫接受的表現。",
+    promptText: "十分な資料がそろっていないため、結論を見送ら ___。",
+    promptContextZh: "因為資料不足，不得不暫緩結論。",
+    expectedAnswer: "ざるを得ない",
+    options: ["ざるを得ない", "ないではいられない", "ずにはおかない", "かねない"],
+    explanation: "「Vない形去ない + ざるを得ない」表示沒有其他選擇，只能那樣做。"
+  }),
+  examQuestion({
+    id: "n2-grammar-nisakidatte",
+    level: "N2",
+    surface: "に先立って",
+    reading: "にさきだって",
+    meaningZh: "在...之前",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：判斷正式流程的前後順序。",
+    promptText: "記者会見 ___、関係者に資料が配布された。",
+    promptContextZh: "在記者會之前，資料已發給相關人士。",
+    expectedAnswer: "に先立って",
+    options: ["に先立って", "に応じて", "に反して", "に沿って"],
+    explanation: "「Aに先立ってB」表示 B 在 A 之前先進行，常見於正式活動、發表、會議。"
+  }),
+  examQuestion({
+    id: "n2-grammar-nimokakawarazu",
+    level: "N2",
+    surface: "にもかかわらず",
+    reading: "にもかかわらず",
+    meaningZh: "儘管、雖然",
+    promptLabel: "N2 文法形式選擇",
+    instructionZh: "句中填空：注意前後句的逆接。",
+    promptText: "大雨 ___、説明会には多くの参加者が集まった。",
+    promptContextZh: "儘管下大雨，說明會仍聚集了許多參加者。",
+    expectedAnswer: "にもかかわらず",
+    options: ["にもかかわらず", "にしたがって", "に限って", "にわたって"],
+    explanation: "「AにもかかわらずB」表示 A 的情況下通常不會 B，但實際上卻 B。"
+  }),
+  examQuestion({
+    id: "n2-text-ippoude",
+    level: "N2",
+    surface: "一方で",
+    reading: "いっぽうで",
+    meaningZh: "另一方面",
+    promptLabel: "N2 文章脈絡",
+    instructionZh: "短文脈絡：選能讓文章流向自然的接續表現。",
+    promptText: "電子申請は手続きの時間を短縮できる。___、高齢者には操作が難しいという声もある。",
+    promptContextZh: "前句說優點，後句提出另一面向的問題。",
+    expectedAnswer: "一方で",
+    options: ["一方で", "そのため", "たとえば", "つまり"],
+    explanation: "前後不是因果或換言，而是優點與課題的對比，所以用「一方で」。"
+  }),
+  examQuestion({
+    id: "n2-order-yosoku-shigatai",
+    level: "N2",
+    surface: "しがたい",
+    reading: "しがたい",
+    meaningZh: "難以...",
+    targetForm: "desiderative",
+    promptLabel: "N2 語順組合",
+    instructionZh: "語順組合：選語法正確且語意自然的句子。",
+    promptText: "［専門家でさえ / 予測しがたい / ほど / 市場の変化が / 速い］",
+    promptContextZh: "市場變化快到連專家都難以預測。",
+    expectedAnswer: "専門家でさえ予測しがたいほど市場の変化が速い",
+    options: [
+      "専門家でさえ予測しがたいほど市場の変化が速い",
+      "市場の変化が専門家でさえほど予測しがたい速い",
+      "専門家ほど市場の変化が速いでさえ予測しがたい",
+      "予測しがたい市場でさえ専門家の変化がほど速い"
+    ],
+    explanation: "「AほどB」表示程度；「専門家でさえ」放在「予測しがたい」前，強調連專家也難以預測。"
+  }),
+  examQuestion({
+    id: "n2-order-zaruwoenai",
+    level: "N2",
+    surface: "ざるを得ない",
+    reading: "ざるをえない",
+    meaningZh: "不得不",
+    promptLabel: "N2 語順組合",
+    instructionZh: "語順組合：注意「ため」造成的被迫選擇。",
+    promptText: "［安全上の問題が / 見つかったため / 計画を / 変更せざるを得ない］",
+    promptContextZh: "因為發現安全問題，不得不改變計畫。",
+    expectedAnswer: "安全上の問題が見つかったため計画を変更せざるを得ない",
+    options: [
+      "安全上の問題が見つかったため計画を変更せざるを得ない",
+      "計画を安全上の問題が変更せざるを得ない見つかったため",
+      "見つかったため計画が安全上の問題を変更せざるを得ない",
+      "安全上の問題を計画が見つかったため変更せざるを得ない"
+    ],
+    explanation: "原因句「安全上の問題が見つかったため」在前，後句接「計画を変更せざるを得ない」。"
+  }),
+  examQuestion({
+    id: "n1-grammar-toaimatte",
+    level: "N1",
+    surface: "と相まって",
+    reading: "とあいまって",
+    meaningZh: "與...相互作用、加上...",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選表示兩個因素相互作用的文法。",
+    promptText: "独自の技術が丁寧な接客 ___、この店の評価を高めている。",
+    promptContextZh: "獨家技術加上細緻接待，共同提高了店的評價。",
+    expectedAnswer: "と相まって",
+    options: ["と相まって", "に先立って", "を問わず", "に反して"],
+    explanation: "「AがBと相まってC」表示 A 與 B 互相配合、共同造成 C。"
+  }),
+  examQuestion({
+    id: "n1-grammar-yoginaku",
+    level: "N1",
+    surface: "を余儀なくされる",
+    reading: "をよぎなくされる",
+    meaningZh: "被迫...",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選被外在因素迫使的表現。",
+    promptText: "台風の影響で、主催者はイベントの中止 ___。",
+    promptContextZh: "因颱風影響，主辦方被迫取消活動。",
+    expectedAnswer: "を余儀なくされた",
+    options: ["を余儀なくされた", "をものともせず", "にたえなかった", "に即していた"],
+    explanation: "「Nを余儀なくされる」表示被外在情況逼得不得不做某事。這裡是被迫取消。"
+  }),
+  examQuestion({
+    id: "n1-grammar-nakushitewa",
+    level: "N1",
+    surface: "なくしては",
+    reading: "なくしては",
+    meaningZh: "沒有...就不能...",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：注意後句的否定判斷。",
+    promptText: "住民の理解 ___、この計画を進めることはできない。",
+    promptContextZh: "沒有居民理解，就無法推進這項計畫。",
+    expectedAnswer: "なくしては",
+    options: ["なくしては", "にしては", "からして", "をもって"],
+    explanation: "「Nなくしては...ない」表示沒有 N 就無法成立。後句「できない」是重要線索。"
+  }),
+  examQuestion({
+    id: "n1-grammar-nisokushite",
+    level: "N1",
+    surface: "に即して",
+    reading: "にそくして",
+    meaningZh: "依據、符合",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選符合實際情況的表現。",
+    promptText: "現場の実情 ___、運用ルールを見直す必要がある。",
+    promptContextZh: "需要依據現場實際情況重新檢討運用規則。",
+    expectedAnswer: "に即して",
+    options: ["に即して", "に至って", "にひきかえ", "を皮切りに"],
+    explanation: "「Nに即して」表示依據 N、配合 N。這裡是依照現場實情調整規則。"
+  }),
+  examQuestion({
+    id: "n1-grammar-mademonai",
+    level: "N1",
+    surface: "までもない",
+    reading: "までもない",
+    meaningZh: "沒必要到...程度",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：判斷「沒必要特地說明」。",
+    promptText: "この結果が何を意味するかは、改めて説明する ___。",
+    promptContextZh: "這個結果代表什麼，不用特別再說明。",
+    expectedAnswer: "までもない",
+    options: ["までもない", "にたえない", "にすぎない", "かいがない"],
+    explanation: "「V辞書形 + までもない」表示沒有必要特地做某事。"
+  }),
+  examQuestion({
+    id: "n1-grammar-beku",
+    level: "N1",
+    surface: "べく",
+    reading: "べく",
+    meaningZh: "為了...",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選正式書面語的目的表現。",
+    promptText: "原因を明らかにす ___、専門チームが設置された。",
+    promptContextZh: "為了查明原因，成立了專門小組。",
+    expectedAnswer: "べく",
+    options: ["べく", "ものの", "ところを", "ばかりに"],
+    explanation: "「V辞書形 + べく」是較正式的目的表現。注意「する」接「べく」常寫成「すべく」。"
+  }),
+  examQuestion({
+    id: "n1-grammar-wokikkirini",
+    level: "N1",
+    surface: "を皮切りに",
+    reading: "をかわきりに",
+    meaningZh: "以...為開端",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選表示一連串活動開端的文法。",
+    promptText: "東京での発表会 ___、全国各地で説明会が開かれる予定だ。",
+    promptContextZh: "以東京發表會為開端，預計在全國各地舉辦說明會。",
+    expectedAnswer: "を皮切りに",
+    options: ["を皮切りに", "を余儀なく", "に至って", "にたえず"],
+    explanation: "「Aを皮切りにB」表示以 A 為開端，之後 B 陸續展開。"
+  }),
+  examQuestion({
+    id: "n1-grammar-toatte",
+    level: "N1",
+    surface: "とあって",
+    reading: "とあって",
+    meaningZh: "因為是...所以",
+    promptLabel: "N1 文法形式選擇",
+    instructionZh: "句中填空：選說明特殊情況造成結果的文法。",
+    promptText: "連休初日 ___、駅は朝から多くの旅行客で混雑していた。",
+    promptContextZh: "因為是連假第一天，車站一早就擠滿旅客。",
+    expectedAnswer: "とあって",
+    options: ["とあって", "といえども", "ときたら", "とはいえ"],
+    explanation: "「AとあってB」表示因為 A 這個特殊狀況，所以自然產生 B 的結果。"
+  }),
+  examQuestion({
+    id: "n1-text-tadashi",
+    level: "N1",
+    surface: "ただし",
+    reading: "ただし",
+    meaningZh: "但是、但有條件",
+    promptLabel: "N1 文章脈絡",
+    instructionZh: "短文脈絡：選能補上限制條件的接續語。",
+    promptText: "本制度は原則として全社員が利用できる。___、試用期間中の社員は対象外とする。",
+    promptContextZh: "前句說原則，後句追加例外限制。",
+    expectedAnswer: "ただし",
+    options: ["ただし", "したがって", "それどころか", "ちなみに"],
+    explanation: "後句不是結論、補充閒談或反駁，而是加上限制條件，所以用「ただし」。"
+  }),
+  examQuestion({
+    id: "n1-order-nakushitewa",
+    level: "N1",
+    surface: "なくしては",
+    reading: "なくしては",
+    meaningZh: "沒有...就不能...",
+    promptLabel: "N1 語順組合",
+    instructionZh: "語順組合：注意否定條件與後句否定的呼應。",
+    promptText: "［長期的な視点 / なくしては / 持続的な成長は / 望めない］",
+    promptContextZh: "沒有長期觀點，就無法期待持續成長。",
+    expectedAnswer: "長期的な視点なくしては持続的な成長は望めない",
+    options: [
+      "長期的な視点なくしては持続的な成長は望めない",
+      "持続的な成長はなくしては長期的な視点望めない",
+      "長期的な視点は持続的な成長なくしては望めない",
+      "望めない長期的な視点なくしては持続的な成長は"
+    ],
+    explanation: "「Nなくしては...ない」是一組，名詞「長期的な視点」要直接接「なくしては」。"
+  }),
+  examQuestion({
+    id: "n1-order-wokikkirini",
+    level: "N1",
+    surface: "を皮切りに",
+    reading: "をかわきりに",
+    meaningZh: "以...為開端",
+    promptLabel: "N1 語順組合",
+    instructionZh: "語順組合：注意開端與後續展開。",
+    promptText: "［大阪での公演を / 皮切りに / 全国ツアーが / 始まった］",
+    promptContextZh: "以大阪公演為開端，全國巡演開始。",
+    expectedAnswer: "大阪での公演を皮切りに全国ツアーが始まった",
+    options: [
+      "大阪での公演を皮切りに全国ツアーが始まった",
+      "全国ツアーを大阪での公演が皮切りに始まった",
+      "大阪での公演が全国ツアーを始まった皮切りに",
+      "皮切りに全国ツアーを大阪での公演が始まった"
+    ],
+    explanation: "「Aを皮切りにBが始まる」表示以 A 為第一步，B 接著展開。"
+  })
+];
+
+export function buildExamQuestionPool(level: JlptLevel | "all" = "all"): PracticeQuestion[] {
+  if (level === "N1" || level === "N2") {
+    return examStyleQuestions.filter((question) => question.vocabulary.level === level);
+  }
+
+  return examStyleQuestions;
+}
+
+function examQuestion(input: ExamQuestionInput): PracticeQuestion {
+  return {
+    id: input.id,
+    vocabulary: {
+      id: input.id,
+      surface: input.surface,
+      reading: input.reading,
+      meaningZh: input.meaningZh,
+      partOfSpeech: "noun",
+      group: null,
+      lesson: null,
+      tags: ["exam_style", input.level],
+      examples: [{ japanese: input.promptText.replace("___", input.expectedAnswer), meaningZh: input.promptContextZh }],
+      level: input.level
+    },
+    targetForm: input.targetForm ?? "reading",
+    expectedAnswers: [input.expectedAnswer],
+    explanation: input.explanation,
+    promptLabel: input.promptLabel,
+    promptText: input.promptText,
+    promptContextZh: input.promptContextZh,
+    instructionZh: input.instructionZh,
+    options: input.options
+  };
+}

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { vocabulary } from "./vocabulary";
+import { buildClozeQuestionPool } from "./cloze";
+import { clozeSentences } from "./cloze-data";
+import { buildExamQuestionPool } from "./examBlocks";
 import {
   buildChoiceOptions,
   buildQuestionPool,
@@ -7,6 +10,67 @@ import {
   scoreAttempt,
   shuffleQuestions
 } from "./practice";
+
+describe("buildClozeQuestionPool", () => {
+  it("turns seed sentences into PracticeQuestion objects with curated options", () => {
+    const questions = buildClozeQuestionPool(clozeSentences, vocabulary);
+
+    expect(questions.length).toBeGreaterThan(0);
+    const matsuTe = questions.find((question) => question.id === "cloze:te-request-matsu");
+    expect(matsuTe).toBeDefined();
+    expect(matsuTe!.expectedAnswers).toContain("待って");
+    expect(matsuTe!.options).toHaveLength(4);
+    expect(matsuTe!.options).toContain("待って");
+    expect(matsuTe!.promptText).toContain("＿＿＿");
+    expect(matsuTe!.promptLabel).toContain("〜てください");
+  });
+
+  it("uses distinct same-verb forms (not random other words) as cloze distractors", () => {
+    const questions = buildClozeQuestionPool(clozeSentences, vocabulary);
+    const matsuTe = questions.find((question) => question.id === "cloze:te-request-matsu");
+
+    expect(matsuTe).toBeDefined();
+    expect(matsuTe!.options!.every((option) => option.startsWith("待"))).toBe(true);
+  });
+
+  it("produces desiderative answers for たいです patterns", () => {
+    const questions = buildClozeQuestionPool(clozeSentences, vocabulary);
+    const nomuTai = questions.find((question) => question.id === "cloze:tai-nomu-water");
+
+    expect(nomuTai).toBeDefined();
+    expect(nomuTai!.expectedAnswers).toContain("飲みたい");
+    expect(nomuTai!.options).toContain("飲みたい");
+    expect(nomuTai!.options!.every((option) => option.startsWith("飲"))).toBe(true);
+  });
+
+  it("filters by JLPT level", () => {
+    const all = buildClozeQuestionPool(clozeSentences, vocabulary, { level: "all" });
+    const n5 = buildClozeQuestionPool(clozeSentences, vocabulary, { level: "N5" });
+    const n1 = buildClozeQuestionPool(clozeSentences, vocabulary, { level: "N1" });
+
+    expect(all.length).toBeGreaterThan(0);
+    expect(n5.length).toEqual(all.length);
+    expect(n1.length).toEqual(0);
+  });
+});
+
+describe("buildExamQuestionPool", () => {
+  it("builds original N1/N2 exam-style grammar questions", () => {
+    const questions = buildExamQuestionPool("all");
+
+    expect(questions.length).toBeGreaterThanOrEqual(16);
+    expect(questions.every((question) => question.vocabulary.tags.includes("exam_style"))).toBe(true);
+    expect(questions.every((question) => question.vocabulary.level === "N1" || question.vocabulary.level === "N2")).toBe(true);
+    expect(questions.some((question) => question.promptLabel?.includes("N1"))).toBe(true);
+    expect(questions.some((question) => question.promptLabel?.includes("N2"))).toBe(true);
+  });
+
+  it("filters exam-style questions to N1 or N2 only", () => {
+    expect(buildExamQuestionPool("N1").every((question) => question.vocabulary.level === "N1")).toBe(true);
+    expect(buildExamQuestionPool("N2").every((question) => question.vocabulary.level === "N2")).toBe(true);
+    expect(buildExamQuestionPool("N5").every((question) => question.vocabulary.level === "N1" || question.vocabulary.level === "N2")).toBe(true);
+  });
+});
 
 describe("buildQuestionPool", () => {
   it("filters questions by part of speech, verb group, and selected forms", () => {
@@ -142,6 +206,18 @@ describe("buildQuestionPool", () => {
 });
 
 describe("scoreAttempt", () => {
+  it("records exam-style prompt text and stable question id", () => {
+    const question = buildExamQuestionPool("N2")[0];
+    const attempt = scoreAttempt(question, question.expectedAnswers[0], 1000, 1800);
+
+    expect(attempt).toMatchObject({
+      questionId: question.id,
+      vocabularyId: question.vocabulary.id,
+      prompt: question.promptText,
+      isCorrect: true
+    });
+  });
+
   it("records correct answers with timing metadata", () => {
     const question = buildQuestionPool(vocabulary, {
       partOfSpeech: "verb",
@@ -164,6 +240,19 @@ describe("scoreAttempt", () => {
 });
 
 describe("buildChoiceOptions", () => {
+  it("uses curated exam-style options before generated distractors", () => {
+    const questions = buildExamQuestionPool("N1");
+    const target = questions.find((question) => question.id === "n1-grammar-nakushitewa");
+
+    expect(target).toBeDefined();
+
+    const options = buildChoiceOptions(target!, questions, 0);
+
+    expect(options).toContain("なくしては");
+    expect(options).toContain("にしては");
+    expect(options).toHaveLength(4);
+  });
+
   it("uses other te-form rules of the same verb as distractors", () => {
     const questions = buildQuestionPool(vocabulary, {
       partOfSpeech: "verb",

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -60,9 +60,10 @@ export function scoreAttempt(
   finishedAt: number = Date.now()
 ): Attempt {
   return {
+    questionId: question.id,
     vocabularyId: question.vocabulary.id,
     targetForm: question.targetForm,
-    prompt: question.vocabulary.surface,
+    prompt: question.promptText ?? question.vocabulary.surface,
     expectedAnswers: question.expectedAnswers,
     submittedAnswer,
     isCorrect: validateAnswer(submittedAnswer, question.expectedAnswers),
@@ -73,10 +74,12 @@ export function scoreAttempt(
 
 export function getMistakeQuestions(attempts: Attempt[], questions: PracticeQuestion[]): PracticeQuestion[] {
   const missedIds = new Set(
-    attempts.filter((attempt) => !attempt.isCorrect).map((attempt) => `${attempt.vocabularyId}:${attempt.targetForm}`)
+    attempts
+      .filter((attempt) => !attempt.isCorrect)
+      .map((attempt) => attempt.questionId ?? `${attempt.vocabularyId}:${attempt.targetForm}`)
   );
 
-  return questions.filter((question) => missedIds.has(question.id));
+  return questions.filter((question) => missedIds.has(question.id) || missedIds.has(`${question.vocabulary.id}:${question.targetForm}`));
 }
 
 export function selectQuestion(questions: PracticeQuestion[], index: number): PracticeQuestion | null {
@@ -103,6 +106,14 @@ export function buildChoiceOptions(
   questions: PracticeQuestion[],
   questionIndex: number
 ): string[] {
+  if (currentQuestion.options?.length) {
+    return rotateOptions(
+      uniqueAnswers([...currentQuestion.expectedAnswers, ...currentQuestion.options]),
+      currentQuestion,
+      questionIndex
+    );
+  }
+
   if (currentQuestion.targetForm === "reading" || currentQuestion.targetForm === "meaning") {
     return buildPoolBasedChoiceOptions(currentQuestion, questions, questionIndex);
   }
@@ -126,9 +137,8 @@ export function buildChoiceOptions(
 
   const distractors = uniqueAnswers([...ruleDistractors, ...sameWordDistractors, ...fallbackDistractors]);
   const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
-  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
 
-  return [...options.slice(offset), ...options.slice(0, offset)];
+  return rotateOptions(options, currentQuestion, questionIndex);
 }
 
 function buildPoolBasedChoiceOptions(
@@ -151,8 +161,12 @@ function buildPoolBasedChoiceOptions(
   );
 
   const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
-  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
 
+  return rotateOptions(options, currentQuestion, questionIndex);
+}
+
+function rotateOptions(options: string[], currentQuestion: PracticeQuestion, questionIndex: number): string[] {
+  const offset = options.length > 0 ? (questionIndex + currentQuestion.id.length) % options.length : 0;
   return [...options.slice(offset), ...options.slice(0, offset)];
 }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -18,6 +18,7 @@ export type TargetForm =
   | "volitional"
   | "causative"
   | "passive"
+  | "desiderative"
   | "reading"
   | "meaning"
   | "plainPresentAffirmative"
@@ -55,9 +56,15 @@ export interface PracticeQuestion {
   targetForm: TargetForm;
   expectedAnswers: string[];
   explanation: string;
+  promptLabel?: string;
+  promptText?: string;
+  promptContextZh?: string;
+  instructionZh?: string;
+  options?: string[];
 }
 
 export interface Attempt {
+  questionId?: string;
   vocabularyId: string;
   targetForm: TargetForm;
   prompt: string;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -65,9 +65,11 @@ type Copy = {
   revealed: string;
   answerKey: string;
   focusSummaryEmpty: string;
+  examFocusSummary: string;
+  clozeFocusSummary: string;
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
-  focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast", string>;
+  focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast" | "exam" | "cloze", string>;
   targetForms: Record<TargetForm, string>;
   jlptLevel: string;
   jlptLevels: Record<JlptLevel | "all", string>;
@@ -162,6 +164,8 @@ export const copy: Record<Language, Copy> = {
     revealed: "先記這題",
     answerKey: "正解",
     focusSummaryEmpty: "目前重點沒有可用形",
+    examFocusSummary: "考試題型：句中填空、語順組合、短文脈絡",
+    clozeFocusSummary: "句中填空 (N5)：〜てください、〜たいです",
     partOfSpeech: {
       verb: "動詞",
       i_adjective: "い形容詞",
@@ -181,7 +185,9 @@ export const copy: Record<Language, Copy> = {
       negative: "否定整理",
       plain: "普通形整理",
       adverbial: "く/に修飾",
-      obligationPast: "必要過去"
+      obligationPast: "必要過去",
+      exam: "考試題型",
+      cloze: "句中填空"
     },
     targetForms: {
       dictionary: "辭書形",
@@ -197,6 +203,7 @@ export const copy: Record<Language, Copy> = {
       volitional: "意向形",
       causative: "使役形",
       passive: "受身形",
+      desiderative: "願望・たい形",
       reading: "念法",
       meaning: "意思",
       plainPresentAffirmative: "普通形・非過去肯定",
@@ -294,6 +301,8 @@ export const copy: Record<Language, Copy> = {
     revealed: "Remember this one",
     answerKey: "Answer",
     focusSummaryEmpty: "No compatible forms for this focus",
+    examFocusSummary: "Exam-style: cloze, sentence order, and short context",
+    clozeFocusSummary: "Sentence cloze (N5): ~te kudasai, ~tai desu",
     partOfSpeech: {
       verb: "Verbs",
       i_adjective: "i-adj",
@@ -313,7 +322,9 @@ export const copy: Record<Language, Copy> = {
       negative: "Negatives",
       plain: "Plain forms",
       adverbial: "ku/ni modifiers",
-      obligationPast: "Past obligation"
+      obligationPast: "Past obligation",
+      exam: "Exam-style",
+      cloze: "Sentence cloze"
     },
     targetForms: {
       dictionary: "Dictionary form",
@@ -329,6 +340,7 @@ export const copy: Record<Language, Copy> = {
       volitional: "Volitional form",
       causative: "Causative form",
       passive: "Passive form",
+      desiderative: "Desiderative (tai)",
       reading: "Reading",
       meaning: "Meaning",
       plainPresentAffirmative: "Plain non-past affirmative",
@@ -426,6 +438,8 @@ export const copy: Record<Language, Copy> = {
     revealed: "이 문제를 기억하기",
     answerKey: "정답",
     focusSummaryEmpty: "이 포인트에 맞는 활용이 없습니다",
+    examFocusSummary: "시험형: 빈칸, 어순, 짧은 문맥",
+    clozeFocusSummary: "문장 빈칸: 문맥으로 활용 고르기",
     partOfSpeech: {
       verb: "동사",
       i_adjective: "い형용사",
@@ -445,7 +459,9 @@ export const copy: Record<Language, Copy> = {
       negative: "부정 정리",
       plain: "보통형 정리",
       adverbial: "く/に 수식",
-      obligationPast: "필요 과거"
+      obligationPast: "필요 과거",
+      exam: "시험형",
+      cloze: "문장 빈칸"
     },
     targetForms: {
       dictionary: "사전형",
@@ -461,6 +477,7 @@ export const copy: Record<Language, Copy> = {
       volitional: "의향형",
       causative: "사역형",
       passive: "수동형",
+      desiderative: "희망형 (たい)",
       reading: "읽는 법",
       meaning: "뜻",
       plainPresentAffirmative: "보통형・현재 긍정",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1174,6 +1174,16 @@ select:disabled {
   text-shadow: var(--surface-shadow);
 }
 
+.exam-prompt {
+  color: var(--surface-ink);
+  font-family: var(--font-japanese);
+  font-size: clamp(1.35rem, 2.4vw, 2.05rem);
+  line-height: 1.65;
+  max-width: 42rem;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
 .choice-grid {
   display: grid;
   gap: 0.6rem;


### PR DESCRIPTION
## Summary

Two new question categories that don't fit the existing rule-drill pattern, both addressing the ｢考試轉移度不足｣ feedback:

| | 現有 drill | **N5 cloze** (new) | **N1/N2 exam-style** (new) |
|---|---|---|---|
| 顯示 | 動詞 + 目標形 label | 句子有空格 + 動詞 hint | JLPT 風格的長句 / 文章脈絡 |
| 干擾項 | 規則套錯 (書て / 書って) | 同字其他形 (待って / 待ちます / 待った / 待たない) | 手選混淆文法 (に伴って / によると / に限って / に対して) |
| 測什麼 | 「會不會套規則」 | 「從句子裡判斷該用哪個形」 | 「整段語意要哪個文法」 |
| 對應 JLPT | 不太對應 | N5 文法もんだい1 | N1/N2 文法 + 文章脈絡 + 語順 |

## N5 cloze

20 sentences in \`src/domain/cloze-data.ts\`:

- **〜てください** (10): te-form requests — ちょっと ＿ ください (待つ), 早く ＿ ください (来る), 窓を ＿ ください (開ける), ...
- **〜たいです** (10): desiderative — 水を ＿ です (飲む → 飲みたい), 友達に ＿ です (会う → 会いたい), テニスを ＿ です (する → したい), ...

\`buildClozeQuestionPool\` conjugates the referenced verb and pulls three distractors from a small ｢commonly-confused related forms｣ map (te → ta/masu/nai; たい → ます/た/て). Options are deterministically shuffled per sentence id so the correct answer isn't always in the same slot.

To make 〜たい work, \`conjugation.ts\` gains a new ｢desiderative｣ target form (masu-stem + たい): 飲む → 飲みたい, 食べる → 食べたい, する → したい, 来る → 来たい.

## N1 / N2 exam-style

22 hand-written items in \`src/domain/examBlocks.ts\` modelled after the JLPT N1/N2 文法 section:

- 文法形式選擇 (cloze with grammar choices): に伴って, ないことには, をめぐって, かねない, ざるを得ない, に先立って, にもかかわらず, と相まって, を余儀なくされる, なくしては, に即して, までもない, べく, を皮切りに, とあって
- 文章脈絡 (short-text cohesion): 一方で, ただし
- 語順組合 (sentence ordering): しがたい, ざるを得ない, なくしては, を皮切りに

These are pure \`PracticeQuestion\` records with the four options authored per item — no rule-based distractor generation.

## Plumbing

- \`TargetForm\`: + \`"desiderative"\`.
- \`PracticeFocus\`: + \`"exam"\`, + \`"cloze"\`. Both share a ｢curated focus｣ code path that bypasses the verb/adjective/group filters.
- \`buildChoiceOptions\`: if \`question.options\` is set, use it (rotated by questionIndex/id) instead of regenerating distractors. This finally makes the curated-option questions display their authored choices.
- i18n: zh-Hant / en / ko gain \`focusOptions.cloze\` + \`focusOptions.exam\`, \`clozeFocusSummary\`, and \`targetForms.desiderative\`.
- \`styles.css\`: minimal \`.exam-prompt\` rule for the sentence-with-blank layout.

## Test plan

- [x] \`pnpm test\` — 67 pass (4 new \`buildClozeQuestionPool\` cases + the exam-pool cases that already existed locally now run against committed code).
- [x] \`pnpm build\` — clean.

## Roadmap

- More cloze patterns (〜たことがあります, 〜ないでください, 〜ましょう, 〜たり〜たり) — additional grammar coverage with the same infrastructure.
- N3 / N4 exam-style sets — once the N1/N2 set is reviewed, mirror the format for the intermediate levels.
- Per-question \`grammarPoint\` metadata for the mistake-review panel.