### PR TITLE
refactor: remove the JLPT level filter from the practice UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import {
   shuffleQuestions
 } from "./domain/practice";
 import { createAttemptStore } from "./domain/storage";
-import type { Attempt, JlptLevel, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
+import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./domain/types";
 import { vocabulary } from "./domain/vocabulary";
 import { copy, getInitialLanguage, languageOptions, storeLanguage, type Language } from "./i18n";
 import "./styles.css";
@@ -84,7 +84,6 @@ const formOptions: TargetForm[] = [
   "plainPastNegative"
 ];
 
-const jlptLevels: Array<JlptLevel | "all"> = ["all", "N5", "N4", "N3", "N2", "N1"];
 
 const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; verbOnly?: boolean }> = [
   { value: "single", targetForms: [] },
@@ -298,7 +297,6 @@ export default function App() {
   const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>("single");
   const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
   const [language, setLanguage] = useState<Language>(() => getInitialLanguage());
-  const [jlptLevel, setJlptLevel] = useState<JlptLevel | "all">("all");
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
@@ -347,25 +345,22 @@ export default function App() {
     () => {
       void sessionSeed;
       if (isExamFocus) {
-        return shuffleQuestions(buildExamQuestionPool(jlptLevel));
+        return shuffleQuestions(buildExamQuestionPool());
       }
 
       if (isClozeFocus) {
-        return shuffleQuestions(
-          buildClozeQuestionPool(clozeSentences, vocabulary, { level: jlptLevel })
-        );
+        return shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary));
       }
 
       return shuffleQuestions(
         buildQuestionPool(vocabulary, {
           partOfSpeech,
           verbGroup,
-          targetForms,
-          level: jlptLevel
+          targetForms
         })
       );
     },
-    [isExamFocus, isClozeFocus, partOfSpeech, targetForms, verbGroup, jlptLevel, sessionSeed]
+    [isExamFocus, isClozeFocus, partOfSpeech, targetForms, verbGroup, sessionSeed]
   );
   const currentQuestion = selectQuestion(questions, questionIndex);
   const choiceOptions = useMemo(
@@ -409,10 +404,6 @@ export default function App() {
   };
 
   const handlePracticeFocusChange = (nextFocus: PracticeFocus) => {
-    if (nextFocus === "exam" && jlptLevel !== "all" && jlptLevel !== "N1" && jlptLevel !== "N2") {
-      setJlptLevel("all");
-    }
-
     setPracticeFocus(nextFocus);
     resetSession();
   };
@@ -475,9 +466,6 @@ export default function App() {
     setVerbGroup(preset.verbGroup ?? "all");
     setPracticeFocus(preset.practiceFocus);
     setTargetForm(preset.targetForm);
-    if (preset.practiceFocus === "exam" && jlptLevel !== "all" && jlptLevel !== "N1" && jlptLevel !== "N2") {
-      setJlptLevel("all");
-    }
     resetSession();
     setAppView("challenge");
   };
@@ -601,31 +589,6 @@ export default function App() {
                   }}
                 >
                   {t.verbGroups[option]}
-                </button>
-              ))}
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend>{t.jlptLevel}</legend>
-            <div className="segmented focus-segmented">
-              {jlptLevels.map((option) => (
-                <button
-                  key={option}
-                  type="button"
-                  className={jlptLevel === option ? "selected" : ""}
-                  disabled={isExamFocus && option !== "all" && option !== "N1" && option !== "N2"}
-                  onClick={() => {
-                    setJlptLevel(option);
-                    if (option === "N1" || option === "N2") {
-                      setPartOfSpeech("mixed");
-                      setPracticeFocus("single");
-                      setTargetForm("reading");
-                    }
-                    resetSession();
-                  }}
-                >
-                  {t.jlptLevels[option]}
                 </button>
               ))}
             </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,4 @@
-import type { JlptLevel, PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
+import type { PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
 
 export type Language = "zh-Hant" | "en" | "ko";
 
@@ -70,9 +70,7 @@ type Copy = {
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
   focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast" | "exam" | "cloze", string>;
-  targetForms: Record<TargetForm, string>;
-  jlptLevel: string;
-  jlptLevels: Record<JlptLevel | "all", string>;
+  targetForms: Record<TargetForm, string>;
   lessonCardFocus: string[];
 };
 
@@ -211,15 +209,6 @@ export const copy: Record<Language, Copy> = {
       plainPastAffirmative: "普通形・過去肯定",
       plainPastNegative: "普通形・過去否定"
     },
-    jlptLevel: "JLPT 級別",
-    jlptLevels: {
-      all: "全部",
-      N5: "N5",
-      N4: "N4",
-      N3: "N3",
-      N2: "N2",
-      N1: "N1"
-    },
     lessonCardFocus: ["て形 / た形音便", "ないで / なくて / なかった", "形容詞與名詞型"]
   },
   en: {
@@ -348,15 +337,6 @@ export const copy: Record<Language, Copy> = {
       plainPastAffirmative: "Plain past affirmative",
       plainPastNegative: "Plain past negative"
     },
-    jlptLevel: "JLPT level",
-    jlptLevels: {
-      all: "All",
-      N5: "N5",
-      N4: "N4",
-      N3: "N3",
-      N2: "N2",
-      N1: "N1"
-    },
     lessonCardFocus: ["Te/Ta sound changes", "naide / nakute / nakatta", "Adjectives and noun-like forms"]
   },
   ko: {
@@ -484,15 +464,6 @@ export const copy: Record<Language, Copy> = {
       plainPresentNegative: "보통형・현재 부정",
       plainPastAffirmative: "보통형・과거 긍정",
       plainPastNegative: "보통형・과거 부정"
-    },
-    jlptLevel: "JLPT 등급",
-    jlptLevels: {
-      all: "전체",
-      N5: "N5",
-      N4: "N4",
-      N3: "N3",
-      N2: "N2",
-      N1: "N1"
     },
     lessonCardFocus: ["て/た 음편", "ないで / なくて / なかった", "형용사와 명사형"]
   }


### PR DESCRIPTION
## Summary

Per user direction: ｢我不希望有難度分級｣ — remove the difficulty grading UI.

The N5/N4/N3/N2/N1 segmented control caused more confusion than it solved:
- N3/N4 had no data, so those buttons gave an empty pool.
- The N1/N2 buttons needed a silent \`partOfSpeech + targetForm\` auto-switch to actually show questions, which was a hidden behavior.

The app no longer surfaces a difficulty grade. The content set (which currently targets N1-N3) determines difficulty implicitly.

## Removed

- JLPT-level fieldset in the practice settings panel.
- \`jlptLevel\` state + setter + \`jlptLevels\` constant in App.tsx.
- The auto-switch side effect that fired when a learner picked N1 or N2.
- The ｢exam focus needs N1/N2｣ reset paths in \`handlePracticeFocusChange\` and \`startDrill\`.
- \`jlptLevel\` argument from the \`buildQuestionPool\` / \`buildExamQuestionPool\` / \`buildClozeQuestionPool\` calls in App.
- \`jlptLevel\` / \`jlptLevels\` keys in the Copy type + zh-Hant / en / ko translations.
- \`JlptLevel\` import in App.tsx and i18n.ts.

## Left intact

- \`level?: JlptLevel\` on \`VocabularyItem\` — dormant metadata for future use.
- The \`level\` filter parameter on \`QuestionOptions\` / pool builders — still optional; domain tests continue to exercise it.
- All cloze / exam infrastructure untouched (verified — 75 tests pass).

## Test plan

- [x] \`pnpm test\` — 75 pass.
- [x] \`pnpm build\` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed JLPT level selector from practice controls
  * Removed cloze focus mode option
  * Questions no longer filtered by JLPT level
  * Updated focus descriptions and localized content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/Jabiko/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->