### PR TITLE
refactor(learning): extract learning blocks to a data module (PR A)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -140,6 +140,33 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("必要過去・なければならなかった")).toBeInTheDocument();
   });
 
+  it("redirects to the prereq chapter when prereqs are incomplete on 必要過去", async () => {
+    const user = userEvent.setup();
+    // No seedProgress -- start with a clean slate so 必要過去 has all
+    // three recommended prereqs incomplete.
+    render(<App />);
+
+    // Open the 必要過去 chapter.
+    await user.click(screen.getByRole("button", { name: "查看：必要過去" }));
+
+    // The drill CTA must not be present: launching obligationPast
+    // practice with the gate still on would silently fall back to a
+    // single-form drill, which is the bug Codex flagged.
+    expect(screen.queryByRole("button", { name: "練必要過去" })).not.toBeInTheDocument();
+
+    // Instead, the chapter offers a one-click jump to the first
+    // incomplete prereq (adverbial → "先分清楚く / に").
+    const prereqCta = screen.getByRole("button", { name: "先看前置：先分清楚く / に" });
+    expect(prereqCta).toBeInTheDocument();
+
+    await user.click(prereqCta);
+
+    // Active chapter switches to adverbial; obligationPast content no
+    // longer rendered.
+    expect(screen.getAllByRole("heading", { name: "先分清楚く / に" }).length).toBeGreaterThan(0);
+    expect(screen.queryByText("学生 -> 学生にならなければならなかった")).not.toBeInTheDocument();
+  });
+
   it("starts the challenge from the learning path", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,14 +36,16 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "挑戰" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "一章一章解鎖" })).toBeInTheDocument();
     expect(screen.getAllByRole("heading", { name: "先分清楚く / に" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByRole("button", { name: "開始第 1 關" }).length).toBeGreaterThan(0);
     expect(screen.getByText("高い -> 高く")).toBeInTheDocument();
     expect(screen.getByText("静か -> 静かに")).toBeInTheDocument();
     expect(screen.getByText("学生 -> 学生に")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "練く/に修飾" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "查看：ない形家族" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "查看：動詞て形 / た形" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "必要過去：完成前置後解鎖" })).toBeDisabled();
+    // 必要過去 is always clickable now (no lock UI); only the active
+    // chapter's body content is rendered, so its examples should not
+    // appear in the default view.
+    expect(screen.getByRole("button", { name: "查看：必要過去" })).toBeEnabled();
     expect(screen.queryByText("学生 -> 学生にならなければならなかった")).not.toBeInTheDocument();
     expect(screen.queryByText("否定て形・ないで")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "開始挑戰" })).toBeInTheDocument();
@@ -62,11 +64,13 @@ describe("App", () => {
     expect(screen.queryByText("学生 -> 学生にならなければならなかった")).not.toBeInTheDocument();
   });
 
-  it("starts the first prerequisite from the hero", async () => {
+  it("starts the first prerequisite from the recommended chapter CTA", async () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.click(screen.getAllByRole("button", { name: "開始第 1 關" })[0]);
+    // Default-active chapter is "先分清楚く / に"; its く/に drill button is
+    // the equivalent of the old "開始第 1 關" hero CTA.
+    await user.click(screen.getByRole("button", { name: "練く/に修飾" }));
 
     expect(screen.getByRole("button", { name: "く/に修飾" })).toHaveClass("selected");
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("修飾形・く/に")).toBeInTheDocument();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import {
   Eye,
   GraduationCap,
   Languages,
-  Lock,
   Moon,
   RotateCcw,
   Sun,
@@ -16,6 +15,14 @@ import { ADJECTIVE_FORMS, VERB_FORMS } from "./domain/conjugation";
 import { buildClozeQuestionPool } from "./domain/cloze";
 import { clozeSentences } from "./domain/cloze-data";
 import { buildExamQuestionPool } from "./domain/examBlocks";
+import {
+  getIncompletePrereqs,
+  isLearningBlockComplete,
+  isObligationUnlocked,
+  learningBlocks,
+  type LearningBlock,
+  type LearningBlockDrillPreset
+} from "./domain/learningBlocks";
 import {
   buildChoiceOptions,
   buildQuestionPool,
@@ -40,23 +47,7 @@ type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "o
 type PracticeMode = "basic" | "cloze" | "exam";
 type AppView = "learn" | "challenge";
 type Theme = "light" | "dark";
-type DrillPreset = {
-  partOfSpeech: PartOfSpeech | "mixed";
-  verbGroup?: VerbGroup | "all";
-  practiceFocus: PracticeFocus;
-  targetForm: TargetForm;
-};
-type UnlockStageId = "adverbial" | "negative" | "teTa" | "obligationPast";
-type UnlockStage = {
-  id: UnlockStageId;
-  kicker: string;
-  title: string;
-  body: string;
-  example: string;
-  actionLabel: string;
-  preset: DrillPreset;
-  requiredForms: TargetForm[];
-};
+type DrillPreset = LearningBlockDrillPreset;
 
 const THEME_STORAGE_KEY = "jabiko.theme";
 
@@ -111,178 +102,7 @@ const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; ver
 
 const practiceModeOrder: PracticeMode[] = ["basic", "cloze", "exam"];
 
-const verbGroupGuide = [
-  {
-    group: "一類動詞",
-    rule: "最後一個假名會換段或音便。",
-    examples: ["書く -> 書きます", "読む -> 読みます", "帰る -> 帰ります"],
-    note: "像「帰る」雖然以る結尾，但仍是一類，要另外記。"
-  },
-  {
-    group: "二類動詞",
-    rule: "先去掉最後的る，再接語尾。",
-    examples: ["食べる -> 食べます", "見る -> 見ます", "起きる -> 起きます"],
-    note: "二類通常比較規則：食べる、見る、起きる。"
-  },
-  {
-    group: "三類動詞",
-    rule: "する、来る是不規則，直接記形。",
-    examples: ["する -> します", "来る -> 来ます", "勉強する -> 勉強します"],
-    note: "名詞 + する 也跟 する 一起變。"
-  }
-];
-
-const teTaRows = [
-  { ending: "く", te: "いて", ta: "いた", example: "書く -> 書いて / 書いた" },
-  { ending: "ぐ", te: "いで", ta: "いだ", example: "泳ぐ -> 泳いで / 泳いだ" },
-  { ending: "す", te: "して", ta: "した", example: "話す -> 話して / 話した" },
-  { ending: "う・つ・る", te: "って", ta: "った", example: "待つ -> 待って / 待った" },
-  { ending: "む・ぶ・ぬ", te: "んで", ta: "んだ", example: "読む -> 読んで / 読んだ" }
-];
-
-const negativePipelines = [
-  {
-    title: "ない形",
-    formula: "書く -> 書かない",
-    body: "一類動詞先把最後假名換成あ段，再接ない；う結尾要變わない。"
-  },
-  {
-    title: "否定て形・ないで",
-    formula: "書かない -> 書かないで",
-    body: "不是從て形變否定。先做ない形，再接ないで。"
-  },
-  {
-    title: "否定接續・なくて",
-    formula: "書かない -> 書かなくて",
-    body: "也是先做ない形，再把ない換成なくて。常用來接理由或狀態。"
-  },
-  {
-    title: "否定過去",
-    formula: "書かない -> 書かなかった",
-    body: "不是從た形變否定。先做ない形，再把ない換成なかった。"
-  }
-];
-
-const adjectiveRows = [
-  {
-    type: "い形容詞",
-    cue: "去い，加く或かった",
-    examples: ["高い -> 高く", "高い -> 高くない", "高い -> 高かった"],
-    note: "修飾動詞用く；否定過去是くなかった，不是かった再否定。"
-  },
-  {
-    type: "な形容詞",
-    cue: "修飾動詞加に，句尾像名詞句",
-    examples: ["静か -> 静かに", "静かだ", "静かだった"],
-    note: "修飾動詞用に；過去是だった，不是把な留下來加た。"
-  },
-  {
-    type: "名詞",
-    cue: "修飾或方向常加に",
-    examples: ["学生 -> 学生に", "学生だ", "学生だった"],
-    note: "名詞加に常用在變成某身分或方向；句尾過去用だった。"
-  }
-];
-
-const obligationPastRows = [
-  {
-    title: "動詞",
-    formula: "書く -> 書かなければならなかった",
-    body: "先做ない形「書かない」，再把ない換成「なければならなかった」。"
-  },
-  {
-    title: "い形容詞",
-    formula: "高い -> 高くならなければならなかった",
-    body: "先做「高くなる」，再把なる變成必要過去。"
-  },
-  {
-    title: "な形容詞",
-    formula: "静か -> 静かにならなければならなかった",
-    body: "先加に做「静かになる」，過去放在最後的ならなかった。"
-  },
-  {
-    title: "名詞",
-    formula: "学生 -> 学生にならなければならなかった",
-    body: "你卡住的型就在這裡：名詞 + に + ならなければならなかった。"
-  }
-];
-
-const unlockStages: UnlockStage[] = [
-  {
-    id: "adverbial",
-    kicker: "第 1 關",
-    title: "先分清楚く / に",
-    body: "い形容詞去い加く；な形容詞和名詞先加に。必要過去的に就是從這裡來。",
-    example: "高く / 静かに / 学生に",
-    actionLabel: "開始第 1 關",
-    preset: {
-      partOfSpeech: "mixed",
-      verbGroup: "all",
-      practiceFocus: "adverbial",
-      targetForm: "adverbial"
-    },
-    requiredForms: ["adverbial"]
-  },
-  {
-    id: "negative",
-    kicker: "第 2 關",
-    title: "ない形家族",
-    body: "先把ない、ないで、なくて、なかった整理成同一條線。",
-    example: "書かない -> 書かなかった",
-    actionLabel: "練第 2 關",
-    preset: {
-      partOfSpeech: "verb",
-      verbGroup: "all",
-      practiceFocus: "negative",
-      targetForm: "nai"
-    },
-    requiredForms: ["nai", "negativeTe", "negativeContinuative", "plainPastNegative"]
-  },
-  {
-    id: "teTa",
-    kicker: "第 3 關",
-    title: "動詞て形 / た形",
-    body: "熟悉一類動詞音便後，再處理更長的句型比較穩。",
-    example: "読む -> 読んで / 読んだ",
-    actionLabel: "練第 3 關",
-    preset: {
-      partOfSpeech: "verb",
-      verbGroup: "godan",
-      practiceFocus: "teTa",
-      targetForm: "te"
-    },
-    requiredForms: ["te", "ta"]
-  },
-  {
-    id: "obligationPast",
-    kicker: "最後解鎖",
-    title: "必要過去",
-    body: "前面三關都答對過後，再練「にならなければならなかった」。",
-    example: "学生 + に + ならなければならなかった",
-    actionLabel: "練必要過去",
-    preset: {
-      partOfSpeech: "noun",
-      verbGroup: "all",
-      practiceFocus: "obligationPast",
-      targetForm: "obligationPast"
-    },
-    requiredForms: ["obligationPast"]
-  }
-];
-
 const attemptStore = createAttemptStore();
-
-function isLearningStageComplete(attempts: Attempt[], stage: UnlockStage): boolean {
-  return stage.requiredForms.every((targetForm) =>
-    attempts.some((attempt) => attempt.isCorrect && attempt.targetForm === targetForm)
-  );
-}
-
-function isObligationUnlocked(attempts: Attempt[]): boolean {
-  return unlockStages
-    .filter((stage) => stage.id !== "obligationPast")
-    .every((stage) => isLearningStageComplete(attempts, stage));
-}
 
 export default function App() {
   const [appView, setAppView] = useState<AppView>("learn");
@@ -761,162 +581,39 @@ function LearningPanel({
   onStartDrill: (preset: DrillPreset) => void;
 }) {
   const t = copy[language];
-  const obligationIsUnlocked = isObligationUnlocked(progressAttempts);
-  const stageCards = unlockStages.map((stage) => {
-    const complete = isLearningStageComplete(progressAttempts, stage);
-    const locked = stage.id === "obligationPast" && !obligationIsUnlocked;
-    return { ...stage, complete, locked };
-  });
-  const recommendedStage = stageCards.find((stage) => !stage.complete && !stage.locked) ?? stageCards[stageCards.length - 1];
-  const [selectedChapterId, setSelectedChapterId] = useState<UnlockStageId | null>(null);
-  const selectedStage = stageCards.find((stage) => stage.id === selectedChapterId);
-  const activeStage = selectedStage && !selectedStage.locked ? selectedStage : recommendedStage;
+  // PR A: surface only the "basic" learning blocks. PR C will introduce
+  // exam-prep blocks alongside these.
+  const blockCards = learningBlocks
+    .filter((block) => block.group === "basic")
+    .map((block) => ({
+      block,
+      complete: isLearningBlockComplete(progressAttempts, block),
+      incompletePrereqs: getIncompletePrereqs(progressAttempts, block)
+    }));
 
-  const renderChapterLesson = () => {
-    switch (activeStage.id) {
-      case "adverbial":
-        return (
-          <div className="chapter-lesson">
-            <div className="rule-matrix three-column">
-              {adjectiveRows.map((row) => (
-                <article className="rule-card" key={row.type}>
-                  <h4>{row.type}</h4>
-                  <p>{row.cue}</p>
-                  <div className="formula-row" aria-label={`${row.type}例子`}>
-                    {row.examples.map((example) => (
-                      <code key={example}>{example}</code>
-                    ))}
-                  </div>
-                  <small>{row.note}</small>
-                </article>
-              ))}
-            </div>
-            <div className="inline-action-row">
-              <button
-                className="inline-drill-button"
-                type="button"
-                onClick={() =>
-                  onStartDrill({
-                    partOfSpeech: "i_adjective",
-                    verbGroup: "all",
-                    practiceFocus: "plain",
-                    targetForm: "plainPresentNegative"
-                  })
-                }
-              >
-                <ArrowRight aria-hidden="true" />
-                {t.drillIAdjective}
-              </button>
-              <button
-                className="inline-drill-button"
-                type="button"
-                onClick={() =>
-                  onStartDrill({
-                    partOfSpeech: "na_adjective",
-                    verbGroup: "all",
-                    practiceFocus: "plain",
-                    targetForm: "plainPresentNegative"
-                  })
-                }
-              >
-                <ArrowRight aria-hidden="true" />
-                {t.drillNaAdjective}
-              </button>
-              <button
-                className="inline-drill-button"
-                type="button"
-                onClick={() => onStartDrill(activeStage.preset)}
-              >
-                <ArrowRight aria-hidden="true" />
-                {t.drillAdverbial}
-              </button>
-            </div>
-          </div>
-        );
+  // Pick the first incomplete block whose prereqs are also complete; fall
+  // back to the first incomplete (even if a prereq is still open) and
+  // finally to the very first block.
+  const recommended =
+    blockCards.find((card) => !card.complete && card.incompletePrereqs.length === 0)
+    ?? blockCards.find((card) => !card.complete)
+    ?? blockCards[0];
 
-      case "negative":
-        return (
-          <div className="chapter-lesson">
-            <div className="pipeline-grid">
-              {negativePipelines.map((item) => (
-                <article className="pipeline-card" key={item.title}>
-                  <span>{item.title}</span>
-                  <code>{item.formula}</code>
-                  <p>{item.body}</p>
-                </article>
-              ))}
-            </div>
-            <button className="inline-drill-button" type="button" onClick={() => onStartDrill(activeStage.preset)}>
-              <ArrowRight aria-hidden="true" />
-              {t.drillNegative}
-            </button>
-          </div>
-        );
+  const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+  const activeCard = blockCards.find((card) => card.block.id === selectedBlockId) ?? recommended;
+  const active = activeCard.block;
 
-      case "teTa":
-        return (
-          <div className="chapter-lesson">
-            <div className="rule-matrix three-column">
-              {verbGroupGuide.map((item) => (
-                <article className="rule-card" key={item.group}>
-                  <h4>{item.group}</h4>
-                  <p>{item.rule}</p>
-                  <div className="formula-row" aria-label={`${item.group}例子`}>
-                    {item.examples.map((example) => (
-                      <code key={example}>{example}</code>
-                    ))}
-                  </div>
-                  <small>{item.note}</small>
-                </article>
-              ))}
-            </div>
-            <div className="sound-table" role="table" aria-label={t.teTaTableLabel}>
-              <div className="sound-row sound-head" role="row">
-                <span role="columnheader">{t.tableEnding}</span>
-                <span role="columnheader">{t.tableTe}</span>
-                <span role="columnheader">{t.tableTa}</span>
-                <span role="columnheader">{t.tableExample}</span>
-              </div>
-              {teTaRows.map((row) => (
-                <div className="sound-row" role="row" key={row.ending}>
-                  <span role="cell">{row.ending}</span>
-                  <code role="cell">{row.te}</code>
-                  <code role="cell">{row.ta}</code>
-                  <code role="cell">{row.example}</code>
-                </div>
-              ))}
-            </div>
-            <button className="inline-drill-button" type="button" onClick={() => onStartDrill(activeStage.preset)}>
-              <ArrowRight aria-hidden="true" />
-              {t.drillGodanTeTa}
-            </button>
-          </div>
-        );
+  // Resolve the drill button label from the i18n copy table. The schema
+  // stores a plain string key so new drill labels don't require schema
+  // updates.
+  const drillButtonLabel = (drill: { labelKey: string }): string => {
+    const labels = t as unknown as Record<string, string>;
+    return labels[drill.labelKey] ?? drill.labelKey;
+  };
 
-      case "obligationPast":
-        return (
-          <div className="chapter-lesson">
-            <div className="pipeline-grid">
-              {obligationPastRows.map((item) => (
-                <article className="pipeline-card" key={item.title}>
-                  <span>{item.title}</span>
-                  <code>{item.formula}</code>
-                  <p>{item.body}</p>
-                </article>
-              ))}
-            </div>
-            <button
-              className="inline-drill-button"
-              type="button"
-              disabled={!obligationIsUnlocked}
-              onClick={() => onStartDrill(activeStage.preset)}
-            >
-              {obligationIsUnlocked ? <ArrowRight aria-hidden="true" /> : <Lock aria-hidden="true" />}
-              {obligationIsUnlocked ? t.drillObligationPast : "完成前置後解鎖"}
-            </button>
-          </div>
-        );
-    }
+  const blockTitleById = (id: string): string => {
+    const found = learningBlocks.find((b) => b.id === id);
+    return found ? found.title : id;
   };
 
   return (
@@ -926,22 +623,26 @@ function LearningPanel({
           <div className="chapter-index-copy">
             <p className="eyebrow">課程章節</p>
             <h2>一章一章解鎖</h2>
-            <p>首頁只放章節目錄。選一章後，右邊才顯示該章規則、例子與練習。</p>
+            <p>選一章看規則、例子與常見陷阱，再到挑戰頁練。</p>
           </div>
 
           <div className="chapter-list">
-            {stageCards.map((stage) => (
+            {blockCards.map(({ block, complete, incompletePrereqs }) => (
               <button
-                className={`chapter-list-button${stage.id === activeStage.id ? " selected" : ""}${stage.complete ? " complete" : ""}`}
+                key={block.id}
                 type="button"
-                key={stage.id}
-                disabled={stage.locked}
-                aria-label={stage.locked ? `${stage.title}：完成前置後解鎖` : `查看：${stage.title}`}
-                onClick={() => setSelectedChapterId(stage.id)}
+                className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
+                aria-label={`查看：${block.title}`}
+                aria-pressed={block.id === active.id}
+                onClick={() => setSelectedBlockId(block.id)}
               >
-                <span>{stage.complete ? "完成" : stage.locked ? "鎖定" : stage.kicker}</span>
-                <strong>{stage.title}</strong>
-                <small>{stage.locked ? "完成前置後解鎖" : stage.example}</small>
+                <span>{complete ? "完成" : block.kicker ?? block.category}</span>
+                <strong>{block.title}</strong>
+                <small>
+                  {incompletePrereqs.length > 0
+                    ? `建議先看：${incompletePrereqs.map(blockTitleById).join("、")}`
+                    : block.subtitle}
+                </small>
               </button>
             ))}
           </div>
@@ -954,21 +655,58 @@ function LearningPanel({
 
         <section className="chapter-content" aria-labelledby="active-chapter-title">
           <div className="chapter-content-head">
-            <p className="eyebrow">{activeStage.kicker}</p>
-            <h3 id="active-chapter-title">{activeStage.title}</h3>
-            <p>{activeStage.body}</p>
-            <div className="focus-formula" aria-label={`${activeStage.title}例子`}>
-              <span>{activeStage.example}</span>
-            </div>
-            <div className="chapter-actions">
-              <button className="start-challenge" type="button" onClick={() => onStartDrill(activeStage.preset)}>
-                <ArrowRight aria-hidden="true" />
-                {activeStage.complete ? "複習這一章" : activeStage.actionLabel}
-              </button>
-              <span>{obligationIsUnlocked ? "必要過去已解鎖" : "必要過去會在前置完成後解鎖"}</span>
-            </div>
+            <p className="eyebrow">{active.kicker ?? active.category}</p>
+            <h3 id="active-chapter-title">{active.title}</h3>
+            <p>{active.explanation}</p>
+            {active.subtitle ? (
+              <div className="focus-formula" aria-label={`${active.title}例子`}>
+                <span>{active.subtitle}</span>
+              </div>
+            ) : null}
+            {activeCard.incompletePrereqs.length > 0 ? (
+              <p className="block-prereq-hint">
+                建議先看：{activeCard.incompletePrereqs.map(blockTitleById).join("、")}
+              </p>
+            ) : null}
           </div>
-          {renderChapterLesson()}
+
+          <div className="chapter-lesson">
+            <div className="pipeline-grid">
+              {active.examples.map((example) => (
+                <article className="pipeline-card" key={example.formula}>
+                  <code>{example.formula}</code>
+                  {example.note ? <p>{example.note}</p> : null}
+                </article>
+              ))}
+            </div>
+
+            {active.pitfalls && active.pitfalls.length > 0 ? (
+              <div className="block-pitfalls">
+                <p className="block-pitfalls-title">常見陷阱</p>
+                <ul>
+                  {active.pitfalls.map((pitfall) => (
+                    <li key={pitfall}>{pitfall}</li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+
+            {active.drills && active.drills.length > 0 ? (
+              <div className="inline-action-row">
+                {active.drills.map((drill) => (
+                  <button
+                    key={drill.labelKey}
+                    className="inline-drill-button"
+                    type="button"
+                    onClick={() => onStartDrill(drill.preset)}
+                  >
+                    <ArrowRight aria-hidden="true" />
+                    {drillButtonLabel(drill)}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
         </section>
       </div>
     </section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -691,7 +691,23 @@ function LearningPanel({
               </div>
             ) : null}
 
-            {active.drills && active.drills.length > 0 ? (
+            {activeCard.incompletePrereqs.length > 0 ? (
+              // Prereqs not yet done. Don't expose the drill CTA -- the
+              // challenge page would silently fall back to a different
+              // focus (see the obligationUnlocked filter on focusOptions
+              // / effectivePracticeFocus). Instead, offer a one-click
+              // jump to the first incomplete prereq block.
+              <div className="inline-action-row">
+                <button
+                  className="inline-drill-button"
+                  type="button"
+                  onClick={() => setSelectedBlockId(activeCard.incompletePrereqs[0])}
+                >
+                  <ArrowRight aria-hidden="true" />
+                  先看前置：{blockTitleById(activeCard.incompletePrereqs[0])}
+                </button>
+              </div>
+            ) : active.drills && active.drills.length > 0 ? (
               <div className="inline-action-row">
                 {active.drills.map((drill) => (
                   <button

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -33,10 +33,11 @@ export type LearningBlock = {
    */
   drills?: LearningBlockDrill[];
   /**
-   * (PR C) Question IDs to filter the exam mode to when launching from
-   * an N1/N2 攻略 block. Unused by basic blocks.
+   * (PR C) Question IDs from the exam pool that an N1/N2 攻略 block
+   * relates to. When launched, the challenge page will filter exam
+   * mode to just these questions. Unused by basic blocks.
    */
-  examFilterIds?: string[];
+  relatedExamIds?: string[];
   /**
    * Block ids that the learner is recommended to look at first. Does not
    * gate access -- just surfaces a hint when those prereqs aren't done.

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -1,0 +1,236 @@
+import type { PartOfSpeech, TargetForm, VerbGroup } from "./types";
+
+export type LearningBlockDrillPreset = {
+  partOfSpeech: PartOfSpeech | "mixed";
+  verbGroup?: VerbGroup | "all";
+  practiceFocus: "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast";
+  targetForm: TargetForm;
+};
+
+export type LearningBlockDrill = {
+  /**
+   * Key into the i18n `copy[language]` object pointing at the button label
+   * (e.g. "drillAdverbial"). Kept as a plain string so the schema doesn't
+   * have to expand whenever a new drill label is added.
+   */
+  labelKey: string;
+  preset: LearningBlockDrillPreset;
+};
+
+export type LearningBlock = {
+  id: string;
+  group: "basic" | "exam";
+  category: string;
+  kicker?: string;
+  title: string;
+  subtitle: string;
+  explanation: string;
+  examples: Array<{ formula: string; note?: string }>;
+  pitfalls?: string[];
+  /**
+   * One or more drill buttons. The first entry is the primary action;
+   * additional entries render as secondary buttons in the same row.
+   */
+  drills?: LearningBlockDrill[];
+  /**
+   * (PR C) Question IDs to filter the exam mode to when launching from
+   * an N1/N2 攻略 block. Unused by basic blocks.
+   */
+  examFilterIds?: string[];
+  /**
+   * Block ids that the learner is recommended to look at first. Does not
+   * gate access -- just surfaces a hint when those prereqs aren't done.
+   */
+  recommendedAfter?: string[];
+  /**
+   * Target forms the learner needs to answer correctly at least once to
+   * mark this block as 完成 in the index. Optional -- some blocks (e.g.
+   * exam-prep 攻略) don't have a single matching practice form.
+   */
+  requiredForms?: TargetForm[];
+};
+
+export const learningBlocks: LearningBlock[] = [
+  {
+    id: "adverbial",
+    group: "basic",
+    category: "形容詞 / 名詞 修飾",
+    kicker: "基礎修飾",
+    title: "先分清楚く / に",
+    subtitle: "高く / 静かに / 学生に",
+    explanation:
+      "い形容詞去い加く修飾動詞；な形容詞與名詞先加に。後面「必要過去」用到的に也是從這裡延伸出來，所以這關要先打好底。",
+    examples: [
+      { formula: "高い -> 高く", note: "い形容詞修飾動詞用く" },
+      { formula: "高い -> 高くない / 高くなかった", note: "否定／否定過去都從く再變" },
+      { formula: "静か -> 静かに", note: "な形容詞修飾動詞用に" },
+      { formula: "静か -> 静かだ / 静かだった", note: "句尾像名詞句" },
+      { formula: "学生 -> 学生に", note: "名詞加に常用在身分／方向" },
+      { formula: "学生 -> 学生だった", note: "名詞句尾過去用だった" }
+    ],
+    pitfalls: [
+      "い形容詞否定過去是くなかった，不是かった再否定",
+      "な形容詞過去是だった，不要把な留下來再加た"
+    ],
+    drills: [
+      {
+        labelKey: "drillIAdjective",
+        preset: {
+          partOfSpeech: "i_adjective",
+          verbGroup: "all",
+          practiceFocus: "plain",
+          targetForm: "plainPresentNegative"
+        }
+      },
+      {
+        labelKey: "drillNaAdjective",
+        preset: {
+          partOfSpeech: "na_adjective",
+          verbGroup: "all",
+          practiceFocus: "plain",
+          targetForm: "plainPresentNegative"
+        }
+      },
+      {
+        labelKey: "drillAdverbial",
+        preset: {
+          partOfSpeech: "mixed",
+          verbGroup: "all",
+          practiceFocus: "adverbial",
+          targetForm: "adverbial"
+        }
+      }
+    ],
+    requiredForms: ["adverbial"]
+  },
+  {
+    id: "negative",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "ない形整理",
+    title: "ない形家族",
+    subtitle: "書かない -> 書かなかった",
+    explanation:
+      "把ない、ないで、なくて、なかった串成同一條線。所有否定的延伸（接續、過去）都是先做ない形，再從ない再變。",
+    examples: [
+      { formula: "書く -> 書かない", note: "一類動詞先換あ段；う結尾要變わ" },
+      { formula: "書かない -> 書かないで", note: "否定て形：不是從て形變否定" },
+      { formula: "書かない -> 書かなくて", note: "否定接續：常用來接理由或狀態" },
+      { formula: "書かない -> 書かなかった", note: "否定過去：不是從た形變否定" }
+    ],
+    pitfalls: [
+      "否定不要從て形變、要從ない形變",
+      "う結尾的一類動詞要變わない（買う -> 買わない），不是あない"
+    ],
+    drills: [
+      {
+        labelKey: "drillNegative",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "negative",
+          targetForm: "nai"
+        }
+      }
+    ],
+    requiredForms: ["nai", "negativeTe", "negativeContinuative", "plainPastNegative"]
+  },
+  {
+    id: "teTa",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "音便整理",
+    title: "動詞て形 / た形",
+    subtitle: "読む -> 読んで / 読んだ",
+    explanation:
+      "熟悉一類動詞的音便（く→いて、ぐ→いで、す→して、う・つ・る→って、む・ぶ・ぬ→んで），任何句型都能直接套。",
+    examples: [
+      { formula: "書く -> 書いて / 書いた", note: "く結尾：いて／いた" },
+      { formula: "泳ぐ -> 泳いで / 泳いだ", note: "ぐ結尾：いで／いだ" },
+      { formula: "話す -> 話して / 話した", note: "す結尾：して／した" },
+      { formula: "待つ -> 待って / 待った", note: "う・つ・る結尾：って／った" },
+      { formula: "読む -> 読んで / 読んだ", note: "む・ぶ・ぬ結尾：んで／んだ" }
+    ],
+    pitfalls: [
+      "二類動詞直接去る加て／た（食べる -> 食べて／食べた），不走音便",
+      "「帰る」雖然以る結尾，但是一類，要走音便（帰る -> 帰って／帰った）"
+    ],
+    drills: [
+      {
+        labelKey: "drillGodanTeTa",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "godan",
+          practiceFocus: "teTa",
+          targetForm: "te"
+        }
+      }
+    ],
+    requiredForms: ["te", "ta"]
+  },
+  {
+    id: "obligationPast",
+    group: "basic",
+    category: "進階句型",
+    kicker: "綜合應用",
+    title: "必要過去",
+    subtitle: "学生 + に + ならなければならなかった",
+    explanation:
+      "把「必要 (なければならない)」推到過去（なければならなかった）。動詞直接做；形容詞和名詞要先變成「-くなる / -になる」再做必要過去。",
+    examples: [
+      { formula: "書く -> 書かなければならなかった", note: "動詞：先做ない形「書かない」，再換ない為なければならなかった" },
+      { formula: "高い -> 高くならなければならなかった", note: "い形容詞：先做高くなる，再變必要過去" },
+      { formula: "静か -> 静かにならなければならなかった", note: "な形容詞：先加に做静かになる" },
+      { formula: "学生 -> 学生にならなければならなかった", note: "名詞：最容易卡的型在這裡" }
+    ],
+    pitfalls: [
+      "形容詞、名詞要先變成「-くなる / -になる」再加必要過去",
+      "過去要放在最後的ならなかった，不是放在前面"
+    ],
+    drills: [
+      {
+        labelKey: "drillObligationPast",
+        preset: {
+          partOfSpeech: "noun",
+          verbGroup: "all",
+          practiceFocus: "obligationPast",
+          targetForm: "obligationPast"
+        }
+      }
+    ],
+    recommendedAfter: ["adverbial", "negative", "teTa"],
+    requiredForms: ["obligationPast"]
+  }
+];
+
+type CompletionAttempt = { isCorrect: boolean; targetForm: string };
+
+export function isLearningBlockComplete(attempts: CompletionAttempt[], block: LearningBlock): boolean {
+  if (!block.requiredForms || block.requiredForms.length === 0) return false;
+  return block.requiredForms.every((targetForm) =>
+    attempts.some((attempt) => attempt.isCorrect && attempt.targetForm === targetForm)
+  );
+}
+
+/**
+ * Returns the recommended-prerequisite block ids that are NOT yet complete.
+ * Used to surface a soft hint ("建議先看：XX") -- access is never gated.
+ */
+export function getIncompletePrereqs(attempts: CompletionAttempt[], block: LearningBlock): string[] {
+  if (!block.recommendedAfter || block.recommendedAfter.length === 0) return [];
+  return block.recommendedAfter.filter((prereqId) => {
+    const prereq = learningBlocks.find((b) => b.id === prereqId);
+    return Boolean(prereq) && !isLearningBlockComplete(attempts, prereq!);
+  });
+}
+
+/**
+ * Kept for the challenge-page focus filter: it still hides the 必要過去
+ * option until the learner has worked through the basics. The learning
+ * page itself no longer uses this -- every block is always clickable.
+ */
+export function isObligationUnlocked(attempts: CompletionAttempt[]): boolean {
+  const block = learningBlocks.find((b) => b.id === "obligationPast");
+  if (!block) return true;
+  return getIncompletePrereqs(attempts, block).length === 0;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -847,6 +847,46 @@ button svg {
   line-height: 1.55;
 }
 
+.block-pitfalls {
+  background: color-mix(in srgb, var(--vermilion) 10%, var(--paper));
+  border: 1px solid color-mix(in srgb, var(--vermilion) 36%, var(--rule));
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+}
+
+.block-pitfalls-title {
+  color: var(--vermilion);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0 0 0.4rem;
+  text-transform: uppercase;
+}
+
+.block-pitfalls ul {
+  color: var(--ink);
+  line-height: 1.6;
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.block-pitfalls li {
+  overflow-wrap: anywhere;
+}
+
+.block-pitfalls li + li {
+  margin-top: 0.32rem;
+}
+
+.block-prereq-hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-style: italic;
+  line-height: 1.5;
+  margin: 0.5rem 0 0;
+  overflow-wrap: anywhere;
+}
+
 .inline-action-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
> **PR A of A → B1 → B2 stack.** Architectural foundation only — no new content. PR B1/B2 add new chapters; PR C adds N1/N2 攻略 blocks; PR D/E follow per earlier plan.

## 動機

學習頁的內容塞在 App.tsx 裡：5 個 hardcoded constants（verbGroupGuide / teTaRows / negativePipelines / adjectiveRows / obligationPastRows）+ unlockStages 陣列 + per-id switch render。每加一章就要再多一份 constant、多一個 case、App.tsx 又長一截。而且 obligationPast 還是用 `disabled` 制，跟 PR #25「不能點的部分」哲學衝突。

這支 PR 把架構拉正、現有 4 章搬進資料模組、不新增任何內容。PR B1/B2 才開始加新章節。

## 改動

### 新檔：`src/domain/learningBlocks.ts`
- `LearningBlock` schema：`id / group / category / kicker / title / subtitle / explanation / examples / pitfalls / drills / examFilterIds / recommendedAfter / requiredForms`
- `learningBlocks[]`：4 個現有章節（adverbial / negative / teTa / obligationPast）按新 schema 重組
  - 多了 `pitfalls` 陣列（從原本 body 文字裡挖出來的具體陷阱）
  - `drills` 支援多個 button（adverbial 的 い形容詞/な形容詞/く・に 三個 CTA 直接列在這）
- helper：`isLearningBlockComplete / getIncompletePrereqs / isObligationUnlocked`
  - 最後一個從 App.tsx 搬過來——挑戰頁的 focus filter 還需要它

### `App.tsx` LearningPanel 重寫
- 一套通用 layout 渲染所有 block（examples grid + pitfalls callout + drill button row）
- 必要過去**不再 disabled** — 隨時可點，prereqs 未完成時顯示「建議先看：XX」soft hint
- 移除原本冗餘的「開始第 X 關」top CTA（actionLabel 概念退役）
- chapter-list 加 `aria-pressed`（沿用 PR #25 的 accessibility 標準）
- 移除 5 個 hardcoded constants、UnlockStage type、unlockStages 陣列、isLearningStageComplete、isObligationUnlocked、per-id switch
- **App.tsx 淨減 ~220 行**（472 - / 232 +）

### `styles.css`
- 新增 `.block-pitfalls`（vermilion callout）+ `.block-prereq-hint`（italic muted）
- 重用既有的 `.pipeline-grid` / `.pipeline-card` 渲染 examples

### `App.test.tsx`
- 兩個斷言隨架構調整：
  1. `必要過去：完成前置後解鎖` disabled 斷言 → 改成 `查看：必要過去` enabled
  2. 點「開始第 1 關」→ 改成點「練く/に修飾」（功能等價）

## 沒做的（之後 PR 處理）
- 新內容（PR B1: 8 動詞 / B2: 7 形容詞・名詞・句型）
- N1/N2 攻略 block + exam mode id-filter（PR C）
- 錯題補強推薦（PR D）
- 視覺整理 + 進度 indicator（PR E）

## Test plan
- [x] `pnpm test` — 76/76 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — clean (CSS 28.63 kB, JS 389.64 kB — JS 比之前小 ~2 kB 因為移除大量內聯 JSX)
- [x] `node scripts/check-exam-options.mjs` — 155/155 entries, 0 problems
- [ ] Manual preview：
  - [ ] 學習頁四個章節（adverbial / negative / teTa / obligationPast）切換正常
  - [ ] 必要過去章節按鈕不再灰掉、隨時可點
  - [ ] 必要過去章節在 prereq 未完成時顯示「建議先看：先分清楚く / に、ない形家族、動詞て形 / た形」hint
  - [ ] 每個章節的 examples / pitfalls / drill 按鈕都正確渲染
  - [ ] 從學習頁 drill 按鈕跳到挑戰頁時自動進入「基礎變化」模式（PR #25 行為）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced prerequisite system for chapters—complete foundational content before unlocking advanced topics
  * Added pitfalls section highlighting common grammar mistakes for each chapter
  * Quick-jump navigation to incomplete prerequisite chapters for streamlined learning flow

* **Tests**
  * Updated test suite to verify prerequisite chapter gating and navigation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/Jabiko/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->