### PR TITLE
feat(learning): add 8 verb-basic chapters (PR B1)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -127,6 +127,26 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("修飾形・く/に")).toBeInTheDocument();
   });
 
+  it("renders the new verb-basic blocks and runs a ます drill from the ます chapter", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // The new chapters surface in the chapter list.
+    expect(screen.getByRole("button", { name: "查看：ます形" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "查看：可能形 (V られる)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "查看：使役形 (V せる/させる)" })).toBeInTheDocument();
+
+    // Open the ます chapter; its example formulas and drill button render.
+    await user.click(screen.getByRole("button", { name: "查看：ます形" }));
+    expect(screen.getByText("書く → 書きます")).toBeInTheDocument();
+    expect(screen.getByText("食べる → 食べます")).toBeInTheDocument();
+
+    // Click the drill CTA -- challenge page should land in basic mode
+    // with the masu target form selected.
+    await user.click(screen.getByRole("button", { name: "練ます形" }));
+    expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("ます形")).toBeInTheDocument();
+  });
+
   it("starts an obligation past drill from the learning guide", async () => {
     const user = userEvent.setup();
     seedProgress(["adverbial", "nai", "negativeTe", "negativeContinuative", "plainPastNegative", "te", "ta"]);

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -201,6 +201,291 @@ export const learningBlocks: LearningBlock[] = [
     ],
     recommendedAfter: ["adverbial", "negative", "teTa"],
     requiredForms: ["obligationPast"]
+  },
+  {
+    id: "verb-types",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "基礎判斷",
+    title: "動詞三類怎麼分",
+    subtitle: "書く（一類）/ 食べる（二類）/ する・来る（三類）",
+    explanation:
+      "日語動詞分三類，所有變化都先看「字典形＋上下文」判類，再套規則。る結尾不代表就是二類，要先分對類，後面的變化才會跟著對。",
+    examples: [
+      { formula: "書く（一類）→ 書きます", note: "う段結尾通常為一類" },
+      { formula: "読む（一類）→ 読みます", note: "む結尾走一類" },
+      { formula: "食べる（二類）→ 食べます", note: "前面是え段の る → 通常是二類" },
+      { formula: "見る（二類）→ 見ます", note: "前面是い段の る → 通常是二類" },
+      { formula: "する → します", note: "三類：直接記" },
+      { formula: "来る → 来ます", note: "三類，讀作きます（不是くます）" }
+    ],
+    pitfalls: [
+      "「帰る」「走る」「入る」「切る」雖然以る結尾，但是一類，要走音便",
+      "「勉強する」「練習する」這種 N + する 也跟 する 同類，當三類處理",
+      "判斷時要看整個字典形，不要只看結尾一字"
+    ],
+    drills: [
+      {
+        labelKey: "drillMasu",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "masu"
+        }
+      }
+    ],
+    requiredForms: ["masu"]
+  },
+  {
+    id: "masu",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "基礎敬語",
+    title: "ます形",
+    subtitle: "書く → 書きます / 食べる → 食べます",
+    explanation:
+      "敬語句尾的基本形，也是後面たい、ながら、ことができる 等的接續基礎（V ます形 = V 連用形）。一類動詞最後一字換い段＋ます；二類去る＋ます；三類直接記。",
+    examples: [
+      { formula: "書く → 書きます", note: "一類：く換き＋ます" },
+      { formula: "読む → 読みます", note: "一類：む換み＋ます" },
+      { formula: "食べる → 食べます", note: "二類：去る＋ます" },
+      { formula: "起きる → 起きます", note: "二類" },
+      { formula: "する → します", note: "三類" },
+      { formula: "来る → 来ます", note: "三類，讀作きます" }
+    ],
+    pitfalls: [
+      "う結尾不是換あ段；是換い段（買う → 買います，不是買あます）",
+      "二類不走音便，直接去る加ます就好",
+      "「来る」變ます形時讀作き，不是く（与て形 来て 的讀法一樣）"
+    ],
+    drills: [
+      {
+        labelKey: "drillMasu",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "masu"
+        }
+      }
+    ],
+    requiredForms: ["masu"]
+  },
+  {
+    id: "plain",
+    group: "basic",
+    category: "句型骨架",
+    kicker: "普通形整理",
+    title: "普通形四格",
+    subtitle: "書く / 書かない / 書いた / 書かなかった",
+    explanation:
+      "普通形是字典形＋ない／た／なかった 四格。同層句型（と思う、と言う、んです、つもり）都接普通形。記得「現在肯定」就是字典形本身。",
+    examples: [
+      { formula: "書く → 書く / 書かない / 書いた / 書かなかった", note: "動詞：辞書／ない／た／なかった" },
+      { formula: "高い → 高い / 高くない / 高かった / 高くなかった", note: "い形容詞：去い再加" },
+      { formula: "静か → 静かだ / 静かではない / 静かだった / 静かではなかった", note: "な形容詞" },
+      { formula: "学生 → 学生だ / 学生ではない / 学生だった / 学生ではなかった", note: "名詞與な形容詞同型" }
+    ],
+    pitfalls: [
+      "な形容詞和名詞的肯定句尾要加だ（静かだ／学生だ），不是直接接後句",
+      "「普通形 + んです」是常見的「強調 / 理由」表達，沒有だ會卡住",
+      "接続詞や引用 と思う / と言う 都吃普通形，不是ます形"
+    ],
+    drills: [
+      {
+        labelKey: "drillPlain",
+        preset: {
+          partOfSpeech: "mixed",
+          verbGroup: "all",
+          practiceFocus: "plain",
+          targetForm: "plainPresentAffirmative"
+        }
+      }
+    ],
+    requiredForms: [
+      "plainPresentAffirmative",
+      "plainPresentNegative",
+      "plainPastAffirmative",
+      "plainPastNegative"
+    ]
+  },
+  {
+    id: "potential",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "能力表達",
+    title: "可能形 (V られる)",
+    subtitle: "書く → 書ける / 食べる → 食べられる",
+    explanation:
+      "「能做某事」。一類動詞最後一字換え段＋る；二類去る＋られる；三類：する → できる、来る → 来られる。原本的「を」常變「が」（本を読む → 本が読める）。",
+    examples: [
+      { formula: "書く → 書ける", note: "一類：く換け＋る" },
+      { formula: "読む → 読める", note: "一類：む換め＋る" },
+      { formula: "食べる → 食べられる", note: "二類：去る＋られる" },
+      { formula: "見る → 見られる", note: "二類，注意不是「見れる」(ら抜き)" },
+      { formula: "する → できる", note: "三類：不規則" },
+      { formula: "来る → 来られる", note: "三類，讀作こられる" }
+    ],
+    pitfalls: [
+      "口語會說「見れる／食べれる」（ら抜き言葉），但正式書面、考試要寫「見られる／食べられる」",
+      "句子裡的「を」常變「が」：本を読む → 本が読める",
+      "「する」要記成「できる」，不是「しられる」"
+    ],
+    drills: [
+      {
+        labelKey: "drillPotential",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "potential"
+        }
+      }
+    ],
+    recommendedAfter: ["verb-types"],
+    requiredForms: ["potential"]
+  },
+  {
+    id: "volitional",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "意志・邀請",
+    title: "意向形 (V よう)",
+    subtitle: "書く → 書こう / 食べる → 食べよう",
+    explanation:
+      "表「我們...吧」或「自己想做」。一類動詞最後一字換お段＋う；二類去る＋よう；三類：する → しよう、来る → 来よう。常配と思う／とする 表自我決定或正要做。",
+    examples: [
+      { formula: "書く → 書こう", note: "一類：く換こ＋う" },
+      { formula: "読む → 読もう", note: "一類：む換も＋う" },
+      { formula: "食べる → 食べよう", note: "二類：去る＋よう" },
+      { formula: "見る → 見よう", note: "二類" },
+      { formula: "する → しよう", note: "三類" },
+      { formula: "来る → 来よう", note: "三類，讀作こよう" }
+    ],
+    pitfalls: [
+      "ます形變ましょう，意向變こう／よう；別把這兩個混在一起",
+      "「ようとする」是「正要做（卻被打斷）」，常見搭配",
+      "口語邀請：行こう、食べよう；書面或對外人正式：ましょう"
+    ],
+    drills: [
+      {
+        labelKey: "drillVolitional",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "volitional"
+        }
+      }
+    ],
+    recommendedAfter: ["verb-types"],
+    requiredForms: ["volitional"]
+  },
+  {
+    id: "passive",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "被動表達",
+    title: "受身形 (V られる)",
+    subtitle: "叱る → 叱られる / 食べる → 食べられる",
+    explanation:
+      "「被...」。一類動詞最後一字換あ段＋れる；二類去る＋られる；三類：する → される、来る → 来られる。施動者用「に」標記（先生に叱られた）。",
+    examples: [
+      { formula: "叱る → 叱られる", note: "一類：る換ら＋れる" },
+      { formula: "読む → 読まれる", note: "一類：む換ま＋れる" },
+      { formula: "食べる → 食べられる", note: "二類：與可能形同形，靠語境判別" },
+      { formula: "する → される", note: "三類" },
+      { formula: "来る → 来られる", note: "三類（「迷惑の受身」：被人來打擾）" }
+    ],
+    pitfalls: [
+      "二類受身和可能形外形相同（食べられる），要從上下文判別",
+      "う結尾的一類動詞要變わ：買う → 買われる（不是買あれる）",
+      "「に」標記施動者，「を」標記受動的物：先生に名前を呼ばれた"
+    ],
+    drills: [
+      {
+        labelKey: "drillPassive",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "passive"
+        }
+      }
+    ],
+    recommendedAfter: ["verb-types"],
+    requiredForms: ["passive"]
+  },
+  {
+    id: "causative",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "命令／允許",
+    title: "使役形 (V せる/させる)",
+    subtitle: "書く → 書かせる / 食べる → 食べさせる",
+    explanation:
+      "「讓 X 做／強迫 X 做」。一類動詞最後一字換あ段＋せる；二類去る＋させる；三類：する → させる、来る → 来させる。強制 vs 允許 由助詞 (に／を) 與語境決定。",
+    examples: [
+      { formula: "書く → 書かせる", note: "一類：く換か＋せる" },
+      { formula: "読む → 読ませる", note: "一類：む換ま＋せる" },
+      { formula: "食べる → 食べさせる", note: "二類：去る＋させる" },
+      { formula: "見る → 見させる", note: "二類" },
+      { formula: "する → させる", note: "三類" },
+      { formula: "来る → 来させる", note: "三類，讀作こさせる" }
+    ],
+    pitfalls: [
+      "う結尾的一類動詞要變わ：手伝う → 手伝わせる",
+      "「に」「を」標記受役者，搭配差別大（息子に行かせる／息子を行かせる）",
+      "「させられる」是使役被動「被迫做」，常考"
+    ],
+    drills: [
+      {
+        labelKey: "drillCausative",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "causative"
+        }
+      }
+    ],
+    recommendedAfter: ["verb-types"],
+    requiredForms: ["causative"]
+  },
+  {
+    id: "desiderative",
+    group: "basic",
+    category: "動詞變化",
+    kicker: "願望表達",
+    title: "たい・たがる（願望）",
+    subtitle: "行きたい（我）／行きたがる（他）",
+    explanation:
+      "第一人稱用 V ます形 + たい（い形容詞變化），第三人稱用 V ます形 + たがる（動詞變化）。文法和變化邏輯不同要分開記。",
+    examples: [
+      { formula: "行く → 行きたい / 行きたくない / 行きたかった", note: "第一人稱：い形容詞變化" },
+      { formula: "食べる → 食べたい", note: "二類也是去る＋たい（不要去ます形再去る）" },
+      { formula: "妹は 行きたがる / 行きたがっている", note: "第三人稱：動詞變化（がる／がっている）" },
+      { formula: "子供は 食べたがっている", note: "第三人稱當下願望多用ている" }
+    ],
+    pitfalls: [
+      "「私は行きたがる」是錯句；自己的願望用「たい」",
+      "他人現在的願望多用「たがっている」(具體當下)，「たがる」較常表一般傾向",
+      "「を」可變「が」：水を飲みたい／水が飲みたい（後者更口語）"
+    ],
+    drills: [
+      {
+        labelKey: "drillDesiderative",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "single",
+          targetForm: "desiderative"
+        }
+      }
+    ],
+    recommendedAfter: ["masu"],
+    requiredForms: ["desiderative"]
   }
 ];
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -40,6 +40,13 @@ type Copy = {
   drillNaAdjective: string;
   drillAdverbial: string;
   drillObligationPast: string;
+  drillMasu: string;
+  drillPlain: string;
+  drillPotential: string;
+  drillVolitional: string;
+  drillPassive: string;
+  drillCausative: string;
+  drillDesiderative: string;
   startChallenge: string;
   settingsLabel: string;
   todayPractice: string;
@@ -137,6 +144,13 @@ export const copy: Record<Language, Copy> = {
     drillNaAdjective: "練な形容詞",
     drillAdverbial: "練く/に修飾",
     drillObligationPast: "練必要過去",
+    drillMasu: "練ます形",
+    drillPlain: "練普通形",
+    drillPotential: "練可能形",
+    drillVolitional: "練意向形",
+    drillPassive: "練受身形",
+    drillCausative: "練使役形",
+    drillDesiderative: "練たい・たがる",
     startChallenge: "開始挑戰",
     settingsLabel: "練習設定",
     todayPractice: "今日練習",
@@ -267,6 +281,13 @@ export const copy: Record<Language, Copy> = {
     drillNaAdjective: "Drill na-adjectives",
     drillAdverbial: "Drill ku/ni modifiers",
     drillObligationPast: "Drill past obligation",
+    drillMasu: "Drill masu form",
+    drillPlain: "Drill plain forms",
+    drillPotential: "Drill potential form",
+    drillVolitional: "Drill volitional form",
+    drillPassive: "Drill passive form",
+    drillCausative: "Drill causative form",
+    drillDesiderative: "Drill tai / tagaru",
     startChallenge: "Start challenge",
     settingsLabel: "Practice settings",
     todayPractice: "Today's practice",
@@ -397,6 +418,13 @@ export const copy: Record<Language, Copy> = {
     drillNaAdjective: "な형용사 연습",
     drillAdverbial: "く/に 수식 연습",
     drillObligationPast: "필요 과거 연습",
+    drillMasu: "ます형 연습",
+    drillPlain: "보통형 연습",
+    drillPotential: "가능형 연습",
+    drillVolitional: "의향형 연습",
+    drillPassive: "수동형 연습",
+    drillCausative: "사역형 연습",
+    drillDesiderative: "たい・たがる 연습",
     startChallenge: "도전 시작",
     settingsLabel: "연습 설정",
     todayPractice: "오늘의 연습",


### PR DESCRIPTION
> **PR B1 of A → B1 → B2 stack.** Pure content addition on top of PR A's schema. No App.tsx render changes; no schema changes. PR B2 (形容詞・名詞・句型) comes next.

## 動機

PR A 拉好了學習頁的資料架構但沒加新內容。這支補上 8 個動詞變化章節，把練習引擎支援的每一種動詞活用都納入學習頁。

## 新增章節（8）

| Category | Title | Drill target |
|---|---|---|
| 基礎判斷 | 動詞三類怎麼分 | masu |
| 基礎敬語 | ます形 | masu |
| 普通形整理 | 普通形四格 | plainPresentAffirmative |
| 能力表達 | 可能形 (V られる) | potential |
| 意志・邀請 | 意向形 (V よう) | volitional |
| 被動表達 | 受身形 (V られる) | passive |
| 命令／允許 | 使役形 (V せる/させる) | causative |
| 願望表達 | たい・たがる | desiderative |

每章內容：
- 4-6 個 example formula + note pair（涵蓋三類動詞、強調差異）
- 2-3 條 pitfalls（典型誤解：う段換成あ段、ら抜き、来る 讀法、を/が 切換 等）
- 1 個 drill 按鈕指向對應的 target form

## 前置設定 (recommendedAfter)
- verb-types & masu：都 drill masu，但 masu **沒有** recommendedAfter — 它是最基本的形，應該隨時可練
- potential / volitional / passive / causative：`recommendedAfter: ["verb-types"]`（這些變化嚴格需要先懂三類）
- desiderative：`recommendedAfter: ["masu"]`（〜たい 接 V ます形）
- 正解任何一次 ます 之後，verb-types 與 masu 都標完成，4 個進階變化也跟著解鎖

## i18n
7 個新 drill 按鈕 labels（drillMasu / drillPlain / drillPotential / drillVolitional / drillPassive / drillCausative / drillDesiderative），三語都齊。

## Test plan
- [x] `pnpm test` — 78/78 pass（新增 1 個：locks 3 個新章節在 list + 從 ます 章節跳挑戰頁的 drill flow）
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — clean（JS +11 kB / CSS unchanged）
- [x] `node scripts/check-exam-options.mjs` — 155/155 entries, 0 problems
- [ ] Manual preview：
  - [ ] 學習頁左側章節 list 從 4 個變成 12 個，新章節排在原 4 章後
  - [ ] 「查看：可能形 (V られる)」/「查看：使役形」等都可點
  - [ ] 點進「可能形」會看到「先看前置：動詞三類怎麼分」CTA（因為 verb-types 未完成）
  - [ ] 完成一次 ます 之後，verb-types 與 masu 都顯示「完成」
  - [ ] 此時點「可能形」CTA 變成「練可能形」可直接 drill