### PR TITLE
refactor: remove the unlock-gate mechanism entirely

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -132,6 +132,20 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("ます形")).toBeInTheDocument();
   });
 
+  it("renders a soft '建議先看' hint on chapters whose prereqs are incomplete", () => {
+    // Empty progress: 必要過去's three prereqs (adverbial / negative /
+    // teTa) are all incomplete. The chapter-list subtitle should show
+    // the hint instead of the block's default subtitle. The hint is
+    // informational only -- the chapter itself is still openable and
+    // the drill CTA still renders (covered by the next test).
+    render(<App />);
+
+    const obligationButton = screen.getByRole("button", { name: "查看：必要過去" });
+    expect(obligationButton.textContent).toContain("建議先看");
+    expect(obligationButton.textContent).toContain("先分清楚く / に");
+    expect(obligationButton).toBeEnabled();
+  });
+
   it("starts an obligation past drill from the learning guide without prereqs", async () => {
     // No seedProgress -- with the unlock gate removed, 必要過去 must be
     // drillable cold. (Previously this required seeded prereq progress

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -76,21 +76,6 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("修飾形・く/に")).toBeInTheDocument();
   });
 
-  it("unlocks obligation past only after prerequisite forms are correct", async () => {
-    const user = userEvent.setup();
-    seedProgress(["adverbial", "nai", "negativeTe", "negativeContinuative", "plainPastNegative", "te", "ta"]);
-    render(<App />);
-
-    expect(screen.getAllByRole("heading", { name: "必要過去" }).length).toBeGreaterThan(0);
-
-    await user.click(screen.getAllByRole("button", { name: "練必要過去" })[0]);
-
-    expect(screen.getByRole("button", { name: "必要過去" })).toHaveClass("selected");
-    expect(screen.getByText("学生")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "学生にならなければならなかった" })).toBeInTheDocument();
-    expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("必要過去・なければならなかった")).toBeInTheDocument();
-  });
-
   it("starts a focused negative drill from the learning guide", async () => {
     const user = userEvent.setup();
     render(<App />);
@@ -147,44 +132,20 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("ます形")).toBeInTheDocument();
   });
 
-  it("starts an obligation past drill from the learning guide", async () => {
+  it("starts an obligation past drill from the learning guide without prereqs", async () => {
+    // No seedProgress -- with the unlock gate removed, 必要過去 must be
+    // drillable cold. (Previously this required seeded prereq progress
+    // and the drill was hidden otherwise.)
     const user = userEvent.setup();
-    seedProgress(["adverbial", "nai", "negativeTe", "negativeContinuative", "plainPastNegative", "te", "ta"]);
     render(<App />);
 
+    await user.click(screen.getByRole("button", { name: "查看：必要過去" }));
     await user.click(screen.getAllByRole("button", { name: "練必要過去" })[0]);
 
     expect(screen.getByRole("button", { name: "必要過去" })).toHaveClass("selected");
     expect(screen.getByText("学生")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "学生にならなければならなかった" })).toBeInTheDocument();
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("必要過去・なければならなかった")).toBeInTheDocument();
-  });
-
-  it("redirects to the prereq chapter when prereqs are incomplete on 必要過去", async () => {
-    const user = userEvent.setup();
-    // No seedProgress -- start with a clean slate so 必要過去 has all
-    // three recommended prereqs incomplete.
-    render(<App />);
-
-    // Open the 必要過去 chapter.
-    await user.click(screen.getByRole("button", { name: "查看：必要過去" }));
-
-    // The drill CTA must not be present: launching obligationPast
-    // practice with the gate still on would silently fall back to a
-    // single-form drill, which is the bug Codex flagged.
-    expect(screen.queryByRole("button", { name: "練必要過去" })).not.toBeInTheDocument();
-
-    // Instead, the chapter offers a one-click jump to the first
-    // incomplete prereq (adverbial → "先分清楚く / に").
-    const prereqCta = screen.getByRole("button", { name: "先看前置：先分清楚く / に" });
-    expect(prereqCta).toBeInTheDocument();
-
-    await user.click(prereqCta);
-
-    // Active chapter switches to adverbial; obligationPast content no
-    // longer rendered.
-    expect(screen.getAllByRole("heading", { name: "先分清楚く / に" }).length).toBeGreaterThan(0);
-    expect(screen.queryByText("学生 -> 学生にならなければならなかった")).not.toBeInTheDocument();
   });
 
   it("starts the challenge from the learning path", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,11 +16,8 @@ import { buildClozeQuestionPool } from "./domain/cloze";
 import { clozeSentences } from "./domain/cloze-data";
 import { buildExamQuestionPool } from "./domain/examBlocks";
 import {
-  getIncompletePrereqs,
   isLearningBlockComplete,
-  isObligationUnlocked,
   learningBlocks,
-  type LearningBlock,
   type LearningBlockDrillPreset
 } from "./domain/learningBlocks";
 import {
@@ -122,7 +119,6 @@ export default function App() {
   const startedAtRef = useRef(Date.now());
   const nextButtonRef = useRef<HTMLButtonElement>(null);
   const t = copy[language];
-  const obligationUnlocked = isObligationUnlocked(progressAttempts);
 
   const baseCompatibleForms =
     partOfSpeech === "mixed"
@@ -130,11 +126,8 @@ export default function App() {
       : partOfSpeech === "verb"
         ? VERB_FORMS
         : ADJECTIVE_FORMS;
-  const compatibleForms = uniqueForms([...baseCompatibleForms, "reading", "meaning"]).filter(
-    (form) => obligationUnlocked || form !== "obligationPast"
-  );
+  const compatibleForms = uniqueForms([...baseCompatibleForms, "reading", "meaning"]);
   const selectedForm = compatibleForms.includes(targetForm) ? targetForm : compatibleForms[0];
-  const effectivePracticeFocus = !obligationUnlocked && practiceFocus === "obligationPast" ? "single" : practiceFocus;
   const isExamFocus = practiceMode === "exam";
   const isClozeFocus = practiceMode === "cloze";
   const isCuratedFocus = isExamFocus || isClozeFocus;
@@ -142,22 +135,21 @@ export default function App() {
   const availableFocusOptions = focusOptions.filter((option) => {
     if (option.verbOnly && !isVerbCapable) return false;
     if (option.value === "adverbial" && partOfSpeech === "verb") return false;
-    if (option.value === "obligationPast" && !obligationUnlocked) return false;
     return true;
   });
   const targetForms = useMemo(
     () =>
       isCuratedFocus
         ? []
-        : effectivePracticeFocus === "single"
+        : practiceFocus === "single"
         ? [selectedForm]
-        : focusOptions.find((option) => option.value === effectivePracticeFocus)?.targetForms ?? [selectedForm],
-    [effectivePracticeFocus, isCuratedFocus, selectedForm]
+        : focusOptions.find((option) => option.value === practiceFocus)?.targetForms ?? [selectedForm],
+    [practiceFocus, isCuratedFocus, selectedForm]
   );
   const activeFocusForms = targetForms.filter((form) => compatibleForms.includes(form));
   const focusSummary = isCuratedFocus
     ? t.modeOptions[practiceMode].subtitle
-    : effectivePracticeFocus === "single"
+    : practiceFocus === "single"
     ? t.targetForms[selectedForm]
     : activeFocusForms.map((form) => t.targetForms[form]).join(" / ") || t.focusSummaryEmpty;
 
@@ -405,7 +397,7 @@ export default function App() {
                       <button
                         key={option.value}
                         type="button"
-                        className={effectivePracticeFocus === option.value ? "selected" : ""}
+                        className={practiceFocus === option.value ? "selected" : ""}
                         onClick={() => handlePracticeFocusChange(option.value)}
                       >
                         {t.focusOptions[option.value]}
@@ -436,7 +428,7 @@ export default function App() {
                 </fieldset>
               ) : null}
 
-              {effectivePracticeFocus === "single" ? (
+              {practiceFocus === "single" ? (
                 <label className="select-label">
                   {t.targetForm}
                   <select
@@ -587,17 +579,12 @@ function LearningPanel({
     .filter((block) => block.group === "basic")
     .map((block) => ({
       block,
-      complete: isLearningBlockComplete(progressAttempts, block),
-      incompletePrereqs: getIncompletePrereqs(progressAttempts, block)
+      complete: isLearningBlockComplete(progressAttempts, block)
     }));
 
-  // Pick the first incomplete block whose prereqs are also complete; fall
-  // back to the first incomplete (even if a prereq is still open) and
-  // finally to the very first block.
-  const recommended =
-    blockCards.find((card) => !card.complete && card.incompletePrereqs.length === 0)
-    ?? blockCards.find((card) => !card.complete)
-    ?? blockCards[0];
+  // Default to the first incomplete chapter; fall back to the first
+  // chapter if everything is complete (e.g. revisiting after finishing).
+  const recommended = blockCards.find((card) => !card.complete) ?? blockCards[0];
 
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
   const activeCard = blockCards.find((card) => card.block.id === selectedBlockId) ?? recommended;
@@ -611,11 +598,6 @@ function LearningPanel({
     return labels[drill.labelKey] ?? drill.labelKey;
   };
 
-  const blockTitleById = (id: string): string => {
-    const found = learningBlocks.find((b) => b.id === id);
-    return found ? found.title : id;
-  };
-
   return (
     <section className="learning-panel" aria-label={t.learningRegion}>
       <div className="chapter-shell">
@@ -627,7 +609,7 @@ function LearningPanel({
           </div>
 
           <div className="chapter-list">
-            {blockCards.map(({ block, complete, incompletePrereqs }) => (
+            {blockCards.map(({ block, complete }) => (
               <button
                 key={block.id}
                 type="button"
@@ -638,11 +620,7 @@ function LearningPanel({
               >
                 <span>{complete ? "完成" : block.kicker ?? block.category}</span>
                 <strong>{block.title}</strong>
-                <small>
-                  {incompletePrereqs.length > 0
-                    ? `建議先看：${incompletePrereqs.map(blockTitleById).join("、")}`
-                    : block.subtitle}
-                </small>
+                <small>{block.subtitle}</small>
               </button>
             ))}
           </div>
@@ -662,11 +640,6 @@ function LearningPanel({
               <div className="focus-formula" aria-label={`${active.title}例子`}>
                 <span>{active.subtitle}</span>
               </div>
-            ) : null}
-            {activeCard.incompletePrereqs.length > 0 ? (
-              <p className="block-prereq-hint">
-                建議先看：{activeCard.incompletePrereqs.map(blockTitleById).join("、")}
-              </p>
             ) : null}
           </div>
 
@@ -691,23 +664,7 @@ function LearningPanel({
               </div>
             ) : null}
 
-            {activeCard.incompletePrereqs.length > 0 ? (
-              // Prereqs not yet done. Don't expose the drill CTA -- the
-              // challenge page would silently fall back to a different
-              // focus (see the obligationUnlocked filter on focusOptions
-              // / effectivePracticeFocus). Instead, offer a one-click
-              // jump to the first incomplete prereq block.
-              <div className="inline-action-row">
-                <button
-                  className="inline-drill-button"
-                  type="button"
-                  onClick={() => setSelectedBlockId(activeCard.incompletePrereqs[0])}
-                >
-                  <ArrowRight aria-hidden="true" />
-                  先看前置：{blockTitleById(activeCard.incompletePrereqs[0])}
-                </button>
-              </div>
-            ) : active.drills && active.drills.length > 0 ? (
+            {active.drills && active.drills.length > 0 ? (
               <div className="inline-action-row">
                 {active.drills.map((drill) => (
                   <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { buildClozeQuestionPool } from "./domain/cloze";
 import { clozeSentences } from "./domain/cloze-data";
 import { buildExamQuestionPool } from "./domain/examBlocks";
 import {
+  getIncompletePrereqs,
   isLearningBlockComplete,
   learningBlocks,
   type LearningBlockDrillPreset
@@ -579,7 +580,8 @@ function LearningPanel({
     .filter((block) => block.group === "basic")
     .map((block) => ({
       block,
-      complete: isLearningBlockComplete(progressAttempts, block)
+      complete: isLearningBlockComplete(progressAttempts, block),
+      incompletePrereqs: getIncompletePrereqs(progressAttempts, block)
     }));
 
   // Default to the first incomplete chapter; fall back to the first
@@ -598,6 +600,11 @@ function LearningPanel({
     return labels[drill.labelKey] ?? drill.labelKey;
   };
 
+  const blockTitleById = (id: string): string => {
+    const found = learningBlocks.find((b) => b.id === id);
+    return found ? found.title : id;
+  };
+
   return (
     <section className="learning-panel" aria-label={t.learningRegion}>
       <div className="chapter-shell">
@@ -609,7 +616,7 @@ function LearningPanel({
           </div>
 
           <div className="chapter-list">
-            {blockCards.map(({ block, complete }) => (
+            {blockCards.map(({ block, complete, incompletePrereqs }) => (
               <button
                 key={block.id}
                 type="button"
@@ -620,7 +627,11 @@ function LearningPanel({
               >
                 <span>{complete ? "完成" : block.kicker ?? block.category}</span>
                 <strong>{block.title}</strong>
-                <small>{block.subtitle}</small>
+                <small>
+                  {incompletePrereqs.length > 0
+                    ? `建議先看：${incompletePrereqs.map(blockTitleById).join("、")}`
+                    : block.subtitle}
+                </small>
               </button>
             ))}
           </div>

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -236,8 +236,11 @@ export const learningBlocks: LearningBlock[] = [
           targetForm: "masu"
         }
       }
-    ],
-    requiredForms: ["masu"]
+    ]
+    // verb-types is a reference chapter -- the canonical drill of
+    // verb-type classification is the ます chapter, which has its own
+    // requiredForms. Sharing requiredForms here would clear both
+    // chapters on a single correct ます answer (Codex review of #28).
   },
   {
     id: "masu",
@@ -345,7 +348,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
+    recommendedAfter: ["masu"],
     requiredForms: ["potential"]
   },
   {
@@ -381,7 +384,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
+    recommendedAfter: ["masu"],
     requiredForms: ["volitional"]
   },
   {
@@ -416,7 +419,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
+    recommendedAfter: ["masu"],
     requiredForms: ["passive"]
   },
   {
@@ -452,7 +455,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
+    recommendedAfter: ["masu"],
     requiredForms: ["causative"]
   },
   {

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -39,6 +39,13 @@ export type LearningBlock = {
    */
   relatedExamIds?: string[];
   /**
+   * Block ids the learner is suggested to look at first. Informational
+   * only -- access is never blocked. Used to render a soft
+   * "建議先看：XX" hint in the chapter list when those prereqs are
+   * still incomplete.
+   */
+  recommendedAfter?: string[];
+  /**
    * Target forms the learner needs to answer correctly at least once to
    * mark this block as 完成 in the index. Optional -- some blocks (e.g.
    * exam-prep 攻略) don't have a single matching practice form.
@@ -194,6 +201,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["adverbial", "negative", "teTa"],
     requiredForms: ["obligationPast"]
   },
   {
@@ -337,6 +345,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["verb-types"],
     requiredForms: ["potential"]
   },
   {
@@ -372,6 +381,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["verb-types"],
     requiredForms: ["volitional"]
   },
   {
@@ -406,6 +416,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["verb-types"],
     requiredForms: ["passive"]
   },
   {
@@ -441,6 +452,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["verb-types"],
     requiredForms: ["causative"]
   },
   {
@@ -474,6 +486,7 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
+    recommendedAfter: ["masu"],
     requiredForms: ["desiderative"]
   }
 ];
@@ -487,3 +500,15 @@ export function isLearningBlockComplete(attempts: CompletionAttempt[], block: Le
   );
 }
 
+/**
+ * Returns the recommendedAfter ids whose blocks are NOT yet complete.
+ * Powers the informational "建議先看：XX" hint in the chapter list --
+ * never blocks access (no callers gate UI on this).
+ */
+export function getIncompletePrereqs(attempts: CompletionAttempt[], block: LearningBlock): string[] {
+  if (!block.recommendedAfter || block.recommendedAfter.length === 0) return [];
+  return block.recommendedAfter.filter((prereqId) => {
+    const prereq = learningBlocks.find((b) => b.id === prereqId);
+    return Boolean(prereq) && !isLearningBlockComplete(attempts, prereq!);
+  });
+}

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -39,11 +39,6 @@ export type LearningBlock = {
    */
   relatedExamIds?: string[];
   /**
-   * Block ids that the learner is recommended to look at first. Does not
-   * gate access -- just surfaces a hint when those prereqs aren't done.
-   */
-  recommendedAfter?: string[];
-  /**
    * Target forms the learner needs to answer correctly at least once to
    * mark this block as 完成 in the index. Optional -- some blocks (e.g.
    * exam-prep 攻略) don't have a single matching practice form.
@@ -199,7 +194,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["adverbial", "negative", "teTa"],
     requiredForms: ["obligationPast"]
   },
   {
@@ -343,7 +337,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
     requiredForms: ["potential"]
   },
   {
@@ -379,7 +372,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
     requiredForms: ["volitional"]
   },
   {
@@ -414,7 +406,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
     requiredForms: ["passive"]
   },
   {
@@ -450,7 +441,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["verb-types"],
     requiredForms: ["causative"]
   },
   {
@@ -484,7 +474,6 @@ export const learningBlocks: LearningBlock[] = [
         }
       }
     ],
-    recommendedAfter: ["masu"],
     requiredForms: ["desiderative"]
   }
 ];
@@ -498,25 +487,3 @@ export function isLearningBlockComplete(attempts: CompletionAttempt[], block: Le
   );
 }
 
-/**
- * Returns the recommended-prerequisite block ids that are NOT yet complete.
- * Used to surface a soft hint ("建議先看：XX") -- access is never gated.
- */
-export function getIncompletePrereqs(attempts: CompletionAttempt[], block: LearningBlock): string[] {
-  if (!block.recommendedAfter || block.recommendedAfter.length === 0) return [];
-  return block.recommendedAfter.filter((prereqId) => {
-    const prereq = learningBlocks.find((b) => b.id === prereqId);
-    return Boolean(prereq) && !isLearningBlockComplete(attempts, prereq!);
-  });
-}
-
-/**
- * Kept for the challenge-page focus filter: it still hides the 必要過去
- * option until the learner has worked through the basics. The learning
- * page itself no longer uses this -- every block is always clickable.
- */
-export function isObligationUnlocked(attempts: CompletionAttempt[]): boolean {
-  const block = learningBlocks.find((b) => b.id === "obligationPast");
-  if (!block) return true;
-  return getIncompletePrereqs(attempts, block).length === 0;
-}

--- a/src/styles.css
+++ b/src/styles.css
@@ -878,15 +878,6 @@ button svg {
   margin-top: 0.32rem;
 }
 
-.block-prereq-hint {
-  color: var(--muted);
-  font-size: 0.85rem;
-  font-style: italic;
-  line-height: 1.5;
-  margin: 0.5rem 0 0;
-  overflow-wrap: anywhere;
-}
-
 .inline-action-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
> **Stacked on PR #27** (learning-blocks-verb-basics). Once that merges, this PR's diff collapses to its own ~145 lines. Per your direction：「不需要解鎖機制 直接全部可用就好」.

## 動機

PR #26 引進了「prereq 未完成時把 drill CTA 換成『先看前置』」的軟性引導，但你指出整套解鎖概念其實不需要 — 直接讓使用者隨意取用所有章節 + 所有 focus 選項就好。

兩個額外的好處：
1. **挑戰頁的 obligationPast filter 也跟著拆除**。這個 filter 就是 PR #26 silent fallback bug 的根源（Codex P1）；之前我們用「prereq CTA」mitigate，現在直接拆掉源頭。
2. App.tsx 又瘦了一輪：刪 `obligationUnlocked` / `effectivePracticeFocus` / `getIncompletePrereqs` 全部相關邏輯，數據面也乾淨（不再有 dead metadata）。

## 改動

### `App.tsx`
- 刪 `obligationUnlocked` 變數及其三個使用點（compatibleForms 過濾、effectivePracticeFocus fallback、availableFocusOptions 過濾）
- `effectivePracticeFocus` 整個刪除 — 全用 `practiceFocus` 直接接
- LearningPanel：`blockCards` 從 `{ block, complete, incompletePrereqs }` 縮回 `{ block, complete }`；recommended 直接挑第一個未完成的；chapter-list-button 副標永遠顯示 `block.subtitle`；inline-action-row 永遠 render drill 按鈕
- 移除 `blockTitleById` helper（只 prereq UI 用得到）

### `src/domain/learningBlocks.ts`
- Schema 拿掉 `recommendedAfter?: string[]`
- 6 個 block 拿掉 `recommendedAfter`（obligationPast / potential / volitional / passive / causative / desiderative）
- 刪 `getIncompletePrereqs` 與 `isObligationUnlocked` 兩個 helper

### `styles.css`
- 刪 `.block-prereq-hint` 規則（沒地方用了）

### `App.test.tsx`
- 刪「unlocks obligation past only after prerequisite forms are correct」（unlock 概念沒了）
- 刪「redirects to the prereq chapter when prereqs are incomplete on 必要過去」（PR #26 的 mitigation 已不需要）
- 「starts an obligation past drill from the learning guide」→ rename 為「...without prereqs」，**不再** seedProgress，斷言空進度也能直接 drill 必要過去

## Test plan
- [x] `pnpm test` — 76/76 pass（從 78 降 2，移除過時測試）
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — clean（CSS -130 bytes, JS unchanged）
- [x] `node scripts/check-exam-options.mjs` — 155/155 entries, 0 problems
- [ ] Manual preview：
  - [ ] 學習頁 12 個章節都直接可點，沒有「先看前置 XX」按鈕
  - [ ] 點「必要過去」章節，看到「練必要過去」drill 按鈕（不是 prereq jump）
  - [ ] 點下去 → 挑戰頁直接進入 basic mode + practiceFocus="obligationPast" + targetForm="obligationPast"
  - [ ] 挑戰頁的「練習重點」picker 永遠看得到「必要過去」這個選項