### PR TITLE
feat(learning): add 4 N5 sentence-pattern reference chapters (B2)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -132,6 +132,38 @@ describe("App", () => {
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("ます形")).toBeInTheDocument();
   });
 
+  it("renders the new sentence-pattern reference chapters and reaches their related drill", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // The four new B2 chapters surface in the chapter list.
+    expect(
+      screen.getByRole("button", { name: "查看：てください / てもいい / てはいけない" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "查看：なくてもいい（不必）" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "查看：てもらう / てくれる / てあげる" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "查看：と思う / と言う（引用・意見）" })
+    ).toBeInTheDocument();
+
+    // Open the request/permission chapter; its examples and the related
+    // te-form drill button render.
+    await user.click(
+      screen.getByRole("button", { name: "查看：てください / てもいい / てはいけない" })
+    );
+    expect(screen.getByText("書く → 書いてください")).toBeInTheDocument();
+    expect(screen.getByText("食べる → 食べてもいいですか")).toBeInTheDocument();
+
+    // The drill button is the te-form practice -- since these are
+    // reference chapters with no requiredForms of their own, the
+    // related drill lets the learner go practice the prerequisite
+    // form (te-form音便) directly.
+    await user.click(screen.getByRole("button", { name: "練一類て/た" }));
+    expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("て形")).toBeInTheDocument();
+  });
+
   it("renders a soft '建議先看' hint on chapters whose prereqs are incomplete", () => {
     // Empty progress: 必要過去's three prereqs (adverbial / negative /
     // teTa) are all incomplete. The chapter-list subtitle should show

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -136,7 +136,7 @@ describe("App", () => {
     const user = userEvent.setup();
     render(<App />);
 
-    // The four new B2 chapters surface in the chapter list.
+    // All four B2 chapters surface in the chapter list (smoke check).
     expect(
       screen.getByRole("button", { name: "查看：てください / てもいい / てはいけない" })
     ).toBeInTheDocument();
@@ -148,20 +148,50 @@ describe("App", () => {
       screen.getByRole("button", { name: "查看：と思う / と言う（引用・意見）" })
     ).toBeInTheDocument();
 
-    // Open the request/permission chapter; its examples and the related
-    // te-form drill button render.
-    await user.click(
-      screen.getByRole("button", { name: "查看：てください / てもいい / てはいけない" })
-    );
-    expect(screen.getByText("書く → 書いてください")).toBeInTheDocument();
-    expect(screen.getByText("食べる → 食べてもいいですか")).toBeInTheDocument();
+    // For each new chapter, walk: open chapter → confirm an example
+    // renders → click the related drill → confirm the practice region
+    // lands on the expected target form. This catches drill-mapping
+    // regressions on any of the four chapters individually.
+    type DrillCase = { chapter: string; example: string; drill: string; form: string | RegExp };
+    const cases: DrillCase[] = [
+      {
+        chapter: "查看：てください / てもいい / てはいけない",
+        example: "書く → 書いてください",
+        drill: "練一類て/た",
+        form: "て形"
+      },
+      {
+        chapter: "查看：なくてもいい（不必）",
+        example: "書く → 書かなくてもいい",
+        drill: "練否定整理",
+        form: "ない形"
+      },
+      {
+        chapter: "查看：てもらう / てくれる / てあげる",
+        example: "友達が 教えてくれた",
+        drill: "練一類て/た",
+        form: "て形"
+      },
+      {
+        chapter: "查看：と思う / と言う（引用・意見）",
+        example: "明日は雨だ → 明日は雨だと思う",
+        drill: "練普通形",
+        // The plain focus shuffles across all four plain forms; any of
+        // the four 普通形・... labels is acceptable as the first
+        // question's form. Match the prefix only.
+        form: /普通形・/
+      }
+    ];
 
-    // The drill button is the te-form practice -- since these are
-    // reference chapters with no requiredForms of their own, the
-    // related drill lets the learner go practice the prerequisite
-    // form (te-form音便) directly.
-    await user.click(screen.getByRole("button", { name: "練一類て/た" }));
-    expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("て形")).toBeInTheDocument();
+    for (const { chapter, example, drill, form } of cases) {
+      // Return to the learning view (idempotent if already there).
+      await user.click(screen.getByRole("button", { name: "學習" }));
+      await user.click(screen.getByRole("button", { name: chapter }));
+      expect(screen.getByText(example)).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: drill }));
+      expect(within(screen.getByRole("region", { name: "目前題目" })).getByText(form)).toBeInTheDocument();
+    }
   });
 
   it("renders a soft '建議先看' hint on chapters whose prereqs are incomplete", () => {

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -491,6 +491,143 @@ export const learningBlocks: LearningBlock[] = [
     ],
     recommendedAfter: ["masu"],
     requiredForms: ["desiderative"]
+  },
+  {
+    id: "te-kudasai",
+    group: "basic",
+    category: "句型",
+    kicker: "請求 / 許可",
+    title: "てください / てもいい / てはいけない",
+    subtitle: "書いてください / 食べてもいい / 入ってはいけません",
+    explanation:
+      "三個 N5 必背的 V て形句型：請求對方做（てください）、徵求許可（てもいい）、強烈禁止（てはいけない）。先把 て形 音便記熟，再記三個句尾的差別就能直接套。",
+    examples: [
+      { formula: "書く → 書いてください", note: "請對方做這個動作" },
+      { formula: "食べる → 食べてもいいですか", note: "尋求許可，加「ですか」更禮貌" },
+      { formula: "入る → 入ってはいけません", note: "強烈禁止（規定、警告）" },
+      { formula: "ここで写真を撮る → 撮ってもいい", note: "省略「ですか」變成「可以做」的陳述" }
+    ],
+    pitfalls: [
+      "三句型都需要 V て形作前置；先把 て形 音便（いて／いで／して／って／んで）記熟才能正確接",
+      "「ないでください」(請不要做) 比「てはいけません」(禁止) 軟，請對方時用前者較自然",
+      "「もいい」常省略「ですか」變陳述，要看語境分清是徵求許可還是給予許可"
+    ],
+    drills: [
+      {
+        labelKey: "drillGodanTeTa",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "godan",
+          practiceFocus: "teTa",
+          targetForm: "te"
+        }
+      }
+    ],
+    recommendedAfter: ["teTa"]
+    // Reference chapter -- no single requiredForms. Practicing the
+    // underlying て形 is the canonical drill (linked above).
+  },
+  {
+    id: "nakute-mo-ii",
+    group: "basic",
+    category: "句型",
+    kicker: "不必要",
+    title: "なくてもいい（不必）",
+    subtitle: "書かなくてもいい / 高くなくてもいい / 学生でなくてもいい",
+    explanation:
+      "表「不做也可以、沒必要做」。動詞用 Vない形 把ない換成 なくてもいい；形容詞用「-くなくてもいい」；名詞用「-でなくてもいい」。",
+    examples: [
+      { formula: "書く → 書かなくてもいい", note: "動詞：ない形 + なくてもいい" },
+      { formula: "来る → 来なくてもいい", note: "三類動詞：直接記" },
+      { formula: "高い → 高くなくてもいい", note: "い形容詞：去い加 -くなくてもいい" },
+      { formula: "学生 → 学生でなくてもいい", note: "名詞 / な形容詞：-でなくてもいい" }
+    ],
+    pitfalls: [
+      "反義是「なければならない」(必須做)，要分清「不必」與「必須」",
+      "名詞用「でなくてもいい」（不是「ではないでもいい」）",
+      "口語常省略「いい」後面的「です」，正式書面要加上"
+    ],
+    drills: [
+      {
+        labelKey: "drillNegative",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "all",
+          practiceFocus: "negative",
+          targetForm: "nai"
+        }
+      }
+    ],
+    recommendedAfter: ["negative"]
+    // Reference chapter -- the related drill is the ない形 family.
+  },
+  {
+    id: "te-morau",
+    group: "basic",
+    category: "句型",
+    kicker: "授受表現",
+    title: "てもらう / てくれる / てあげる",
+    subtitle: "教えてもらう / 教えてくれる / 教えてあげる",
+    explanation:
+      "日語特殊的「授受」表現，視角不同：「てあげる」是「我（內側）對別人做」、「てくれる」是「別人對我做」、「てもらう」是「我主動請別人幫忙」。視角判錯是這個句型最大的坑。",
+    examples: [
+      { formula: "友達が 教えてくれた", note: "別人對我做：朋友（為我）教" },
+      { formula: "友達に 教えてもらった", note: "我主動請別人做：請朋友教（並接受）" },
+      { formula: "弟に 教えてあげた", note: "我對別人做：我（為弟弟）教" },
+      { formula: "先生に 来ていただいた", note: "「いただく」是「もらう」的謙讓，對上位用" }
+    ],
+    pitfalls: [
+      "別人對我做事一律用「てくれる」家族，不能用「てあげる」（容易記混）",
+      "對上位／長輩用「ていただく」(=てもらう 謙讓) 或「てくださる」(=てくれる 尊敬)",
+      "助詞配對：てもらう／てあげる 用「に」標記做事者；てくれる 用「が」"
+    ],
+    drills: [
+      {
+        labelKey: "drillGodanTeTa",
+        preset: {
+          partOfSpeech: "verb",
+          verbGroup: "godan",
+          practiceFocus: "teTa",
+          targetForm: "te"
+        }
+      }
+    ],
+    recommendedAfter: ["teTa"]
+    // Reference chapter -- te-form practice is the canonical drill.
+  },
+  {
+    id: "to-omou",
+    group: "basic",
+    category: "句型",
+    kicker: "引用 / 意見",
+    title: "と思う / と言う（引用・意見）",
+    subtitle: "明日は雨だと思う / 「行く」と言った",
+    explanation:
+      "用「と」標記引用內容，再接「思う」(認為) 或「言う」(說)。引用內容必須用普通形結尾，不能用ます形。這就是為什麼前面普通形那一章那麼重要。",
+    examples: [
+      { formula: "明日は雨だ → 明日は雨だと思う", note: "個人意見：我覺得明天會下雨" },
+      { formula: "行く → 「行く」と言った", note: "直接引用：他說「我要去」" },
+      { formula: "美味しい → 美味しいと思う", note: "い形容詞的普通形直接接と" },
+      { formula: "学生だ → 学生だと言った", note: "な形容詞 / 名詞要保留「だ」" }
+    ],
+    pitfalls: [
+      "引用內容用普通形，不要用ます形（×「雨ですと思う」）",
+      "な形容詞和名詞要加「だ」（×「静かと思う」→ ○「静かだと思う」）",
+      "口語可把「と」說成「って」：「行くって言った」"
+    ],
+    drills: [
+      {
+        labelKey: "drillPlain",
+        preset: {
+          partOfSpeech: "mixed",
+          verbGroup: "all",
+          practiceFocus: "plain",
+          targetForm: "plainPresentAffirmative"
+        }
+      }
+    ],
+    recommendedAfter: ["plain"]
+    // Reference chapter -- the related drill is the plain-form four-cell.
   }
 ];
 


### PR DESCRIPTION
> Continuation of the learning-page expansion. Stand-alone PR on top of `main`.

## 動機

延續 PR #26（PR A 架構）和 PR #27（PR B1 8 個動詞基礎章節）。原本 B2 規劃 7 個 adj / noun / 句型 block，但實際上：
- 「い形容詞 / な形容詞 / 名詞」普通形四格已經在 B1 的 `plain` 章節合併呈現了
- 「く/に修飾」「たい/たがる」「必要過去」分別在 PR A / B1 已涵蓋

剩下沒做的就是 4 個 N5 句型參考章節，這支 PR 補上。

## 加進來的 4 個章節

| ID | 標題 | 內容 |
|---|---|---|
| `te-kudasai` | てください / てもいい / てはいけない | 請求 / 許可 / 禁止 |
| `nakute-mo-ii` | なくてもいい（不必）| 不必做 |
| `te-morau` | てもらう / てくれる / てあげる | 授受表現 |
| `to-omou` | と思う / と言う（引用・意見）| 引用句型 |

每章都按既有 schema：explanation / examples / pitfalls / drills / recommendedAfter。

## 為什麼是「參考章節」（no requiredForms）

練習引擎裡沒有對應「てください」這種句型本身的 targetForm — 句型是由 て形 等基礎變化堆出來的。PR #28 verb-types/masu 那次 Codex review 提醒過：**多章共用 requiredForms 會造成幻覺完成**（一次答對就把多章標完成）。

所以這 4 章採參考章節定位：
- 沒有自己的 requiredForms → 不會出現「完成」badge
- 每章的 drill 按鈕指向底層形變化（て形 / ない形 / 普通形）
- `recommendedAfter` 指向對應的既有章節，hint 自然引導學習者先打底再上句型

## i18n

**沒加任何新 key** — 4 章都複用既有的 `drillGodanTeTa` / `drillNegative` / `drillPlain`。

## 測試

新增 `renders the new sentence-pattern reference chapters and reaches their related drill`：斷言 4 章按鈕在清單裡、打開 て-family 章看到例句、點 drill 按鈕進入挑戰頁 + て形 練習。

## Test plan
- [x] `pnpm test` — 78/78 pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — clean (CSS unchanged, JS +5 kB 從新章節內容來)
- [x] `node scripts/check-exam-options.mjs` — 155/155, 0 problems
- [x] `git diff --check` — clean
- [ ] Manual：4 章按鈕都點得開、examples / pitfalls / drill 按鈕都正確 render、drill 點下去進挑戰頁

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Four new Japanese sentence-pattern lessons added: te-kudasai, nakute-mo-ii, te-morau, and to-omou patterns with example transformations and practice drills.

* **Tests**
  * Added test coverage to verify new lessons render correctly and drills function as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nurockplayer/Jabiko/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->