### PR TITLE
perf(home): precompute content-stats to de-eager the landing view (code-split prep 1/2)

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -2,22 +2,21 @@ import { AlertTriangle, ArrowRight, BookOpen } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
-import { buildExamQuestionPool } from "../domain/examBlocks";
-import { buildSentencePatternPool } from "../domain/sentencePatterns";
-import { jlptVocabulary } from "../domain/vocabulary-jlpt";
+import { CONTENT_STATS } from "../domain/contentStats";
 
-// Content-volume snapshot rendered above the entry cards. Computed
-// once at module load -- the underlying data (learningBlocks, exam
-// pool, sentence patterns, jlptVocabulary) is static at runtime and
-// only changes when a content batch ships, which rebuilds the bundle
-// anyway. Pre-computing avoids re-running buildExamQuestionPool on
-// every HomePanel render.
+// Content-volume snapshot rendered above the entry cards. The exam /
+// pattern / vocab counts come from CONTENT_STATS (hardcoded, drift-
+// guarded by contentStats.test.ts) so the eager home view never has to
+// import the heavy question-pool / vocabulary data modules -- that data
+// loads only when the learner enters the practice flow. Only `chapters`
+// is read live, from the lightweight learningBlocks module the home
+// progress badges already depend on.
 const HOME_CONTENT_STATS = {
   chapters: learningBlocks.filter((block) => block.group === "basic").length,
-  examItems: buildExamQuestionPool("all").length,
-  n1Grammar: buildExamQuestionPool("N1").filter((q) => q.promptLabel === "文法形式選擇").length,
-  patternChecks: buildSentencePatternPool().length,
-  vocab: jlptVocabulary.length
+  examItems: CONTENT_STATS.examItems,
+  n1Grammar: CONTENT_STATS.n1Grammar,
+  patternChecks: CONTENT_STATS.patternChecks,
+  vocab: CONTENT_STATS.vocab
 };
 
 // First view the learner lands on. Three layers:

--- a/src/domain/contentStats.test.ts
+++ b/src/domain/contentStats.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { CONTENT_STATS } from "./contentStats";
+import { buildExamQuestionPool } from "./examBlocks";
+import { buildSentencePatternPool } from "./sentencePatterns";
+import { jlptVocabulary } from "./vocabulary-jlpt";
+
+// Drift guard: CONTENT_STATS is hardcoded so the home view doesn't have
+// to import the heavy data modules (see contentStats.ts). This test is
+// what keeps the hardcoded numbers honest -- if a content batch changes
+// any count, this fails and the new number must be written into
+// contentStats.ts. It's free to import the heavy builders here; test
+// files are never part of the shipped bundle.
+describe("CONTENT_STATS", () => {
+  it("matches the live exam-pool item count", () => {
+    expect(CONTENT_STATS.examItems).toBe(buildExamQuestionPool("all").length);
+  });
+
+  it("matches the live N1 文法形式選擇 count", () => {
+    expect(CONTENT_STATS.n1Grammar).toBe(
+      buildExamQuestionPool("N1").filter((question) => question.promptLabel === "文法形式選擇").length
+    );
+  });
+
+  it("matches the live sentence-pattern count", () => {
+    expect(CONTENT_STATS.patternChecks).toBe(buildSentencePatternPool().length);
+  });
+
+  it("matches the live JLPT vocabulary count", () => {
+    expect(CONTENT_STATS.vocab).toBe(jlptVocabulary.length);
+  });
+});

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -1,0 +1,20 @@
+// Snapshot of the content-volume counts shown on the home dashboard.
+//
+// These are hardcoded numbers, NOT computed at runtime, on purpose: the
+// home screen is the eager landing view, and computing them live would
+// force it to statically import the heavy question-pool / vocabulary
+// data modules (examBlocks alone is ~288 KB) -- pulling all of that into
+// the initial bundle just to render a one-line stat strip. Hardcoding
+// lets the home view stay light; the heavy data is loaded only when the
+// learner actually enters the practice flow.
+//
+// The counts only change when a content batch ships (which rebuilds the
+// bundle anyway). `contentStats.test.ts` asserts these stay in sync with
+// the live builders, so any drift fails CI until the numbers are
+// updated here.
+export const CONTENT_STATS = {
+  examItems: 287,
+  n1Grammar: 109,
+  patternChecks: 32,
+  vocab: 579
+} as const;


### PR DESCRIPTION
## What

**Prep for the route-level code-split** (PR 1 of 2). `HomePanel` is the eager landing view, but it computed its content-volume strip by calling the live builders at module load:

```ts
examItems: buildExamQuestionPool("all").length,
n1Grammar: buildExamQuestionPool("N1").filter(...).length,
patternChecks: buildSentencePatternPool().length,
vocab: jlptVocabulary.length,
```

That statically pulled **`examBlocks` (~288 KB)**, `sentencePatterns`, and `jlptVocabulary` into the initial bundle — just to render five numbers on the home screen.

## Change

- New `src/domain/contentStats.ts` — a hardcoded `CONTENT_STATS` snapshot of those counts.
- New `src/domain/contentStats.test.ts` — a **drift guard**: asserts the snapshot equals the live builder counts. A content batch that changes any count fails CI until the number is updated. (Test files aren't bundled, so importing the heavy builders there is free.)
- `HomePanel` now imports only `learningBlocks` (already needed for the progress badges); the exam / vocab / pattern data modules leave its import graph.

## Why a separate PR (and why the bundle doesn't drop yet)

`examBlocks` still reaches the initial chunk through `usePracticeSession` and `MockExamPanel`, so the bundle is unchanged here (596 kB). This PR isolates the low-risk, zero-behaviour-change de-eagering of the landing view. **PR 2** lazy-loads `ChallengePanel` + `MockExamPanel` and lifts `progressAttempts` — at which point `examBlocks` finally leaves the initial chunk and first-load JS drops substantially.

## Impact

- **No behavioural change** — the home stats render the same numbers (287 exam items / 109 N1 grammar / 32 pattern checks / 579 vocab).

## Verification

- `tsc --noEmit` ✅
- `vitest run` ✅ **122/122** (4 new `contentStats` drift tests)
- `vite build` ✅
- `check:exam` ✅
