### PR TITLE
perf: lazy-load challenge + mock views — cut initial JS ~58% (code-split 2/2)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import App from "./App";
 
 function seedProgress(targetForms: string[]) {
@@ -30,6 +30,21 @@ async function gotoLearn(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe("App", () => {
+  // The challenge + mock views are React.lazy in App, and React.lazy only
+  // suspends on its first resolution. Prime both chunks once here so every
+  // test below renders them synchronously regardless of run order --
+  // otherwise whichever test first navigates to a view would run its
+  // synchronous assertions before the lazy chunk finished loading.
+  beforeAll(async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+    await user.click(screen.getByRole("button", { name: "模擬考" }));
+    await screen.findByRole("region", { name: "模擬考" });
+    unmount();
+  });
+
   afterEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("data-theme");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,28 @@
-import { useState } from "react";
+import { lazy, Suspense, useMemo, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
+import { countDueReviews } from "./domain/srs";
 import { copy, type Language } from "./i18n";
-import {
-  ChallengePanel,
-  HomePanel,
-  LearningPanel,
-  MockExamPanel,
-  RulesPanel
-} from "./components";
+import { HomePanel, LearningPanel, RulesPanel } from "./components";
 import { useTheme } from "./hooks/useTheme";
-import { usePracticeSession } from "./hooks/usePracticeSession";
+import { useProgressAttempts } from "./hooks/useProgressAttempts";
+import type { SessionInit } from "./hooks/usePracticeSession";
 import "./styles.css";
+
+// Lazy routes. The challenge view owns the practice engine, which
+// statically imports the entire question bank (examBlocks alone is
+// ~288 KB); the mock-exam picker reads the exam pool too. Loading them
+// with React.lazy keeps that data out of the initial bundle -- it's
+// fetched only when the learner actually opens those views. They're
+// imported straight from their modules (not the components barrel) on
+// purpose; see components/index.ts.
+const ChallengePanel = lazy(() =>
+  import("./components/ChallengePanel").then((module) => ({ default: module.ChallengePanel }))
+);
+const MockExamPanel = lazy(() =>
+  import("./components/MockExamPanel").then((module) => ({ default: module.MockExamPanel }))
+);
 
 type AppView = "home" | "learn" | "rules" | "challenge" | "mock";
 type DrillPreset = LearningBlockDrillPreset;
@@ -26,38 +36,37 @@ export default function App() {
   const t = copy[language];
 
   const { theme, toggleTheme } = useTheme();
-  const session = usePracticeSession(language);
-  const {
-    reviewQueue,
-    progressAttempts,
-    setPartOfSpeech,
-    setVerbGroup,
-    setTargetForm,
-    setPracticeFocus,
-    setPracticeMode,
-    setPracticeFilter,
-    resetSession
-  } = session;
+  const { progressAttempts, recordAttempt } = useProgressAttempts();
+  // Lightweight, pool-free count for the home/learn review badge (see
+  // countDueReviews). The full review queue -- which needs the question
+  // pool to resolve due items -- is built inside the lazy challenge view.
+  const reviewCount = useMemo(() => countDueReviews(progressAttempts), [progressAttempts]);
+  // The drill the challenge view starts with on its next mount. Set by
+  // the "start X" actions just before navigating; undefined = the default
+  // basic drill. Read once when ChallengePanel mounts (it owns the
+  // session), so changing it while already in the challenge is a no-op.
+  const [launch, setLaunch] = useState<SessionInit | undefined>(undefined);
 
   const themeToggleLabel = theme === "dark" ? t.themeLight : t.themeDark;
   const ThemeIcon = theme === "dark" ? Sun : Moon;
 
-  const startDrill = (preset: DrillPreset) => {
-    setPracticeMode("basic");
-    setPracticeFilter({});
-    setPartOfSpeech(preset.partOfSpeech);
-    setVerbGroup(preset.verbGroup ?? "all");
-    setPracticeFocus(preset.practiceFocus);
-    setTargetForm(preset.targetForm);
-    resetSession();
+  const openChallenge = (request?: SessionInit) => {
+    setLaunch(request);
     setAppView("challenge");
   };
 
+  const startDrill = (preset: DrillPreset) => {
+    openChallenge({
+      mode: "basic",
+      partOfSpeech: preset.partOfSpeech,
+      verbGroup: preset.verbGroup ?? "all",
+      practiceFocus: preset.practiceFocus,
+      targetForm: preset.targetForm
+    });
+  };
+
   const startPatternDrill = (patternIds: SentencePatternId[]) => {
-    setPracticeMode("pattern");
-    setPracticeFilter({ patternIds });
-    resetSession();
-    setAppView("challenge");
+    openChallenge({ mode: "pattern", filter: { patternIds } });
   };
 
   return (
@@ -101,7 +110,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "challenge" ? "selected" : ""}
-          onClick={() => setAppView("challenge")}
+          onClick={() => openChallenge()}
         >
           {t.challenge}
         </button>
@@ -118,55 +127,54 @@ export default function App() {
         <HomePanel
           language={language}
           progressAttempts={progressAttempts}
-          reviewCount={reviewQueue.length}
-          onNavigate={(target) => setAppView(target)}
-          onStartReview={() => {
-            setPracticeMode("review");
-            setPracticeFilter({});
-            resetSession();
-            setAppView("challenge");
-          }}
-          onStartVocab={() => {
-            setPracticeMode("vocab");
-            setPracticeFilter({});
-            resetSession();
-            setAppView("challenge");
-          }}
+          reviewCount={reviewCount}
+          onNavigate={(target) => (target === "challenge" ? openChallenge() : setAppView(target))}
+          onStartReview={() => openChallenge({ mode: "review" })}
+          onStartVocab={() => openChallenge({ mode: "vocab" })}
         />
       ) : appView === "learn" ? (
         <LearningPanel
           language={language}
           progressAttempts={progressAttempts}
-          reviewCount={reviewQueue.length}
-          onStartChallenge={() => setAppView("challenge")}
-          onStartReview={() => {
-            setPracticeMode("review");
-            setPracticeFilter({});
-            resetSession();
-            setAppView("challenge");
-          }}
+          reviewCount={reviewCount}
+          onStartChallenge={() => openChallenge()}
+          onStartReview={() => openChallenge({ mode: "review" })}
           onStartDrill={startDrill}
           onStartPatternDrill={startPatternDrill}
         />
       ) : appView === "rules" ? (
         <RulesPanel language={language} />
       ) : appView === "mock" ? (
-        <MockExamPanel
-          language={language}
-          onStartSection={(level, promptLabel) => {
-            setPracticeMode("exam");
-            setPracticeFilter({ examSection: { level, promptLabel } });
-            resetSession();
-            setAppView("challenge");
-          }}
-        />
+        <Suspense fallback={<PanelFallback label={t.loading} />}>
+          <MockExamPanel
+            language={language}
+            onStartSection={(level, promptLabel) =>
+              openChallenge({ mode: "exam", filter: { examSection: { level, promptLabel } } })
+            }
+          />
+        </Suspense>
       ) : (
-        <ChallengePanel
-          session={session}
-          language={language}
-          onExit={() => setAppView("home")}
-        />
+        <Suspense fallback={<PanelFallback label={t.loading} />}>
+          <ChallengePanel
+            init={launch}
+            progressAttempts={progressAttempts}
+            recordAttempt={recordAttempt}
+            language={language}
+            onExit={() => setAppView("home")}
+          />
+        </Suspense>
       )}
     </main>
+  );
+}
+
+// Suspense placeholder while a lazy view chunk loads. Sized minimally;
+// the chunks are small enough that on a warm cache this is a single
+// frame, but it keeps the layout from collapsing on first open.
+function PanelFallback({ label }: { label: string }) {
+  return (
+    <div className="panel-loading" role="status" aria-live="polite">
+      {label}
+    </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,14 @@ export default function App() {
   const ThemeIcon = theme === "dark" ? Sun : Moon;
 
   const openChallenge = (request?: SessionInit) => {
+    // `request` seeds the session when ChallengePanel MOUNTS (its
+    // usePracticeSession reads init via useState initializers). Every
+    // init-carrying caller fires from a non-challenge panel (home /
+    // learn / mock), so navigating in always mounts ChallengePanel fresh
+    // and the seed applies. Don't call this with a non-undefined request
+    // from INSIDE the challenge view -- the panel is already mounted, so
+    // the seed would be silently ignored. (The nav-bar 挑戰 button calls
+    // it with no request, which is a deliberate no-op when already there.)
     setLaunch(request);
     setAppView("challenge");
   };

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -1,12 +1,12 @@
 import { ArrowRight, BookOpen, Eye, GraduationCap, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../i18n";
-import type { PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
+import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
 import { DarumaSpot, PaperNoteSpot, TeaCupSpot } from "../illustrations";
 import { ExamPrompt } from "./ExamPrompt";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { SpeakButton } from "./SpeakButton";
 import type { Feedback } from "./types";
-import type { PracticeMode, PracticeSession } from "../hooks/usePracticeSession";
+import { usePracticeSession, type PracticeMode, type SessionInit } from "../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
 
@@ -58,20 +58,28 @@ function partOfSpeechLabel(partOfSpeech: PartOfSpeech, language: Language): stri
 }
 
 // The challenge workspace: the three-column practice layout (mode/setup
-// controls, the active drill, and the running mistake list). All session
-// state + handlers come from usePracticeSession via the `session` prop;
-// `onExit` returns to the home dashboard from the review completion /
-// empty screens.
+// controls, the active drill, and the running mistake list). This is the
+// lazily-loaded view that owns the practice session -- usePracticeSession
+// (and the heavy question-data it imports) only loads when the learner
+// enters the challenge. `init` is the launch request (which drill to
+// start); `progressAttempts` / `recordAttempt` are the App-owned attempt
+// history; `onExit` returns to the home dashboard from the review
+// completion / empty screens.
 export function ChallengePanel({
-  session,
+  init,
+  progressAttempts,
+  recordAttempt,
   language,
   onExit
 }: {
-  session: PracticeSession;
+  init?: SessionInit;
+  progressAttempts: Attempt[];
+  recordAttempt: (attempt: Attempt) => void;
   language: Language;
   onExit: () => void;
 }) {
   const t = copy[language];
+  const session = usePracticeSession({ language, init, progressAttempts, recordAttempt });
   const {
     partOfSpeech,
     verbGroup,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,10 +1,12 @@
-// Barrel for the view panels + leaf presentational components extracted
-// from App.tsx. Keeps App's import list short; add future components here.
-export { ChallengePanel } from "./ChallengePanel";
+// Barrel for the EAGERLY-loaded view panels + leaf presentational
+// components. ChallengePanel and MockExamPanel are intentionally NOT
+// re-exported here: they pull in the heavy question-pool data, so App
+// lazy-loads them with React.lazy directly from their modules. Listing
+// them in this barrel would make that data eager again (any App import
+// from the barrel would drag them into the initial bundle).
 export { HomePanel } from "./HomePanel";
 export { LearningPanel } from "./LearningPanel";
 export { RulesPanel } from "./RulesPanel";
-export { MockExamPanel } from "./MockExamPanel";
 export { ExamPrompt } from "./ExamPrompt";
 export { FeedbackPanel } from "./FeedbackPanel";
 export { SpeakButton } from "./SpeakButton";

--- a/src/domain/srs.ts
+++ b/src/domain/srs.ts
@@ -125,6 +125,27 @@ export function getDueQuestions(
 }
 
 /**
+ * Count items currently due (dueAt <= now), WITHOUT a question pool.
+ *
+ * This is the lightweight count behind the home/learn "N 個等待複習"
+ * badge. getDueQuestions needs the full question pool to return the
+ * actual review items (and to drop states whose question no longer
+ * exists), but the badge only needs a number -- and forcing the pool
+ * just for a count would pull the heavy question-data modules into the
+ * eager initial bundle. The trade-off: this can include a state whose
+ * question was since removed from the bank (a stale +1 until that item
+ * ages out), which is acceptable for a nudge.
+ */
+export function countDueReviews(attempts: Attempt[], now: number = Date.now()): number {
+  const states = computeReviewStates(attempts);
+  let count = 0;
+  for (const state of states.values()) {
+    if (state.dueAt <= now) count++;
+  }
+  return count;
+}
+
+/**
  * Count items scheduled to come due within the next `daysAhead` days.
  * Excludes items already due (those go to getDueQuestions). Useful for
  * "X coming up this week" forward-looking UI if we ever add it.

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -15,7 +15,6 @@ import {
   selectQuestion,
   shuffleQuestions
 } from "../domain/practice";
-import { createAttemptStore } from "../domain/storage";
 import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
 import { vocabulary } from "../domain/vocabulary";
 import { jlptVocabulary } from "../domain/vocabulary-jlpt";
@@ -29,6 +28,20 @@ export type PracticeFilter = {
   // Narrows exam mode to one JLPT section (by level + promptLabel), set
   // when the learner taps a section card in the 模擬考 picker.
   examSection?: { level: MockExamLevel; promptLabel: string };
+};
+
+// Initial configuration the challenge view is launched with. App sets
+// this (the "launch request") when the learner taps a learning-block
+// drill, a mock section, or a review/vocab entry, then mounts the lazy
+// ChallengePanel; usePracticeSession seeds its initial state from it.
+// Undefined / empty -> the default basic drill (verb · godan · て形).
+export type SessionInit = {
+  mode?: PracticeMode;
+  filter?: PracticeFilter;
+  partOfSpeech?: PartOfSpeech | "mixed";
+  verbGroup?: VerbGroup | "all";
+  practiceFocus?: PracticeFocus;
+  targetForm?: TargetForm;
 };
 
 const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; verbOnly?: boolean }> = [
@@ -54,30 +67,43 @@ const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; ver
   }
 ];
 
-const attemptStore = createAttemptStore();
-
 function uniqueForms(forms: TargetForm[]): TargetForm[] {
   return Array.from(new Set(forms));
 }
 
-// The stateful core of the practice experience: owns all session state
-// (mode / filters / current question / feedback / score), derives the
-// active question pool, and exposes the handlers the challenge view binds
-// to. Extracted from App so App is just the shell + view router.
-// `language` feeds the focus-summary copy lookups.
-export function usePracticeSession(language: Language) {
-  const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | "mixed">("verb");
-  const [verbGroup, setVerbGroup] = useState<VerbGroup | "all">("godan");
-  const [targetForm, setTargetForm] = useState<TargetForm>("te");
-  const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>("single");
-  const [practiceMode, setPracticeMode] = useState<PracticeMode>("basic");
-  const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>({});
+// The stateful core of the practice experience: owns all in-session
+// state (mode / filters / current question / feedback / score), derives
+// the active question pool, and exposes the handlers the challenge view
+// binds to. Lives in the lazily-loaded ChallengePanel so the heavy
+// question-data modules it imports stay out of the initial bundle.
+//   - `init` seeds the initial drill config (the launch request).
+//   - `progressAttempts` / `recordAttempt` are owned by App
+//     (useProgressAttempts) so the always-mounted home/learn dashboards
+//     can read history without loading this hook; we read it for the
+//     review queue and append to it on each answer.
+//   - `language` feeds the focus-summary copy lookups.
+export function usePracticeSession({
+  language,
+  init,
+  progressAttempts,
+  recordAttempt
+}: {
+  language: Language;
+  init?: SessionInit;
+  progressAttempts: Attempt[];
+  recordAttempt: (attempt: Attempt) => void;
+}) {
+  const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | "mixed">(init?.partOfSpeech ?? "verb");
+  const [verbGroup, setVerbGroup] = useState<VerbGroup | "all">(init?.verbGroup ?? "godan");
+  const [targetForm, setTargetForm] = useState<TargetForm>(init?.targetForm ?? "te");
+  const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>(init?.practiceFocus ?? "single");
+  const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "basic");
+  const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>(init?.filter ?? {});
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback>(null);
   const [attempts, setAttempts] = useState<Attempt[]>([]);
-  const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
   const startedAtRef = useRef(Date.now());
   const nextButtonRef = useRef<HTMLButtonElement>(null);
   const t = copy[language];
@@ -323,8 +349,7 @@ export function usePracticeSession(language: Language) {
 
     const attempt = scoreAttempt(currentQuestion, choice, startedAtRef.current);
     setAttempts((current) => [...current, attempt]);
-    setProgressAttempts((current) => [...current, attempt]);
-    attemptStore.add(attempt);
+    recordAttempt(attempt);
     setFeedback({ status: attempt.isCorrect ? "correct" : "incorrect", question: currentQuestion });
   };
 
@@ -352,8 +377,7 @@ export function usePracticeSession(language: Language) {
     const attempt = scoreAttempt(currentQuestion, "", startedAtRef.current);
     const missedAttempt = { ...attempt, isCorrect: false, submittedAnswer: "(revealed)" };
     setAttempts((current) => [...current, missedAttempt]);
-    setProgressAttempts((current) => [...current, missedAttempt]);
-    attemptStore.add(missedAttempt);
+    recordAttempt(missedAttempt);
     setSelectedChoice(null);
     setFeedback({ status: "revealed", question: currentQuestion });
   };
@@ -375,7 +399,6 @@ export function usePracticeSession(language: Language) {
     selectedChoice,
     feedback,
     attempts,
-    progressAttempts,
     setPartOfSpeech,
     setVerbGroup,
     setTargetForm,

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { createAttemptStore } from "../domain/storage";
 import type { Attempt } from "../domain/types";
 
@@ -15,10 +15,13 @@ const attemptStore = createAttemptStore();
 export function useProgressAttempts() {
   const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
 
-  const recordAttempt = (attempt: Attempt) => {
+  // Stable identity (setProgressAttempts is stable; attemptStore is a
+  // module singleton) so passing it down to the challenge view doesn't
+  // change on every answer.
+  const recordAttempt = useCallback((attempt: Attempt) => {
     setProgressAttempts((current) => [...current, attempt]);
     attemptStore.add(attempt);
-  };
+  }, []);
 
   return { progressAttempts, recordAttempt };
 }

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { createAttemptStore } from "../domain/storage";
+import type { Attempt } from "../domain/types";
+
+// One persistent attempt store for the app session.
+const attemptStore = createAttemptStore();
+
+// Owns the lifetime attempt history (loaded from storage on mount,
+// appended on every answer). Lifted OUT of usePracticeSession so it can
+// live in the always-mounted App shell: the home/learn dashboards read
+// it for progress + the review badge, while the lazily-loaded challenge
+// view only needs to append to it via recordAttempt. Keeping it here is
+// also what lets usePracticeSession (and the heavy question-pool data it
+// imports) stay out of the initial bundle.
+export function useProgressAttempts() {
+  const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
+
+  const recordAttempt = (attempt: Attempt) => {
+    setProgressAttempts((current) => [...current, attempt]);
+    attemptStore.add(attempt);
+  };
+
+  return { progressAttempts, recordAttempt };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,6 +10,7 @@ export type Copy = {
   themeLight: string;
   themeDark: string;
   flowLabel: string;
+  loading: string;
   home: string;
   learn: string;
   rules: string;
@@ -153,6 +154,7 @@ export const copy: Record<Language, Copy> = {
     themeLight: "淺色模式",
     themeDark: "深色模式",
     flowLabel: "學習流程",
+    loading: "載入中…",
     home: "首頁",
     learn: "學習",
     rules: "規則表",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1447,6 +1447,17 @@ select:disabled {
   color: var(--muted);
 }
 
+/* Suspense fallback shown while a lazy view chunk (challenge / mock)
+ * loads. Keeps the area from collapsing so the layout doesn't jump when
+ * the real panel swaps in. */
+.panel-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 18rem;
+  color: var(--muted);
+}
+
 .review-done {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

**The first-load win** (PR 2 of 2, follows #40). Lazy-load the challenge + mock views so the 288 KB exam bank and the practice engine load only when the learner opens them.

## Before / after (`vite build`)

| Chunk | Before | After |
|---|---|---|
| **initial `index.js`** | 596 kB (gz 180) | **252 kB (gz 80)** |
| `examBlocks.js` | _(in initial)_ | 255 kB (gz 71) · lazy |
| `ChallengePanel.js` | _(in initial)_ | 85 kB (gz 29) · lazy |
| `MockExamPanel.js` | _(in initial)_ | 5 kB (gz 1.6) · lazy |

Initial JS drops **~58%** (gzip 180 → 80 kB). The `(!) chunk > 500 kB` warning is gone.

## How

`App` called `usePracticeSession` unconditionally (for the review badge), and that hook statically imports the question bank — so the exam data shipped on the home screen. Breaking that eager chain:

- **`ChallengePanel` + `MockExamPanel` are now `React.lazy`** (imported directly, dropped from the barrel so they aren't re-pulled into the initial chunk). `ChallengePanel` now *owns* `usePracticeSession`.
- **`progressAttempts` lifted to App** via a new lightweight `useProgressAttempts` (storage + types only), so the always-mounted home/learn dashboards read history without loading the engine. The lazy session reads it for the review queue and appends via `recordAttempt`.
- **Review badge → `countDueReviews`** (new in `srs.ts`): a pool-free due count. It can over-count a since-removed question until it ages out — fine for a badge; the in-review queue stays pool-accurate.
- **Launch config**: the "start drill / open challenge" actions set a `SessionInit` that seeds the session on mount, instead of poking setters before navigating.
- Suspense fallbacks (`.panel-loading` + i18n `loading`) cover the chunk loads.

## Behaviour note

Leaving the challenge view and returning now starts a **fresh session** rather than resuming the previous one — the view unmounts when inactive, which is inherent to loading the engine on demand. (Drill launches already reset the session, so this only affects nav-away-and-back mid-drill.) The full App integration suite passes unchanged.

## Tests

`App.test.tsx` primes the two lazy chunks once in `beforeAll` (React.lazy only suspends on first resolution), so the existing synchronous assertions hold.

## Verification

- `tsc --noEmit` ✅
- `vitest run` ✅ **122/122**
- `check:exam` ✅
- `vite build` ✅ (chunks above; no size warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented visual loading indicators for challenge and mock exam views to provide feedback when navigating between practice features.
  * Enhanced performance by optimizing how views load, resulting in smoother transitions and more responsive interactions during practice sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->