### PR TITLE
feat: 今日練習 (daily mix) — one-tap due-first + mixed-section session

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -441,6 +441,19 @@ describe("App", () => {
     expect(screen.queryByText(/やいなや/)).not.toBeInTheDocument();
   });
 
+  it("starts a 今日練習 session from the home entry", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    // The prominent home CTA launches the mixed daily session.
+    await user.click(screen.getByRole("button", { name: /開始今日練習/ }));
+
+    // Lands in the challenge view with a question and the 今日練習 mode
+    // card selected.
+    await screen.findByRole("region", { name: "目前題目" });
+    expect(screen.getByRole("button", { name: /今日練習/ })).toHaveClass("selected");
+  });
+
   it("mock exam is a section picker that launches a filtered exam drill", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ export default function App() {
           onNavigate={(target) => (target === "challenge" ? openChallenge() : setAppView(target))}
           onStartReview={() => openChallenge({ mode: "review" })}
           onStartVocab={() => openChallenge({ mode: "vocab" })}
+          onStartDaily={() => openChallenge({ mode: "daily" })}
         />
       ) : appView === "learn" ? (
         <LearningPanel

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -33,7 +33,7 @@ const formOptions: TargetForm[] = [
   "plainPastNegative"
 ];
 
-const practiceModeOrder: PracticeMode[] = ["basic", "cloze", "pattern", "exam", "vocab", "review"];
+const practiceModeOrder: PracticeMode[] = ["daily", "basic", "cloze", "pattern", "exam", "vocab", "review"];
 
 function choiceOptionClass(choice: string, selectedChoice: string | null, feedback: Feedback): string {
   const classes = ["choice-option"];
@@ -102,7 +102,7 @@ export function ChallengePanel({
     modeCounts,
     currentQuestion,
     reviewEmpty,
-    reviewExhausted,
+    sessionExhausted,
     choiceOptions,
     mistakeQuestions,
     correctCount,
@@ -136,7 +136,7 @@ export function ChallengePanel({
             const count =
               mode === "review"
                 ? reviewQueue.length
-                : mode === "basic"
+                : mode === "basic" || mode === "daily"
                 ? null
                 : modeCounts[mode];
             return (
@@ -326,15 +326,19 @@ export function ChallengePanel({
 
           {feedback ? <FeedbackPanel feedback={feedback} language={language} /> : null}
         </>
-      ) : reviewExhausted ? (
+      ) : sessionExhausted ? (
         <div className="empty-state review-done">
           <DarumaSpot />
-          <h2>{t.reviewDoneTitle}</h2>
-          <p>{t.reviewDoneBody(correctCount, attempts.length - correctCount)}</p>
+          <h2>{practiceMode === "daily" ? t.dailyDoneTitle : t.reviewDoneTitle}</h2>
+          <p>
+            {practiceMode === "daily"
+              ? t.dailyDoneBody(correctCount, attempts.length - correctCount)
+              : t.reviewDoneBody(correctCount, attempts.length - correctCount)}
+          </p>
           <div className="review-done-actions">
             <button className="next-button" type="button" onClick={resetSession}>
               <RotateCcw aria-hidden="true" />
-              {t.reviewDoneAgain}
+              {practiceMode === "daily" ? t.dailyDoneAgain : t.reviewDoneAgain}
             </button>
             <button className="ghost-button" type="button" onClick={onExit}>
               {t.reviewDoneExit}

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -341,7 +341,7 @@ export function ChallengePanel({
               {practiceMode === "daily" ? t.dailyDoneAgain : t.reviewDoneAgain}
             </button>
             <button className="ghost-button" type="button" onClick={onExit}>
-              {t.reviewDoneExit}
+              {practiceMode === "daily" ? t.dailyDoneExit : t.reviewDoneExit}
             </button>
           </div>
         </div>

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, ArrowRight, BookOpen } from "lucide-react";
+import { AlertTriangle, ArrowRight, BookOpen, CalendarCheck } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
@@ -35,7 +35,8 @@ export function HomePanel({
   reviewCount,
   onNavigate,
   onStartReview,
-  onStartVocab
+  onStartVocab,
+  onStartDaily
 }: {
   language: Language;
   progressAttempts: Attempt[];
@@ -43,6 +44,7 @@ export function HomePanel({
   onNavigate: (target: "learn" | "challenge" | "mock") => void;
   onStartReview: () => void;
   onStartVocab: () => void;
+  onStartDaily: () => void;
 }) {
   const t = copy[language];
 
@@ -83,6 +85,18 @@ export function HomePanel({
           <p>{t.homeHeroIntro}</p>
         </div>
       </header>
+
+      {/* Primary daily entry: the one-tap "今日練習" that builds a
+          due-reviews-first + mixed-section session. Top of the page so
+          it's the default action a returning learner reaches for. */}
+      <button type="button" className="home-banner home-banner-daily" onClick={onStartDaily}>
+        <CalendarCheck aria-hidden="true" />
+        <span className="home-banner-text">
+          <strong>{t.homeDailyMain}</strong>
+          <small>{t.homeDailySub}</small>
+        </span>
+        <ArrowRight aria-hidden="true" />
+      </button>
 
       {/* Content-volume strip: tells first-time visitors what they're
           walking into without resorting to SaaS-style metric tiles.

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -15,14 +15,14 @@ import {
   selectQuestion,
   shuffleQuestions
 } from "../domain/practice";
-import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
+import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "../domain/types";
 import { vocabulary } from "../domain/vocabulary";
 import { jlptVocabulary } from "../domain/vocabulary-jlpt";
 import { copy, type Language } from "../i18n";
 import type { Feedback } from "../components/types";
 
 export type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast";
-export type PracticeMode = "basic" | "cloze" | "pattern" | "exam" | "review" | "vocab";
+export type PracticeMode = "basic" | "cloze" | "daily" | "pattern" | "exam" | "review" | "vocab";
 export type PracticeFilter = {
   patternIds?: SentencePatternId[];
   // Narrows exam mode to one JLPT section (by level + promptLabel), set
@@ -69,6 +69,36 @@ const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; ver
 
 function uniqueForms(forms: TargetForm[]): TargetForm[] {
   return Array.from(new Set(forms));
+}
+
+const DAILY_TARGET = 20;
+
+// Builds the "今日練習" set: due SRS reviews first (capped at half so a
+// big backlog still leaves room for variety), then an even, de-clustered
+// mix of fresh exam + vocab items to fill out the session. It's a FINITE
+// pass -- the learner works through the set once and gets a completion
+// screen, same as review mode. v1 is an even mix; weighting toward the
+// learner's weak sections is a follow-up (needs attempt metadata).
+function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
+  const dueTake = due.slice(0, Math.ceil(DAILY_TARGET / 2));
+  const dueIds = new Set(dueTake.map((question) => question.id));
+  const fresh = shuffleQuestions(
+    [
+      ...buildExamQuestionPool(),
+      ...buildQuestionPool(jlptVocabulary, {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["reading"]
+      })
+    ].filter((question) => !dueIds.has(question.id))
+  ).slice(0, DAILY_TARGET - dueTake.length);
+  // De-cluster by section/type so consecutive questions aren't all the
+  // same kind (exam items carry promptLabel; vocab falls back to its
+  // targetForm, "reading").
+  return reduceAdjacentClusters(
+    [...dueTake, ...fresh],
+    (question) => question.promptLabel ?? question.targetForm
+  );
 }
 
 // The stateful core of the practice experience: owns all in-session
@@ -121,8 +151,9 @@ export function usePracticeSession({
   const isPatternFocus = practiceMode === "pattern";
   const isReviewFocus = practiceMode === "review";
   const isVocabFocus = practiceMode === "vocab";
+  const isDailyFocus = practiceMode === "daily";
   const isCuratedFocus =
-    isExamFocus || isClozeFocus || isPatternFocus || isReviewFocus || isVocabFocus;
+    isExamFocus || isClozeFocus || isPatternFocus || isReviewFocus || isVocabFocus || isDailyFocus;
 
   // Union pool used to materialise the review queue: any question the
   // learner has ever encountered (across exam / cloze / pattern / basic)
@@ -257,6 +288,12 @@ export function usePracticeSession({
         );
       }
 
+      if (isDailyFocus) {
+        // Snapshot the current due queue at session start (same as review
+        // mode); the live reviewQueue stays excluded from the deps below.
+        return composeDailySet(reviewQueue);
+      }
+
       return shuffleQuestions(
         buildQuestionPool(vocabulary, {
           partOfSpeech,
@@ -284,6 +321,7 @@ export function usePracticeSession({
       isPatternFocus,
       isReviewFocus,
       isVocabFocus,
+      isDailyFocus,
       practiceFilter.patternIds,
       practiceFilter.examSection,
       partOfSpeech,
@@ -292,18 +330,19 @@ export function usePracticeSession({
       sessionSeed
     ]
   );
-  // Review mode is a FINITE pass over the currently-due snapshot: walk
-  // each item once, no modulo wrap, then stop. Every other mode is an
-  // endless drill (modulo wrap via selectQuestion). Looping review would
-  // re-show items the learner just cleared -- exactly the "錯題一直輪迴"
-  // report. Correctly-answered items leave the SRS due set (next
-  // session), wrong ones reset to box 0 and return next session.
-  const currentQuestion = isReviewFocus
+  // Review and 今日練習 are FINITE passes over a snapshot: walk each item
+  // once, no modulo wrap, then stop (and show a completion screen). Every
+  // other mode is an endless drill (modulo wrap via selectQuestion).
+  // Looping review would re-show items the learner just cleared -- exactly
+  // the "錯題一直輪迴" report. Correctly-answered items leave the SRS due
+  // set (next session), wrong ones reset to box 0 and return next session.
+  const isFinitePass = isReviewFocus || isDailyFocus;
+  const currentQuestion = isFinitePass
     ? questions[questionIndex] ?? null
     : selectQuestion(questions, questionIndex);
   const reviewEmpty = isReviewFocus && questions.length === 0;
-  const reviewExhausted =
-    isReviewFocus && questions.length > 0 && questionIndex >= questions.length;
+  const sessionExhausted =
+    isFinitePass && questions.length > 0 && questionIndex >= questions.length;
   const choiceOptions = useMemo(
     () => (currentQuestion ? buildChoiceOptions(currentQuestion, questions, questionIndex) : []),
     [currentQuestion, questionIndex, questions]
@@ -413,7 +452,7 @@ export function usePracticeSession({
     modeCounts,
     currentQuestion,
     reviewEmpty,
-    reviewExhausted,
+    sessionExhausted,
     choiceOptions,
     mistakeQuestions,
     correctCount,

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -107,13 +107,16 @@ function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
     freshSlots - vocabFresh.length
   );
 
-  // De-cluster by section/type so consecutive questions aren't all the
-  // same kind (exam items carry promptLabel; vocab falls back to its
-  // targetForm, "reading").
-  return reduceAdjacentClusters(
-    [...dueTake, ...vocabFresh, ...examFresh],
+  // De-cluster only the FRESH portion so consecutive fresh questions
+  // aren't all the same kind (exam items carry promptLabel; vocab falls
+  // back to its targetForm, "reading"). The due block stays first, in its
+  // most-overdue-first order -- declustering the whole set would let fresh
+  // items slip between due items and break the "reviews first" promise.
+  const fresh = reduceAdjacentClusters(
+    [...vocabFresh, ...examFresh],
     (question) => question.promptLabel ?? question.targetForm
   );
+  return [...dueTake, ...fresh];
 }
 
 // The stateful core of the practice experience: owns all in-session

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -72,31 +72,46 @@ function uniqueForms(forms: TargetForm[]): TargetForm[] {
 }
 
 const DAILY_TARGET = 20;
+// Reserve enough fresh vocab-reading items that their pool-based
+// distractors (drawn from same-targetForm peers within the session) can
+// always fill a full 4-option grid. Without this floor, a daily set that
+// happened to land only 1-2 vocab items would render those 漢字読み
+// questions with too few choices.
+const DAILY_VOCAB_MIN = Math.floor(DAILY_TARGET / 4);
 
 // Builds the "今日練習" set: due SRS reviews first (capped at half so a
-// big backlog still leaves room for variety), then an even, de-clustered
-// mix of fresh exam + vocab items to fill out the session. It's a FINITE
-// pass -- the learner works through the set once and gets a completion
-// screen, same as review mode. v1 is an even mix; weighting toward the
-// learner's weak sections is a follow-up (needs attempt metadata).
+// big backlog still leaves room for variety), then a de-clustered mix of
+// fresh vocab (a reserved minimum) + exam items to fill out the session.
+// It's a FINITE pass -- the learner works through the set once and gets a
+// completion screen, same as review mode. v1 is an even mix; weighting
+// toward the learner's weak sections is a follow-up (needs attempt
+// metadata).
 function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
   const dueTake = due.slice(0, Math.ceil(DAILY_TARGET / 2));
-  const dueIds = new Set(dueTake.map((question) => question.id));
-  const fresh = shuffleQuestions(
-    [
-      ...buildExamQuestionPool(),
-      ...buildQuestionPool(jlptVocabulary, {
-        partOfSpeech: "mixed",
-        verbGroup: "all",
-        targetForms: ["reading"]
-      })
-    ].filter((question) => !dueIds.has(question.id))
-  ).slice(0, DAILY_TARGET - dueTake.length);
+  // Exclude EVERY due item from the fresh pools -- not just the capped
+  // slice -- so an over-cap due item can't slip back in mislabelled as a
+  // fresh question (which would drop its most-overdue-first SRS ordering).
+  const dueIds = new Set(due.map((question) => question.id));
+  const isFresh = (question: PracticeQuestion) => !dueIds.has(question.id);
+  const freshSlots = DAILY_TARGET - dueTake.length;
+
+  const vocabFresh = shuffleQuestions(
+    buildQuestionPool(jlptVocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"]
+    }).filter(isFresh)
+  ).slice(0, Math.min(DAILY_VOCAB_MIN, freshSlots));
+  const examFresh = shuffleQuestions(buildExamQuestionPool().filter(isFresh)).slice(
+    0,
+    freshSlots - vocabFresh.length
+  );
+
   // De-cluster by section/type so consecutive questions aren't all the
   // same kind (exam items carry promptLabel; vocab falls back to its
   // targetForm, "reading").
   return reduceAdjacentClusters(
-    [...dueTake, ...fresh],
+    [...dueTake, ...vocabFresh, ...examFresh],
     (question) => question.promptLabel ?? question.targetForm
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -142,6 +142,7 @@ export type Copy = {
   dailyDoneTitle: string;
   dailyDoneBody: (cleared: number, remaining: number) => string;
   dailyDoneAgain: string;
+  dailyDoneExit: string;
   speakAriaLabel: string;
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
@@ -317,6 +318,7 @@ export const copy: Record<Language, Copy> = {
     dailyDoneBody: (cleared, remaining) =>
       `今天練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，下次複習時會再出現。`,
     dailyDoneAgain: "再練一組",
+    dailyDoneExit: "回首頁",
     speakAriaLabel: "朗讀日文",
     partOfSpeech: {
       verb: "動詞",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -315,7 +315,7 @@ export const copy: Record<Language, Copy> = {
     reviewDoneExit: "回首頁",
     dailyDoneTitle: "今日練習完成！",
     dailyDoneBody: (cleared, remaining) =>
-      `今天練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，明天再出現。`,
+      `今天練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，下次複習時會再出現。`,
     dailyDoneAgain: "再練一組",
     speakAriaLabel: "朗讀日文",
     partOfSpeech: {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -30,6 +30,8 @@ export type Copy = {
   homeBannerReviewSub: string;
   homeBannerContinueMain: (chapter: string) => string;
   homeBannerContinueSub: string;
+  homeDailyMain: string;
+  homeDailySub: string;
   homeStatsLabel: string;
   homeStatsAttempts: string;
   homeStatsAccuracy: string;
@@ -118,7 +120,7 @@ export type Copy = {
   revealed: string;
   answerKey: string;
   focusSummaryEmpty: string;
-  modeOptions: Record<"basic" | "cloze" | "exam" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
+  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
   homeCardVocabTitle: string;
   homeCardVocabSub: string;
@@ -137,6 +139,9 @@ export type Copy = {
   reviewDoneBody: (cleared: number, remaining: number) => string;
   reviewDoneAgain: string;
   reviewDoneExit: string;
+  dailyDoneTitle: string;
+  dailyDoneBody: (cleared: number, remaining: number) => string;
+  dailyDoneAgain: string;
   speakAriaLabel: string;
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
@@ -176,6 +181,8 @@ export const copy: Record<Language, Copy> = {
     homeBannerReviewSub: "跨 session 累積的錯題，答對才會移出。",
     homeBannerContinueMain: (chapter) => `繼續學：${chapter}`,
     homeBannerContinueSub: "上次還沒完成的章節。",
+    homeDailyMain: "開始今日練習",
+    homeDailySub: "先清到期複習，再混合文法・語順・漢字読み練一輪。",
     homeStatsLabel: "整體進度",
     homeStatsAttempts: "累積已答",
     homeStatsAccuracy: "總正答率",
@@ -280,6 +287,7 @@ export const copy: Record<Language, Copy> = {
     answerKey: "正解",
     focusSummaryEmpty: "目前重點沒有可用形",
     modeOptions: {
+      daily: { title: "今日練習", subtitle: "複習優先 · 文法 / 語順 / 漢字読み混合一輪" },
       basic: { title: "基礎變化", subtitle: "詞類變化練習 · 課本詞彙" },
       cloze: { title: "句中填空", subtitle: "N5 文型 · 〜てください / 〜たいです" },
       pattern: { title: "句型練習", subtitle: "N5/N4 句型判斷 · 視角 / 許可 / 引用 / 不必" },
@@ -305,6 +313,10 @@ export const copy: Record<Language, Copy> = {
       `這一輪複習了 ${cleared + remaining} 題，答對 ${cleared}、還要再練 ${remaining}。答對的會排到之後，答錯的下次複習會再出現。`,
     reviewDoneAgain: "再複習一輪",
     reviewDoneExit: "回首頁",
+    dailyDoneTitle: "今日練習完成！",
+    dailyDoneBody: (cleared, remaining) =>
+      `今天練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，明天再出現。`,
+    dailyDoneAgain: "再練一組",
     speakAriaLabel: "朗讀日文",
     partOfSpeech: {
       verb: "動詞",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1862,6 +1862,14 @@ select:disabled {
   color: var(--summary-text);
 }
 
+/* Primary daily-practice entry: matcha accent so it reads as the
+   headline action, distinct from the vermilion review banner. */
+.home-banner-daily {
+  background: color-mix(in srgb, var(--matcha) 12%, var(--paper));
+  border-color: color-mix(in srgb, var(--matcha) 45%, var(--panel-border));
+  color: var(--matcha-dark);
+}
+
 .home-banner-text {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

**今日練習 (daily mix) — v1.** A prominent one-tap entry on the home screen that builds a single finite practice set tuned for daily study:

1. **Due SRS reviews first** (capped at half the set, so a large backlog still leaves room for variety).
2. Filled out with an **even, de-clustered mix of fresh** items — exam 文法形式 / 文章脈絡 / 語順 / 漢字読み + vocab (~20 total).
3. Work through it once → **completion screen** (same finite-pass model as review mode), with "再練一組" to compose a fresh set.

## Why

You said daily practice is what you'll use most over the next few days. This makes the default action a single tap that blends spaced-repetition (due first) with broad exposure (mixed fresh), instead of manually picking a mode each time.

## How

- New `daily` `PracticeMode` + `composeDailySet()` in `usePracticeSession`. It reads the due queue + builds from the exam/vocab pools — and since `usePracticeSession` lives in the **lazy challenge chunk**, none of that touches the initial bundle.
- Finite-pass logic generalised from review-only to review **and** daily (`isFinitePass`; `reviewExhausted` → `sessionExhausted`). Completion copy switches on mode (今日練習完成 vs 複習完成).
- Daily shows up both as the **headline home CTA** (matcha banner) and as the **first card in the in-challenge mode toggle**.

## Scope (v1)

Even mix. **Weakness-weighting** (bias toward your weak sections) + the **弱點 dashboard** are the planned follow-up — they need the small `Attempt` metadata addition we discussed.

## Behaviour note

Daily is a finite pass (like review): leaving mid-set and returning starts a fresh set (consistent with the lazy-view session model).

## Verification

- `tsc --noEmit` ✅
- `vitest run` ✅ **131/131** (incl. a new daily-launch test)
- `check:exam` ✅ 8/8 (typed guard)
- `vite build` ✅ — initial chunk ~254 kB, `examBlocks` still a separate lazy chunk, no size warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Daily Practice" mode with a prominent home page banner for quick access. Daily practice sessions compile curated question sets combining recent reviews with fresh content.
  * Added dedicated completion screens with daily-specific messaging and navigation options.

* **Tests**
  * Added test coverage verifying Daily Practice initiates correctly from the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->