### PR TITLE
docs: repoint exam-guard references to corepack pnpm check:exam

### DIFF
--- a/docs/claude-exam-batch-2-short-prompt.md
+++ b/docs/claude-exam-batch-2-short-prompt.md
@@ -8,6 +8,6 @@
 - 同一個文法點可以重複，但必須是不同情境、不同語意線索、不同 distractor family；不要只因 `surface` 重複就跳過。
 - 優先匯入 6 題「文章脈絡」，再選 6-8 題「文法形式選擇」；「語順組合」因選項較長，匯入前要注意手機 UI。
 - 題目必須原創，不可抄官方、考古題、JLPT workbook 或網路題庫；公開來源只能參考題型和 coverage。
-- 匯入後跑 `node scripts/check-exam-options.mjs`、`corepack pnpm test`、`corepack pnpm build`。
+- 匯入後跑 `corepack pnpm check:exam`、`corepack pnpm test`、`corepack pnpm build`。
 
 PR summary 請列：匯入幾題、跳過/重寫哪些題、為什麼、驗證結果。

--- a/docs/claude-exam-grammar-review-prompt.md
+++ b/docs/claude-exam-grammar-review-prompt.md
@@ -74,7 +74,7 @@
 完成後至少跑：
 
 ```bash
-node scripts/check-exam-options.mjs
+corepack pnpm check:exam
 corepack pnpm test
 corepack pnpm build
 ```

--- a/docs/exam-grammar-original-question-list.md
+++ b/docs/exam-grammar-original-question-list.md
@@ -31,7 +31,7 @@ Implementation notes:
 - IDs use `candidate-...` to make it clear these are staging items.
   Rename before committing to `examBlocks.ts` if needed.
 - Keep `promptLabel` visible-level-free.
-- Run `node scripts/check-exam-options.mjs`, tests, and build after porting.
+- Run `corepack pnpm check:exam`, tests, and build after porting.
 
 ## N2 Candidates
 

--- a/docs/exam-grammar-rewrite-backlog.md
+++ b/docs/exam-grammar-rewrite-backlog.md
@@ -467,7 +467,7 @@ Use this prompt when asking Claude to implement a batch:
 - 優先 N1/N2，可少量 N3 但不要標示給使用者。
 
 完成後跑：
-- node scripts/check-exam-options.mjs
+- corepack pnpm check:exam
 - corepack pnpm test
 - corepack pnpm build
 
@@ -486,5 +486,5 @@ Before merging a grammar batch, review these:
 - Is `promptContextZh` allowed to be a full translation only after answer?
 - Does explanation teach the minimal-pair difference?
 - Are all options in a natural Japanese register?
-- Did `check-exam-options.mjs`, test, and build pass?
+- Did `check:exam`, test, and build pass?
 

--- a/docs/exam-public-practice-quality-review-and-batch-2.md
+++ b/docs/exam-public-practice-quality-review-and-batch-2.md
@@ -94,7 +94,7 @@ When importing:
 - Run:
 
 ```bash
-node scripts/check-exam-options.mjs
+corepack pnpm check:exam
 corepack pnpm test
 corepack pnpm build
 ```

--- a/scripts/add-n1-grammar-batch-2.mjs
+++ b/scripts/add-n1-grammar-batch-2.mjs
@@ -8,8 +8,8 @@
 //   - surface must NOT match any existing surface in examBlocks.ts
 //   - each item carries 4 options (1 correct + 3 distractors that are
 //     also real N1 patterns)
-//   - hintZh must pass scripts/check-exam-options.mjs (no token of
-//     length >= 2 from meaningZh appearing in hintZh)
+//   - hintZh must pass the content guard (corepack pnpm check:exam): no
+//     token of length >= 2 from meaningZh appearing in hintZh
 //   - explanation must say WHY each distractor is wrong (matches the
 //     PR #31 review bar Codex set on distractor quality)
 //

--- a/scripts/add-n1-grammar-batch-3.mjs
+++ b/scripts/add-n1-grammar-batch-3.mjs
@@ -3,7 +3,7 @@
 //   - 100% original, no third-party question bank used.
 //   - Each item has 4 options (1 correct + 3 real N1 distractors with
 //     explicit "why each is wrong" notes in the explanation).
-//   - hintZh passes the leak guard in scripts/check-exam-options.mjs.
+//   - hintZh passes the leak guard (corepack pnpm check:exam).
 //   - id starts with "n1-grammar-" and is unique across the bank.
 //   - surface does not duplicate any existing surface in examBlocks.
 //

--- a/scripts/add-n2-grammar-batch-1.mjs
+++ b/scripts/add-n2-grammar-batch-1.mjs
@@ -9,8 +9,8 @@
 //   - 4 options each (1 correct + 3 real patterns chosen so only one
 //     actually fits -- avoids the "two valid answers" trap), with the
 //     explanation saying why each distractor is wrong.
-//   - hintZh must pass scripts/check-exam-options.mjs (no >=2-char token
-//     from meaningZh may appear in hintZh).
+//   - hintZh must pass the content guard (corepack pnpm check:exam): no
+//     >=2-char token from meaningZh may appear in hintZh.
 //   - id unique, surface not already in the bank.
 //
 // Run: node scripts/add-n2-grammar-batch-1.mjs


### PR DESCRIPTION
Follow-up to #42 (Codex review). After deleting `scripts/check-exam-options.mjs` (now the typed `contentGuard.test.ts`), several docs and migration-script comments still pointed at `node scripts/check-exam-options.mjs` -- which now fails. Repointed all 8 references to `corepack pnpm check:exam`.

P2 (docs a future run would follow): claude-exam-batch-2-short-prompt, claude-exam-grammar-review-prompt, exam-public-practice-quality-review-and-batch-2, exam-grammar-rewrite-backlog, exam-grammar-original-question-list.
P3 (script header comments): add-n1-grammar-batch-2/3, add-n2-grammar-batch-1.

Docs/comments only -- no code change.