### PR TITLE
fix(exam): never show the surface/meaning row for exam items (pre-answer leak)

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ExamPrompt } from "./ExamPrompt";
+import { examStyleQuestions } from "../domain/examBlocks";
+import { buildClozeQuestionPool } from "../domain/cloze";
+import { clozeSentences } from "../domain/cloze-data";
+import { vocabulary } from "../domain/vocabulary";
+
+describe("ExamPrompt answer-leak guard", () => {
+  it("hides the surface・reading・meaning row for an exam item whose surface contains the answer", () => {
+    // n3-grammar-tahougaii: surface「たほうがいい」CONTAINS answer「ほうがいい」
+    // (the た already sits in the prompt「行った」). The old exact-match guard
+    // let the row through, so the pre-answer line spelled out the answer +
+    // its「比較好（建議）」gloss. The row must now be suppressed.
+    const item = examStyleQuestions.find((question) => question.id === "n3-grammar-tahougaii");
+    expect(item).toBeDefined();
+
+    const { container } = render(<ExamPrompt question={item!} language="zh-Hant" />);
+
+    // The prompt sentence and the neutral situation hint still render...
+    expect(screen.getByText(/病院へ行った/)).toBeInTheDocument();
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+    // ...but the leaky surface・reading・meaning vocab row is gone.
+    expect(container.querySelector("p.reading")).toBeNull();
+    expect(screen.queryByText(/たほうがいい/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/比較好（建議）/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the surface・reading・meaning row for cloze items", () => {
+    // For cloze items the surface is the dictionary form -- a legit "which
+    // verb" cue, not the answer -- so the row must still show.
+    const cloze = buildClozeQuestionPool(clozeSentences, vocabulary)[0];
+    const { container } = render(<ExamPrompt question={cloze} language="zh-Hant" />);
+
+    const vocabRow = container.querySelector("p.reading");
+    expect(vocabRow).not.toBeNull();
+    expect(vocabRow?.textContent).toContain(cloze.vocabulary.surface);
+  });
+});

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -12,19 +12,21 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
   // line. Skip the vocab row for those items -- the prompt label
   // already names the pattern.
   const isSentencePattern = question.vocabulary.tags?.includes("sentence_pattern");
-  // ANSWER-LEAK GUARD: for 文法形式選擇 items the surface IS the answer
-  // (e.g. surface「ものの」== the correct choice); for 漢字読み items the
-  // reading IS the answer (e.g. reading「とどこおって」). Rendering the
-  // surface・reading・meaning row pre-answer therefore hands the learner
-  // the answer. Only show that row when neither surface nor reading is
-  // one of the expected answers -- which keeps it for cloze items
-  // (待つ -> answer 待って, surface is a legit "which verb" hint) but
-  // hides it for grammar / kanji-reading. The full answer always shows
-  // post-answer in FeedbackPanel.
+  // ANSWER-LEAK GUARD. The surface・reading・meaning row is a genuine
+  // pre-answer hint for CLOZE items (待つ -> answer 待って: surface 待つ is a
+  // legit "which verb" cue). For EXAM-style items it is not: the synthetic
+  // vocabulary's surface IS the grammar pattern / target word and its
+  // meaningZh is the answer's own gloss, so showing it hands over the
+  // answer. An exact "surface ∈ answers" check isn't enough -- it misses
+  // cases where the surface only CONTAINS the answer (surface「たほうがいい」
+  // vs answer「ほうがいい」, the た already sitting in the prompt「行った」),
+  // which still spells it out. So hide the row for every exam-style item;
+  // the full answer + meaning always show post-answer in FeedbackPanel.
+  const isExamStyle = question.vocabulary.tags?.includes("exam_style");
   const answerSet = new Set(question.expectedAnswers);
   const vocabRowLeaksAnswer =
     answerSet.has(question.vocabulary.surface) || answerSet.has(question.vocabulary.reading);
-  const showVocabRow = !isSentencePattern && !vocabRowLeaksAnswer;
+  const showVocabRow = !isSentencePattern && !isExamStyle && !vocabRowLeaksAnswer;
   // Pre-answer Chinese: prefer the neutral hint when authored; fall back
   // to the full translation for items that haven't been audited yet
   // (legacy exam items). The full translation still appears in the


### PR DESCRIPTION
## Bug

In an exam question (第6題, `n3-grammar-tahougaii`), the **pre-answer** line spelled out the answer:

> 熱がありますね。早く病院へ行った ___
> 發燒時對就醫安排的判斷。
> **たほうがいい・たほうがいい・…比較好（建議）**   ← leak

That third line is `ExamPrompt`'s `surface・reading・meaning` vocab row. It handed over the answer (`ほうがいい`) and its「建議」function before the learner picked.

## Root cause

The leak guard only hid that row when `surface`/`reading` **exactly equalled** an expected answer. It caught `surface「ものの」== answer「ものの」`, but here `surface「たほうがいい」` only **contains** `answer「ほうがいい」` (the `た` already sits in the prompt `行った`), so it slipped through. This affects a whole class of exam items, not just this one (`這些`).

## Fix

For **exam-style** items the synthetic `vocabulary.surface` *is* the grammar pattern / target word and `meaningZh` *is* the answer's own gloss — so that row is never a useful pre-answer hint, only a leak. Hide it for every exam-style item (tagged `exam_style`).

- **Cloze items keep the row** — there the dictionary-form `surface` (待つ → answer 待って) is a legit "which verb" cue.
- The full answer + meaning + explanation still show **post-answer** in `FeedbackPanel`.

## Tests

New `src/components/ExamPrompt.test.tsx`:
- exam item whose surface contains the answer → vocab row **hidden** (prompt + neutral hint still render).
- cloze item → vocab row **kept**.

## Verification

- `tsc --noEmit` ✅
- `vitest run` ✅ **133/133** (incl. the new ExamPrompt tests; the existing exam-leak integration test still passes)
- `check:exam` ✅ 8/8
- `vite build` ✅ (initial chunk ~254 kB, examBlocks still lazy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exam-style answer protection by expanding vocabulary row suppression to all exam-style questions, ensuring consistent information hiding during exams.

* **Tests**
  * Added comprehensive test coverage for the answer-leak guard to verify vocabulary information is properly hidden across different exam-style question types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->