### PR TITLE
feat(feedback): explain reading + grammar distractors in the post-answer 解析

### DIFF
--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -324,7 +324,9 @@ export function ChallengePanel({
             </button>
           </div>
 
-          {feedback ? <FeedbackPanel feedback={feedback} language={language} /> : null}
+          {feedback ? (
+            <FeedbackPanel feedback={feedback} language={language} options={choiceOptions} />
+          ) : null}
         </>
       ) : sessionExhausted ? (
         <div className="empty-state review-done">

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeedbackPanel } from "./FeedbackPanel";
+import { buildQuestionPool } from "../domain/practice";
+import { jlptVocabulary } from "../domain/vocabulary-jlpt";
+import { lookupWordsByReading } from "../domain/readingLookup";
+
+const readingPool = buildQuestionPool(jlptVocabulary, {
+  partOfSpeech: "mixed",
+  verbGroup: "all",
+  targetForms: ["reading"]
+});
+
+describe("FeedbackPanel distractor gloss", () => {
+  it("lists each reading distractor with the word it reads, and marks non-existent readings", () => {
+    const question = readingPool[0];
+    const answer = question.expectedAnswers[0];
+    const realDistractor = readingPool
+      .map((q) => q.expectedAnswers[0])
+      .find((reading) => reading !== answer)!;
+    const fakeDistractor = "ぜったいにそんざいしないよみ";
+    const realWords = lookupWordsByReading(realDistractor);
+
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={[answer, realDistractor, fakeDistractor]}
+      />
+    );
+
+    const gloss = container.querySelector(".distractor-gloss");
+    expect(gloss).not.toBeNull();
+    const text = gloss?.textContent ?? "";
+    expect(text).toContain("其他選項");
+    // Real distractor reading shows the word it reads...
+    expect(realWords.length).toBeGreaterThan(0);
+    expect(text).toContain(`${realDistractor}（${realWords[0]}`);
+    // ...the made-up reading is marked as having no word...
+    expect(text).toContain("無對應詞");
+    // ...and the correct answer is not listed among the distractors.
+    expect(text).not.toContain(`${answer}（`);
+  });
+
+  it("renders no distractor gloss for non-reading questions", () => {
+    const question = { ...readingPool[0], targetForm: "te" as const };
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={["a", "b", "c"]}
+      />
+    );
+    expect(container.querySelector(".distractor-gloss")).toBeNull();
+  });
+});

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { buildQuestionPool } from "../domain/practice";
 import { jlptVocabulary } from "../domain/vocabulary-jlpt";
+import { examStyleQuestions } from "../domain/examBlocks";
 import { lookupWordsByReading } from "../domain/readingLookup";
+import { lookupPatternMeaning } from "../domain/patternMeaning";
 
 const readingPool = buildQuestionPool(jlptVocabulary, {
   partOfSpeech: "mixed",
@@ -40,6 +42,34 @@ describe("FeedbackPanel distractor gloss", () => {
     expect(text).toContain("無對應詞");
     // ...and the correct answer is not listed among the distractors.
     expect(text).not.toContain(`${answer}（`);
+  });
+
+  it("glosses grammar distractors with each pattern's meaning (not 無對應詞)", () => {
+    // Grammar items default targetForm to "reading", so this also guards
+    // against the reading-gloss path firing for them.
+    const grammarItems = examStyleQuestions.filter((q) => q.promptLabel === "文法形式選擇");
+    const question = grammarItems[0];
+    const answer = question.expectedAnswers[0];
+    // Another grammar item's answer is a distractor the bank can gloss.
+    const other = grammarItems.find((g) => g.expectedAnswers[0] !== answer)!;
+    const distractor = other.expectedAnswers[0];
+    const meaning = lookupPatternMeaning(distractor);
+
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={[answer, distractor]}
+      />
+    );
+
+    const gloss = container.querySelector(".distractor-gloss");
+    expect(gloss).not.toBeNull();
+    const text = gloss?.textContent ?? "";
+    expect(meaning).not.toBeNull();
+    expect(text).toContain(`${distractor}（${meaning}`);
+    // Grammar patterns are real, so they must never be marked 無對應詞.
+    expect(text).not.toContain("無對應詞");
   });
 
   it("renders no distractor gloss for non-reading questions", () => {

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -1,21 +1,40 @@
 import { CheckCircle2, XCircle } from "lucide-react";
 import { copy, type Language } from "../i18n";
+import { lookupWordsByReading } from "../domain/readingLookup";
 import type { Feedback } from "./types";
 
 // Post-answer panel: shows correct/incorrect/revealed status, the
-// accepted answer(s), the explanation, and an example sentence.
+// accepted answer(s), the explanation, an example sentence, and -- for
+// reading drills -- what each distractor option actually was.
 export function FeedbackPanel({
   feedback,
-  language
+  language,
+  options
 }: {
   feedback: NonNullable<Feedback>;
   language: Language;
+  options: string[];
 }) {
   const t = copy[language];
   const isCorrect = feedback.status === "correct";
   const isRevealed = feedback.status === "revealed";
   const title = isCorrect ? t.correct : isRevealed ? t.revealed : t.incorrect;
   const Icon = isCorrect ? CheckCircle2 : XCircle;
+
+  // For reading drills the options are bare readings, so a wrong pick
+  // teaches nothing on its own. List each distractor with the word it
+  // reads (たいしょう -> 対象); mark any reading that matches no real word.
+  const isReading = feedback.question.targetForm === "reading";
+  const answers = new Set(feedback.question.expectedAnswers);
+  const distractorGloss = isReading
+    ? options
+        .filter((option) => !answers.has(option))
+        .map((reading) => {
+          const words = lookupWordsByReading(reading);
+          return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
+        })
+        .join("・")
+    : "";
 
   return (
     <section className={`feedback ${isCorrect ? "correct" : isRevealed ? "revealed" : "incorrect"}`} aria-live="polite">
@@ -25,6 +44,11 @@ export function FeedbackPanel({
       </div>
       <p className="answer-key">{t.answerKey}：{feedback.question.expectedAnswers.join(" / ")}</p>
       <p>{feedback.question.explanation}</p>
+      {distractorGloss ? (
+        <p className="distractor-gloss">
+          {t.feedbackOtherOptions}：{distractorGloss}
+        </p>
+      ) : null}
       {feedback.question.vocabulary.examples[0] ? (
         <p className="example">
           {feedback.question.vocabulary.examples[0].japanese}

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -1,11 +1,13 @@
 import { CheckCircle2, XCircle } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { lookupWordsByReading } from "../domain/readingLookup";
+import { lookupPatternMeaning } from "../domain/patternMeaning";
 import type { Feedback } from "./types";
 
 // Post-answer panel: shows correct/incorrect/revealed status, the
-// accepted answer(s), the explanation, an example sentence, and -- for
-// reading drills -- what each distractor option actually was.
+// accepted answer(s), the explanation, an example sentence, and -- where
+// it helps -- what each distractor option actually was (the word a
+// reading spells, or a grammar pattern's meaning).
 export function FeedbackPanel({
   feedback,
   language,
@@ -21,20 +23,39 @@ export function FeedbackPanel({
   const title = isCorrect ? t.correct : isRevealed ? t.revealed : t.incorrect;
   const Icon = isCorrect ? CheckCircle2 : XCircle;
 
-  // For reading drills the options are bare readings, so a wrong pick
-  // teaches nothing on its own. List each distractor with the word it
-  // reads (たいしょう -> 対象); mark any reading that matches no real word.
-  const isReading = feedback.question.targetForm === "reading";
+  // Annotate the distractors so a wrong pick teaches something. NOTE all
+  // exam items default targetForm to "reading", so we gate on promptLabel,
+  // not targetForm, to tell reading drills from grammar items.
+  const promptLabel = feedback.question.promptLabel ?? "";
   const answers = new Set(feedback.question.expectedAnswers);
-  const distractorGloss = isReading
-    ? options
-        .filter((option) => !answers.has(option))
-        .map((reading) => {
-          const words = lookupWordsByReading(reading);
-          return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
-        })
-        .join("・")
-    : "";
+  const distractors = options.filter((option) => !answers.has(option));
+
+  // Reading drills (vocab 単字 = no promptLabel; exam 漢字読み): options are
+  // bare kana, so show the word each reads and flag any reading that
+  // matches no real word.
+  const isReadingGloss =
+    promptLabel === "漢字読み" || (promptLabel === "" && feedback.question.targetForm === "reading");
+  // Grammar-form items: options are patterns, so show each pattern's gloss.
+  const isGrammarGloss = promptLabel === "文法形式選擇" || promptLabel === "文章脈絡";
+
+  let distractorGloss = "";
+  if (isReadingGloss) {
+    distractorGloss = distractors
+      .map((reading) => {
+        const words = lookupWordsByReading(reading);
+        return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
+      })
+      .join("・");
+  } else if (isGrammarGloss) {
+    const glossed = distractors.map((pattern) => ({ pattern, meaning: lookupPatternMeaning(pattern) }));
+    // Only show the line if the bank knew at least one pattern -- otherwise
+    // it would just re-list the options with no added information.
+    if (glossed.some((entry) => entry.meaning)) {
+      distractorGloss = glossed
+        .map((entry) => (entry.meaning ? `${entry.pattern}（${entry.meaning}）` : entry.pattern))
+        .join("・");
+    }
+  }
 
   return (
     <section className={`feedback ${isCorrect ? "correct" : isRevealed ? "revealed" : "incorrect"}`} aria-live="polite">

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,13 +1,15 @@
-// Barrel for the EAGERLY-loaded view panels + leaf presentational
-// components. ChallengePanel and MockExamPanel are intentionally NOT
-// re-exported here: they pull in the heavy question-pool data, so App
-// lazy-loads them with React.lazy directly from their modules. Listing
-// them in this barrel would make that data eager again (any App import
-// from the barrel would drag them into the initial bundle).
+// Barrel for the EAGERLY-loaded view panels only (HomePanel /
+// LearningPanel / RulesPanel), which App imports directly.
+//
+// Everything else is intentionally NOT re-exported here:
+//   - ChallengePanel / MockExamPanel pull in the heavy question-pool
+//     data and are React.lazy'd in App.
+//   - The leaf components (ExamPrompt / FeedbackPanel / SpeakButton) and
+//     the Feedback type are used ONLY by the lazy ChallengePanel, which
+//     imports them directly from their modules.
+// Re-exporting any of them would make App's barrel import drag them --
+// and their data (e.g. FeedbackPanel -> readingLookup -> jlptVocabulary)
+// -- back into the initial bundle.
 export { HomePanel } from "./HomePanel";
 export { LearningPanel } from "./LearningPanel";
 export { RulesPanel } from "./RulesPanel";
-export { ExamPrompt } from "./ExamPrompt";
-export { FeedbackPanel } from "./FeedbackPanel";
-export { SpeakButton } from "./SpeakButton";
-export type { Feedback } from "./types";

--- a/src/domain/patternMeaning.ts
+++ b/src/domain/patternMeaning.ts
@@ -1,0 +1,28 @@
+import { examStyleQuestions } from "./examBlocks";
+
+// pattern (an option string a learner sees in a 文法 question) -> its
+// Chinese gloss, sourced from wherever that pattern is an exam item's
+// answer or surface in the bank. Used post-answer to annotate grammar
+// distractors (ものの -> 雖然…但是), turning a wrong pick into a quick
+// "what was that one?" note. Built once at module load; only ever loaded
+// inside the lazy challenge chunk (examBlocks already lives there).
+const patternToMeaning = new Map<string, string>();
+for (const question of examStyleQuestions) {
+  const meaning = question.vocabulary.meaningZh;
+  if (!meaning) continue;
+  for (const key of [question.vocabulary.surface, ...question.expectedAnswers]) {
+    if (key && !patternToMeaning.has(key)) {
+      patternToMeaning.set(key, meaning);
+    }
+  }
+}
+
+/**
+ * Chinese gloss for a grammar pattern if the bank knows it, else null.
+ * Distractors not present in the bank stay un-annotated (they are still
+ * real patterns -- unlike reading distractors, "not found" is not a
+ * content defect here).
+ */
+export function lookupPatternMeaning(pattern: string): string | null {
+  return patternToMeaning.get(pattern) ?? null;
+}

--- a/src/domain/readingLookup.ts
+++ b/src/domain/readingLookup.ts
@@ -1,0 +1,24 @@
+import { jlptVocabulary } from "./vocabulary-jlpt";
+import { vocabulary } from "./vocabulary";
+
+// reading (kana) -> the distinct surface forms that carry that reading,
+// across the JLPT + basic vocab. Used post-answer to tell the learner
+// what each reading distractor actually was (e.g. たいしょう -> 対象),
+// turning a wrong pick into a vocab review. Built once at module load;
+// this module only loads inside the lazy challenge chunk.
+const readingToSurfaces = new Map<string, string[]>();
+for (const item of [...jlptVocabulary, ...vocabulary]) {
+  const surfaces = readingToSurfaces.get(item.reading) ?? [];
+  if (!surfaces.includes(item.surface)) {
+    surfaces.push(item.surface);
+  }
+  readingToSurfaces.set(item.reading, surfaces);
+}
+
+/**
+ * Surface forms in the bank that have this reading. Empty array when the
+ * reading matches no known word -- the caller marks those as "no word".
+ */
+export function lookupWordsByReading(reading: string): string[] {
+  return readingToSurfaces.get(reading) ?? [];
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -119,6 +119,8 @@ export type Copy = {
   incorrect: string;
   revealed: string;
   answerKey: string;
+  feedbackOtherOptions: string;
+  feedbackNoWord: string;
   focusSummaryEmpty: string;
   modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
@@ -286,6 +288,8 @@ export const copy: Record<Language, Copy> = {
     incorrect: "再想一下",
     revealed: "先記這題",
     answerKey: "正解",
+    feedbackOtherOptions: "其他選項",
+    feedbackNoWord: "無對應詞",
     focusSummaryEmpty: "目前重點沒有可用形",
     modeOptions: {
       daily: { title: "今日練習", subtitle: "複習優先 · 文法 / 語順 / 漢字読み混合一輪" },

--- a/src/styles.css
+++ b/src/styles.css
@@ -1397,6 +1397,11 @@ select:disabled {
   font-weight: 800;
 }
 
+.distractor-gloss {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .example {
   border-top: 1px solid var(--example-rule);
   margin-bottom: 0;


### PR DESCRIPTION
## What

After answering, the 解析 now explains each **wrong** option, so a wrong pick teaches something:

- **Reading drills** (単字 / 漢字読み) — `たいしょう（対象）・せいちょう（成長）・きょうつう（共通）`; a reading matching no real word shows `（無對應詞）`.
- **Grammar items** (文法形式選擇 / 文章脈絡) — each distractor pattern shows its meaning, e.g. `ものの（雖然…但是）`. Patterns the bank doesn't know stay un-annotated (they're real patterns — no `無對應詞` for grammar).

## How

- `src/domain/readingLookup.ts` — reading → word (over JLPT + basic vocab).
- `src/domain/patternMeaning.ts` — pattern → meaning (over the exam bank).
- `FeedbackPanel` picks the gloss by **`promptLabel`**, not `targetForm`.

### Why gate on promptLabel (important)

Every exam item defaults `targetForm` to `"reading"`, so the first cut's `targetForm === "reading"` gate would have fired the reading gloss for **grammar / vocab / 語順** items too and marked every option `無對應詞`. Now:
- reading gloss → `漢字読み`, or no promptLabel + reading (the 単字 drill)
- grammar gloss → `文法形式選擇` / `文章脈絡`
- `語順組合` / `類義替換` / `詞彙*` → no gloss

## Bundle

`FeedbackPanel` is used only by the lazy `ChallengePanel`, so it's dropped from the components barrel (the dead re-export was dragging `FeedbackPanel` + vocab data into `index`, 254→284 kB). `readingLookup`/`patternMeaning` deps (vocab, examBlocks) already live in the lazy chunk. **`index` back to 254 kB**, verified.

## Tests

`FeedbackPanel.test.tsx`: reading distractor → word; fake reading → 無對應詞; grammar distractor → pattern meaning (never 無對應詞); no gloss for non-reading/grammar. `ExamPrompt`/`FeedbackPanel` together.

- `tsc` ✅ · `vitest` **136/136** ✅ · `check:exam` ✅ · `build` ✅ (index 253.96 kB, examBlocks 255 kB lazy, no warning)
