### PR TITLE
feat(feedback): tag the post-answer 解析 with the JLPT level

### DIFF
--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { buildQuestionPool } from "../domain/practice";
 import { jlptVocabulary } from "../domain/vocabulary-jlpt";
 import { examStyleQuestions } from "../domain/examBlocks";
+import { buildSentencePatternPool } from "../domain/sentencePatterns";
 import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
 
@@ -82,5 +83,66 @@ describe("FeedbackPanel distractor gloss", () => {
       />
     );
     expect(container.querySelector(".distractor-gloss")).toBeNull();
+  });
+
+  it("tags the post-answer panel with the question's JLPT level, and hides it when absent", () => {
+    const examItem = examStyleQuestions.find((q) => q.vocabulary.level === "N1")!;
+    const { container, unmount } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: examItem }}
+        language="zh-Hant"
+        options={examItem.options ?? []}
+      />
+    );
+    expect(container.querySelector(".feedback-level")?.textContent).toBe("N1");
+    unmount();
+
+    // Basic/cloze items have no level -> no tag.
+    const noLevel = {
+      ...readingPool[0],
+      vocabulary: { ...readingPool[0].vocabulary, level: undefined }
+    };
+    const { container: c2 } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: noLevel }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    expect(c2.querySelector(".feedback-level")).toBeNull();
+  });
+
+  it("shows a distractor gloss only for reading + grammar item types (gating matrix)", () => {
+    const sample = (label: string) => examStyleQuestions.find((q) => q.promptLabel === label)!;
+    const textGrammar = sample("文章脈絡");
+    // Another grammar item's answer -> a distractor the bank can gloss.
+    const grammarAnswer = examStyleQuestions.find(
+      (q) => q.promptLabel === "文法形式選擇" && q.expectedAnswers[0] !== textGrammar.expectedAnswers[0]
+    )!.expectedAnswers[0];
+    const kanjiReading = sample("漢字読み");
+
+    const cases = [
+      // reading drills -> gloss shown (even a no-word reading is marked).
+      { question: kanjiReading, options: [kanjiReading.expectedAnswers[0], "なにかのよみ"], gloss: true },
+      // grammar form / text grammar -> gloss shown (distractor has a meaning).
+      { question: textGrammar, options: [textGrammar.expectedAnswers[0], grammarAnswer], gloss: true },
+      // these item types -> never a gloss (and never 無對應詞).
+      { question: sample("語順組合"), options: ["a", "b"], gloss: false },
+      { question: sample("詞彙填空"), options: ["a", "b"], gloss: false },
+      { question: buildSentencePatternPool()[0], options: ["a", "b"], gloss: false }
+    ];
+
+    for (const testCase of cases) {
+      const { container, unmount } = render(
+        <FeedbackPanel
+          feedback={{ status: "incorrect", question: testCase.question }}
+          language="zh-Hant"
+          options={testCase.options}
+        />
+      );
+      const hasGloss = container.querySelector(".distractor-gloss") !== null;
+      expect(hasGloss, `promptLabel=${testCase.question.promptLabel ?? "(none)"}`).toBe(testCase.gloss);
+      unmount();
+    }
   });
 });

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -67,7 +67,7 @@ export function FeedbackPanel({
         <Icon aria-hidden="true" />
         <h2>{title}</h2>
         {level ? (
-          <span className="feedback-level" title={`JLPT ${level}`}>
+          <span className="feedback-level" title={`JLPT ${level}`} aria-label={`JLPT ${level}`}>
             {level}
           </span>
         ) : null}

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -22,6 +22,10 @@ export function FeedbackPanel({
   const isRevealed = feedback.status === "revealed";
   const title = isCorrect ? t.correct : isRevealed ? t.revealed : t.incorrect;
   const Icon = isCorrect ? CheckCircle2 : XCircle;
+  // Post-answer JLPT level tag (N1/N2/N3) for items that carry one -- exam
+  // questions + JLPT vocab. Shown only here, never pre-answer, so it can't
+  // tip off the question. Basic/cloze/pattern items have no level -> hidden.
+  const level = feedback.question.vocabulary.level;
 
   // Annotate the distractors so a wrong pick teaches something. NOTE all
   // exam items default targetForm to "reading", so we gate on promptLabel,
@@ -62,6 +66,11 @@ export function FeedbackPanel({
       <div className="feedback-title">
         <Icon aria-hidden="true" />
         <h2>{title}</h2>
+        {level ? (
+          <span className="feedback-level" title={`JLPT ${level}`}>
+            {level}
+          </span>
+        ) : null}
       </div>
       <p className="answer-key">{t.answerKey}：{feedback.question.expectedAnswers.join(" / ")}</p>
       <p>{feedback.question.explanation}</p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1380,6 +1380,19 @@ select:disabled {
   width: 1.2rem;
 }
 
+/* JLPT level tag (N1/N2/N3) pushed to the right of the feedback heading.
+   Neutral colour so it doesn't pick up the correct/incorrect title hue. */
+.feedback-level {
+  margin-left: auto;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  color: var(--muted);
+}
+
 .feedback.correct .feedback-title {
   color: var(--green);
 }


### PR DESCRIPTION
## 做什麼

答題後的「解析」標題列加一個 **JLPT 等級小標（N1/N2/N3）**——文法 / 單字題現在會標示它是 N 幾。

- 來源：`question.vocabulary.level`（exam 題 + JLPT 單字有；basic / cloze / pattern 沒有 → 不顯示）。
- **只在答題後**顯示，不會洩漏到題目（答題前 ExamPrompt 不動；promptLabel「不顯示等級」的規則也不動）。
- 小 pill 用中性色，不搶 正解/再想一下 的標題顏色。

## 順帶（Codex 在 #46 的建議）

補上 **gating matrix test**，把各題型的 distractor gloss 行為鎖死，未來新增題型不易 regression：

| promptLabel | gloss |
|---|---|
| 漢字読み、念法(無 promptLabel) | reading → 詞 |
| 文法形式選擇、文章脈絡 | grammar → 意思 |
| 語順組合、詞彙填空、句型練習：* | 無（也不會「無對應詞」） |

## 驗證

`tsc` ✅ · `vitest` **138/138**（+ 等級標註 + matrix）✅ · `check:exam` 8/8 ✅ · `build` ✅（index 253.96 kB，examBlocks 仍獨立 lazy chunk）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feedback panels now display the JLPT level of questions as a badge when available.

* **Tests**
  * Extended test coverage to verify JLPT level badge visibility and conditional rendering of glossary information based on question and content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->