### PR TITLE
feat(drill): voicing-aware perturbation distractors for reading drills (Phase 1)

### DIFF
--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -628,18 +628,15 @@ describe("buildChoiceOptions (vocab reading distractors)", () => {
     expect(uniqueSets.size).toBeGreaterThanOrEqual(6);
   });
 
-  it("keeps distractors in the same length band as the answer", () => {
-    // For any 4-kana answer, the band is all 4-kana readings, so every
-    // distractor should also be 4-kana (the two-kana readings never win
-    // the similarity ranking).
-    for (const question of fourKana) {
-      const index = readingQuestions.indexOf(question);
-      const answer = question.expectedAnswers[0];
-      const distractors = buildChoiceOptions(question, readingQuestions, index).filter(
-        (option) => option !== answer
-      );
-      expect(distractors.every((option) => option.length === 4)).toBe(true);
-    }
+  it("uses voicing/length perturbations of the answer as reading distractors", () => {
+    // Reading distractors now perturb the answer (voicing / long vowel /
+    // gemination) rather than pulling other words' readings. 公開 こうかい
+    // has exactly three perturbations -- ごうかい (こ->ご), こうがい (か->が),
+    // こうか (drop the long vowel) -- so こうがい must appear as an option.
+    const target = readingQuestions.find((q) => q.expectedAnswers[0] === "こうかい")!;
+    const index = readingQuestions.indexOf(target);
+    const options = buildChoiceOptions(target, readingQuestions, index);
+    expect(options).toContain("こうがい");
   });
 
   it("is stable across repeated calls (no per-render reshuffle)", () => {

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -645,6 +645,18 @@ describe("buildChoiceOptions (vocab reading distractors)", () => {
     const second = buildChoiceOptions(q, readingQuestions, 0);
     expect(first).toEqual(second);
   });
+
+  it("leaves a baked 漢字読み item on its authored options (no perturbation)", () => {
+    // A reading item that ships baked options must keep using them -- the
+    // perturbation path is only for option-less vocab reading drills.
+    const baked = buildExamQuestionPool("all").find(
+      (q) => q.promptLabel === "漢字読み" && (q.options?.length ?? 0) > 0
+    );
+    expect(baked).toBeDefined();
+    const options = buildChoiceOptions(baked!, [baked!], 0);
+    const authored = new Set([...baked!.expectedAnswers, ...(baked!.options ?? [])]);
+    expect(new Set(options)).toEqual(authored);
+  });
 });
 
 describe("reduceAdjacentClusters", () => {

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -7,6 +7,7 @@ import {
   VERB_FORMS
 } from "./conjugation";
 import { getDueQuestions } from "./srs";
+import { generateReadingConfusers } from "./readingConfusers";
 import type {
   Attempt,
   JlptLevel,
@@ -145,7 +146,11 @@ export function buildChoiceOptions(
     );
   }
 
-  if (currentQuestion.targetForm === "reading" || currentQuestion.targetForm === "meaning") {
+  if (currentQuestion.targetForm === "reading") {
+    return buildReadingChoiceOptions(currentQuestion, questions, questionIndex);
+  }
+
+  if (currentQuestion.targetForm === "meaning") {
     return buildPoolBasedChoiceOptions(currentQuestion, questions, questionIndex);
   }
 
@@ -228,6 +233,57 @@ function buildPoolBasedChoiceOptions(
   const picked = seededSample(band, CHOICE_COUNT - 1, hashString(currentQuestion.id));
   const options = [correctAnswer, ...picked];
 
+  return rotateOptions(options, currentQuestion, questionIndex);
+}
+
+// Reading drills get PERTURBATION distractors: variants of the correct
+// reading along the axes learners confuse -- voicing (か/が), long vowels
+// (こう/こ), gemination (がっこう/がこう). These are far more testing than
+// "some other word's reading". The pool (other readings) is only a
+// top-up when a short reading yields fewer than CHOICE_COUNT-1
+// perturbations. Sampling is seeded by the question id so the option set
+// is stable across re-renders (no reshuffle after answering).
+function buildReadingChoiceOptions(
+  currentQuestion: PracticeQuestion,
+  questions: PracticeQuestion[],
+  questionIndex: number
+): string[] {
+  const correctAnswer = currentQuestion.expectedAnswers[0];
+  const acceptedAnswers = new Set(currentQuestion.expectedAnswers);
+  const vocab = currentQuestion.vocabulary;
+  const seed = hashString(currentQuestion.id);
+
+  let distractors = seededSample(
+    generateReadingConfusers(correctAnswer, acceptedAnswers),
+    CHOICE_COUNT - 1,
+    seed
+  );
+
+  if (distractors.length < CHOICE_COUNT - 1) {
+    const used = new Set<string>([...acceptedAnswers, ...distractors]);
+    const poolCandidates: string[] = [];
+    for (const question of questions) {
+      if (question.vocabulary.id === vocab.id) continue;
+      if (question.targetForm !== "reading") continue;
+      const text = question.expectedAnswers[0];
+      if (!text || used.has(text)) continue;
+      used.add(text);
+      poolCandidates.push(text);
+    }
+    const ranked = poolCandidates
+      .map((text) => ({
+        text,
+        score: readingSimilarity(correctAnswer, text),
+        tiebreak: hashString(text + currentQuestion.id)
+      }))
+      .sort((a, b) => b.score - a.score || a.tiebreak - b.tiebreak)
+      .map((entry) => entry.text);
+    const band = ranked.slice(0, Math.min(ranked.length, DISTRACTOR_BAND));
+    const topUp = seededSample(band, CHOICE_COUNT - 1 - distractors.length, seed ^ 0x9e3779b9);
+    distractors = uniqueAnswers([...distractors, ...topUp]);
+  }
+
+  const options = [correctAnswer, ...distractors.slice(0, CHOICE_COUNT - 1)];
   return rotateOptions(options, currentQuestion, questionIndex);
 }
 

--- a/src/domain/readingConfusers.test.ts
+++ b/src/domain/readingConfusers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { generateReadingConfusers } from "./readingConfusers";
+
+describe("generateReadingConfusers", () => {
+  it("produces voicing confusers (清/濁)", () => {
+    const out = generateReadingConfusers("こうそう");
+    expect(out).toContain("ごうそう"); // こ -> ご
+    expect(out).toContain("こうぞう"); // そ -> ぞ
+  });
+
+  it("de-voices an already-voiced reading and drops gemination", () => {
+    const out = generateReadingConfusers("がっこう");
+    expect(out).toContain("かっこう"); // が -> か
+    expect(out).toContain("がこう"); // っ dropped
+  });
+
+  it("drops a trailing long vowel", () => {
+    expect(generateReadingConfusers("こう")).toContain("こ");
+    expect(generateReadingConfusers("せい")).toContain("せ");
+  });
+
+  it("handles 拗音 and 半濁 readings", () => {
+    expect(generateReadingConfusers("しょう")).toContain("じょう"); // し -> じ
+    expect(generateReadingConfusers("はん")).toContain("ばん"); // は -> ば
+    expect(generateReadingConfusers("はん")).toContain("ぱん"); // は -> ぱ
+  });
+
+  it("never returns the reading itself or an excluded answer", () => {
+    // ごう would be a real alternate reading -> exclude it so it can't be a distractor.
+    const out = generateReadingConfusers("こう", new Set(["こう", "ごう"]));
+    expect(out).not.toContain("こう");
+    expect(out).not.toContain("ごう");
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it("returns unique, non-empty variants", () => {
+    const out = generateReadingConfusers("こうそう");
+    expect(new Set(out).size).toBe(out.length);
+    expect(out.every((variant) => variant.length > 0 && variant !== "こうそう")).toBe(true);
+  });
+});

--- a/src/domain/readingConfusers.ts
+++ b/src/domain/readingConfusers.ts
@@ -1,0 +1,68 @@
+// Generates "looks right but wrong" reading distractors by perturbing the
+// correct reading along the axes JLPT learners actually confuse:
+//   - voicing: 清 vs 濁 vs 半濁  (か/が, さ/ざ, は/ば/ぱ ...)
+//   - long vowel: こう vs こ, せい vs せ
+//   - gemination: がっこう vs がこう
+//
+// These are far more confusing than "some other word's reading" because
+// they differ from the answer by exactly the feature being tested. Used
+// as the primary distractor source for reading drills (the pool is only a
+// top-up when a short reading yields too few perturbations).
+
+// Single-mora voicing swaps, in BOTH directions (清→濁/半濁 and back), so
+// a correct reading that is already voiced (がっこう) still yields a
+// de-voiced confuser (かっこう).
+const VOICE_VARIANTS: Record<string, string[]> = {
+  か: ["が"], き: ["ぎ"], く: ["ぐ"], け: ["げ"], こ: ["ご"],
+  さ: ["ざ"], し: ["じ"], す: ["ず"], せ: ["ぜ"], そ: ["ぞ"],
+  た: ["だ"], ち: ["ぢ"], つ: ["づ"], て: ["で"], と: ["ど"],
+  は: ["ば", "ぱ"], ひ: ["び", "ぴ"], ふ: ["ぶ", "ぷ"], へ: ["べ", "ぺ"], ほ: ["ぼ", "ぽ"],
+  が: ["か"], ぎ: ["き"], ぐ: ["く"], げ: ["け"], ご: ["こ"],
+  ざ: ["さ"], じ: ["し"], ず: ["す"], ぜ: ["せ"], ぞ: ["そ"],
+  だ: ["た"], ぢ: ["ち"], づ: ["つ"], で: ["て"], ど: ["と"],
+  ば: ["は", "ぱ"], び: ["ひ", "ぴ"], ぶ: ["ふ", "ぷ"], べ: ["へ", "ぺ"], ぼ: ["ほ", "ぽ"],
+  ぱ: ["は", "ば"], ぴ: ["ひ", "び"], ぷ: ["ふ", "ぶ"], ぺ: ["へ", "べ"], ぽ: ["ほ", "ぼ"]
+};
+
+/**
+ * Confusable variants of `reading`, excluding the reading itself and any
+ * member of `exclude` (pass the question's accepted answers so a variant
+ * can never coincide with the correct reading). Order is deterministic;
+ * the caller samples from it with a stable seed.
+ */
+export function generateReadingConfusers(reading: string, exclude: Set<string> = new Set()): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const add = (variant: string) => {
+    if (!variant || variant === reading || exclude.has(variant) || seen.has(variant)) return;
+    seen.add(variant);
+    out.push(variant);
+  };
+
+  const chars = [...reading];
+
+  // Voicing toggles: one mora changed at a time (the most tempting kind of
+  // near-miss). しょう -> じょう comes for free since the swap hits し.
+  for (let i = 0; i < chars.length; i++) {
+    const variants = VOICE_VARIANTS[chars[i]];
+    if (!variants) continue;
+    for (const alt of variants) {
+      add(chars.slice(0, i).join("") + alt + chars.slice(i + 1).join(""));
+    }
+  }
+
+  // Drop a trailing long vowel (こう -> こ, せい -> せ). Adding one is
+  // skipped: it tends to produce unnatural kana, and dropping already
+  // covers the こう/こ confusion symmetrically across the item set.
+  const last = chars[chars.length - 1];
+  if (chars.length > 1 && (last === "う" || last === "い")) {
+    add(chars.slice(0, -1).join(""));
+  }
+
+  // Drop gemination (がっこう -> がこう).
+  if (reading.includes("っ")) {
+    add(reading.replace(/っ/g, ""));
+  }
+
+  return out;
+}


### PR DESCRIPTION
## 做什麼（Phase 1）

念法 / 漢字読み 的**干擾選項改成「擾動正解讀音」**生成，沿學習者最常混淆的軸，取代舊的「抓別的詞讀音」：

- **濁音** 清/濁/半濁（か/が、さ/ざ、は/ば/ぱ），雙向
- **長音**（こう/こ、せい/せ）
- **促音**（がっこう/がこう）

## 怎麼做

- 新 `src/domain/readingConfusers.ts`：`generateReadingConfusers(讀音, 排除集)` 生變體（單音替換 = 最迷惑；排除正解/已接受讀音，所以變體**不會是正解**）。
- `buildChoiceOptions` 的 reading → 新 `buildReadingChoiceOptions`：**擾動優先**，舊 pool（別字讀音、相似度排序）只在「短讀音擾動不足」時補。取樣 seeded-by-id（穩定、答題後不重洗）。
- `meaning` 題不變；**有 baked options 的 exam 題（漢字読み 等）不受影響**（仍用作者選項）——擾動只作用於 vocab-mode 念法 drill。

## 品質

- 擾動是「差一個音」的近似 → 比舊 pool 干擾更強、直接針對濁音。
- 排除正解集 → 不會把正解當干擾。
- 變體都是合法 kana（單音 swap / 刪）。

## 測試

`readingConfusers.test.ts`（濁音/長音/促音、排除、唯一、非空）；`practice.test.ts` reading 案例更新——舊「同長度 band」斷言換成擾動斷言（公開 こうかい → こうがい）；4-options / 不共用干擾集 / 穩定 仍成立。

## Bundle

新程式都在 lazy challenge chunk；**index 仍 253.96 kB**，examBlocks 仍獨立。

驗證：tsc ✅ · vitest **144/144** ✅ · check:exam 8/8 ✅ · build ✅
