### PR TITLE
feat(kanji): 漢字音読み 速查表 v1a (browse, homophone families)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -30,11 +30,11 @@ async function gotoLearn(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe("App", () => {
-  // The challenge + mock views are React.lazy in App, and React.lazy only
-  // suspends on its first resolution. Prime both chunks once here so every
-  // test below renders them synchronously regardless of run order --
-  // otherwise whichever test first navigates to a view would run its
-  // synchronous assertions before the lazy chunk finished loading.
+  // The challenge / mock / kanji views are React.lazy in App, and
+  // React.lazy only suspends on its first resolution. Prime the chunks
+  // once here so every test below renders them synchronously regardless of
+  // run order -- otherwise whichever test first navigates to a view would
+  // run its synchronous assertions before the lazy chunk finished loading.
   beforeAll(async () => {
     const user = userEvent.setup();
     const { unmount } = render(<App />);
@@ -42,6 +42,8 @@ describe("App", () => {
     await screen.findByRole("region", { name: "目前題目" });
     await user.click(screen.getByRole("button", { name: "模擬考" }));
     await screen.findByRole("region", { name: "模擬考" });
+    await user.click(screen.getByRole("button", { name: "漢字" }));
+    await screen.findByRole("heading", { name: /漢字音読み/ });
     unmount();
   });
 
@@ -641,6 +643,22 @@ describe("App", () => {
     expect(screen.getByText("題庫範圍")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "N1＋N2" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "N2＋N3" })).toBeInTheDocument();
+  });
+
+  it("opens the 漢字音読み table and shows example words for a kanji", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "漢字" }));
+
+    // The table renders, grouped by homophone family.
+    expect(await screen.findByRole("heading", { name: /漢字音読み/ })).toBeInTheDocument();
+    // Tap the 解 kanji cell -> its example words (from the vocab bank) show.
+    await user.click(screen.getByRole("button", { name: /解.*かい/s }));
+    expect(screen.getByText("例詞")).toBeInTheDocument();
+    // 解決's reading is unique to the example row (its surface 解決 also
+    // shows as its own meaningZh, so assert on the reading instead).
+    expect(screen.getByText("かいけつ")).toBeInTheDocument();
   });
 
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,8 +23,13 @@ const ChallengePanel = lazy(() =>
 const MockExamPanel = lazy(() =>
   import("./components/MockExamPanel").then((module) => ({ default: module.MockExamPanel }))
 );
+// 漢字音読み 速查 also pulls the vocab data (for example words), so it's
+// lazy too -- imported directly from its module, not the barrel.
+const KanjiOnyomiPanel = lazy(() =>
+  import("./components/KanjiOnyomiPanel").then((module) => ({ default: module.KanjiOnyomiPanel }))
+);
 
-type AppView = "home" | "learn" | "rules" | "challenge" | "mock";
+type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock";
 type DrillPreset = LearningBlockDrillPreset;
 
 export default function App() {
@@ -117,6 +122,13 @@ export default function App() {
         </button>
         <button
           type="button"
+          className={appView === "kanji" ? "selected" : ""}
+          onClick={() => setAppView("kanji")}
+        >
+          {t.kanji}
+        </button>
+        <button
+          type="button"
           className={appView === "challenge" ? "selected" : ""}
           onClick={() => openChallenge()}
         >
@@ -153,6 +165,10 @@ export default function App() {
         />
       ) : appView === "rules" ? (
         <RulesPanel language={language} />
+      ) : appView === "kanji" ? (
+        <Suspense fallback={<PanelFallback label={t.loading} />}>
+          <KanjiOnyomiPanel language={language} />
+        </Suspense>
       ) : appView === "mock" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
           <MockExamPanel

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState } from "react";
+import { copy, type Language } from "../i18n";
+import type { JlptLevel } from "../domain/types";
+import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
+import { SpeakButton } from "./SpeakButton";
+
+const LEVELS: Array<JlptLevel | "all"> = ["all", "N1", "N2"];
+
+// 漢字音読み 速查表: browse kanji grouped by their primary 音読み
+// (homophone families -- the こう / しょう / せい ... that learners mix up),
+// filter by level, search, and open a card showing the reading + real
+// example words (pulled from the vocab bank) with TTS. The point is to
+// confirm readings without getting fooled by voicing; the example words
+// keep it anchored to how the kanji actually reads inside compounds.
+export function KanjiOnyomiPanel({ language }: { language: Language }) {
+  const t = copy[language];
+  const [query, setQuery] = useState("");
+  const [level, setLevel] = useState<JlptLevel | "all">("all");
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const families = useMemo(() => {
+    const q = query.trim();
+    const matched = kanjiOnyomi.filter((entry) => {
+      if (level !== "all" && entry.level !== level) return false;
+      if (!q) return true;
+      return (
+        entry.kanji.includes(q) ||
+        entry.onyomi.some((reading) => reading.includes(q)) ||
+        entry.meaningZh.includes(q)
+      );
+    });
+    const byReading = new Map<string, KanjiOnyomiEntry[]>();
+    for (const entry of matched) {
+      const key = entry.onyomi[0];
+      const bucket = byReading.get(key);
+      if (bucket) bucket.push(entry);
+      else byReading.set(key, [entry]);
+    }
+    // Biggest families first -- they're the most useful "don't mix these up"
+    // groups; ties broken by reading for stable order.
+    return [...byReading.entries()].sort(
+      (a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0])
+    );
+  }, [query, level]);
+
+  const detail = selected ? kanjiOnyomi.find((entry) => entry.kanji === selected) ?? null : null;
+  const examples = detail ? kanjiExamples(detail.kanji) : [];
+
+  return (
+    <section className="kanji-panel" aria-label={t.kanjiTitle}>
+      <header className="kanji-head">
+        <h2>{t.kanjiTitle}</h2>
+        <p>{t.kanjiIntro}</p>
+      </header>
+
+      <div className="kanji-controls">
+        <input
+          type="search"
+          className="kanji-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={t.kanjiSearchPlaceholder}
+          aria-label={t.kanjiSearchPlaceholder}
+        />
+        <div className="segmented">
+          {LEVELS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={level === option ? "selected" : ""}
+              onClick={() => setLevel(option)}
+            >
+              {option === "all" ? t.kanjiLevelAll : option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {detail ? (
+        <div className="kanji-card" aria-live="polite">
+          <div className="kanji-card-head">
+            <span className="kanji-card-char">{detail.kanji}</span>
+            <div>
+              <p className="kanji-card-onyomi">
+                {detail.onyomi.join("・")}
+                <small>{t.kanjiOnyomiLabel}</small>
+                <SpeakButton text={detail.onyomi[0]} language={language} />
+              </p>
+              <p className="kanji-card-mean">{detail.meaningZh}</p>
+            </div>
+          </div>
+          <p className="kanji-examples-label">{t.kanjiExamplesLabel}</p>
+          {examples.length > 0 ? (
+            <ul className="kanji-examples">
+              {examples.map((example) => (
+                <li key={example.surface}>
+                  <span className="kanji-example-surface">
+                    {example.surface}
+                    <SpeakButton text={example.surface} language={language} />
+                  </span>
+                  <span className="kanji-example-reading">{example.reading}</span>
+                  <span className="kanji-example-mean">{example.meaningZh}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="kanji-no-examples">{t.kanjiNoExamples}</p>
+          )}
+        </div>
+      ) : null}
+
+      {families.length > 0 ? (
+        families.map(([reading, entries]) => (
+          <div className="kanji-family" key={reading}>
+            <h3 className="kanji-family-head">
+              {reading}
+              <small>{t.kanjiOnyomiLabel}</small>
+              <span className="kanji-family-count">{entries.length}</span>
+            </h3>
+            <div className="kanji-grid">
+              {entries.map((entry) => (
+                <button
+                  key={entry.kanji}
+                  type="button"
+                  className={`kanji-cell${selected === entry.kanji ? " selected" : ""}`}
+                  aria-pressed={selected === entry.kanji}
+                  onClick={() => setSelected(entry.kanji)}
+                >
+                  <span className="kanji-cell-char">{entry.kanji}</span>
+                  <span className="kanji-cell-read">{entry.onyomi.join("・")}</span>
+                  <span className="kanji-cell-mean">{entry.meaningZh}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ))
+      ) : (
+        <p className="kanji-empty">{t.kanjiSearchEmpty}</p>
+      )}
+    </section>
+  );
+}

--- a/src/domain/kanjiOnyomi.test.ts
+++ b/src/domain/kanjiOnyomi.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { kanjiOnyomi, kanjiExamples } from "./kanjiOnyomi";
+
+describe("kanjiOnyomi", () => {
+  it("every entry is a single kanji with hiragana onyomi + a gloss", () => {
+    for (const entry of kanjiOnyomi) {
+      expect([...entry.kanji]).toHaveLength(1);
+      expect(entry.onyomi.length).toBeGreaterThan(0);
+      // onyomi is stored in hiragana (to match the reading drills).
+      expect(entry.onyomi.every((reading) => /^[ぁ-ゖ]+$/.test(reading))).toBe(true);
+      expect(entry.meaningZh.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate kanji", () => {
+    const all = kanjiOnyomi.map((entry) => entry.kanji);
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it("pulls real example words that contain the kanji", () => {
+    const examples = kanjiExamples("機");
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples.every((example) => example.surface.includes("機"))).toBe(true);
+    expect(examples.every((example) => example.reading.length > 0 && example.meaningZh.length > 0)).toBe(true);
+  });
+
+  it("caps and sorts examples shortest-first", () => {
+    const examples = kanjiExamples("関", 3);
+    expect(examples.length).toBeLessThanOrEqual(3);
+    for (let i = 1; i < examples.length; i++) {
+      expect(examples[i].surface.length).toBeGreaterThanOrEqual(examples[i - 1].surface.length);
+    }
+  });
+});

--- a/src/domain/kanjiOnyomi.ts
+++ b/src/domain/kanjiOnyomi.ts
@@ -1,0 +1,68 @@
+import type { JlptLevel } from "./types";
+import { jlptVocabulary } from "./vocabulary-jlpt";
+
+// 音読み (on'yomi) study table -- a self-authored subset, NOT imported from
+// KANJIDIC (keeps the bank original + license-clean, matching the rest of
+// the content). Each entry is just the kanji + its reading(s) + a Chinese
+// gloss + level; EXAMPLE WORDS are pulled at runtime from jlptVocabulary
+// (see kanjiExamples), so the table always centres on real words (the
+// reading lives in the compound, not in an isolated kanji) and needs no
+// hand-maintained example list.
+//
+// onyomi is stored in HIRAGANA to match the reading drills + Phase 1
+// confusers (the UI labels it as 音読み). The first entry is the primary
+// reading and drives the homophone grouping.
+export type KanjiOnyomiEntry = {
+  kanji: string;
+  onyomi: string[];
+  meaningZh: string;
+  level: JlptLevel;
+};
+
+export const kanjiOnyomi: KanjiOnyomiEntry[] = [
+  // -- かい --------------------------------------------------------------
+  { kanji: "解", onyomi: ["かい", "げ"], meaningZh: "解開、理解", level: "N2" },
+  { kanji: "開", onyomi: ["かい"], meaningZh: "打開、開始", level: "N2" },
+  { kanji: "介", onyomi: ["かい"], meaningZh: "介於、介紹", level: "N2" },
+  { kanji: "改", onyomi: ["かい"], meaningZh: "改變、修改", level: "N2" },
+  // -- き ----------------------------------------------------------------
+  { kanji: "機", onyomi: ["き"], meaningZh: "機械、時機", level: "N2" },
+  { kanji: "危", onyomi: ["き"], meaningZh: "危險", level: "N2" },
+  { kanji: "規", onyomi: ["き"], meaningZh: "規則、規範", level: "N2" },
+  { kanji: "基", onyomi: ["き"], meaningZh: "基礎、根基", level: "N2" },
+  // -- かん --------------------------------------------------------------
+  { kanji: "観", onyomi: ["かん"], meaningZh: "觀看、看法", level: "N2" },
+  { kanji: "関", onyomi: ["かん"], meaningZh: "關係、相關", level: "N2" },
+  { kanji: "感", onyomi: ["かん"], meaningZh: "感覺、感受", level: "N2" },
+  // -- せい --------------------------------------------------------------
+  { kanji: "成", onyomi: ["せい", "じょう"], meaningZh: "完成、形成", level: "N2" },
+  { kanji: "正", onyomi: ["せい", "しょう"], meaningZh: "正確、端正", level: "N2" },
+  { kanji: "制", onyomi: ["せい"], meaningZh: "制度、控制", level: "N2" },
+  // -- たい --------------------------------------------------------------
+  { kanji: "対", onyomi: ["たい"], meaningZh: "相對、對於", level: "N2" },
+  { kanji: "退", onyomi: ["たい"], meaningZh: "後退、退出", level: "N2" },
+  // -- ちょう ------------------------------------------------------------
+  { kanji: "調", onyomi: ["ちょう"], meaningZh: "調查、調整", level: "N2" },
+  { kanji: "張", onyomi: ["ちょう"], meaningZh: "主張、伸張", level: "N2" },
+  // -- じょう ------------------------------------------------------------
+  { kanji: "情", onyomi: ["じょう"], meaningZh: "情感、情報", level: "N2" },
+  { kanji: "状", onyomi: ["じょう"], meaningZh: "狀態、形狀", level: "N2" },
+  // -- つう --------------------------------------------------------------
+  { kanji: "通", onyomi: ["つう"], meaningZh: "通過、普遍", level: "N2" }
+];
+
+export type KanjiExample = { surface: string; reading: string; meaningZh: string };
+
+/**
+ * Real words from jlptVocabulary that contain this kanji -- the example
+ * compounds shown on the kanji card. Sorted shortest-first (the simplest
+ * compound reads most clearly) and capped, since a kanji card only needs
+ * a few illustrative words, not every occurrence.
+ */
+export function kanjiExamples(kanji: string, limit = 6): KanjiExample[] {
+  return jlptVocabulary
+    .filter((item) => item.surface.includes(kanji))
+    .sort((a, b) => a.surface.length - b.surface.length)
+    .slice(0, limit)
+    .map((item) => ({ surface: item.surface, reading: item.reading, meaningZh: item.meaningZh }));
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -55,6 +55,15 @@ export type Copy = {
   mockSectionIntro: string;
   mockSectionCount: (count: number) => string;
   mockSectionEmpty: string;
+  kanji: string;
+  kanjiTitle: string;
+  kanjiIntro: string;
+  kanjiSearchPlaceholder: string;
+  kanjiLevelAll: string;
+  kanjiOnyomiLabel: string;
+  kanjiExamplesLabel: string;
+  kanjiNoExamples: string;
+  kanjiSearchEmpty: string;
   learningRegion: string;
   studyBeforeRecall: string;
   learnTitle: string;
@@ -210,6 +219,15 @@ export const copy: Record<Language, Copy> = {
     mockSectionIntro: "選一個 JLPT 題型，直接練那一區。每題作答後即時看解析；錯題會自動進弱點複習。",
     mockSectionCount: (count) => `${count} 題`,
     mockSectionEmpty: "準備中",
+    kanji: "漢字",
+    kanjiTitle: "漢字音読み 速查",
+    kanjiIntro: "依音読み（同音家族）查漢字，確認讀音、別被濁音搞混；點漢字看例詞。",
+    kanjiSearchPlaceholder: "搜尋漢字、讀音、意思",
+    kanjiLevelAll: "全部",
+    kanjiOnyomiLabel: "音読み",
+    kanjiExamplesLabel: "例詞",
+    kanjiNoExamples: "（暫無收錄例詞）",
+    kanjiSearchEmpty: "找不到符合的漢字。",
     learningRegion: "學習",
     studyBeforeRecall: "先學習，再回想",
     learnTitle: "先學會，再挑戰",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1495,6 +1495,194 @@ select:disabled {
   color: var(--muted);
 }
 
+/* ---- 漢字音読み 速查 ------------------------------------------------ */
+.kanji-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.kanji-head h2 {
+  margin: 0;
+}
+
+.kanji-head p {
+  margin: 0.3rem 0 0;
+  color: var(--muted);
+}
+
+.kanji-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.kanji-search {
+  flex: 1 1 12rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--panel-border);
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.kanji-card {
+  border: 1px solid color-mix(in srgb, var(--matcha) 45%, var(--panel-border));
+  background: color-mix(in srgb, var(--matcha) 10%, var(--paper));
+  border-radius: 0.85rem;
+  padding: 1rem;
+}
+
+.kanji-card-head {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.kanji-card-char {
+  font-size: 3rem;
+  line-height: 1;
+  color: var(--ink);
+}
+
+.kanji-card-onyomi {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 1.3rem;
+  color: var(--matcha-dark);
+}
+
+.kanji-card-onyomi small {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.kanji-card-mean {
+  margin: 0.2rem 0 0;
+  color: var(--ink);
+}
+
+.kanji-examples-label {
+  margin: 0.8rem 0 0.3rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.kanji-examples {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.kanji-examples li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.kanji-example-surface {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.kanji-example-reading {
+  color: var(--matcha-dark);
+}
+
+.kanji-example-mean {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.kanji-no-examples {
+  color: var(--muted);
+}
+
+.kanji-family {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kanji-family-head {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 1.1rem;
+  color: var(--ink);
+}
+
+.kanji-family-head small {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.kanji-family-count {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.kanji-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
+  gap: 0.5rem;
+}
+
+.kanji-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  padding: 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--panel-border);
+  background: var(--paper);
+  cursor: pointer;
+  text-align: left;
+}
+
+.kanji-cell:hover {
+  box-shadow: var(--button-hover-shadow);
+}
+
+.kanji-cell.selected {
+  border-color: var(--matcha);
+  background: color-mix(in srgb, var(--matcha) 12%, var(--paper));
+}
+
+.kanji-cell-char {
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--ink);
+}
+
+.kanji-cell-read {
+  font-size: 0.85rem;
+  color: var(--matcha-dark);
+}
+
+.kanji-cell-mean {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.kanji-empty {
+  color: var(--muted);
+}
+
 .review-done {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 做什麼（Phase 2 v1a）

新「漢字」分頁：**漢字音読み 速查表**。
- 按 **音読み（同音家族）** 分組（こう / しょう / せい…，學習者最容易混的），等級 filter，搜尋（漢字 / 讀音 / 意思）。
- 點漢字 → 字卡：音読み ＋ 字義 ＋ **例詞**（從 `jlptVocabulary` 自動抽）＋ TTS。
- 目的：確認讀音、別被濁音搞；**例詞為中心**（真正練的是漢字在詞中怎麼讀）。

## 資料（自選 subset，非 KANJIDIC）

- `src/domain/kanjiOnyomi.ts`：自選 **21 字 / 8 家族 / N2**，原創整理，乾淨無授權包袱。
- 音読み 存**平假名**（跟 reading drill 一致）；例詞 **runtime 從 jlptVocabulary 抽**（不手填、不可能抄）。
- 這只是種子；字數之後再分批補（150–200）。

## Bundle

新「漢字」tab **lazy**；`jlptVocabulary` 抽成共用 lazy chunk；**index 254.76 kB**（initial 不變），`KanjiOnyomiPanel` 4.65 kB lazy。

## 範圍

v1a 純 **browse**。「練這組」（filtered reading drill，用 Phase 1 擾動干擾）＋ 更多字 = v1b / 之後（依先前跟 Codex 定的計畫）。

## 驗證

`tsc` ✅ · `vitest` **150/150**（含 kanjiOnyomi 資料測 + App 整合測）✅ · `check:exam` 8/8 ✅ · `build` ✅
