### PR TITLE
feat(practice): JLPT level-range presets + multiline feedback gloss (closes #50)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -627,4 +627,20 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "深色模式" })).toBeInTheDocument();
   });
 
+  it("shows the 題庫範圍 picker in exam mode but not basic mode", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+    // Default basic mode has no level-range picker.
+    expect(screen.queryByText("題庫範圍")).toBeNull();
+
+    // 綜合考題庫 (exam) exposes the N1+N2 / N2+N3 range presets.
+    await user.click(screen.getByRole("button", { name: /綜合考題庫/ }));
+    expect(screen.getByText("題庫範圍")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "N1＋N2" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "N2＋N3" })).toBeInTheDocument();
+  });
+
 });

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -6,6 +6,7 @@ import { ExamPrompt } from "./ExamPrompt";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { SpeakButton } from "./SpeakButton";
 import type { Feedback } from "./types";
+import { LEVEL_RANGE_OPTIONS } from "../domain/levelRange";
 import { usePracticeSession, type PracticeMode, type SessionInit } from "../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
@@ -85,6 +86,8 @@ export function ChallengePanel({
     verbGroup,
     practiceFocus,
     practiceMode,
+    levelRange,
+    showLevelRange,
     selectedForm,
     questionIndex,
     selectedChoice,
@@ -111,6 +114,7 @@ export function ChallengePanel({
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
     handlePracticeModeChange,
+    handleLevelRangeChange,
     handleChoiceSubmit,
     nextQuestion,
     resetSession,
@@ -157,6 +161,25 @@ export function ChallengePanel({
           })}
         </div>
       </fieldset>
+
+      {showLevelRange ? (
+        <fieldset>
+          <legend>{t.levelRange}</legend>
+          <div className="segmented">
+            {LEVEL_RANGE_OPTIONS.map((range) => (
+              <button
+                key={range}
+                type="button"
+                className={levelRange === range ? "selected" : ""}
+                aria-pressed={levelRange === range}
+                onClick={() => handleLevelRangeChange(range)}
+              >
+                {t.levelRangeOptions[range]}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+      ) : null}
 
       {practiceMode === "basic" ? (
         <>

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -45,6 +45,27 @@ describe("FeedbackPanel distractor gloss", () => {
     expect(text).not.toContain(`${answer}（`);
   });
 
+  it("renders each reading distractor on its own line (multiline, answer excluded)", () => {
+    const question = readingPool[0];
+    const answer = question.expectedAnswers[0];
+    const distractors = Array.from(
+      new Set(readingPool.map((q) => q.expectedAnswers[0]).filter((reading) => reading !== answer))
+    ).slice(0, 2);
+
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={[answer, ...distractors]}
+      />
+    );
+
+    // One <li> per distractor (each option on its own line), answer excluded.
+    const items = container.querySelectorAll(".distractor-gloss-list li");
+    expect(items).toHaveLength(distractors.length);
+    items.forEach((li) => expect(li.textContent).not.toContain(`${answer}（`));
+  });
+
   it("glosses grammar distractors with each pattern's meaning (not 無對應詞)", () => {
     // Grammar items default targetForm to "reading", so this also guards
     // against the reading-gloss path firing for them.

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -42,22 +42,22 @@ export function FeedbackPanel({
   // Grammar-form items: options are patterns, so show each pattern's gloss.
   const isGrammarGloss = promptLabel === "文法形式選擇" || promptLabel === "文章脈絡";
 
-  let distractorGloss = "";
+  // One gloss string PER distractor, rendered one-per-line, so a long
+  // option list stays readable on mobile instead of wrapping mid-item.
+  let distractorGlosses: string[] = [];
   if (isReadingGloss) {
-    distractorGloss = distractors
-      .map((reading) => {
-        const words = lookupWordsByReading(reading);
-        return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
-      })
-      .join("・");
+    distractorGlosses = distractors.map((reading) => {
+      const words = lookupWordsByReading(reading);
+      return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
+    });
   } else if (isGrammarGloss) {
     const glossed = distractors.map((pattern) => ({ pattern, meaning: lookupPatternMeaning(pattern) }));
-    // Only show the line if the bank knew at least one pattern -- otherwise
+    // Only show the block if the bank knew at least one pattern -- otherwise
     // it would just re-list the options with no added information.
     if (glossed.some((entry) => entry.meaning)) {
-      distractorGloss = glossed
-        .map((entry) => (entry.meaning ? `${entry.pattern}（${entry.meaning}）` : entry.pattern))
-        .join("・");
+      distractorGlosses = glossed.map((entry) =>
+        entry.meaning ? `${entry.pattern}（${entry.meaning}）` : entry.pattern
+      );
     }
   }
 
@@ -74,10 +74,15 @@ export function FeedbackPanel({
       </div>
       <p className="answer-key">{t.answerKey}：{feedback.question.expectedAnswers.join(" / ")}</p>
       <p>{feedback.question.explanation}</p>
-      {distractorGloss ? (
-        <p className="distractor-gloss">
-          {t.feedbackOtherOptions}：{distractorGloss}
-        </p>
+      {distractorGlosses.length > 0 ? (
+        <div className="distractor-gloss">
+          <p className="distractor-gloss-label">{t.feedbackOtherOptions}：</p>
+          <ul className="distractor-gloss-list">
+            {distractorGlosses.map((gloss) => (
+              <li key={gloss}>{gloss}</li>
+            ))}
+          </ul>
+        </div>
       ) : null}
       {feedback.question.vocabulary.examples[0] ? (
         <p className="example">

--- a/src/domain/examBlocks.ts
+++ b/src/domain/examBlocks.ts
@@ -4660,7 +4660,18 @@ export const examStyleQuestions: PracticeQuestion[] = [
   })
 ];
 
-export function buildExamQuestionPool(level: JlptLevel | "all" = "all"): PracticeQuestion[] {
+export function buildExamQuestionPool(
+  level: JlptLevel | JlptLevel[] | "all" = "all"
+): PracticeQuestion[] {
+  // A level RANGE (e.g. ["N1","N2"] / ["N2","N3"]) -- keep every item in
+  // those levels, no N3 warm-up trimming (the caller asked for that band
+  // explicitly).
+  if (Array.isArray(level)) {
+    const levels = new Set(level);
+    return examStyleQuestions.filter(
+      (question) => question.vocabulary.level !== undefined && levels.has(question.vocabulary.level)
+    );
+  }
   if (level === "N1" || level === "N2" || level === "N3") {
     return examStyleQuestions.filter((question) => question.vocabulary.level === level);
   }

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { levelsForRange, LEVEL_RANGE_OPTIONS } from "./levelRange";
+import { buildExamQuestionPool } from "./examBlocks";
+
+describe("levelsForRange", () => {
+  it("maps presets to JLPT levels and null for all", () => {
+    expect(levelsForRange("all")).toBeNull();
+    expect(levelsForRange("n1n2")).toEqual(["N1", "N2"]);
+    expect(levelsForRange("n2n3")).toEqual(["N2", "N3"]);
+  });
+
+  it("offers 全部 first, then the two target bands", () => {
+    expect(LEVEL_RANGE_OPTIONS[0]).toBe("all");
+    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3"]);
+  });
+});
+
+describe("buildExamQuestionPool level range", () => {
+  it("N1+N2 keeps only N1/N2 items (no N3)", () => {
+    const pool = buildExamQuestionPool(["N1", "N2"]);
+    expect(pool.length).toBeGreaterThan(0);
+    expect(pool.every((q) => q.vocabulary.level === "N1" || q.vocabulary.level === "N2")).toBe(true);
+    expect(pool.some((q) => q.vocabulary.level === "N3")).toBe(false);
+  });
+
+  it("N2+N3 includes the full N3 set and excludes N1", () => {
+    const pool = buildExamQuestionPool(["N2", "N3"]);
+    expect(pool.every((q) => q.vocabulary.level === "N2" || q.vocabulary.level === "N3")).toBe(true);
+    expect(pool.some((q) => q.vocabulary.level === "N1")).toBe(false);
+    // The range pulls the FULL N3 set, more than the "all" pool's warm-up cap.
+    const n3InRange = pool.filter((q) => q.vocabulary.level === "N3").length;
+    const n3InAll = buildExamQuestionPool().filter((q) => q.vocabulary.level === "N3").length;
+    expect(n3InRange).toBeGreaterThan(n3InAll);
+  });
+
+  it("does not regress the single-level and all behaviour", () => {
+    expect(buildExamQuestionPool("N1").every((q) => q.vocabulary.level === "N1")).toBe(true);
+    const all = buildExamQuestionPool();
+    expect(all.some((q) => q.vocabulary.level === "N1")).toBe(true);
+    expect(all.some((q) => q.vocabulary.level === "N2")).toBe(true);
+    // "all" trims N3 to a small warm-up subset.
+    expect(all.filter((q) => q.vocabulary.level === "N3").length).toBeLessThanOrEqual(6);
+  });
+});

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -1,0 +1,22 @@
+import type { JlptLevel } from "./types";
+
+// Practice "level range" presets. A learner studying for N1 typically
+// wants to drill N1+N2; an N2 candidate wants N2+N3. This is a POOL
+// FILTER only -- the level never appears on the question itself (no
+// visible promptLabel); it just narrows which bank items are in play.
+// "all" keeps each pool's own default behaviour (no level narrowing).
+export type LevelRange = "all" | "n1n2" | "n2n3";
+
+// Order shown in the picker (全部 first, then the two target bands).
+export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3"];
+
+const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
+  n1n2: ["N1", "N2"],
+  n2n3: ["N2", "N3"]
+};
+
+// The JLPT levels a range covers, or null for "all" (= no filter; let the
+// pool keep its default mix).
+export function levelsForRange(range: LevelRange): JlptLevel[] | null {
+  return range === "all" ? null : RANGE_LEVELS[range];
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -3,6 +3,7 @@ import { ADJECTIVE_FORMS, VERB_FORMS } from "../domain/conjugation";
 import { buildClozeQuestionPool } from "../domain/cloze";
 import { clozeSentences } from "../domain/cloze-data";
 import { buildExamQuestionPool } from "../domain/examBlocks";
+import { levelsForRange, type LevelRange } from "../domain/levelRange";
 import type { MockExamLevel } from "../domain/mockExam";
 import { buildSentencePatternPool, type SentencePatternId } from "../domain/sentencePatterns";
 import {
@@ -42,6 +43,8 @@ export type SessionInit = {
   verbGroup?: VerbGroup | "all";
   practiceFocus?: PracticeFocus;
   targetForm?: TargetForm;
+  // JLPT level range for the exam (綜合) + vocab (単字) pools; default all.
+  levelRange?: LevelRange;
 };
 
 const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; verbOnly?: boolean }> = [
@@ -147,6 +150,7 @@ export function usePracticeSession({
   const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>(init?.practiceFocus ?? "single");
   const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "basic");
   const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>(init?.filter ?? {});
+  const [levelRange, setLevelRange] = useState<LevelRange>(init?.levelRange ?? "all");
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
@@ -172,6 +176,10 @@ export function usePracticeSession({
   const isDailyFocus = practiceMode === "daily";
   const isCuratedFocus =
     isExamFocus || isClozeFocus || isPatternFocus || isReviewFocus || isVocabFocus || isDailyFocus;
+  // The level-range picker applies to the 綜合考題庫 (exam with no fixed
+  // section) and 単字 pools -- the two banks with JLPT-tagged items. A
+  // mock-launched exam section already fixes the level, so hide it there.
+  const showLevelRange = (isExamFocus && !practiceFilter.examSection) || isVocabFocus;
 
   // Union pool used to materialise the review queue: any question the
   // learner has ever encountered (across exam / cloze / pattern / basic)
@@ -257,7 +265,8 @@ export function usePracticeSession({
             )
           );
         }
-        return shuffleQuestions(buildExamQuestionPool());
+        // 綜合考題庫: optionally narrowed to a level range (N1+N2 / N2+N3).
+        return shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"));
       }
 
       if (isClozeFocus) {
@@ -289,8 +298,12 @@ export function usePracticeSession({
         // 影響 is えいきょう, not えいきゅう. Meaning is still tested,
         // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
         // 詞彙用法 sections -- which is the authentic way to test it.
+        const levels = levelsForRange(levelRange);
+        const vocabSource = levels
+          ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
+          : jlptVocabulary;
         const vocabPool = shuffleQuestions(
-          buildQuestionPool(jlptVocabulary, {
+          buildQuestionPool(vocabSource, {
             partOfSpeech: "mixed",
             verbGroup: "all",
             targetForms: ["reading"]
@@ -345,6 +358,7 @@ export function usePracticeSession({
       partOfSpeech,
       targetForms,
       verbGroup,
+      levelRange,
       sessionSeed
     ]
   );
@@ -394,6 +408,12 @@ export function usePracticeSession({
     // via the picker -- the picker means "give me a fresh mix",
     // whereas a chapter drill button sets a specific patternIds filter.
     setPracticeFilter({});
+    resetSession();
+  };
+
+  const handleLevelRangeChange = (nextRange: LevelRange) => {
+    if (nextRange === levelRange) return;
+    setLevelRange(nextRange);
     resetSession();
   };
 
@@ -451,6 +471,8 @@ export function usePracticeSession({
     verbGroup,
     practiceFocus,
     practiceMode,
+    levelRange,
+    showLevelRange,
     selectedForm,
     questionIndex,
     selectedChoice,
@@ -479,6 +501,7 @@ export function usePracticeSession({
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
     handlePracticeModeChange,
+    handleLevelRangeChange,
     handleChoiceSubmit,
     nextQuestion,
     resetSession,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -99,6 +99,8 @@ export type Copy = {
   todayPractice: string;
   practiceType: string;
   practiceMode: string;
+  levelRange: string;
+  levelRangeOptions: { all: string; n1n2: string; n2n3: string };
   practiceFocus: string;
   verbGroup: string;
   targetForm: string;
@@ -268,6 +270,8 @@ export const copy: Record<Language, Copy> = {
     todayPractice: "今日練習",
     practiceType: "練習類型",
     practiceMode: "練習模式",
+    levelRange: "題庫範圍",
+    levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3" },
     practiceFocus: "練習重點",
     verbGroup: "動詞類別",
     targetForm: "目標形",

--- a/src/styles.css
+++ b/src/styles.css
@@ -1415,6 +1415,25 @@ select:disabled {
   font-size: 0.9rem;
 }
 
+.distractor-gloss-label {
+  margin: 0 0 0.25rem;
+}
+
+.distractor-gloss-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+/* Each distractor on its own line -- on mobile they must not crowd onto
+   one row (issue #50). */
+.distractor-gloss-list li {
+  line-height: 1.4;
+}
+
 .example {
   border-top: 1px solid var(--example-rule);
   margin-bottom: 0;


### PR DESCRIPTION
Closes #50.

**Base:** `main`. Independent of #49 (漢字 table) — different files, no dependency, not stacked.

## 1. JLPT level-range presets（題庫範圍）
- New `src/domain/levelRange.ts`：`all` / `n1n2` / `n2n3` → JLPT 等級。
- `buildExamQuestionPool` 現在也接受**等級陣列**（範圍）；既有單一等級與 `"all"` 行為完全不變。
- `usePracticeSession` 只在 **綜合考題庫（exam 無固定 section）+ 単字（vocab）** 兩個 pool 套用範圍；**daily / review / exam-section flow 完全不動**。
- ChallengePanel 在這兩個 mode 顯示「題庫範圍」segmented（全部 / N1＋N2 / N2＋N3）；mock 帶 section 進來時隱藏（等級已固定）。
- **等級只是 pool filter，永遠不進題目可見的 promptLabel**，只出現在篩選 UI（與答題後的等級標籤）。

## 2. FeedbackPanel 詳解逐行
- 「其他選項」改成每個選項一行（`<ul>`），手機版不再擠成一行。
- **Gating 不變**（仍以 promptLabel 判斷）：単字／漢字読み → reading gloss；文法形式選擇／文章脈絡 → grammar gloss；語順組合／類義替換／詞彙用法／詞彙填空／句型練習 → 不顯示。
- 正解仍排除在清單外；無 gloss 時整塊不顯示。

## 測試 / 驗證
- 新增：`levelRange` pool/filter 行為、FeedbackPanel multiline、exam-mode 範圍 picker 出現。
- **既有 gating matrix 5 案不 regression**。
- `corepack pnpm test` **152/152**、`check:exam` **8/8**、`build` ✅（index **254.05 kB**，examBlocks 仍獨立 lazy chunk）。

> 註：examBlocks.ts 的 diff 只有 `buildExamQuestionPool` 那段（13 行）；用 `core.autocrlf=false` 精確替換、保留原檔 CRLF，避免整檔 line-ending churn。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JLPT level range picker (All, N1+N2, N2+N3) to customize question pools in exam and vocabulary practice modes.

* **Improvements**
  * Distractor explanations in feedback now display as organized lists for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->