### PR TITLE
feat(challenge): expose selection + result via DOM data attributes (closes #51)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -661,4 +661,52 @@ describe("App", () => {
     expect(screen.getByText("かいけつ")).toBeInTheDocument();
   });
 
+  it("exposes data-selected and data-result on choice buttons after answering", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+
+    const grid = screen.getByLabelText("答案選項");
+    const options = within(grid).getAllByRole("button");
+    // Nothing flagged before answering.
+    options.forEach((button) => {
+      expect(button).not.toHaveAttribute("data-selected");
+      expect(button).not.toHaveAttribute("data-result");
+    });
+
+    await user.click(options[0]);
+
+    // Exactly one button carries data-selected="true" -- the one picked.
+    const selected = grid.querySelectorAll('[data-selected="true"]');
+    expect(selected).toHaveLength(1);
+    expect(selected[0]).toBe(options[0]);
+
+    // The picked button gets a result. If wrong, the correct answer is
+    // flagged target; if correct, there is no target.
+    const result = options[0].getAttribute("data-result");
+    expect(["correct", "wrong"]).toContain(result);
+    if (result === "wrong") {
+      const target = grid.querySelector('[data-result="target"]');
+      expect(target).not.toBeNull();
+      expect(target).not.toBe(options[0]);
+    } else {
+      expect(grid.querySelector('[data-result="target"]')).toBeNull();
+    }
+  });
+
+  it("flags the correct answer with data-result=target when revealed", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+
+    await user.click(screen.getByRole("button", { name: "看答案" }));
+
+    const grid = screen.getByLabelText("答案選項");
+    // Revealing flags the correct answer(s) as target, with nothing selected.
+    expect(grid.querySelectorAll('[data-result="target"]').length).toBeGreaterThanOrEqual(1);
+    expect(grid.querySelector('[data-selected="true"]')).toBeNull();
+  });
+
 });

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -323,17 +323,38 @@ export function ChallengePanel({
           </div>
 
           <div className="choice-grid" aria-label={t.answerOptions}>
-            {choiceOptions.map((choice) => (
-              <button
-                key={choice}
-                type="button"
-                className={choiceOptionClass(choice, selectedChoice, feedback)}
-                disabled={Boolean(feedback)}
-                onClick={() => handleChoiceSubmit(choice)}
-              >
-                {choice}
-              </button>
-            ))}
+            {choiceOptions.map((choice) => {
+              // Expose selection + result as DOM data attributes for AI /
+              // browser-automation testability. Derived purely from existing
+              // state -- no change to click handling or to choiceOptionClass
+              // (the visual styling). Multi-answer aware via expectedAnswers.
+              const isSelected = selectedChoice === choice;
+              let dataResult: "correct" | "wrong" | "target" | undefined;
+              if (feedback) {
+                if (isSelected) {
+                  dataResult = feedback.status === "correct" ? "correct" : "wrong";
+                } else if (
+                  feedback.status !== "correct" &&
+                  currentQuestion.expectedAnswers.includes(choice)
+                ) {
+                  // Got it wrong (or revealed) -> flag the correct answer button.
+                  dataResult = "target";
+                }
+              }
+              return (
+                <button
+                  key={choice}
+                  type="button"
+                  className={choiceOptionClass(choice, selectedChoice, feedback)}
+                  disabled={Boolean(feedback)}
+                  onClick={() => handleChoiceSubmit(choice)}
+                  data-selected={isSelected ? "true" : undefined}
+                  data-result={dataResult}
+                >
+                  {choice}
+                </button>
+              );
+            })}
           </div>
 
           <div className="action-row">


### PR DESCRIPTION
Closes #51.

**Base:** `main`. Independent PR — only DOM data attributes on the choice buttons; no題庫 / UI redesign.

## 新增的 DOM attributes（`ChallengePanel` choice buttons）
全部由現有 state 派生，**不改 click handler、不加新 state**：
- `data-selected="true"` — 使用者點選的選項（未選則**不輸出**該屬性，策略一致）。
- `data-result`（答題後才出現）：
  - 答對 → 選中按鈕 `data-result="correct"`
  - 答錯 → 選中按鈕 `data-result="wrong"`
  - 答錯（或按「看答案」）→ 正確答案按鈕 `data-result="target"`
- 多正解：用 `currentQuestion.expectedAnswers.includes(choice)` 判斷 target。

## 是否改變 UI
**沒有。** `choiceOptionClass` 與 selected / correct / wrong 的樣式、鍵盤操作、Enter 下一題、解析顯示全部不動。這些屬性只給 AI / 自動化工具讀，不驅動 CSS。

## 測試
`App.test.tsx` 新增：
- 點選項後 DOM 有且只有該選項 `data-selected="true"`；答題前無 `data-selected` / `data-result`。
- 答對 → `data-result="correct"`；答錯 → 選中 `data-result="wrong"` + 正解 `data-result="target"`。
- 按「看答案」→ 正解 `data-result="target"`、無 `data-selected`。
- 既有流程測試不 regression。

## 驗證
`tsc` ✅ · `vitest` **154** · `check:exam` **8/8** · `build` ✅（index **254.05 kB** 不變）
