### PR TITLE
feat(challenge): surface N1/N2 備考 as parallel mode presets (closes #65)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -629,20 +629,33 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "深色模式" })).toBeInTheDocument();
   });
 
-  it("shows the 題庫範圍 picker in exam mode but not basic mode", async () => {
+  it("lists 綜合考題庫 / N1 備考 / N2 備考 as side-by-side mode presets", async () => {
     const user = userEvent.setup();
     render(<App />);
 
     await user.click(screen.getByRole("button", { name: "挑戰" }));
     await screen.findByRole("region", { name: "目前題目" });
-    // Default basic mode has no level-range picker.
+
+    // The exam pool's level ranges are now first-class mode cards, not an
+    // in-mode "題庫範圍" segmented filter.
+    const exam = screen.getByRole("button", { name: /綜合考題庫/ });
+    const n1 = screen.getByRole("button", { name: /N1 備考/ });
+    const n2 = screen.getByRole("button", { name: /N2 備考/ });
+    expect(exam).toBeInTheDocument();
+    expect(n1).toBeInTheDocument();
+    expect(n2).toBeInTheDocument();
     expect(screen.queryByText("題庫範圍")).toBeNull();
 
-    // 綜合考題庫 (exam) exposes the N1+N2 / N2+N3 range presets.
-    await user.click(screen.getByRole("button", { name: /綜合考題庫/ }));
-    expect(screen.getByText("題庫範圍")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "N1＋N2" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "N2＋N3" })).toBeInTheDocument();
+    // Picking N2 備考 activates it (exam mode + N2+N3 range) and deselects
+    // 綜合. The pool actually narrowing to N2/N3 is covered by
+    // levelRange.test.ts (buildExamQuestionPool(["N2","N3"]) excludes N1).
+    await user.click(n2);
+    expect(n2).toHaveAttribute("aria-pressed", "true");
+    expect(exam).toHaveAttribute("aria-pressed", "false");
+    // The active-mode summary reflects the picked preset's copy (examN2
+    // 「N2＋N3 綜合題」), not the generic 綜合 text -- so that copy now
+    // appears on BOTH the N2 備考 card and the summary (>= 2 occurrences).
+    expect(screen.getAllByText(/N2＋N3 綜合題/).length).toBeGreaterThanOrEqual(2);
   });
 
   it("opens the 漢字音読み table and shows example words for a kanji", async () => {

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -6,7 +6,7 @@ import { ExamPrompt } from "./ExamPrompt";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { SpeakButton } from "./SpeakButton";
 import type { Feedback } from "./types";
-import { LEVEL_RANGE_OPTIONS } from "../domain/levelRange";
+import { LEVEL_RANGE_OPTIONS, type LevelRange } from "../domain/levelRange";
 import { usePracticeSession, type PracticeMode, type SessionInit } from "../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
@@ -34,7 +34,23 @@ const formOptions: TargetForm[] = [
   "plainPastNegative"
 ];
 
-const practiceModeOrder: PracticeMode[] = ["daily", "basic", "cloze", "pattern", "exam", "vocab", "review"];
+// Mode picker entries. The exam pool is surfaced as three side-by-side
+// presets -- 綜合考題庫 (all levels) plus N1 備考 (N1+N2) and N2 備考
+// (N2+N3) -- so the備考 ranges are first-class picks rather than a filter
+// hidden inside the exam mode. `id` doubles as the i18n / count key.
+type ModePresetId = PracticeMode | "examN1" | "examN2";
+type ModePreset = { id: ModePresetId; mode: PracticeMode; levelRange?: LevelRange };
+const modePresetOrder: ModePreset[] = [
+  { id: "daily", mode: "daily" },
+  { id: "basic", mode: "basic" },
+  { id: "cloze", mode: "cloze" },
+  { id: "pattern", mode: "pattern" },
+  { id: "exam", mode: "exam", levelRange: "all" },
+  { id: "examN1", mode: "exam", levelRange: "n1n2" },
+  { id: "examN2", mode: "exam", levelRange: "n2n3" },
+  { id: "vocab", mode: "vocab" },
+  { id: "review", mode: "review" }
+];
 
 function choiceOptionClass(choice: string, selectedChoice: string | null, feedback: Feedback): string {
   const classes = ["choice-option"];
@@ -101,6 +117,7 @@ export function ChallengePanel({
     isVerbCapable,
     availableFocusOptions,
     focusSummary,
+    activeModeCopyKey,
     reviewQueue,
     modeCounts,
     currentQuestion,
@@ -113,7 +130,7 @@ export function ChallengePanel({
     nextButtonRef,
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
-    handlePracticeModeChange,
+    applyModePreset,
     handleLevelRangeChange,
     handleChoiceSubmit,
     nextQuestion,
@@ -136,23 +153,28 @@ export function ChallengePanel({
       <fieldset>
         <legend>{t.practiceMode}</legend>
         <div className="mode-toggle">
-          {practiceModeOrder.map((mode) => {
+          {modePresetOrder.map((preset) => {
             const count =
-              mode === "review"
+              preset.mode === "review"
                 ? reviewQueue.length
-                : mode === "basic" || mode === "daily"
+                : preset.mode === "basic" || preset.mode === "daily"
                 ? null
-                : modeCounts[mode];
+                : modeCounts[preset.id as keyof typeof modeCounts];
+            // The exam presets share one mode; the active one is whichever
+            // matches the current level range.
+            const selected =
+              practiceMode === preset.mode &&
+              (preset.mode !== "exam" || (preset.levelRange ?? "all") === levelRange);
             return (
               <button
-                key={mode}
+                key={preset.id}
                 type="button"
-                className={`mode-card${practiceMode === mode ? " selected" : ""}`}
-                aria-pressed={practiceMode === mode}
-                onClick={() => handlePracticeModeChange(mode)}
+                className={`mode-card${selected ? " selected" : ""}`}
+                aria-pressed={selected}
+                onClick={() => applyModePreset(preset.mode, preset.levelRange ?? "all")}
               >
-                <strong>{t.modeOptions[mode].title}</strong>
-                <small>{t.modeOptions[mode].subtitle}</small>
+                <strong>{t.modeOptions[preset.id].title}</strong>
+                <small>{t.modeOptions[preset.id].subtitle}</small>
                 {count !== null ? (
                   <span className="mode-card-count">{t.modeQuestionCount(count)}</span>
                 ) : null}
@@ -261,7 +283,7 @@ export function ChallengePanel({
         </>
       ) : (
         <div className="mode-description">
-          <p>{t.modeOptions[practiceMode].subtitle}</p>
+          <p>{t.modeOptions[activeModeCopyKey].subtitle}</p>
         </div>
       )}
 

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -179,7 +179,10 @@ export function usePracticeSession({
   // The level-range picker applies to the 綜合考題庫 (exam with no fixed
   // section) and 単字 pools -- the two banks with JLPT-tagged items. A
   // mock-launched exam section already fixes the level, so hide it there.
-  const showLevelRange = (isExamFocus && !practiceFilter.examSection) || isVocabFocus;
+  // The exam pool's level ranges are now their own mode-picker presets
+  // (綜合 / N1 備考 / N2 備考), so the in-mode range segmented is only
+  // needed for the vocab pool.
+  const showLevelRange = isVocabFocus;
 
   // Union pool used to materialise the review queue: any question the
   // learner has ever encountered (across exam / cloze / pattern / basic)
@@ -220,6 +223,8 @@ export function usePracticeSession({
       cloze: buildClozeQuestionPool(clozeSentences, vocabulary).length,
       pattern: buildSentencePatternPool().length,
       exam: buildExamQuestionPool().length,
+      examN1: buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length,
+      examN2: buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length,
       vocab: buildQuestionPool(jlptVocabulary, {
         partOfSpeech: "mixed",
         verbGroup: "all",
@@ -244,8 +249,20 @@ export function usePracticeSession({
     [practiceFocus, isCuratedFocus, selectedForm]
   );
   const activeFocusForms = targetForms.filter((form) => compatibleForms.includes(form));
+  // Exam mode is one PracticeMode but three picker presets (綜合 / N1 備考
+  // / N2 備考). Map the active mode+range to the matching copy key so the
+  // summary + mode description reflect the chosen 備考 preset, not the
+  // generic 綜合考題庫 text.
+  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" =
+    practiceMode === "exam"
+      ? levelRange === "n1n2"
+        ? "examN1"
+        : levelRange === "n2n3"
+          ? "examN2"
+          : "exam"
+      : practiceMode;
   const focusSummary = isCuratedFocus
-    ? t.modeOptions[practiceMode].subtitle
+    ? t.modeOptions[activeModeCopyKey].subtitle
     : practiceFocus === "single"
     ? t.targetForms[selectedForm]
     : activeFocusForms.map((form) => t.targetForms[form]).join(" / ") || t.focusSummaryEmpty;
@@ -401,12 +418,15 @@ export function usePracticeSession({
     resetSession();
   };
 
-  const handlePracticeModeChange = (nextMode: PracticeMode) => {
-    if (nextMode === practiceMode) return;
+  // The mode picker lists the exam pool as three side-by-side presets
+  // (綜合 / N1 備考 / N2 備考), so picking one sets BOTH the mode and its
+  // level range at once. Non-exam presets pass "all" (a no-op for the
+  // modes that ignore levelRange). Clearing the filter keeps the picker a
+  // "fresh mix" (a chapter drill button is what sets a patternIds filter).
+  const applyModePreset = (nextMode: PracticeMode, nextRange: LevelRange = "all") => {
+    if (nextMode === practiceMode && nextRange === levelRange) return;
     setPracticeMode(nextMode);
-    // Clear any chapter-driven filter when the learner switches modes
-    // via the picker -- the picker means "give me a fresh mix",
-    // whereas a chapter drill button sets a specific patternIds filter.
+    setLevelRange(nextRange);
     setPracticeFilter({});
     resetSession();
   };
@@ -488,6 +508,7 @@ export function usePracticeSession({
     isVerbCapable,
     availableFocusOptions,
     focusSummary,
+    activeModeCopyKey,
     reviewQueue,
     modeCounts,
     currentQuestion,
@@ -500,7 +521,7 @@ export function usePracticeSession({
     nextButtonRef,
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
-    handlePracticeModeChange,
+    applyModePreset,
     handleLevelRangeChange,
     handleChoiceSubmit,
     nextQuestion,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -133,7 +133,7 @@ export type Copy = {
   feedbackOtherOptions: string;
   feedbackNoWord: string;
   focusSummaryEmpty: string;
-  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
+  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
   homeCardVocabTitle: string;
   homeCardVocabSub: string;
@@ -319,6 +319,8 @@ export const copy: Record<Language, Copy> = {
       cloze: { title: "句中填空", subtitle: "N5 文型 · 〜てください / 〜たいです" },
       pattern: { title: "句型練習", subtitle: "N5/N4 句型判斷 · 視角 / 許可 / 引用 / 不必" },
       exam: { title: "綜合考題庫", subtitle: "N1/N2 為主 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
+      examN1: { title: "N1 備考", subtitle: "N1＋N2 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
+      examN2: { title: "N2 備考", subtitle: "N2＋N3 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
       vocab: { title: "単字讀音", subtitle: "N1/N2 漢字詞 · 選正確讀音（よみ）" },
       review: { title: "弱點複習", subtitle: "把上次答錯的題目重練到對為止" }
     },


### PR DESCRIPTION
Closes #65.

把 JLPT 範圍（N1＋N2 / N2＋N3）從「綜合考題庫」mode 內的 segmented filter，**提升成練習模式列表裡的並列獨立項**。

## 改動
- 練習模式列表：**綜合考題庫(全部) / N1 備考(N1＋N2) / N2 備考(N2＋N3)** 三項並列（與単字讀音、弱點複習等並排）。
- 點一項同時設 `mode + levelRange`（`applyModePreset`）。
- 移除 exam 的「題庫範圍」segmented（vocab 的保留，行為不變）。

## 複用既有機制（非新邏輯）
`SessionInit.levelRange` + `buildExamQuestionPool(range)` + `levelsForRange`（#50 已建）。pool filter 本身不變，仍由 `levelRange.test.ts` 覆蓋（`buildExamQuestionPool(["N2","N3"])` 不含 N1）。

## 檔案
- `ChallengePanel.tsx`：`modePresetOrder`（exam 拆 3 preset）+ `selected`（mode＋levelRange 推導）+ `applyModePreset` onClick
- `usePracticeSession.ts`：`applyModePreset` handler + `modeCounts` 加 examN1/examN2 + `showLevelRange` 收斂為僅 vocab
- `i18n.ts`：N1 備考 / N2 備考 title＋subtitle
- `App.test.tsx`：原 in-mode picker 測試改成並列 preset 驗證

## 是否改 UI / bundle
- 視覺：mode picker 多兩張卡（沿用既有 `mode-card` 樣式），無新 CSS。
- bundle：index 255.07 kB（+~0.2，純 i18n 文案）；preset 邏輯在 ChallengePanel 的 lazy chunk；examBlocks 仍獨立 lazy。

## 驗證
`tsc` ✅ · `vitest` **159** · `check:exam` **8/8** · `build` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added N1 and N2 exam mode presets as separate selection options
  * Exam mode selection interface now features side-by-side preset buttons for streamlined mode switching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->