### PR TITLE
feat(challenge): collapse the pre-answer hint behind a 提示 toggle (closes #69)

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { ExamPrompt } from "./ExamPrompt";
 import { examStyleQuestions } from "../domain/examBlocks";
@@ -17,13 +18,52 @@ describe("ExamPrompt answer-leak guard", () => {
 
     const { container } = render(<ExamPrompt question={item!} language="zh-Hant" />);
 
-    // The prompt sentence and the neutral situation hint still render...
+    // The prompt sentence renders; the neutral situation hint is now behind
+    // the 提示 toggle (collapsed by default), so its text isn't shown yet.
     expect(screen.getByText(/病院へ行った/)).toBeInTheDocument();
-    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
-    // ...but the leaky surface・reading・meaning vocab row is gone.
+    expect(screen.getByRole("button", { name: "提示" })).toBeInTheDocument();
+    expect(screen.queryByText("發燒時對就醫安排的判斷。")).not.toBeInTheDocument();
+    // ...and the leaky surface・reading・meaning vocab row is gone.
     expect(container.querySelector("p.reading")).toBeNull();
     expect(screen.queryByText(/たほうがいい/)).not.toBeInTheDocument();
     expect(screen.queryByText(/比較好（建議）/)).not.toBeInTheDocument();
+  });
+
+  it("reveals the pre-answer hint only after tapping 提示, and collapses again", async () => {
+    const user = userEvent.setup();
+    const item = examStyleQuestions.find((question) => question.id === "n3-grammar-tahougaii");
+    render(<ExamPrompt question={item!} language="zh-Hant" />);
+
+    const toggle = screen.getByRole("button", { name: "提示" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("發燒時對就醫安排的判斷。")).not.toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "隱藏提示" })).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(screen.getByRole("button", { name: "隱藏提示" }));
+    expect(screen.queryByText("發燒時對就醫安排的判斷。")).not.toBeInTheDocument();
+  });
+
+  it("collapses the hint again when the question changes", async () => {
+    const user = userEvent.setup();
+    const first = examStyleQuestions.find((question) => question.id === "n3-grammar-tahougaii");
+    const second = examStyleQuestions.find(
+      (question) => question.id !== first!.id && (question.hintZh ?? question.promptContextZh)
+    );
+    expect(second).toBeDefined();
+    const { rerender } = render(<ExamPrompt question={first!} language="zh-Hant" />);
+
+    // Expand the hint on the first question.
+    await user.click(screen.getByRole("button", { name: "提示" }));
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+
+    // Switching to another question resets the toggle to collapsed
+    // (useEffect keyed by question.id), so the new question starts hidden.
+    rerender(<ExamPrompt question={second!} language="zh-Hant" />);
+    expect(screen.getByRole("button", { name: "提示" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("發燒時對就醫安排的判斷。")).not.toBeInTheDocument();
   });
 
   it("keeps the surface・reading・meaning row for cloze items", () => {

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from "react";
 import { GraduationCap } from "lucide-react";
-import { type Language } from "../i18n";
+import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
 import { SpeakButton } from "./SpeakButton";
 
@@ -7,6 +8,16 @@ import { SpeakButton } from "./SpeakButton";
 // sentence with the blank, a neutral pre-answer hint, and (when safe) a
 // surface・reading・meaning vocab row.
 export function ExamPrompt({ question, language }: { question: PracticeQuestion; language: Language }) {
+  const t = copy[language];
+  // The pre-answer hint sits behind a toggle so the learner attempts the
+  // question first and reveals the hint only when stuck. Reset to hidden
+  // on every question change (keyed by id) so each new question starts
+  // collapsed.
+  const [showHint, setShowHint] = useState(false);
+  useEffect(() => {
+    setShowHint(false);
+  }, [question.id]);
+
   // Sentence-pattern items use placeholder surface/reading (the pattern
   // id) which would render as a meaningless "te-kudasai・te-kudasai・..."
   // line. Skip the vocab row for those items -- the prompt label
@@ -44,7 +55,19 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
           <SpeakButton text={question.promptText} language={language} />
         ) : null}
       </p>
-      {preAnswerHint ? <p className="meaning">{preAnswerHint}</p> : null}
+      {preAnswerHint ? (
+        <div className="hint-block">
+          <button
+            type="button"
+            className="hint-toggle"
+            aria-expanded={showHint}
+            onClick={() => setShowHint((shown) => !shown)}
+          >
+            {showHint ? t.hideHint : t.showHint}
+          </button>
+          {showHint ? <p className="meaning">{preAnswerHint}</p> : null}
+        </div>
+      ) : null}
       {showVocabRow ? (
         <p className="reading">
           {question.vocabulary.surface}・{question.vocabulary.reading}・{question.vocabulary.meaningZh}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -132,6 +132,8 @@ export type Copy = {
   answerKey: string;
   feedbackOtherOptions: string;
   feedbackNoWord: string;
+  showHint: string;
+  hideHint: string;
   focusSummaryEmpty: string;
   modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
@@ -312,6 +314,8 @@ export const copy: Record<Language, Copy> = {
     answerKey: "正解",
     feedbackOtherOptions: "其他選項",
     feedbackNoWord: "無對應詞",
+    showHint: "提示",
+    hideHint: "隱藏提示",
     focusSummaryEmpty: "目前重點沒有可用形",
     modeOptions: {
       daily: { title: "今日練習", subtitle: "複習優先 · 文法 / 語順 / 漢字読み混合一輪" },

--- a/src/styles.css
+++ b/src/styles.css
@@ -1286,6 +1286,33 @@ select:disabled {
   text-align: left;
 }
 
+/* Collapsible pre-answer hint (ExamPrompt). The toggle button is low-key
+   so it doesn't compete with the prompt; the hint text reuses .meaning. */
+.hint-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+}
+
+.hint-toggle {
+  align-self: flex-start;
+  padding: 0.25rem 0.7rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.hint-toggle:hover,
+.hint-toggle[aria-expanded="true"] {
+  color: var(--ink);
+  border-color: var(--matcha);
+}
+
 .choice-grid {
   display: grid;
   gap: 0.6rem;


### PR DESCRIPTION
Closes #69.

題目句下方的中文提示小字（例如「『断る』是拒絕邀請、要求」）原本直接顯示，改成可開關的「提示」按鈕。

## 改動
- **預設收起**（只顯示「提示」按鈕），讓使用者先自己作答。
- 點「提示」展開、點「隱藏提示」收合（toggle）。
- **換題自動收起**（依 `question.id` reset）。
- `aria-expanded`、鍵盤可操作；沒有提示的題不顯示按鈕。

## 檔案
- `src/components/ExamPrompt.tsx`（`showHint` state + `useEffect` reset + toggle 按鈕）
- `src/i18n.ts`（提示 / 隱藏提示）
- `src/styles.css`（`.hint-toggle` / `.hint-block`，低調樣式）
- `src/components/ExamPrompt.test.tsx`（預設收起 + toggle 行為 + 收合）

## 是否改 UI
提示從常駐小字改成按鈕開關；其餘 prompt 版面不變。答題後 FeedbackPanel 的解析不受影響。

## 驗證
`tsc` ✅ · `vitest` **160** · `check:exam` **8/8** · `build` ✅（index 254.90 kB、examBlocks 仍獨立 lazy chunk）
