### PR TITLE
feat(challenge): split today's stats into a 今日戰報 block, clean up 錯題複習 (closes #71)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -658,6 +658,22 @@ describe("App", () => {
     expect(screen.getAllByText(/N2＋N3 綜合題/).length).toBeGreaterThanOrEqual(2);
   });
 
+  it("shows accuracy in the 今日戰報 stats block, not on the 錯題複習 heading", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+
+    // Accuracy is a labelled value with a progress bar in 今日戰報.
+    expect(screen.getByText("目前正解率")).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+
+    // The 錯題複習 panel no longer carries the percentage (which read as a
+    // mistake-list count); the progress bar lives only in 戰報.
+    const reviewPanel = screen.getByLabelText("錯題");
+    expect(within(reviewPanel).queryByRole("progressbar")).toBeNull();
+  });
+
   it("opens the 漢字音読み table and shows example words for a kanji", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -289,19 +289,35 @@ export function ChallengePanel({
 
       <p className="focus-summary">{focusSummary}</p>
 
-      <div className="score-strip" aria-label="本次練習成績">
-        <span>
-          <strong>{attempts.length}</strong>
-          {t.answered}
-        </span>
-        <span>
-          <strong>{correctCount}</strong>
-          {t.correctShort}
-        </span>
-        <span>
-          <strong>{mistakeQuestions.length}</strong>
-          {t.reviewShort}
-        </span>
+      <div className="score-report" role="group" aria-label="今日戰報">
+        <div className="score-strip">
+          <span>
+            <strong>{attempts.length}</strong>
+            {t.answered}
+          </span>
+          <span>
+            <strong>{correctCount}</strong>
+            {t.correctShort}
+          </span>
+          <span>
+            <strong>{mistakeQuestions.length}</strong>
+            {t.reviewShort}
+          </span>
+        </div>
+        <p className="score-accuracy">
+          <span className="score-accuracy-label">{t.accuracyLabel}</span>
+          <strong className="score-accuracy-value">{accuracy}%</strong>
+        </p>
+        <div
+          className="score-bar"
+          role="progressbar"
+          aria-valuenow={accuracy}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={t.accuracyLabel}
+        >
+          <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
+        </div>
       </div>
 
       <button className="ghost-button" type="button" onClick={resetSession}>
@@ -446,7 +462,6 @@ export function ChallengePanel({
     <aside className="review-panel" aria-label={t.mistakesLabel}>
       <div className="review-heading">
         <h2>{t.mistakeReview}</h2>
-        <span>{accuracy}%</span>
       </div>
       {mistakeQuestions.length > 0 ? (
         <ul>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -116,6 +116,7 @@ export type Copy = {
   answered: string;
   correctShort: string;
   reviewShort: string;
+  accuracyLabel: string;
   resetSession: string;
   currentQuestion: string;
   questionNumber: (value: number) => string;
@@ -298,6 +299,7 @@ export const copy: Record<Language, Copy> = {
     answered: "已答",
     correctShort: "正解",
     reviewShort: "複習",
+    accuracyLabel: "目前正解率",
     resetSession: "重設本次",
     currentQuestion: "目前題目",
     questionNumber: (value) => `第 ${value} 題`,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1166,13 +1166,19 @@ select:disabled {
   margin: 0;
 }
 
+.score-report {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  margin: 1rem 0;
+}
+
 .score-strip {
   border-bottom: 1px solid var(--rule);
   border-top: 1px solid var(--rule);
   display: grid;
   gap: 0.4rem;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin: 1rem 0;
   padding: 0.8rem 0;
 }
 
@@ -1189,6 +1195,41 @@ select:disabled {
   color: var(--ink);
   font-size: 1.25rem;
   line-height: 1;
+}
+
+/* 今日戰報 accuracy: enlarged value + labelled + progress bar, kept
+   separate from the 錯題複習 list so the rate isn't read as a count. */
+.score-accuracy {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  margin: 0;
+}
+
+.score-accuracy-label {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.score-accuracy-value {
+  color: var(--matcha-dark);
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.score-bar {
+  background: var(--rule);
+  border-radius: 999px;
+  height: 0.5rem;
+  overflow: hidden;
+}
+
+.score-bar-fill {
+  background: var(--matcha);
+  border-radius: 999px;
+  display: block;
+  height: 100%;
+  transition: width 0.3s ease;
 }
 
 .prompt-header {


### PR DESCRIPTION
Closes #71.

挑戰頁側邊欄的答對率「46%」原本放在「錯題複習」標題右側，會被誤讀成錯題清單的進度。把它移進統計區、並讓錯題複習標題保持乾淨。

## 改動
- **今日戰報**（`score-report`）：已答 / 正解 / 複習 三個計數 + **放大、有標籤的「目前正解率 X%」+ 進度條**。
- **錯題複習** 標題：只剩標題，右側不再有百分比。
- 進度條有 `role="progressbar"` + `aria-valuenow/min/max` + label。

## 檔案
- `src/components/ChallengePanel.tsx`（score-report 包裝 + 進度條；review-heading 移除 accuracy span）
- `src/i18n.ts`（accuracyLabel「目前正解率」）
- `src/styles.css`（`.score-report` / `.score-accuracy` / `.score-bar`）
- `src/App.test.tsx`（accuracy 顯示在戰報 + 進度條；錯題複習 panel 無 progressbar）

## 是否改流程 / UI 行為
否。只動側邊欄統計的呈現與錯題複習標題；答題流程、pool、錯題清單內容都不變。

## 驗證
`tsc` ✅ · `vitest` **162** · `check:exam` **8/8** · `build` ✅（index 255.14 kB、examBlocks 仍獨立 lazy chunk）
