### PR TITLE
feat(challenge): expose answer state on the drill container for embedded AI (closes #75)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -738,4 +738,40 @@ describe("App", () => {
     expect(grid.querySelector('[data-selected="true"]')).toBeNull();
   });
 
+  it("exposes the whole answer state on the drill container for embedded AI", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    const panel = await screen.findByRole("region", { name: "目前題目" });
+
+    // Before answering: unanswered, with no selection / expected answer leaked.
+    expect(panel).toHaveAttribute("data-result", "unanswered");
+    expect(panel).not.toHaveAttribute("data-selected");
+    expect(panel).not.toHaveAttribute("data-expected-answer");
+    expect(panel).toHaveAttribute("data-question-id");
+
+    const grid = screen.getByLabelText("答案選項");
+    const options = within(grid).getAllByRole("button");
+    await user.click(options[0]);
+
+    // After answering: the container summarises selection + result + answer.
+    expect(panel).toHaveAttribute("data-selected", options[0].textContent ?? "");
+    expect(["correct", "wrong"]).toContain(panel.getAttribute("data-result"));
+    expect(panel).toHaveAttribute("data-expected-answer");
+  });
+
+  it("marks the drill container revealed (no selection) after 看答案", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    const panel = await screen.findByRole("region", { name: "目前題目" });
+
+    await user.click(screen.getByRole("button", { name: "看答案" }));
+
+    // Revealing sets result=revealed, exposes the answer, with no selection.
+    expect(panel).toHaveAttribute("data-result", "revealed");
+    expect(panel).not.toHaveAttribute("data-selected");
+    expect(panel).toHaveAttribute("data-expected-answer");
+  });
+
 });

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -139,6 +139,18 @@ export function ChallengePanel({
     handleDrillKeyDown
   } = session;
 
+  // Container-level answer state for embedded AI / browser automation:
+  // collapse feedback into one result string so .drill-panel exposes the
+  // whole state (which question, what was picked, the outcome) in one place
+  // without having to scan the option buttons. "unanswered" until answered.
+  const drillResult = !feedback
+    ? "unanswered"
+    : feedback.status === "correct"
+      ? "correct"
+      : feedback.status === "revealed"
+        ? "revealed"
+        : "wrong";
+
   return (
     <section className="practice-layout" aria-label="Jabiko practice">
     <aside className="controls-panel" aria-label={t.settingsLabel}>
@@ -326,7 +338,16 @@ export function ChallengePanel({
       </button>
     </aside>
 
-    <section className="drill-panel" aria-label={t.currentQuestion} onKeyDown={handleDrillKeyDown}>
+    <section
+      className="drill-panel"
+      aria-label={t.currentQuestion}
+      onKeyDown={handleDrillKeyDown}
+      data-question-id={currentQuestion?.id}
+      data-question-type={currentQuestion?.promptLabel ?? currentQuestion?.targetForm}
+      data-selected={selectedChoice ?? undefined}
+      data-result={drillResult}
+      data-expected-answer={feedback ? currentQuestion?.expectedAnswers.join(" / ") : undefined}
+    >
       {currentQuestion ? (
         <>
           <div className="prompt-header">


### PR DESCRIPTION
Closes #75.

#51 在每個選項 button 上加了 `data-selected` / `data-result`；這支在答題區容器 `.drill-panel` 加**整體摘要**，讓嵌入網頁的 AI / 自動化一處就能讀到完整答題狀態，不必掃 button。

## 新增（`drill-panel` 容器）
- `data-question-id`、`data-question-type`
- `data-selected`：使用者選的選項文字（未選不輸出）
- `data-result`：`unanswered` / `correct` / `wrong` / `revealed`
- `data-expected-answer`：**答題後才有**（答題前不洩漏正解）

全部衍生自既有 state（currentQuestion / selectedChoice / feedback），無新 state、不改 UI 視覺與答題流程。補 #51 的 per-option attributes，不取代。

## 檔案
- `src/components/ChallengePanel.tsx`（`drillResult` derive + drill-panel data attributes）
- `src/App.test.tsx`（未答無 selection/expected；答後容器有 selected + result + expected）

## 驗證
`tsc` ✅ · `vitest` **163** · `build` ✅（index 255.14 kB 不變）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verifying drill container properly exposes answer state and selection data.

* **Updates**
  * Drill panel now exposes answer state, question details, and user selection through DOM attributes for enhanced tracking and integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->