### PR TITLE
fix(ui): 今日戰報 移至右欄「錯題複習」上方

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -664,14 +664,16 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "挑戰" }));
     await screen.findByRole("region", { name: "目前題目" });
 
-    // Accuracy is a labelled value with a progress bar in 今日戰報.
-    expect(screen.getByText("目前正解率")).toBeInTheDocument();
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    // Accuracy is a labelled value with a progress bar, both owned by the
+    // 今日戰報 block (now sitting atop the right-hand 錯題複習 column).
+    const scoreReport = screen.getByLabelText("今日戰報");
+    expect(within(scoreReport).getByText("目前正解率")).toBeInTheDocument();
+    expect(within(scoreReport).getByRole("progressbar")).toBeInTheDocument();
 
-    // The 錯題複習 panel no longer carries the percentage (which read as a
-    // mistake-list count); the progress bar lives only in 戰報.
-    const reviewPanel = screen.getByLabelText("錯題");
-    expect(within(reviewPanel).queryByRole("progressbar")).toBeNull();
+    // The 錯題複習 heading itself still does not carry the percentage
+    // (which previously read as a mistake-list count).
+    const reviewHeading = screen.getByRole("heading", { name: "錯題複習" });
+    expect(reviewHeading.textContent ?? "").not.toMatch(/%/);
   });
 
   it("opens the 漢字音読み table and shows example words for a kanji", async () => {

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -301,37 +301,6 @@ export function ChallengePanel({
 
       <p className="focus-summary">{focusSummary}</p>
 
-      <div className="score-report" role="group" aria-label="今日戰報">
-        <div className="score-strip">
-          <span>
-            <strong>{attempts.length}</strong>
-            {t.answered}
-          </span>
-          <span>
-            <strong>{correctCount}</strong>
-            {t.correctShort}
-          </span>
-          <span>
-            <strong>{mistakeQuestions.length}</strong>
-            {t.reviewShort}
-          </span>
-        </div>
-        <p className="score-accuracy">
-          <span className="score-accuracy-label">{t.accuracyLabel}</span>
-          <strong className="score-accuracy-value">{accuracy}%</strong>
-        </p>
-        <div
-          className="score-bar"
-          role="progressbar"
-          aria-valuenow={accuracy}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-label={t.accuracyLabel}
-        >
-          <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
-        </div>
-      </div>
-
       <button className="ghost-button" type="button" onClick={resetSession}>
         <RotateCcw aria-hidden="true" />
         {t.resetSession}
@@ -481,6 +450,36 @@ export function ChallengePanel({
     </section>
 
     <aside className="review-panel" aria-label={t.mistakesLabel}>
+      <div className="score-report" role="group" aria-label="今日戰報">
+        <div className="score-strip">
+          <span>
+            <strong>{attempts.length}</strong>
+            {t.answered}
+          </span>
+          <span>
+            <strong>{correctCount}</strong>
+            {t.correctShort}
+          </span>
+          <span>
+            <strong>{mistakeQuestions.length}</strong>
+            {t.reviewShort}
+          </span>
+        </div>
+        <p className="score-accuracy">
+          <span className="score-accuracy-label">{t.accuracyLabel}</span>
+          <strong className="score-accuracy-value">{accuracy}%</strong>
+        </p>
+        <div
+          className="score-bar"
+          role="progressbar"
+          aria-valuenow={accuracy}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={t.accuracyLabel}
+        >
+          <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
+        </div>
+      </div>
       <div className="review-heading">
         <h2>{t.mistakeReview}</h2>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1232,6 +1232,12 @@ select:disabled {
   transition: width 0.3s ease;
 }
 
+/* In the right-hand review column the score report sits above the
+   mistake-review heading; give it breathing room from that heading. */
+.review-panel .score-report {
+  margin-bottom: 1.15rem;
+}
+
 .prompt-header {
   align-items: center;
   display: flex;


### PR DESCRIPTION
延續 #71（今日戰報已從錯題標題分離成獨立 block），依回饋『太下面了，放本來右上』，把今日戰報（作答／正解／複習計數＋目前正解率＋進度條）從左欄設定區移到**右欄 review-panel、錯題複習標題正上方**，並加一條 .review-panel .score-report { margin-bottom } 間距。`.score-report` 系列 CSS 為通用選擇器，移欄即自動套用。

## 驗證
- App.test：原『review-panel 內無 progressbar』斷言已過時 → 改為驗證進度條歸『今日戰報』block、且『錯題複習』標題不帶百分比。
- vitest 36/36（App.test）、全量 164 tests、build 綠。