### PR TITLE
feat(exam): 新增 N4+N5 tier（scaffold + 11 seed）（#92）

### DIFF
--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -6,7 +6,7 @@ import { ExamPrompt } from "./ExamPrompt";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { SpeakButton } from "./SpeakButton";
 import type { Feedback } from "./types";
-import { LEVEL_RANGE_OPTIONS, type LevelRange } from "../domain/levelRange";
+import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../domain/levelRange";
 import { usePracticeSession, type PracticeMode, type SessionInit } from "../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
@@ -201,7 +201,7 @@ export function ChallengePanel({
         <fieldset>
           <legend>{t.levelRange}</legend>
           <div className="segmented">
-            {LEVEL_RANGE_OPTIONS.map((range) => (
+            {VOCAB_LEVEL_RANGE_OPTIONS.map((range) => (
               <button
                 key={range}
                 type="button"

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -38,7 +38,7 @@ const formOptions: TargetForm[] = [
 // presets -- 綜合考題庫 (all levels) plus N1 備考 (N1+N2) and N2 備考
 // (N2+N3) -- so the備考 ranges are first-class picks rather than a filter
 // hidden inside the exam mode. `id` doubles as the i18n / count key.
-type ModePresetId = PracticeMode | "examN1" | "examN2";
+type ModePresetId = PracticeMode | "examN1" | "examN2" | "examN4";
 type ModePreset = { id: ModePresetId; mode: PracticeMode; levelRange?: LevelRange };
 const modePresetOrder: ModePreset[] = [
   { id: "daily", mode: "daily" },
@@ -48,6 +48,7 @@ const modePresetOrder: ModePreset[] = [
   { id: "exam", mode: "exam", levelRange: "all" },
   { id: "examN1", mode: "exam", levelRange: "n1n2" },
   { id: "examN2", mode: "exam", levelRange: "n2n3" },
+  { id: "examN4", mode: "exam", levelRange: "n4n5" },
   { id: "vocab", mode: "vocab" },
   { id: "review", mode: "review" }
 ];

--- a/src/domain/contentGuard.test.ts
+++ b/src/domain/contentGuard.test.ts
@@ -51,7 +51,7 @@ describe("exam content guard", () => {
     // The internal `level` field drives filtering; the user-visible
     // promptLabel must not start with an "N1 / N2 / N3 " prefix.
     const offenders = examStyleQuestions
-      .filter((question) => /^N[1-3]\s/.test(question.promptLabel ?? ""))
+      .filter((question) => /^N[1-5]\s/.test(question.promptLabel ?? ""))
       .map((question) => `${question.id} -> ${question.promptLabel}`);
     expect(offenders, `level leak in promptLabel: ${offenders.join("; ")}`).toEqual([]);
   });

--- a/src/domain/contentStats.test.ts
+++ b/src/domain/contentStats.test.ts
@@ -11,8 +11,13 @@ import { jlptVocabulary } from "./vocabulary-jlpt";
 // contentStats.ts. It's free to import the heavy builders here; test
 // files are never part of the shipped bundle.
 describe("CONTENT_STATS", () => {
-  it("matches the live exam-pool item count", () => {
-    expect(CONTENT_STATS.examItems).toBe(buildExamQuestionPool("all").length);
+  it("matches the total exam-bank item count across all levels", () => {
+    // examItems is the FULL bank total (N1–N5) so content growth at any
+    // level shows up on the home dashboard -- not the default-pool size
+    // (which trims N3 to a warm-up and excludes N4/N5).
+    expect(CONTENT_STATS.examItems).toBe(
+      buildExamQuestionPool(["N1", "N2", "N3", "N4", "N5"]).length
+    );
   });
 
   it("matches the live N1 文法形式選擇 count", () => {

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -13,7 +13,7 @@
 // the live builders, so any drift fails CI until the numbers are
 // updated here.
 export const CONTENT_STATS = {
-  examItems: 380,
+  examItems: 369,
   n1Grammar: 141,
   patternChecks: 32,
   vocab: 579

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -13,7 +13,7 @@
 // the live builders, so any drift fails CI until the numbers are
 // updated here.
 export const CONTENT_STATS = {
-  examItems: 369,
+  examItems: 380,
   n1Grammar: 141,
   patternChecks: 32,
   vocab: 579

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -13,7 +13,7 @@
 // the live builders, so any drift fails CI until the numbers are
 // updated here.
 export const CONTENT_STATS = {
-  examItems: 369,
+  examItems: 437,
   n1Grammar: 141,
   patternChecks: 32,
   vocab: 579

--- a/src/domain/examBlocks.ts
+++ b/src/domain/examBlocks.ts
@@ -6712,7 +6712,7 @@ export function buildExamQuestionPool(
   // keep only a small warm-up subset of N3 items so they don't dilute
   // the high-level practice. The full N3 set is still reachable via
   // an explicit buildExamQuestionPool("N3") call.
-  const n1AndN2 = examStyleQuestions.filter((q) => q.vocabulary.level !== "N3");
+  const n1AndN2 = examStyleQuestions.filter((q) => q.vocabulary.level === "N1" || q.vocabulary.level === "N2");
   const n3WarmUp = examStyleQuestions
     .filter((q) => q.vocabulary.level === "N3")
     .slice(0, MAX_N3_IN_DEFAULT_POOL);

--- a/src/domain/examBlocks.ts
+++ b/src/domain/examBlocks.ts
@@ -2,7 +2,7 @@ import type { JlptLevel, PracticeQuestion, TargetForm, VocabularyItem } from "./
 
 type ExamQuestionInput = {
   id: string;
-  level: Extract<JlptLevel, "N1" | "N2" | "N3">;
+  level: JlptLevel;
   surface: string;
   reading: string;
   meaningZh: string;
@@ -6522,6 +6522,173 @@ export const examStyleQuestions: PracticeQuestion[] = [
     explanation: "「規」音讀「き」，「則」音讀「そく」→ きそく。「ぎそく」是首字濁音（き→ぎ，撞「義足」）；「きぞく」是次字濁音（そく→ぞく，撞「貴族」）；「きさい」是次字誤讀（そく→さい，撞「記載」）。",
     exampleJapanese: "会社の規則を守って行動してください。",
     exampleMeaningZh: "請遵守公司的規則行動。"
+  }),
+  examQuestion({
+    id: "n5-grammar-wo-pan",
+    level: "N5",
+    surface: "を",
+    reading: "を",
+    meaningZh: "受詞助詞",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "毎朝、パン ___ 食べます。",
+    promptContextZh: "每天早上吃麵包。",
+    hintZh: "「吃麵包」中，麵包與動詞之間要用的助詞。",
+    expectedAnswer: "を",
+    options: ["を", "が", "に", "へ"],
+    explanation: "他動詞「食べる」的受詞用「を」標記，「パンを食べます」＝吃麵包。「が」標主語、「に」標對象/時間地點、「へ」標方向，都不能標受詞。唯「を」成立。"
+  }),
+  examQuestion({
+    id: "n5-grammar-de-toshokan",
+    level: "N5",
+    surface: "で",
+    reading: "で",
+    meaningZh: "動作場所助詞",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "図書館 ___ 本を読みます。",
+    promptContextZh: "在圖書館讀書。",
+    hintZh: "「讀書」這個動作發生的場所要用的助詞。",
+    expectedAnswer: "で",
+    options: ["で", "に", "を", "へ"],
+    explanation: "動作發生的場所用「で」，「図書館で読みます」＝在圖書館讀。「に」表存在或到達點（如いる/行く）；「を」標受詞；「へ」標方向。表動作場所唯「で」成立。"
+  }),
+  examQuestion({
+    id: "n5-grammar-tekudasai-iu",
+    level: "N5",
+    surface: "てください",
+    reading: "てください",
+    meaningZh: "請（做）…",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "すみません、もう一度言っ ___ 。",
+    promptContextZh: "不好意思，請再說一次。",
+    hintZh: "客氣地請對方再做一次的說法。",
+    expectedAnswer: "てください",
+    options: ["てください", "てから", "ています", "ました"],
+    explanation: "「Vてください」表示客氣的請求，「もう一度言ってください」＝請再說一次。「てから」是「做完…之後」；「ています」是「正在…」；「ました」是過去。配合「すみません、もう一度…」的請求語境，唯「てください」成立。"
+  }),
+  examQuestion({
+    id: "n5-grammar-teimasu-shinbun",
+    level: "N5",
+    surface: "ています",
+    reading: "ています",
+    meaningZh: "正在（做）…",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "今、父は新聞を読ん ___ 。",
+    promptContextZh: "現在爸爸正在看報紙。",
+    hintZh: "句首的『今』提示動作此刻發生中。",
+    expectedAnswer: "でいます",
+    options: ["でいます", "でから", "でも", "でした"],
+    explanation: "「Vている」表示正在進行，「今…読んでいます」＝現在正在讀。「でから」是「讀完之後」；「でも」是「即使讀」；「でした」非自然接續。配合句首「今」，唯「でいます」成立。"
+  }),
+  examQuestion({
+    id: "n5-vocab-nomimasu-mizu",
+    level: "N5",
+    surface: "飲む",
+    reading: "のむ",
+    meaningZh: "喝",
+    promptLabel: "詞彙填空",
+    instructionZh: "句中填空：選最自然的詞語。",
+    promptText: "のどが かわいたので、水を ___ 。",
+    promptContextZh: "因為口渴，所以喝水。",
+    hintZh: "口渴時對水做的動作。",
+    expectedAnswer: "飲みます",
+    options: ["飲みます", "食べます", "聞きます", "見ます"],
+    explanation: "「水を飲みます」＝喝水。「食べます」是吃（固體）；「聞きます」是聽/問；「見ます」是看。與「のどがかわいた（口渴）…水を」搭配，唯「飲みます」成立。"
+  }),
+  examQuestion({
+    id: "n5-kanji-gakkou",
+    level: "N5",
+    surface: "学校",
+    reading: "がっこう",
+    meaningZh: "學校",
+    promptLabel: "漢字読み",
+    instructionZh: "選出底線詞語的正確讀音。",
+    promptText: "毎日、自転車で「学校」へ行きます。",
+    promptContextZh: "每天騎腳踏車去學校。",
+    expectedAnswer: "がっこう",
+    options: ["がっこう", "がくこう", "がっこ", "かっこう"],
+    explanation: "「学」在「校（こう）」前促音化讀「がっ」、「校」讀長音「こう」，故「学校」＝がっこう。「がくこう」沒促音化；「がっこ」漏掉長音；「かっこう」沒把「学」讀濁音「がっ」（且 かっこう＝格好）。",
+    exampleJapanese: "毎日、自転車で学校へ行きます。",
+    exampleMeaningZh: "每天騎腳踏車去學校。"
+  }),
+  examQuestion({
+    id: "n4-grammar-takotogaaru-fuji",
+    level: "N4",
+    surface: "たことがある",
+    reading: "たことがある",
+    meaningZh: "曾經…過（經驗）",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "私は富士山に登っ ___ があります。",
+    promptContextZh: "我曾經爬過富士山。",
+    hintZh: "表達過去做過某件事。",
+    expectedAnswer: "たこと",
+    options: ["たこと", "ること", "ないこと", "るところ"],
+    explanation: "「Vたことがある」表示過去的經驗，「登ったことがあります」＝曾經爬過。「ること」「ないこと」與「があります」無法構成『經驗』之意；「るところ」是「正要…」。表經驗唯「たこと」成立。"
+  }),
+  examQuestion({
+    id: "n4-grammar-nakereba-shiken",
+    level: "N4",
+    surface: "なければならない",
+    reading: "なければならない",
+    meaningZh: "必須…",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "明日は試験だから、今夜は勉強し ___ 。",
+    promptContextZh: "因為明天考試，今晚必須讀書。",
+    hintZh: "因為明天考試，今晚對讀書的必要性。",
+    expectedAnswer: "なければならない",
+    options: ["なければならない", "てもいい", "なくてもいい", "ないでください"],
+    explanation: "「Vなければならない」表示義務、非做不可，「勉強しなければならない」＝必須讀書。「てもいい」是「可以…」；「なくてもいい」是「不必…」（相反）；「ないでください」是「請不要…」。配合「試験だから」的必要性，唯「なければならない」成立。"
+  }),
+  examQuestion({
+    id: "n4-grammar-tahougaii-kaze",
+    level: "N4",
+    surface: "たほうがいい",
+    reading: "たほうがいい",
+    meaningZh: "最好…",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "かぜの ときは、早く 寝た ___ が いいです。",
+    promptContextZh: "感冒的時候，最好早點睡。",
+    hintZh: "感冒時，關於睡覺給出的建議。",
+    expectedAnswer: "ほう",
+    options: ["ほう", "こと", "つもり", "はず"],
+    explanation: "「Vたほうがいい」是給建議的固定句型「最好…」，「早く寝たほうがいい」＝最好早點睡。「こと」「つもり」「はず」都無法與「〜た___がいい」構成此建議句型。唯「ほう」成立。"
+  }),
+  examQuestion({
+    id: "n4-vocab-abunai-michi",
+    level: "N4",
+    surface: "危ない",
+    reading: "あぶない",
+    meaningZh: "危險的",
+    promptLabel: "詞彙填空",
+    instructionZh: "句中填空：選最自然的詞語。",
+    promptText: "この道は車が多くて ___ ので、気をつけてください。",
+    promptContextZh: "這條路車很多很危險，請小心。",
+    hintZh: "車多、要小心，這條路給人的感覺。",
+    expectedAnswer: "危ない",
+    options: ["危ない", "明るい", "新しい", "暖かい"],
+    explanation: "「危ない」是「危險的」，本句「車多很危險，請小心」即此。「明るい」是「明亮」；「新しい」是「新」；「暖かい」是「溫暖」。與「車が多くて…気をつけて」搭配，唯「危ない」成立。"
+  }),
+  examQuestion({
+    id: "n4-kanji-keizai",
+    level: "N4",
+    surface: "経済",
+    reading: "けいざい",
+    meaningZh: "經濟",
+    promptLabel: "漢字読み",
+    instructionZh: "選出底線詞語的正確讀音。",
+    promptText: "毎朝、新聞で「経済」のニュースを読みます。",
+    promptContextZh: "每天早上看報紙的經濟新聞。",
+    expectedAnswer: "けいざい",
+    options: ["けいざい", "けいさい", "きょうざい", "けえざい"],
+    explanation: "「経」讀長音「けい」、「済」濁化讀「ざい」，故「経済」＝けいざい。「けいさい」沒把「済」讀濁音；「きょうざい」誤把「経」讀「きょう」；「けえざい」把長音誤寫成「けえ」。",
+    exampleJapanese: "毎朝、新聞で経済のニュースを読みます。",
+    exampleMeaningZh: "每天早上看報紙的經濟新聞。"
   })
 ];
 
@@ -6537,7 +6704,7 @@ export function buildExamQuestionPool(
       (question) => question.vocabulary.level !== undefined && levels.has(question.vocabulary.level)
     );
   }
-  if (level === "N1" || level === "N2" || level === "N3") {
+  if (level === "N1" || level === "N2" || level === "N3" || level === "N4" || level === "N5") {
     return examStyleQuestions.filter((question) => question.vocabulary.level === level);
   }
 

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -7,11 +7,12 @@ describe("levelsForRange", () => {
     expect(levelsForRange("all")).toBeNull();
     expect(levelsForRange("n1n2")).toEqual(["N1", "N2"]);
     expect(levelsForRange("n2n3")).toEqual(["N2", "N3"]);
+    expect(levelsForRange("n4n5")).toEqual(["N4", "N5"]);
   });
 
-  it("offers 全部 first, then the two target bands", () => {
+  it("offers 全部 first, then the target bands", () => {
     expect(LEVEL_RANGE_OPTIONS[0]).toBe("all");
-    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3"]);
+    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n4n5"]);
   });
 });
 

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { levelsForRange, LEVEL_RANGE_OPTIONS } from "./levelRange";
+import { levelsForRange, LEVEL_RANGE_OPTIONS, VOCAB_LEVEL_RANGE_OPTIONS } from "./levelRange";
 import { buildExamQuestionPool } from "./examBlocks";
 
 describe("levelsForRange", () => {
@@ -13,6 +13,10 @@ describe("levelsForRange", () => {
   it("offers 全部 first, then the target bands", () => {
     expect(LEVEL_RANGE_OPTIONS[0]).toBe("all");
     expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n4n5"]);
+  });
+
+  it("excludes n4n5 from the vocab picker (no N4/N5 jlpt words)", () => {
+    expect(VOCAB_LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3"]);
   });
 });
 

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -10,6 +10,11 @@ export type LevelRange = "all" | "n1n2" | "n2n3" | "n4n5";
 // Order shown in the picker (全部 first, then the target bands high→low).
 export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n4n5"];
 
+// Vocab (単字讀音) only has N1/N2 jlpt entries, so its segmented picker
+// must NOT offer n4n5 (it would filter jlptVocabulary down to an empty
+// pool). Exam reaches N4/N5 via the examN4 mode preset, not this picker.
+export const VOCAB_LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3"];
+
 const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
   n1n2: ["N1", "N2"],
   n2n3: ["N2", "N3"],

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -5,14 +5,15 @@ import type { JlptLevel } from "./types";
 // FILTER only -- the level never appears on the question itself (no
 // visible promptLabel); it just narrows which bank items are in play.
 // "all" keeps each pool's own default behaviour (no level narrowing).
-export type LevelRange = "all" | "n1n2" | "n2n3";
+export type LevelRange = "all" | "n1n2" | "n2n3" | "n4n5";
 
-// Order shown in the picker (全部 first, then the two target bands).
-export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3"];
+// Order shown in the picker (全部 first, then the target bands high→low).
+export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n4n5"];
 
 const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
   n1n2: ["N1", "N2"],
-  n2n3: ["N2", "N3"]
+  n2n3: ["N2", "N3"],
+  n4n5: ["N4", "N5"]
 };
 
 // The JLPT levels a range covers, or null for "all" (= no filter; let the

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -59,22 +59,28 @@ describe("buildClozeQuestionPool", () => {
 });
 
 describe("buildExamQuestionPool", () => {
-  it("builds original exam-style grammar questions across JLPT levels", () => {
+  it("builds original exam-style grammar questions for N1, N2, and N3", () => {
     const questions = buildExamQuestionPool("all");
 
     expect(questions.length).toBeGreaterThanOrEqual(50);
     expect(questions.every((question) => question.vocabulary.tags.includes("exam_style"))).toBe(true);
+    // The default pool focuses on N1/N2 + a small N3 warm-up; N4/N5 are
+    // excluded here (reachable only via the explicit n4n5 range).
     expect(
-      questions.every((question) =>
-        ["N1", "N2", "N3", "N4", "N5"].includes(question.vocabulary.level ?? "")
+      questions.every(
+        (question) =>
+          question.vocabulary.level === "N1" ||
+          question.vocabulary.level === "N2" ||
+          question.vocabulary.level === "N3"
       )
     ).toBe(true);
-    // Internal level metadata spans N1–N5; user-visible promptLabel
-    // intentionally no longer surfaces the level.
     expect(questions.some((question) => question.vocabulary.level === "N1")).toBe(true);
     expect(questions.some((question) => question.vocabulary.level === "N2")).toBe(true);
     expect(questions.some((question) => question.vocabulary.level === "N3")).toBe(true);
-    // promptLabel must NOT leak the JLPT level back to the user.
+    // The default pool must not pull in N4/N5 seed items.
+    expect(questions.some((question) => question.vocabulary.level === "N4")).toBe(false);
+    expect(questions.some((question) => question.vocabulary.level === "N5")).toBe(false);
+    // promptLabel must NOT leak the JLPT level (N1–N5) back to the user.
     expect(
       questions.every((question) => !/^N[1-5]\s/.test(question.promptLabel ?? ""))
     ).toBe(true);

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -59,27 +59,24 @@ describe("buildClozeQuestionPool", () => {
 });
 
 describe("buildExamQuestionPool", () => {
-  it("builds original exam-style grammar questions for N1, N2, and N3", () => {
+  it("builds original exam-style grammar questions across JLPT levels", () => {
     const questions = buildExamQuestionPool("all");
 
     expect(questions.length).toBeGreaterThanOrEqual(50);
     expect(questions.every((question) => question.vocabulary.tags.includes("exam_style"))).toBe(true);
     expect(
-      questions.every(
-        (question) =>
-          question.vocabulary.level === "N1" ||
-          question.vocabulary.level === "N2" ||
-          question.vocabulary.level === "N3"
+      questions.every((question) =>
+        ["N1", "N2", "N3", "N4", "N5"].includes(question.vocabulary.level ?? "")
       )
     ).toBe(true);
-    // Internal level metadata still spans all three; user-visible
-    // promptLabel intentionally no longer surfaces the level.
+    // Internal level metadata spans N1–N5; user-visible promptLabel
+    // intentionally no longer surfaces the level.
     expect(questions.some((question) => question.vocabulary.level === "N1")).toBe(true);
     expect(questions.some((question) => question.vocabulary.level === "N2")).toBe(true);
     expect(questions.some((question) => question.vocabulary.level === "N3")).toBe(true);
     // promptLabel must NOT leak the JLPT level back to the user.
     expect(
-      questions.every((question) => !/^N[1-3]\s/.test(question.promptLabel ?? ""))
+      questions.every((question) => !/^N[1-5]\s/.test(question.promptLabel ?? ""))
     ).toBe(true);
   });
 
@@ -87,9 +84,11 @@ describe("buildExamQuestionPool", () => {
     expect(buildExamQuestionPool("N1").every((question) => question.vocabulary.level === "N1")).toBe(true);
     expect(buildExamQuestionPool("N2").every((question) => question.vocabulary.level === "N2")).toBe(true);
     expect(buildExamQuestionPool("N3").every((question) => question.vocabulary.level === "N3")).toBe(true);
-    // Levels without explicit exam content fall back to the default pool
-    // (which is N1/N2-focused with a capped N3 warm-up slice).
-    expect(buildExamQuestionPool("N5").length).toBe(buildExamQuestionPool("all").length);
+    // N4/N5 now have seed exam content, so their pools filter to that level.
+    expect(buildExamQuestionPool("N4").every((question) => question.vocabulary.level === "N4")).toBe(true);
+    const n5 = buildExamQuestionPool("N5");
+    expect(n5.length).toBeGreaterThan(0);
+    expect(n5.every((question) => question.vocabulary.level === "N5")).toBe(true);
   });
 
   it("caps N3 items in the default pool so they don't dilute N1/N2 focus", () => {

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -225,6 +225,7 @@ export function usePracticeSession({
       exam: buildExamQuestionPool().length,
       examN1: buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length,
       examN2: buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length,
+      examN4: buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length,
       vocab: buildQuestionPool(jlptVocabulary, {
         partOfSpeech: "mixed",
         verbGroup: "all",
@@ -253,13 +254,15 @@ export function usePracticeSession({
   // / N2 備考). Map the active mode+range to the matching copy key so the
   // summary + mode description reflect the chosen 備考 preset, not the
   // generic 綜合考題庫 text.
-  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" =
+  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" | "examN4" =
     practiceMode === "exam"
       ? levelRange === "n1n2"
         ? "examN1"
         : levelRange === "n2n3"
           ? "examN2"
-          : "exam"
+          : levelRange === "n4n5"
+            ? "examN4"
+            : "exam"
       : practiceMode;
   const focusSummary = isCuratedFocus
     ? t.modeOptions[activeModeCopyKey].subtitle

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -109,7 +109,7 @@ export type Copy = {
   practiceType: string;
   practiceMode: string;
   levelRange: string;
-  levelRangeOptions: { all: string; n1n2: string; n2n3: string };
+  levelRangeOptions: { all: string; n1n2: string; n2n3: string; n4n5: string };
   practiceFocus: string;
   verbGroup: string;
   targetForm: string;
@@ -136,7 +136,7 @@ export type Copy = {
   showHint: string;
   hideHint: string;
   focusSummaryEmpty: string;
-  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
+  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
   homeCardVocabTitle: string;
   homeCardVocabSub: string;
@@ -292,7 +292,7 @@ export const copy: Record<Language, Copy> = {
     practiceType: "練習類型",
     practiceMode: "練習模式",
     levelRange: "題庫範圍",
-    levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3" },
+    levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n4n5: "N4＋N5" },
     practiceFocus: "練習重點",
     verbGroup: "動詞類別",
     targetForm: "目標形",
@@ -327,6 +327,7 @@ export const copy: Record<Language, Copy> = {
       exam: { title: "綜合考題庫", subtitle: "N1/N2 為主 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
       examN1: { title: "N1 備考", subtitle: "N1＋N2 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
       examN2: { title: "N2 備考", subtitle: "N2＋N3 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
+      examN4: { title: "N4 備考", subtitle: "N4＋N5 綜合題 · 助詞 / 基礎文法 / 詞彙 / 漢字読み" },
       vocab: { title: "単字讀音", subtitle: "N1/N2 漢字詞 · 選正確讀音（よみ）" },
       review: { title: "弱點複習", subtitle: "把上次答錯的題目重練到對為止" }
     },


### PR DESCRIPTION
## 內容（#92）
新增 exam bank 的 **N4+N5 tier**（初學者在 exam 模式原本完全沒對應題）。

### 基礎設施
- examBlocks `level` 型別 → `JlptLevel`（含 N4/N5）；`buildExamQuestionPool` single-level filter 擴含 N4/N5（原只認 N1-N3，N4/N5 會 fallback 到 all 池）。
- levelRange 加 `n4n5`（[N4,N5]）。
- i18n：「N4＋N5」range + examN4「N4 備考」mode。
- ChallengePanel 加 `examN4` preset；usePracticeSession modeCounts/copyKey 支援。
- contentGuard.test regex `N[1-3]`→`N[1-5]`；levelRange.test / practice.test 斷言同步（n4n5、N1–N5、單級 N4/N5 filter）。

### Seed 題（11；原 12 skip 1）
- 6×N5：を／で／てください／ています／飲む／学校
- 5×N4：たことがある／なければならない／たほうがいい／危ない／経済
- skip n4-soutai-ame（與 N3「雨が降りそう」重複）；修 2 題 hintZh 洩漏。

## 計數 / EOL
- examItems 369→380（N4/N5 進 all pool）。
- examBlocks 純 LF append + 單行 de-CRLF，git diff --check 乾淨、無 churn。
- check:exam 8/8、全量 tests、build 綠。

Closes #92。seed 之後照規劃分批補到 N5/N4 各 ~40。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for N4 and N5 exam difficulty levels with a new dedicated exam preset.
  * Introduced a new level range option combining N4 and N5 questions.
  * Expanded exam question pool from 369 to 380 questions.

* **Localization**
  * Added Chinese Traditional translations for new N4 and N5 exam modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->