### PR TITLE
feat(exam): #106 頑固錯題補強包 4 題（21→keep 4）

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -13,8 +13,8 @@
 // the live builders, so any drift fails CI until the numbers are
 // updated here.
 export const CONTENT_STATS = {
-  examItems: 506,
-  n1Grammar: 141,
+  examItems: 510,
+  n1Grammar: 142,
   patternChecks: 32,
   vocab: 579
 } as const;

--- a/src/domain/exam/items/n1.ts
+++ b/src/domain/exam/items/n1.ts
@@ -3199,5 +3199,36 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "かと思うと",
     options: ["かと思うと", "上は", "こととて", "あげく"],
     explanation: "「Vたかと思うと」表示剛覺得前項發生，下一瞬間就出現後項變化，本句描寫孩子情緒瞬間反轉。「上は」是『既然…就（負起責任）』；「こととて」是書面致歉、正式理由；「あげく」是『經過一番過程後（多為不理想結果）』，三者都無法表達這種短時間內的快速轉換，唯「かと思うと」成立。"
+  }),
+  examQuestion({
+    id: "reinforce-stubborn-kanji-zengen",
+    level: "N1",
+    surface: "漸減",
+    reading: "ぜんげん",
+    meaningZh: "逐漸減少",
+    promptLabel: "漢字読み",
+    instructionZh: "選出底線詞語的正確讀音。",
+    promptText: "人口は十年前をピークに「漸減」している。",
+    promptContextZh: "人口以十年前為高峰，正逐漸減少。",
+    expectedAnswer: "ぜんげん",
+    options: ["ぜんげん", "ざんげん", "ぜんけん", "ぜんしょう"],
+    explanation: "「漸減」讀作「ぜんげん」，指一點一點地減少。「ざんげん」是把「漸」誤讀成「ざん」的語頭誤讀；「ぜんけん」是把後半「減（げん）」清濁讀錯；「ぜんしょう」是混入「減少（げんしょう）」等別的語形。唯「ぜんげん」正確。",
+    exampleJapanese: "人口は十年前をピークに漸減している。",
+    exampleMeaningZh: "人口以十年前為高峰，正逐漸減少。"
+  }),
+  examQuestion({
+    id: "reinforce-stubborn-nishiro-estimate",
+    level: "N1",
+    surface: "にしろ",
+    reading: "にしろ",
+    meaningZh: "即使是也、不管哪個都",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "どちらの案を採用する ___ 、事前に費用の見積もりを出す必要がある。",
+    promptContextZh: "不管採用哪個方案，都必須事先提出費用估算。",
+    hintZh: "兩個選項任選其一，後面的條件都一樣。",
+    expectedAnswer: "にしろ",
+    options: ["にしろ", "とはいえ", "ばかりに", "に沿って"],
+    explanation: "「疑問詞／選擇項＋にしろ」表示「不論是哪一方，後項都成立」的讓步。本句不論採哪個方案都要估價，故選「にしろ」。「とはいえ」是「雖說如此」，需承接既定事實而非選項；「ばかりに」是「就因為…（招致負面結果）」；「に沿って」是「按照」，皆不合。"
   })
 ];

--- a/src/domain/exam/items/n2.ts
+++ b/src/domain/exam/items/n2.ts
@@ -2331,5 +2331,35 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「規」音讀「き」，「則」音讀「そく」→ きそく。「ぎそく」是首字濁音（き→ぎ，撞「義足」）；「きぞく」是次字濁音（そく→ぞく，撞「貴族」）；「きさい」是次字誤讀（そく→さい，撞「記載」）。",
     exampleJapanese: "会社の規則を守って行動してください。",
     exampleMeaningZh: "請遵守公司的規則行動。"
+  }),
+  examQuestion({
+    id: "reinforce-stubborn-nagaramomo-young",
+    level: "N2",
+    surface: "ながらも",
+    reading: "ながらも",
+    meaningZh: "儘管如此仍然",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "経験は浅い ___ 、彼は落ち着いて顧客の苦情に対応した。",
+    promptContextZh: "雖然經驗尚淺，他仍冷靜地處理了顧客的客訴。",
+    hintZh: "條件不利，但表現卻超出預期。",
+    expectedAnswer: "ながらも",
+    options: ["ながらも", "からには", "だけに", "にかけて"],
+    explanation: "「Vます形/イ形/Nながらも」表示「有前項事實，後項卻仍成立」的逆接。本句經驗淺，卻仍冷靜應對客訴，故選「ながらも」。「からには」是「既然…就」；「だけに」是「正因為…才」；「にかけて」表時間範圍或擅長領域，接續與語意皆不合。"
+  }),
+  examQuestion({
+    id: "reinforce-stubborn-uewa-contract",
+    level: "N2",
+    surface: "上は",
+    reading: "うえは",
+    meaningZh: "做了就應當",
+    promptLabel: "文法形式選擇",
+    instructionZh: "句中填空：依文脈選最自然的文法。",
+    promptText: "契約書に署名した ___ 、条件を守る責任がある。",
+    promptContextZh: "簽署了合約之後，就有遵守條件的責任。",
+    hintZh: "做出某項承諾後，必須擔起隨之而來的責任。",
+    expectedAnswer: "上は",
+    options: ["上は", "うえで", "うえに", "うちは"],
+    explanation: "「Vた＋上は」表示「既做了前項，理所當然就要承擔後項的義務或覺悟」。本句簽了約就要守條件，故選「上は」。「うえで」是「在…之後／在…方面」偏中性程序；「うえに」是「加上、而且」的累加；「うちは」是「在…期間」，皆不合。"
   })
 ];


### PR DESCRIPTION
## 內容（#106 頑固錯題補強包）
21 候選 → 收 **4**（N1/N2 題庫已飽和，17 題撞既有 skip，含 ずにはすまない×2 都撞 #73）。
- N1：漸減（漢字読み）、にしろ（見積もり）
- N2：ながらも（経験浅い）、上は（契約）

## 親審（逐題唯一正解）
- zengen：干擾涵蓋語頭誤/清濁/別語混同。
- nagaramomo：だけに 因「經驗淺→冷靜」語意矛盾排除；唯 ながらも 逆接成立。
- にしろ vs とはいえ/ばかりに/に沿って；上は vs うえで/うえに/うちは — 接續或語意皆不合。
- guard 0 洩漏、promptLabel 無級數。

## 匯入 / 計數
- 匯入 #99 拆好的 items/n1.ts（+2）、items/n2.ts（+2）。
- examItems 506→510、n1Grammar 141→142。
- LF append、git diff --check 乾淨。check:exam 8/8、tests、build 綠。

Closes #106。