### PR TITLE
refactor(session): extract pure pool helpers to sessionPools.ts (#102 A)

### DIFF
--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { buildClozeQuestionPool } from "./cloze";
+import { clozeSentences } from "./cloze-data";
+import { buildExamQuestionPool } from "./examBlocks";
+import { levelsForRange } from "./levelRange";
+import { buildQuestionPool } from "./practice";
+import {
+  buildAllKnownQuestions,
+  buildModeCounts,
+  buildPracticeQuestions,
+  composeDailySet,
+  uniqueForms,
+  type PracticePoolParams
+} from "./sessionPools";
+import type { PracticeQuestion } from "./types";
+import { vocabulary } from "./vocabulary";
+import { jlptVocabulary } from "./vocabulary-jlpt";
+
+// Default mode flags = the "basic" drill (every focus flag false). Each
+// test flips exactly the flag(s) for the branch it exercises, so the
+// branch under test is isolated.
+function poolParams(overrides: Partial<PracticePoolParams> = {}): PracticePoolParams {
+  return {
+    isExamFocus: false,
+    isClozeFocus: false,
+    isPatternFocus: false,
+    isReviewFocus: false,
+    isVocabFocus: false,
+    isDailyFocus: false,
+    partOfSpeech: "verb",
+    verbGroup: "godan",
+    targetForms: ["te"],
+    levelRange: "all",
+    reviewQueue: [],
+    ...overrides
+  };
+}
+
+describe("uniqueForms", () => {
+  it("dedupes target forms while preserving first-seen order", () => {
+    expect(uniqueForms(["te", "ta", "te", "reading", "ta"])).toEqual(["te", "ta", "reading"]);
+  });
+});
+
+describe("buildModeCounts", () => {
+  it("reports a count for every static mode card, matching the live builders", () => {
+    const counts = buildModeCounts();
+
+    expect(counts.cloze).toBe(buildClozeQuestionPool(clozeSentences, vocabulary).length);
+    expect(counts.exam).toBe(buildExamQuestionPool().length);
+    // examN1 / examN2 / examN4 are the 備考 presets (issues #65/#92): the
+    // counts come from the matching level RANGE pools, never the default.
+    expect(counts.examN1).toBe(buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length);
+    expect(counts.examN2).toBe(buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length);
+    expect(counts.examN4).toBe(buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length);
+    expect(counts.vocab).toBe(
+      buildQuestionPool(jlptVocabulary, {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["reading"]
+      }).length
+    );
+  });
+
+  it("derives the examN4 preset from the n4n5 range (N4/N5 only)", () => {
+    const counts = buildModeCounts();
+    const n4n5 = buildExamQuestionPool(levelsForRange("n4n5") ?? "all");
+
+    expect(counts.examN4).toBeGreaterThan(0);
+    expect(counts.examN4).toBe(n4n5.length);
+    expect(
+      n4n5.every((q) => q.vocabulary.level === "N4" || q.vocabulary.level === "N5")
+    ).toBe(true);
+  });
+});
+
+describe("buildAllKnownQuestions", () => {
+  it("unions the exam, cloze, pattern, and full vocab pools", () => {
+    const all = buildAllKnownQuestions();
+    const exam = buildExamQuestionPool();
+    const cloze = buildClozeQuestionPool(clozeSentences, vocabulary);
+
+    expect(all.length).toBeGreaterThan(exam.length + cloze.length);
+    const ids = new Set(all.map((q) => q.id));
+    // A sample id from each contributing source must be present.
+    expect(ids.has(exam[0].id)).toBe(true);
+    expect(ids.has(cloze[0].id)).toBe(true);
+    // Vocab reading + meaning forms (both requested in the union) appear.
+    expect(all.some((q) => q.targetForm === "reading")).toBe(true);
+    expect(all.some((q) => q.targetForm === "meaning")).toBe(true);
+  });
+});
+
+describe("buildPracticeQuestions", () => {
+  it("basic mode: builds a shuffled pool for the chosen part of speech / group / form", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "verb", verbGroup: "godan", targetForms: ["te"] })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.vocabulary.partOfSpeech === "verb")).toBe(true);
+    expect(questions.every((q) => q.vocabulary.group === "godan")).toBe(true);
+    expect(questions.every((q) => q.targetForm === "te")).toBe(true);
+  });
+
+  it("exam mode (綜合, range all): mirrors the default exam pool contents", () => {
+    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "all" }));
+    const expected = buildExamQuestionPool("all");
+
+    expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
+  });
+
+  it("exam mode (綜合, n1n2 range): narrows to N1+N2 only", () => {
+    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n1n2" }));
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.every((q) => q.vocabulary.level === "N1" || q.vocabulary.level === "N2")
+    ).toBe(true);
+  });
+
+  it("exam mode (綜合, n2n3 range): narrows to N2+N3 only", () => {
+    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n2n3" }));
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.every((q) => q.vocabulary.level === "N2" || q.vocabulary.level === "N3")
+    ).toBe(true);
+  });
+
+  it("exam mode (備考, n4n5 range): narrows to N4+N5 only (#65/#92)", () => {
+    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n4n5" }));
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.every((q) => q.vocabulary.level === "N4" || q.vocabulary.level === "N5")
+    ).toBe(true);
+  });
+
+  it("exam mode (mock section): filters to the given level + promptLabel", () => {
+    // Pick a real (level, promptLabel) pair straight from the N1 pool so
+    // the section is guaranteed non-empty.
+    const n1 = buildExamQuestionPool("N1");
+    const sample = n1.find((q) => q.promptLabel);
+    expect(sample).toBeDefined();
+    const promptLabel = sample!.promptLabel!;
+
+    const questions = buildPracticeQuestions(
+      poolParams({ isExamFocus: true, examSection: { level: "N1", promptLabel } })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.vocabulary.level === "N1")).toBe(true);
+    expect(questions.every((q) => q.promptLabel === promptLabel)).toBe(true);
+  });
+
+  it("cloze mode: returns the cloze pool (same membership)", () => {
+    const questions = buildPracticeQuestions(poolParams({ isClozeFocus: true }));
+    const expected = buildClozeQuestionPool(clozeSentences, vocabulary);
+
+    expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
+  });
+
+  it("review mode: returns the snapshot queue verbatim (same order, no shuffle)", () => {
+    const snapshot = buildExamQuestionPool("N1").slice(0, 3);
+    const questions = buildPracticeQuestions(
+      poolParams({ isReviewFocus: true, reviewQueue: snapshot })
+    );
+
+    expect(questions).toBe(snapshot);
+  });
+
+  it("vocab mode: reading-only drill, narrowed by level range", () => {
+    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "n1n2" }));
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.targetForm === "reading")).toBe(true);
+    expect(
+      questions.every((q) => q.vocabulary.level === "N1" || q.vocabulary.level === "N2")
+    ).toBe(true);
+  });
+
+  it("vocab mode (range all): keeps the whole JLPT vocab reading pool", () => {
+    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "all" }));
+    const expected = buildQuestionPool(jlptVocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"]
+    });
+
+    expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
+  });
+
+  it("daily mode: composes a finite 今日練習 set from the due snapshot", () => {
+    const due = buildExamQuestionPool("N1").slice(0, 4);
+    const questions = buildPracticeQuestions(poolParams({ isDailyFocus: true, reviewQueue: due }));
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.length).toBeLessThanOrEqual(20);
+    // The due items lead the set (composeDailySet puts reviews first).
+    const dueIds = new Set(due.map((q) => q.id));
+    const leading = questions.slice(0, due.length);
+    expect(leading.every((q) => dueIds.has(q.id))).toBe(true);
+  });
+});
+
+describe("composeDailySet", () => {
+  const makeDue = (n: number): PracticeQuestion[] => buildExamQuestionPool("N1").slice(0, n);
+
+  it("caps the whole set at the daily target of 20", () => {
+    expect(composeDailySet([]).length).toBeLessThanOrEqual(20);
+    expect(composeDailySet(makeDue(40)).length).toBeLessThanOrEqual(20);
+  });
+
+  it("caps due items at half the target so fresh content still fits", () => {
+    const due = makeDue(40);
+    const set = composeDailySet(due);
+    const dueIds = new Set(due.map((q) => q.id));
+    const dueInSet = set.filter((q) => dueIds.has(q.id)).length;
+
+    expect(dueInSet).toBeLessThanOrEqual(10);
+  });
+
+  it("places the due block first, in its incoming (most-overdue-first) order", () => {
+    const due = makeDue(4);
+    const set = composeDailySet(due);
+
+    expect(set.slice(0, due.length).map((q) => q.id)).toEqual(due.map((q) => q.id));
+  });
+
+  it("never lets a due item reappear in the fresh portion", () => {
+    const due = makeDue(4);
+    const set = composeDailySet(due);
+    const dueIds = new Set(due.map((q) => q.id));
+    const fresh = set.slice(due.length);
+
+    expect(fresh.some((q) => dueIds.has(q.id))).toBe(false);
+  });
+
+  it("fills the set with fresh vocab + exam items when there are no due reviews", () => {
+    const set = composeDailySet([]);
+
+    expect(set.length).toBeGreaterThan(0);
+    // With an empty due queue the set is entirely fresh and reserves at
+    // least one vocab reading item (DAILY_VOCAB_MIN floor).
+    expect(set.some((q) => q.targetForm === "reading")).toBe(true);
+  });
+});

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -1,0 +1,250 @@
+// Pure pool-composition helpers for the practice session (issue #102, A).
+//
+// These were inlined in src/hooks/usePracticeSession.ts; they own all the
+// "given a config, build the question pool" logic and depend on NO React
+// state, so they live here as plain functions the hook calls from its
+// memos. The hook keeps only the React state / memo / handler wiring.
+//
+// This module reaches the heavy question-data builders (buildExamQuestionPool
+// alone pulls ~288 KB of exam items), so it must stay on the lazy
+// ChallengePanel chunk: it is imported ONLY by usePracticeSession (which is
+// itself imported only by the lazily-loaded ChallengePanel). Importing it
+// from any eager module (App / the components barrel / the home or learn
+// views) would drag examBlocks back into the initial bundle.
+import { ADJECTIVE_FORMS, VERB_FORMS } from "./conjugation";
+import { buildClozeQuestionPool } from "./cloze";
+import { clozeSentences } from "./cloze-data";
+import { buildExamQuestionPool } from "./examBlocks";
+import { levelsForRange, type LevelRange } from "./levelRange";
+import type { MockExamLevel } from "./mockExam";
+import { buildSentencePatternPool, type SentencePatternId } from "./sentencePatterns";
+import {
+  buildQuestionPool,
+  reduceAdjacentClusters,
+  shuffleQuestions
+} from "./practice";
+import type { PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./types";
+import { vocabulary } from "./vocabulary";
+import { jlptVocabulary } from "./vocabulary-jlpt";
+
+export function uniqueForms(forms: TargetForm[]): TargetForm[] {
+  return Array.from(new Set(forms));
+}
+
+const DAILY_TARGET = 20;
+// Reserve enough fresh vocab-reading items that their pool-based
+// distractors (drawn from same-targetForm peers within the session) can
+// always fill a full 4-option grid. Without this floor, a daily set that
+// happened to land only 1-2 vocab items would render those 漢字読み
+// questions with too few choices.
+const DAILY_VOCAB_MIN = Math.floor(DAILY_TARGET / 4);
+
+// Builds the "今日練習" set: due SRS reviews first (capped at half so a
+// big backlog still leaves room for variety), then a de-clustered mix of
+// fresh vocab (a reserved minimum) + exam items to fill out the session.
+// It's a FINITE pass -- the learner works through the set once and gets a
+// completion screen, same as review mode. v1 is an even mix; weighting
+// toward the learner's weak sections is a follow-up (needs attempt
+// metadata).
+export function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
+  const dueTake = due.slice(0, Math.ceil(DAILY_TARGET / 2));
+  // Exclude EVERY due item from the fresh pools -- not just the capped
+  // slice -- so an over-cap due item can't slip back in mislabelled as a
+  // fresh question (which would drop its most-overdue-first SRS ordering).
+  const dueIds = new Set(due.map((question) => question.id));
+  const isFresh = (question: PracticeQuestion) => !dueIds.has(question.id);
+  const freshSlots = DAILY_TARGET - dueTake.length;
+
+  const vocabFresh = shuffleQuestions(
+    buildQuestionPool(jlptVocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"]
+    }).filter(isFresh)
+  ).slice(0, Math.min(DAILY_VOCAB_MIN, freshSlots));
+  const examFresh = shuffleQuestions(buildExamQuestionPool().filter(isFresh)).slice(
+    0,
+    freshSlots - vocabFresh.length
+  );
+
+  // De-cluster only the FRESH portion so consecutive fresh questions
+  // aren't all the same kind (exam items carry promptLabel; vocab falls
+  // back to its targetForm, "reading"). The due block stays first, in its
+  // most-overdue-first order -- declustering the whole set would let fresh
+  // items slip between due items and break the "reviews first" promise.
+  const fresh = reduceAdjacentClusters(
+    [...vocabFresh, ...examFresh],
+    (question) => question.promptLabel ?? question.targetForm
+  );
+  return [...dueTake, ...fresh];
+}
+
+// Pool size per practice mode, shown on the mode cards so the learner
+// can see how big each bank is before picking. Static pools are
+// computed once; "basic" is intentionally omitted (its size depends on
+// the chosen word type / verb group / form), and "review" is dynamic
+// (the due count) so it's read from reviewQueue at render time.
+export function buildModeCounts() {
+  return {
+    cloze: buildClozeQuestionPool(clozeSentences, vocabulary).length,
+    pattern: buildSentencePatternPool().length,
+    exam: buildExamQuestionPool().length,
+    examN1: buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length,
+    examN2: buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length,
+    examN4: buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length,
+    vocab: buildQuestionPool(jlptVocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["reading"]
+    }).length
+  };
+}
+
+// Union pool used to materialise the review queue: any question the
+// learner has ever encountered (across exam / cloze / pattern / basic)
+// could be in their attempt history, so the queue lookup needs to see
+// them all. Built once and reused -- this is the same set of question
+// factories the four mode-specific branches below call, just unioned.
+export function buildAllKnownQuestions(): PracticeQuestion[] {
+  return [
+    ...buildExamQuestionPool(),
+    ...buildClozeQuestionPool(clozeSentences, vocabulary),
+    ...buildSentencePatternPool(),
+    ...buildQuestionPool(vocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: uniqueForms([
+        ...VERB_FORMS,
+        ...ADJECTIVE_FORMS,
+        "reading",
+        "meaning"
+      ])
+    })
+  ];
+}
+
+// All the inputs the active-pool builder needs from the React layer. The
+// hook derives these from its state (mode flags), props (reviewQueue
+// snapshot), and config (filter / partOfSpeech / verbGroup / targetForms
+// / levelRange), then hands them in so this stays a pure function.
+export type PracticePoolParams = {
+  isExamFocus: boolean;
+  isClozeFocus: boolean;
+  isPatternFocus: boolean;
+  isReviewFocus: boolean;
+  isVocabFocus: boolean;
+  isDailyFocus: boolean;
+  examSection?: { level: MockExamLevel; promptLabel: string };
+  patternIds?: SentencePatternId[];
+  partOfSpeech: PartOfSpeech | "mixed";
+  verbGroup: VerbGroup | "all";
+  targetForms: TargetForm[];
+  levelRange: LevelRange;
+  // Snapshot of the SRS due queue taken at session start; used by the
+  // review and 今日練習 branches. The hook passes the value captured when
+  // its `questions` memo last ran (mode change / explicit reset).
+  reviewQueue: PracticeQuestion[];
+};
+
+// Derives the active question pool for the current mode. This is the body
+// of usePracticeSession's `questions` memo, lifted out verbatim so every
+// mode/range branch (section-filtered exam, 綜合 level-range exam, cloze,
+// pattern, review snapshot, vocab reading drill, 今日練習, basic drill)
+// stays exactly as it was.
+export function buildPracticeQuestions(params: PracticePoolParams): PracticeQuestion[] {
+  const {
+    isExamFocus,
+    isClozeFocus,
+    isPatternFocus,
+    isReviewFocus,
+    isVocabFocus,
+    isDailyFocus,
+    examSection,
+    patternIds,
+    partOfSpeech,
+    verbGroup,
+    targetForms,
+    levelRange,
+    reviewQueue
+  } = params;
+
+  if (isExamFocus) {
+    // Section-filtered when launched from the 模擬考 picker; the
+    // plain "綜合考題庫" mode card leaves examSection unset and
+    // mixes every section.
+    const section = examSection;
+    if (section) {
+      return shuffleQuestions(
+        buildExamQuestionPool(section.level).filter(
+          (question) => question.promptLabel === section.promptLabel
+        )
+      );
+    }
+    // 綜合考題庫: optionally narrowed to a level range (N1+N2 / N2+N3).
+    return shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"));
+  }
+
+  if (isClozeFocus) {
+    return shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary));
+  }
+
+  if (isPatternFocus) {
+    return shuffleQuestions(
+      buildSentencePatternPool({ patternIds })
+    );
+  }
+
+  if (isReviewFocus) {
+    // Snapshot the SRS queue at session start. Subsequent answers
+    // update the LIVE reviewQueue (used by the home banner count),
+    // but this useMemo is intentionally NOT re-keyed on it -- see
+    // the deps comment below for the regression that fixes.
+    // Ordering is preserved (no extra shuffle): getReviewQueue
+    // already sorts most-overdue first.
+    return reviewQueue;
+  }
+
+  if (isVocabFocus) {
+    // 単字 mode: N1/N2 reading drill. Reading-only on purpose --
+    // for a Chinese-speaking learner the kanji usually telegraphs
+    // the meaning (影響 = 影響), so an isolated meaning question is
+    // trivial and can't be rescued by stronger distractors. The
+    // genuinely hard, JLPT-relevant skill is the READING (よみ):
+    // 影響 is えいきょう, not えいきゅう. Meaning is still tested,
+    // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
+    // 詞彙用法 sections -- which is the authentic way to test it.
+    const levels = levelsForRange(levelRange);
+    const vocabSource = levels
+      ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
+      : jlptVocabulary;
+    const vocabPool = shuffleQuestions(
+      buildQuestionPool(vocabSource, {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["reading"]
+      })
+    );
+    // De-run by reading length: consecutive questions then tend to
+    // have different-length answers -> different distractor bands ->
+    // no "same options twice in a row" feel even when the random
+    // shuffle clusters same-length words together.
+    return reduceAdjacentClusters(
+      vocabPool,
+      (question) => String(question.expectedAnswers[0]?.length ?? 0)
+    );
+  }
+
+  if (isDailyFocus) {
+    // Snapshot the current due queue at session start (same as review
+    // mode); the live reviewQueue stays excluded from the deps below.
+    return composeDailySet(reviewQueue);
+  }
+
+  return shuffleQuestions(
+    buildQuestionPool(vocabulary, {
+      partOfSpeech,
+      verbGroup,
+      targetForms
+    })
+  );
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,24 +1,22 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ADJECTIVE_FORMS, VERB_FORMS } from "../domain/conjugation";
-import { buildClozeQuestionPool } from "../domain/cloze";
-import { clozeSentences } from "../domain/cloze-data";
-import { buildExamQuestionPool } from "../domain/examBlocks";
-import { levelsForRange, type LevelRange } from "../domain/levelRange";
+import { type LevelRange } from "../domain/levelRange";
 import type { MockExamLevel } from "../domain/mockExam";
-import { buildSentencePatternPool, type SentencePatternId } from "../domain/sentencePatterns";
+import { type SentencePatternId } from "../domain/sentencePatterns";
 import {
   buildChoiceOptions,
-  buildQuestionPool,
   getMistakeQuestions,
   getReviewQueue,
-  reduceAdjacentClusters,
   scoreAttempt,
-  selectQuestion,
-  shuffleQuestions
+  selectQuestion
 } from "../domain/practice";
-import type { Attempt, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "../domain/types";
-import { vocabulary } from "../domain/vocabulary";
-import { jlptVocabulary } from "../domain/vocabulary-jlpt";
+import {
+  buildAllKnownQuestions,
+  buildModeCounts,
+  buildPracticeQuestions,
+  uniqueForms
+} from "../domain/sessionPools";
+import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
 import { copy, type Language } from "../i18n";
 import type { Feedback } from "../components/types";
 
@@ -69,58 +67,6 @@ const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; ver
     targetForms: ["obligationPast"]
   }
 ];
-
-function uniqueForms(forms: TargetForm[]): TargetForm[] {
-  return Array.from(new Set(forms));
-}
-
-const DAILY_TARGET = 20;
-// Reserve enough fresh vocab-reading items that their pool-based
-// distractors (drawn from same-targetForm peers within the session) can
-// always fill a full 4-option grid. Without this floor, a daily set that
-// happened to land only 1-2 vocab items would render those 漢字読み
-// questions with too few choices.
-const DAILY_VOCAB_MIN = Math.floor(DAILY_TARGET / 4);
-
-// Builds the "今日練習" set: due SRS reviews first (capped at half so a
-// big backlog still leaves room for variety), then a de-clustered mix of
-// fresh vocab (a reserved minimum) + exam items to fill out the session.
-// It's a FINITE pass -- the learner works through the set once and gets a
-// completion screen, same as review mode. v1 is an even mix; weighting
-// toward the learner's weak sections is a follow-up (needs attempt
-// metadata).
-function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
-  const dueTake = due.slice(0, Math.ceil(DAILY_TARGET / 2));
-  // Exclude EVERY due item from the fresh pools -- not just the capped
-  // slice -- so an over-cap due item can't slip back in mislabelled as a
-  // fresh question (which would drop its most-overdue-first SRS ordering).
-  const dueIds = new Set(due.map((question) => question.id));
-  const isFresh = (question: PracticeQuestion) => !dueIds.has(question.id);
-  const freshSlots = DAILY_TARGET - dueTake.length;
-
-  const vocabFresh = shuffleQuestions(
-    buildQuestionPool(jlptVocabulary, {
-      partOfSpeech: "mixed",
-      verbGroup: "all",
-      targetForms: ["reading"]
-    }).filter(isFresh)
-  ).slice(0, Math.min(DAILY_VOCAB_MIN, freshSlots));
-  const examFresh = shuffleQuestions(buildExamQuestionPool().filter(isFresh)).slice(
-    0,
-    freshSlots - vocabFresh.length
-  );
-
-  // De-cluster only the FRESH portion so consecutive fresh questions
-  // aren't all the same kind (exam items carry promptLabel; vocab falls
-  // back to its targetForm, "reading"). The due block stays first, in its
-  // most-overdue-first order -- declustering the whole set would let fresh
-  // items slip between due items and break the "reviews first" promise.
-  const fresh = reduceAdjacentClusters(
-    [...vocabFresh, ...examFresh],
-    (question) => question.promptLabel ?? question.targetForm
-  );
-  return [...dueTake, ...fresh];
-}
 
 // The stateful core of the practice experience: owns all in-session
 // state (mode / filters / current question / feedback / score), derives
@@ -189,24 +135,7 @@ export function usePracticeSession({
   // could be in their attempt history, so the queue lookup needs to see
   // them all. Built once and reused -- this is the same set of question
   // factories the four mode-specific branches below call, just unioned.
-  const allKnownQuestions = useMemo(
-    () => [
-      ...buildExamQuestionPool(),
-      ...buildClozeQuestionPool(clozeSentences, vocabulary),
-      ...buildSentencePatternPool(),
-      ...buildQuestionPool(vocabulary, {
-        partOfSpeech: "mixed",
-        verbGroup: "all",
-        targetForms: uniqueForms([
-          ...VERB_FORMS,
-          ...ADJECTIVE_FORMS,
-          "reading",
-          "meaning"
-        ])
-      })
-    ],
-    []
-  );
+  const allKnownQuestions = useMemo(() => buildAllKnownQuestions(), []);
 
   const reviewQueue = useMemo(
     () => getReviewQueue(progressAttempts, allKnownQuestions),
@@ -218,22 +147,7 @@ export function usePracticeSession({
   // computed once; "basic" is intentionally omitted (its size depends on
   // the chosen word type / verb group / form), and "review" is dynamic
   // (the due count) so it's read from reviewQueue at render time.
-  const modeCounts = useMemo(
-    () => ({
-      cloze: buildClozeQuestionPool(clozeSentences, vocabulary).length,
-      pattern: buildSentencePatternPool().length,
-      exam: buildExamQuestionPool().length,
-      examN1: buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length,
-      examN2: buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length,
-      examN4: buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length,
-      vocab: buildQuestionPool(jlptVocabulary, {
-        partOfSpeech: "mixed",
-        verbGroup: "all",
-        targetForms: ["reading"]
-      }).length
-    }),
-    []
-  );
+  const modeCounts = useMemo(() => buildModeCounts(), []);
   const isVerbCapable = partOfSpeech === "verb" || partOfSpeech === "mixed";
   const availableFocusOptions = focusOptions.filter((option) => {
     if (option.verbOnly && !isVerbCapable) return false;
@@ -273,85 +187,21 @@ export function usePracticeSession({
   const questions = useMemo(
     () => {
       void sessionSeed;
-      if (isExamFocus) {
-        // Section-filtered when launched from the 模擬考 picker; the
-        // plain "綜合考題庫" mode card leaves examSection unset and
-        // mixes every section.
-        const section = practiceFilter.examSection;
-        if (section) {
-          return shuffleQuestions(
-            buildExamQuestionPool(section.level).filter(
-              (question) => question.promptLabel === section.promptLabel
-            )
-          );
-        }
-        // 綜合考題庫: optionally narrowed to a level range (N1+N2 / N2+N3).
-        return shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"));
-      }
-
-      if (isClozeFocus) {
-        return shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary));
-      }
-
-      if (isPatternFocus) {
-        return shuffleQuestions(
-          buildSentencePatternPool({ patternIds: practiceFilter.patternIds })
-        );
-      }
-
-      if (isReviewFocus) {
-        // Snapshot the SRS queue at session start. Subsequent answers
-        // update the LIVE reviewQueue (used by the home banner count),
-        // but this useMemo is intentionally NOT re-keyed on it -- see
-        // the deps comment below for the regression that fixes.
-        // Ordering is preserved (no extra shuffle): getReviewQueue
-        // already sorts most-overdue first.
-        return reviewQueue;
-      }
-
-      if (isVocabFocus) {
-        // 単字 mode: N1/N2 reading drill. Reading-only on purpose --
-        // for a Chinese-speaking learner the kanji usually telegraphs
-        // the meaning (影響 = 影響), so an isolated meaning question is
-        // trivial and can't be rescued by stronger distractors. The
-        // genuinely hard, JLPT-relevant skill is the READING (よみ):
-        // 影響 is えいきょう, not えいきゅう. Meaning is still tested,
-        // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
-        // 詞彙用法 sections -- which is the authentic way to test it.
-        const levels = levelsForRange(levelRange);
-        const vocabSource = levels
-          ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
-          : jlptVocabulary;
-        const vocabPool = shuffleQuestions(
-          buildQuestionPool(vocabSource, {
-            partOfSpeech: "mixed",
-            verbGroup: "all",
-            targetForms: ["reading"]
-          })
-        );
-        // De-run by reading length: consecutive questions then tend to
-        // have different-length answers -> different distractor bands ->
-        // no "same options twice in a row" feel even when the random
-        // shuffle clusters same-length words together.
-        return reduceAdjacentClusters(
-          vocabPool,
-          (question) => String(question.expectedAnswers[0]?.length ?? 0)
-        );
-      }
-
-      if (isDailyFocus) {
-        // Snapshot the current due queue at session start (same as review
-        // mode); the live reviewQueue stays excluded from the deps below.
-        return composeDailySet(reviewQueue);
-      }
-
-      return shuffleQuestions(
-        buildQuestionPool(vocabulary, {
-          partOfSpeech,
-          verbGroup,
-          targetForms
-        })
-      );
+      return buildPracticeQuestions({
+        isExamFocus,
+        isClozeFocus,
+        isPatternFocus,
+        isReviewFocus,
+        isVocabFocus,
+        isDailyFocus,
+        examSection: practiceFilter.examSection,
+        patternIds: practiceFilter.patternIds,
+        partOfSpeech,
+        verbGroup,
+        targetForms,
+        levelRange,
+        reviewQueue
+      });
     },
     // INTENTIONALLY excluding `reviewQueue` from deps. The live queue
     // is reactive to every progressAttempts change (any answered


### PR DESCRIPTION
## 這是 issue #102 的 **A 階段**(純函式抽出)

只做 A：把不依賴 React state 的 pool 組合邏輯從 `src/hooks/usePracticeSession.ts` 抽成純函式到新檔 `src/domain/sessionPools.ts`。**B 階段（ChallengePanel 的 UI 拆分）會在後續另開一支 PR**，本 PR 不涉及任何 UI / props 變更。

### 抽出的純函式 → `src/domain/sessionPools.ts`
- `composeDailySet(due)` — 今日練習 set 組合（原本就是 module-scope 純函式，整段搬移）。
- `buildModeCounts()` — 各 mode 題數（cloze / pattern / exam / examN1 / examN2 / examN4 / vocab），對應原 `modeCounts` memo。
- `buildAllKnownQuestions()` — review queue 用的 union pool，對應原 `allKnownQuestions` memo。
- `buildPracticeQuestions(params)` — 依當前 mode 推導 active 題庫，對應原 `questions` memo。涵蓋**所有現存分支**：模擬考 section 過濾、綜合（all / n1n2 / n2n3 / n4n5 level range）、cloze、pattern、review snapshot、vocab（reading-only + range 過濾）、今日練習、basic drill。完整保留 #65 / #92 的 examN4 / `n4n5` 邏輯。
- `uniqueForms(forms)` — 共用的 form 去重 helper。

`usePracticeSession.ts` 現在只留 React state / memo / handlers，memo body 改成呼叫上述純函式（`reviewQueue` snapshot 以參數傳入以維持原本「intentionally excluded from deps」的行為）。**行為 / 視覺 / 公開 props 語意完全不變。**

### 新增測試 → `src/domain/sessionPools.test.ts`（+20 案例）
- `uniqueForms`：去重 + first-seen 順序。
- `buildModeCounts`：每個 mode key 都有值且與 live builder 一致；examN4 來自 n4n5（N4/N5 only）。
- `buildAllKnownQuestions`：union 涵蓋 exam / cloze / pattern / vocab(reading+meaning) 各來源。
- `buildPracticeQuestions`：basic / exam(all・n1n2・n2n3・n4n5) / exam mock-section / cloze / review(原樣 snapshot) / vocab(range + reading-only) / daily 每個分支。
- `composeDailySet`：總數上限 20、due 上限半數、due 在前且保序、fresh 不含 due、空 due 時的 fresh 組合。

### Code-split 約束（已驗證）
`sessionPools.ts` 只被 `usePracticeSession` import，而後者只被 lazy 的 `ChallengePanel` import → 落在 lazy challenge chunk，未被任何 eager 模組（App / barrel / home / learn / rules）引用。
`pnpm build` 後 `dist/` 確認：
- `examBlocks-C4jeU-JW.js`（449 KB / 127 KB gzip）**仍是獨立 chunk**，hash 與 base 完全相同。
- `index-*.js` 維持 255 KB / 81 KB gzip（無暴增）；grep 確認 index chunk 不含任何 exam 題目資料或 N1 詞彙。
- 抽出邏輯落在 `ChallengePanel-*.js`（+0.44 KB）。

### 驗證結果
- `pnpm test`：**185 passed (15 files)**（base 165 + 新增 20）。
- `tsc --noEmit` + `pnpm build`：綠。
- 改到的 TS 檔以 LF 行尾入庫（已逐 byte 確認 committed blob 無 CR）。