### PR TITLE
chore: 新增專案 CLAUDE.md + pre-commit build hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# Jabiko 專案規則
+
+## 技術棧
+
+- React 19 + TypeScript strict mode + Vite 7 + Vitest 4 + jsdom
+- pnpm 套件管理
+- 領域驅動設計：`src/domain/`（商業邏輯）、`src/components/`（React UI）、`src/hooks/`
+
+## 修改前必讀
+
+- `src/domain/vocabulary.ts` 和 `src/domain/vocabulary-jlpt.ts` 是熱路徑
+- `src/domain/types.ts` 是所有領域型別的定義處
+- `src/domain/contentGuard.test.ts` 是題目內容的正確性驗證關卡
+- 修改任何 domain 檔案時，先讀對應的 `.test.ts` 了解預期行為
+
+## Build 與測試
+
+- TypeScript 改動後跑 `pnpm build` 確保編譯通過
+- 領域邏輯改動後跑 `pnpm test` 確保回歸
+- 只改 React 元件時可以只跑 `pnpm build`
+- `pnpm check:exam` 是題目內容快速驗證，改題庫時必跑
+- build 失敗時先讀錯誤再修，不要盲目重試
+
+## 不變條件
+
+- 不要改變 `src/domain/contentGuard.ts` 的驗證規則，除非透過 issue 討論
+- `src/domain/types.ts` 的型別是合約，不要隨意刪除或破壞向後相容
+- 所有領域邏輯必須在 `src/domain/`，不要在 `src/components/` 放商業邏輯
+- pnpm 為唯一套件管理工具，不產生 npm/yarn/bun lockfile
+
+## 程式碼慣例
+
+- TypeScript strict mode 全開，禁止 `any`，除非有明確註解說明
+- 測試檔與原始檔放在同目錄，命名為 `*.test.ts` 或 `*.test.tsx`
+- React 元件用函式元件 + hooks，不用 class component
+- import 用 ES module 路徑（相對路徑）

--- a/package.json
+++ b/package.json
@@ -10,12 +10,19 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check:exam": "vitest run src/domain/contentGuard.test.ts",
-    "optimize-hero": "node scripts/optimize-hero.mjs"
+    "optimize-hero": "node scripts/optimize-hero.mjs",
+    "pre": "pnpm build"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm build"
   },
   "dependencies": {
     "lucide-react": "^0.561.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["simple-git-hooks", "esbuild", "sharp"]
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
@@ -26,6 +33,7 @@
     "@vitejs/plugin-react": "^5.1.1",
     "jsdom": "^27.3.0",
     "sharp": "^0.35.1",
+    "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.3",
     "vite": "^7.2.7",
     "vitest": "^4.0.15"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       sharp:
         specifier: ^0.35.1
         version: 0.35.1
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1073,6 +1076,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2166,6 +2173,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.35.1
 
   siginfo@2.0.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- 新增專案級 `CLAUDE.md`：定義技術棧（React 19 + TypeScript + Vite 7 + Vitest）、熱路徑（vocabulary/vocabulary-jlpt）、必讀檔案、build/test 指令、不變條件與程式碼慣例
- 新增 `simple-git-hooks` pre-commit hook：每次 `git commit` 前自動跑 `pnpm build`（tsc --noEmit + vite build），約 1 秒，避免 TypeScript 錯誤進入 commit 歷史
- pnpm 設定 `onlyBuiltDependencies` 以允許 simple-git-hooks postinstall 正常執行

## Motivation
降低 Claude Code on DeepSeek 在專案中的犯錯機會：專案級 CLAUDE.md 每次 session 自動載入提供完整上下文，pre-commit hook 在 commit 階段強制擋下編譯失敗。

## Test plan
- [x] `pnpm build` 手動通過（1.05s）
- [x] pre-commit hook 自動觸發驗證（commit 時自動執行並通過）
- [x] `SKIP_SIMPLE_GIT_HOOKS=1 git commit` 可跳過 hook（WIP commit 用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation covering technical stack, build processes, coding conventions, and development guidelines.

* **Chores**
  * Updated build configuration to include pre-commit hooks and dependency management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->