### PR TITLE
fix(exam): 語順組合 題幹詞塊 render-time 打散（#120）

### DIFF
--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { GraduationCap } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
+import { shuffleOrderFragments } from "../domain/wordOrder";
 import { SpeakButton } from "./SpeakButton";
 
 // Renders an exam/cloze/pattern question's prompt: instruction, the
@@ -43,6 +44,13 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
   // (legacy exam items). The full translation still appears in the
   // FeedbackPanel post-answer via vocabulary.examples[0].meaningZh.
   const preAnswerHint = question.hintZh ?? question.promptContextZh;
+  // 語順組合 prompts list their fragments in answer order (［a / b / c / d］),
+  // which spells out the answer. Shuffle them at render time (seeded by id so
+  // it's stable and never reshuffles mid-question). Other labels render as-is.
+  const promptText =
+    question.promptLabel === "語順組合" && question.promptText
+      ? shuffleOrderFragments(question.promptText, question.id)
+      : question.promptText;
   return (
     <>
       <p className="word-kind">
@@ -50,9 +58,9 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
         {question.instructionZh}
       </p>
       <p className="exam-prompt">
-        {question.promptText}
-        {question.promptText ? (
-          <SpeakButton text={question.promptText} language={language} />
+        {promptText}
+        {promptText ? (
+          <SpeakButton text={promptText} language={language} />
         ) : null}
       </p>
       {preAnswerHint ? (

--- a/src/domain/wordOrder.test.ts
+++ b/src/domain/wordOrder.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { shuffleOrderFragments } from "./wordOrder";
+
+describe("shuffleOrderFragments", () => {
+  const prompt = "［長期的な視点 / なくしては / 持続的な成長は / 望めない］";
+  const fragments = ["長期的な視点", "なくしては", "持続的な成長は", "望めない"];
+
+  const parse = (out: string) =>
+    out
+      .slice("［".length, out.length - "］".length)
+      .split("/")
+      .map((f) => f.trim());
+
+  it("returns a permutation of the original fragments, keeping ［］ wrapper", () => {
+    const out = shuffleOrderFragments(prompt, "n1-order-1");
+    expect(out.startsWith("［")).toBe(true);
+    expect(out.endsWith("］")).toBe(true);
+    expect([...parse(out)].sort()).toEqual([...fragments].sort());
+  });
+
+  it("never reproduces the original answer order (no leak)", () => {
+    for (const id of ["a", "b", "c", "n1-order-x", "seed-123", "望めない"]) {
+      expect(shuffleOrderFragments(prompt, id)).not.toBe(prompt);
+    }
+  });
+
+  it("forces a different order even for a 2-fragment prompt", () => {
+    const two = "［前半 / 後半］";
+    for (const id of ["x", "y", "z", "1", "2"]) {
+      expect(shuffleOrderFragments(two, id)).not.toBe(two);
+    }
+  });
+
+  it("is stable for the same seed across calls", () => {
+    expect(shuffleOrderFragments(prompt, "same")).toBe(shuffleOrderFragments(prompt, "same"));
+  });
+
+  it("returns the input unchanged when not a parseable ［...］ list", () => {
+    expect(shuffleOrderFragments("ふつうの文です。", "id")).toBe("ふつうの文です。");
+    expect(shuffleOrderFragments("［ひとつだけ］", "id")).toBe("［ひとつだけ］");
+    expect(shuffleOrderFragments("", "id")).toBe("");
+  });
+});

--- a/src/domain/wordOrder.ts
+++ b/src/domain/wordOrder.ts
@@ -1,0 +1,67 @@
+// 語順組合 (sentence-reordering) prompts list their word fragments in the
+// CORRECT order -- ［a / b / c / d］ -- so a learner can just concatenate
+// them as shown to get the answer without understanding the grammar. This
+// shuffles the fragments at render time so the prompt no longer spells out
+// the answer. Pure display: options / expectedAnswer are untouched.
+
+const OPEN = "［";
+const CLOSE = "］";
+const JOIN = " / ";
+
+/** Stable unsigned 32-bit string hash (mirrors practice.ts for seed parity). */
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (Math.imul(hash, 31) + value.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
+/** mulberry32 seeded PRNG (same as practice.ts) -- deterministic per seed. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Shuffle the fragments of a ［a / b / c / d］ prompt so they no longer
+ * appear in answer order. Seeded by `seed` (the question id) so the order
+ * is stable across re-renders and never reshuffles mid-question -- matching
+ * rotateOptions / seededSample in practice.ts. Guarantees the result differs
+ * from the original order (else it would leak the answer again).
+ *
+ * Returns the input unchanged when it isn't a parseable ［...］ list of two
+ * or more fragments.
+ */
+export function shuffleOrderFragments(promptText: string, seed: string): string {
+  const trimmed = promptText.trim();
+  if (!trimmed.startsWith(OPEN) || !trimmed.endsWith(CLOSE)) return promptText;
+
+  const inner = trimmed.slice(OPEN.length, trimmed.length - CLOSE.length);
+  const fragments = inner
+    .split("/")
+    .map((fragment) => fragment.trim())
+    .filter((fragment) => fragment.length > 0);
+  if (fragments.length < 2) return promptText;
+
+  const rand = mulberry32(hashString(seed));
+  const shuffled = [...fragments];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  // If the seeded shuffle happened to reproduce the original (answer) order,
+  // rotate by one so the prompt never leaks the answer. With >=2 distinct
+  // fragments a single rotation always differs from the original.
+  if (shuffled.every((fragment, i) => fragment === fragments[i])) {
+    shuffled.push(shuffled.shift()!);
+  }
+
+  return `${OPEN}${shuffled.join(JOIN)}${CLOSE}`;
+}


### PR DESCRIPTION
修「語順組合」題幹洩答：promptText 以正解順序列詞塊（［a / b / c / d］），照顯示串接即得正解、不需懂文法。新增 src/domain/wordOrder.ts 的 shuffleOrderFragments（seeded by question id、re-render 穩定、保證 != 原順序避免再洩答）+ 單元測試；ExamPrompt 僅對 語順組合 題 render 打散後字串。純顯示改動，不動 options/expectedAnswer，render-time fix 覆蓋全 20 題（n1 12 / n2 8）與未來新增。test 190 / build 綠。Closes #120