### PR TITLE
feat(domain): 加 adverb 詞性，重分類 漫然/突如（#60）

### DIFF
--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -437,6 +437,12 @@ function isFormCompatible(item: VocabularyItem, targetForm: TargetForm): boolean
     return true;
   }
 
+  // Adverbs (e.g. 漫然/突如) have no conjugation; only the reading/meaning
+  // drills above apply to them -- never generate a conjugation question.
+  if (item.partOfSpeech === "adverb") {
+    return false;
+  }
+
   if (item.partOfSpeech === "verb") {
     return VERB_FORMS.includes(targetForm);
   }

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { buildClozeQuestionPool } from "./cloze";
 import { clozeSentences } from "./cloze-data";
+import { ADJECTIVE_FORMS } from "./conjugation";
 import { buildExamQuestionPool } from "./examBlocks";
 import { levelsForRange } from "./levelRange";
 import { buildQuestionPool } from "./practice";
@@ -244,5 +245,21 @@ describe("composeDailySet", () => {
     // With an empty due queue the set is entirely fresh and reserves at
     // least one vocab reading item (DAILY_VOCAB_MIN floor).
     expect(set.some((q) => q.targetForm === "reading")).toBe(true);
+  });
+});
+
+describe("buildQuestionPool part-of-speech handling (#60)", () => {
+  it("does not generate conjugation drills for adverbs", () => {
+    const adverb = jlptVocabulary.find((item) => item.partOfSpeech === "adverb");
+    expect(adverb).toBeDefined();
+    // Adverbs (e.g. 漫然/突如) have no conjugation; pairing one with every
+    // adjective conjugation form must yield zero questions. Only reading /
+    // meaning drills are valid for them.
+    const drills = buildQuestionPool([adverb!], {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ADJECTIVE_FORMS
+    });
+    expect(drills).toEqual([]);
   });
 });

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,4 +1,4 @@
-export type PartOfSpeech = "verb" | "i_adjective" | "na_adjective" | "noun";
+export type PartOfSpeech = "verb" | "i_adjective" | "na_adjective" | "noun" | "adverb";
 
 export type VerbGroup = "godan" | "ichidan" | "irregular";
 

--- a/src/domain/vocabulary-jlpt.test.ts
+++ b/src/domain/vocabulary-jlpt.test.ts
@@ -35,4 +35,17 @@ describe("jlptVocabulary integrity", () => {
       .map((item) => item.surface || "(empty)");
     expect(incomplete).toEqual([]);
   });
+
+  // #60: words used adverbially (漫然と／たる, 突如として) must not be
+  // mislabelled as plain nouns -- the UI shows the part-of-speech and the
+  // practice engine groups distractors by it.
+  it("labels adverbial words as adverb, not noun", () => {
+    const adverbials = ["漫然", "突如"];
+    const offenders = adverbials
+      .map((surface) => jlptVocabulary.find((item) => item.surface === surface))
+      .filter((item): item is NonNullable<typeof item> => Boolean(item))
+      .filter((item) => item.partOfSpeech !== "adverb")
+      .map((item) => `${item.surface}=${item.partOfSpeech}`);
+    expect(offenders).toEqual([]);
+  });
 });

--- a/src/domain/vocabulary-jlpt.ts
+++ b/src/domain/vocabulary-jlpt.ts
@@ -24,6 +24,7 @@ function entry(
 const n2N = (s: string, r: string, m: string) => entry("N2", "noun", s, r, m);
 const n2A = (s: string, r: string, m: string) => entry("N2", "na_adjective", s, r, m);
 const n1N = (s: string, r: string, m: string) => entry("N1", "noun", s, r, m);
+const n1Adv = (s: string, r: string, m: string) => entry("N1", "adverb", s, r, m);
 const n1A = (s: string, r: string, m: string) => entry("N1", "na_adjective", s, r, m);
 
 const n2Vocabulary: VocabularyItem[] = [
@@ -518,7 +519,7 @@ const n1Vocabulary: VocabularyItem[] = [
   n1N("貌", "ぼう", "外貌"),
   n1N("謀略", "ぼうりゃく", "謀略"),
   n1N("摩擦", "まさつ", "摩擦"),
-  n1N("漫然", "まんぜん", "茫然、漫不經心"),
+  n1Adv("漫然", "まんぜん", "茫然、漫不經心"),
   n1N("無謀", "むぼう", "魯莽、無謀"),
   n1N("名目", "めいもく", "名目"),
   n1N("黙認", "もくにん", "默認"),
@@ -571,7 +572,7 @@ const n1Vocabulary: VocabularyItem[] = [
   n1N("是正", "ぜせい", "糾正"),
   n1N("中枢", "ちゅうすう", "中樞、核心"),
   n1N("同調", "どうちょう", "附和、同步"),
-  n1N("突如", "とつじょ", "突然"),
+  n1Adv("突如", "とつじょ", "突然"),
   n1N("内訳", "うちわけ", "明細"),
   n1N("難航", "なんこう", "進展不順"),
   n1N("排除", "はいじょ", "排除"),

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -366,6 +366,7 @@ export const copy: Record<Language, Copy> = {
       i_adjective: "い形容詞",
       na_adjective: "な形容詞",
       noun: "名詞",
+      adverb: "副詞",
       mixed: "混合"
     },
     verbGroups: {


### PR DESCRIPTION
漫然（漫然と/たる）、突如（突如として）是副詞性，原用 n1N 誤標 noun → 誤導 UI 詞性 label + practice distractor grouping。

- types PartOfSpeech 加 `adverb`
- 新增 n1Adv helper，漫然/突如 改用它
- i18n partOfSpeech 加「副詞」label
- adverb 不進 basic-mode partOfSpeechOptions（副詞無活用，正確）

TDD：先加 failing vocab test（red）→ 加 adverb 支援（green）。test 194 / check:exam 8 / build 綠。Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for adverbs as a word classification in the vocabulary system
  * Reclassified two JLPT vocabulary entries to correctly reflect adverb classification

* **Tests**
  * Added validation tests for adverb-classified vocabulary entries

* **Localization**
  * Added Traditional Chinese translation for adverb classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->