### PR TITLE
feat(challenge): 鍵盤快捷作答（#132）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -566,6 +566,40 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "聞いて" })).toBeInTheDocument();
   });
 
+  it("answers the MCQ drill with the matching number key (1-4)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await gotoLearn(user);
+    await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+
+    // Options are shuffled, so find 書いて's slot and press its 1-based
+    // position. The number key must select AND submit that option, even
+    // with focus outside the drill (a global, focus-independent shortcut).
+    const grid = screen.getByLabelText("答案選項");
+    const options = within(grid).getAllByRole("button");
+    const correctSlot = options.findIndex((button) => button.textContent === "書いて");
+    expect(correctSlot).toBeGreaterThanOrEqual(0);
+
+    await user.keyboard(String(correctSlot + 1));
+
+    expect(screen.getByRole("heading", { name: "正解" })).toBeInTheDocument();
+  });
+
+  it("ignores a number key past the option count", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await gotoLearn(user);
+    await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+
+    // Only 4 options exist; pressing 9 must not submit anything.
+    await user.keyboard("9");
+
+    expect(screen.queryByRole("heading", { name: "正解" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "再想一下" })).not.toBeInTheDocument();
+  });
+
   it("lets the learner focus on negative transformations", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -172,6 +172,8 @@ export function DrillPanel({
             })}
           </div>
 
+          {!feedback ? <p className="kbd-hint">{t.keyboardHint}</p> : null}
+
           <div className="action-row">
             <button className="ghost-button" type="button" onClick={revealAnswer} disabled={Boolean(feedback)}>
               <Eye aria-hidden="true" />

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -339,6 +339,42 @@ export function usePracticeSession({
     }
   };
 
+  // Desktop shortcut: press 1-9 to pick (and submit) the matching MCQ
+  // option. A GLOBAL document listener -- not the drill section's
+  // onKeyDown -- because the choice buttons are never auto-focused before
+  // answering, so a section-scoped handler would miss the keypress unless
+  // the learner first tabbed in. Only active while a question is open and
+  // unanswered; skipped when a text field is focused (so it never hijacks
+  // typing) or when a modifier is held (leave browser/OS chords alone).
+  // (Enter/Space-to-advance after feedback stays on handleDrillKeyDown,
+  // which works because the next button is auto-focused once answered.)
+  useEffect(() => {
+    if (!currentQuestion || feedback) {
+      return;
+    }
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) {
+        return;
+      }
+      if (event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+      if (event.key < "1" || event.key > "9") {
+        return;
+      }
+      const choice = choiceOptions[Number(event.key) - 1];
+      if (choice === undefined) {
+        return;
+      }
+      event.preventDefault();
+      handleChoiceSubmit(choice);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [currentQuestion, feedback, choiceOptions, handleChoiceSubmit]);
+
   return {
     partOfSpeech,
     verbGroup,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -135,6 +135,7 @@ export type Copy = {
   feedbackNoWord: string;
   showHint: string;
   hideHint: string;
+  keyboardHint: string;
   focusSummaryEmpty: string;
   modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
@@ -321,6 +322,7 @@ export const copy: Record<Language, Copy> = {
     feedbackNoWord: "無對應詞",
     showHint: "提示",
     hideHint: "隱藏提示",
+    keyboardHint: "桌面快捷：按 1–4 選答、Enter 進下一題",
     focusSummaryEmpty: "目前重點沒有可用形",
     modeOptions: {
       daily: { title: "今日練習", subtitle: "複習優先 · 文法 / 語順 / 漢字読み混合一輪" },

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -235,12 +235,16 @@
   color: var(--ink);
 }
 
-/* Subtle 1-4 number badge: a desktop affordance hinting the matching
-   digit picks this option (see usePracticeSession's keydown shortcut).
-   A CSS counter -- not DOM text -- so it never enters the button's
-   accessible name or textContent. */
+/* Subtle 1-4 number badge hinting the matching digit picks this option
+   (see usePracticeSession's keydown shortcut). The "/ ''" gives the
+   generated content an EMPTY accessibility alt-text, so screen readers
+   do not fold the digit into the button's accessible name -- Chromium /
+   WebKit otherwise include ::before content in the computed name, which
+   would announce "1 書いて" instead of "書いて". Kept out of the DOM (a
+   counter, not text) so it never touches textContent either. Hidden once
+   answered, when the shortcut is inactive. */
 .choice-option::before {
-  content: counter(choice);
+  content: counter(choice) / "";
   counter-increment: choice;
   position: absolute;
   top: 0.3rem;
@@ -249,6 +253,10 @@
   font-weight: 700;
   line-height: 1;
   opacity: 0.4;
+}
+
+.choice-option:disabled::before {
+  display: none;
 }
 
 .kbd-hint {

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -196,9 +196,11 @@
   display: grid;
   gap: 0.6rem;
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  counter-reset: choice;
 }
 
 .choice-option {
+  position: relative;
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 88%, var(--indigo) 12%), var(--field-bg));
   border-color: color-mix(in srgb, var(--field-border) 80%, var(--indigo));
@@ -231,6 +233,29 @@
   background: var(--feedback-incorrect-bg);
   border-color: var(--vermilion);
   color: var(--ink);
+}
+
+/* Subtle 1-4 number badge: a desktop affordance hinting the matching
+   digit picks this option (see usePracticeSession's keydown shortcut).
+   A CSS counter -- not DOM text -- so it never enters the button's
+   accessible name or textContent. */
+.choice-option::before {
+  content: counter(choice);
+  counter-increment: choice;
+  position: absolute;
+  top: 0.3rem;
+  left: 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  opacity: 0.4;
+}
+
+.kbd-hint {
+  margin: 0.1rem 0 0;
+  font-size: 0.78rem;
+  text-align: center;
+  color: color-mix(in srgb, var(--ink) 55%, transparent);
 }
 
 .next-button {


### PR DESCRIPTION
## 目標
桌面快速作答：數字鍵選答、Enter 繼續，並讓使用者知道可以用鍵盤。

## 做了什麼
- **1–9 數字鍵**：選擇對應選項並直接提交。用**全域 document keydown 監聽**（非 section onKeyDown）——因為作答前選項按鈕不會 auto-focus，section-scoped handler 收不到鍵；全域才可靠。
- **守則**：焦點在 `<input>/<textarea>/contentEditable` 時不攔截（不干擾打字）；按住 Ctrl/Cmd/Alt 時放行（不搶瀏覽器快捷）；僅在「有題目且未作答」時生效。
- **Enter/Space 進下一題**：維持原本的 section handler（答題後 next-button 會 auto-focus，故原生可用），未改動。
- **選項 1–4 標號**：用 CSS counter（`.choice-option::before`）純視覺加上，**不動 DOM、不改 accessible name**（既有 `getByRole(name)` 測試不受影響）。
- **鍵盤提示**：選項下方一行細微說明「桌面快捷：按 1–4 選答、Enter 進下一題」（i18n `keyboardHint`，僅作答前顯示）。

## 無障礙
選項仍是可 focus/點擊的 button，快捷只是加分；標號為裝飾性 ::before，不進 accessible name。

## TDD / 驗證
- RED→GREEN：先加「數字鍵選對應選項」測試見其失敗，再實作。
- 另測「超出選項數的數字鍵被忽略」。
- 全測 197 passed（+2）、build 綠。

Closes #132。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcuts: press number keys (1–4) to quickly select and submit multiple-choice answers.
  * Displays keyboard hint prompting users about available shortcuts.
  * Visual number badges now appear next to each answer option for reference.

* **Tests**
  * Added tests verifying number-key answer selection and validation of out-of-range key presses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->