### PR TITLE
test(content-guard): 題目品質自動 lint（#139）

### DIFF
--- a/src/domain/contentGuard.test.ts
+++ b/src/domain/contentGuard.test.ts
@@ -49,9 +49,11 @@ describe("exam content guard", () => {
 
   it("never surfaces the JLPT level in promptLabel", () => {
     // The internal `level` field drives filtering; the user-visible
-    // promptLabel must not start with an "N1 / N2 / N3 " prefix.
+    // promptLabel must not lead with an "N1".."N5" token. Use a word
+    // boundary (\b) -- matching the importer's check -- so "N3文法" (no
+    // space, CJK right after) is caught too, not only "N3 文法".
     const offenders = examStyleQuestions
-      .filter((question) => /^N[1-5]\s/.test(question.promptLabel ?? ""))
+      .filter((question) => /^N[1-5]\b/.test(question.promptLabel ?? ""))
       .map((question) => `${question.id} -> ${question.promptLabel}`);
     expect(offenders, `level leak in promptLabel: ${offenders.join("; ")}`).toEqual([]);
   });
@@ -73,6 +75,82 @@ describe("exam content guard", () => {
       if (leaked) offenders.push(`${question.id}: "${leaked}"`);
     }
     expect(offenders, `hintZh leaks a meaningZh token: ${offenders.join("; ")}`).toEqual([]);
+  });
+
+  it("offers kana-only options on 漢字読み items", () => {
+    // 漢字読み tests the READING, so every option must be kana -- a kanji or
+    // romaji option would give the answer away by being the odd one out.
+    // Confusers should differ by 清濁/長音/促音/近形假名, not by script.
+    const isKana = (value: string) => /^[぀-ヿ]+$/.test(value);
+    const offenders: string[] = [];
+    for (const question of examStyleQuestions) {
+      if (question.promptLabel !== "漢字読み") continue;
+      const nonKana = (question.options ?? []).filter((option) => !isKana(option));
+      if (nonKana.length > 0) {
+        offenders.push(`${question.id}: [${nonKana.join(", ")}]`);
+      }
+    }
+    expect(offenders, `漢字読み non-kana options: ${offenders.join("; ")}`).toEqual([]);
+  });
+
+  it("has no duplicate options within any item", () => {
+    // A repeated option silently turns a 1-of-4 into a 1-of-3 (or worse).
+    const offenders = examStyleQuestions
+      .filter((question) => {
+        const options = question.options;
+        return options ? new Set(options).size !== options.length : false;
+      })
+      .map((question) => question.id);
+    expect(offenders, `items with duplicate options: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("gives every item a non-empty explanation", () => {
+    // The post-answer explanation is the learning payload; an empty one is
+    // a quality-floor breach.
+    const offenders = examStyleQuestions
+      .filter((question) => !question.explanation || question.explanation.trim() === "")
+      .map((question) => question.id);
+    expect(offenders, `items with empty explanation: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("keeps 語順組合 prompts shuffleable (a ［...］ list of >=2 fragments)", () => {
+    // 語順組合 prompts list their fragments in ANSWER order inside ［ ］, and
+    // ExamPrompt render-shuffles them (#120) so the prompt doesn't spell out
+    // the answer. That shuffle is a no-op unless the prompt parses as a
+    // bracketed "/"-separated list of >=2 fragments -- mirror wordOrder.ts's
+    // parser so an unshuffleable prompt fails loudly instead of leaking.
+    const offenders: string[] = [];
+    for (const question of examStyleQuestions) {
+      if (question.promptLabel !== "語順組合") continue;
+      const text = (question.promptText ?? "").trim();
+      if (!text.startsWith("［") || !text.endsWith("］")) {
+        offenders.push(`${question.id}: not a ［...］ list`);
+        continue;
+      }
+      const fragments = text
+        .slice(1, -1)
+        .split("/")
+        .map((fragment) => fragment.trim())
+        .filter((fragment) => fragment.length > 0);
+      if (fragments.length < 2) {
+        offenders.push(`${question.id}: <2 fragments`);
+      }
+    }
+    expect(offenders, `unshuffleable 語順組合 prompts: ${offenders.join("; ")}`).toEqual([]);
+  });
+
+  it("has no two items sharing an identical promptText", () => {
+    // A duplicated sentence-with-blank means two "different" questions are
+    // really the same drill -- usually a copy-paste slip when authoring a
+    // batch. Skip items without a promptText (plain conjugation drills).
+    const counts = new Map<string, number>();
+    for (const question of examStyleQuestions) {
+      const text = question.promptText?.trim();
+      if (!text) continue;
+      counts.set(text, (counts.get(text) ?? 0) + 1);
+    }
+    const duplicates = [...counts].filter(([, n]) => n > 1).map(([text]) => text);
+    expect(duplicates, `duplicate promptText: ${duplicates.join(" | ")}`).toEqual([]);
   });
 });
 

--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -81,8 +81,10 @@ describe("buildExamQuestionPool", () => {
     expect(questions.some((question) => question.vocabulary.level === "N4")).toBe(false);
     expect(questions.some((question) => question.vocabulary.level === "N5")).toBe(false);
     // promptLabel must NOT leak the JLPT level (N1–N5) back to the user.
+    // Word boundary (\b) matches the importer + contentGuard check, so a
+    // no-space "N3文法" leak is caught here too.
     expect(
-      questions.every((question) => !/^N[1-5]\s/.test(question.promptLabel ?? ""))
+      questions.every((question) => !/^N[1-5]\b/.test(question.promptLabel ?? ""))
     ).toBe(true);
   });
 


### PR DESCRIPTION
## 目標
把「已知會出事的題目品質缺陷類」變成 `check:exam` 自動 lint，防回歸。#139 即授權觸碰 contentGuard（CLAUDE.md 不變條件）。

## 新增 5 個 lint（皆確定性、每個 collect 全部 offender 一次列出）
1. **漢字読み 選項全假名**：`promptLabel === 漢字読み` 的 options 必為純假名（漢字/拉丁會因「異類」洩答）。
2. **選項不重複**：任一題 options 去重後長度不變。
3. **explanation 非空**：每題都有非空解析（品質下限）。
4. **語順組合 可打散**：promptText 必為 ［...］ 且 split 後 ≥2 段——鏡像 `wordOrder.ts` 解析，確保 #120 render-shuffle 真的有東西可打散、不洩答。
5. **題幹不重複**：沒有兩題共用完全相同的 promptText（抓批次複製貼上漏改）。

## 順手
level-leak regex `^N[1-5]\s` → `^N[1-5]\b`，對齊 importer（連「N3文法」這種無空白前綴也擋）。

## 驗證
- 現有題庫**全數通過**（check:exam 8 → 13）。
- 為確保不是 no-op：注入一個漢字 options 到 漢字読み 題 → lint 1 如期 RED、offender 訊息正確 → 還原。
- 全測 202（+5）、build 綠。

Closes #139。後續 #140（LLM-judge 語意第二道）、#141（讀音工具）。