### PR TITLE
feat(scripts): kuromoji 讀音驗證 dev script（#141）

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check:exam": "vitest run src/domain/contentGuard.test.ts",
+    "check:readings": "node scripts/check-readings.mjs",
     "optimize-hero": "node scripts/optimize-hero.mjs",
     "pre": "pnpm build"
   },
@@ -39,6 +40,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "jsdom": "^27.3.0",
+    "kuromoji": "^0.1.2",
     "sharp": "^0.35.1",
     "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       jsdom:
         specifier: ^27.3.0
         version: 27.4.0
+      kuromoji:
+        specifier: ^0.1.2
+        version: 0.1.2
       sharp:
         specifier: ^0.35.1
         version: 0.35.1
@@ -837,6 +840,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async@2.6.4:
+    resolution: {integrity: sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==}
+
   baseline-browser-mapping@2.10.31:
     resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
     engines: {node: '>=6.0.0'}
@@ -903,6 +909,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  doublearray@0.0.2:
+    resolution: {integrity: sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==}
 
   electron-to-chromium@1.5.360:
     resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
@@ -992,6 +1001,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kuromoji@0.1.2:
+    resolution: {integrity: sha512-V0dUf+C2LpcPEXhoHLMAop/bOht16Dyr+mDiIE39yX3vqau7p80De/koFqpiTcL1zzdZlc3xuHZ8u5gjYRfFaQ==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
@@ -1303,6 +1318,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
 snapshots:
 
@@ -1930,6 +1948,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async@2.6.4:
+    dependencies:
+      lodash: 4.18.1
+
   baseline-browser-mapping@2.10.31: {}
 
   bidi-js@1.0.3:
@@ -1984,6 +2006,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  doublearray@0.0.2: {}
 
   electron-to-chromium@1.5.360: {}
 
@@ -2096,6 +2120,14 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  kuromoji@0.1.2:
+    dependencies:
+      async: 2.6.4
+      doublearray: 0.0.2
+      zlibjs: 0.3.1
+
+  lodash@4.18.1: {}
 
   lru-cache@11.5.0: {}
 
@@ -2356,3 +2388,5 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  zlibjs@0.3.1: {}

--- a/scripts/check-readings.mjs
+++ b/scripts/check-readings.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// =============================================================================
+// check-readings.mjs -- objective reading validation for 漢字読み items (#141)
+// =============================================================================
+//
+// Gate F of the question-quality chain (A=contentGuard lints #139, B=LLM-judge
+// #140, F=this). A confirms format, B catches semantic double-answers; F adds an
+// OBJECTIVE cross-check that a 漢字読み item's expectedAnswer really is a reading
+// of the tested word, using kuromoji.js morphological analysis (IPADIC).
+//
+// Dev-only: kuromoji is a devDependency, NOT in the app bundle. This is a human
+// reference report -- it ALWAYS exits 0 and never gates CI (a mismatch usually
+// means "a human should look", not "broken": kuromoji returns the single most
+// likely reading, so a legitimate alternate reading shows up as a mismatch too).
+//
+//   node scripts/check-readings.mjs        (or: corepack pnpm check:readings)
+//
+// Source of items: the per-level src/domain/exam/items/n{1..5}.ts files are
+// parsed as text (same pure-Node, no-transpile approach as import-exam-items
+// .mjs). We validate the 「」-underlined word IN promptText (the actually
+// tested form), NOT the `surface` headword -- those differ when the question
+// tests a conjugated form (surface 滞る, tested 「滞って」, answer とどこおって).
+//
+// NOT validated here (kuromoji tokenises WORDS, not isolated-kanji on'yomi):
+//   * the kanjiOnyomi.ts study table -- needs a kanji->readings dict (KANJIDIC
+//     class), a possible future extension.
+//   * whether a DISTRACTOR is also a legitimate reading (needs all readings of a
+//     word; kuromoji gives only the top one). Left for a JMdict-backed follow-up.
+// =============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import kuromoji from "kuromoji";
+
+const require = createRequire(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const ITEMS_DIR = path.join(REPO_ROOT, "src", "domain", "exam", "items");
+const KANJI_READING_LABEL = "漢字読み";
+
+// kuromoji ships its IPADIC dictionary inside the package; point the builder at
+// that dir (resolved from the installed package, so it works on any checkout).
+const DIC_PATH = path.join(path.dirname(require.resolve("kuromoji/package.json")), "dict");
+
+// Katakana (U+30A1..U+30F6) -> hiragana, so kuromoji readings (katakana) can be
+// compared against the hiragana expectedAnswer. The long-vowel ー is left as-is.
+const kataToHira = (value) =>
+  value.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+
+// --- extract 漢字読み items (surface + expectedAnswer) from the .ts sources ---
+function collectKanjiReadingItems() {
+  const items = [];
+  for (const name of fs.readdirSync(ITEMS_DIR)) {
+    if (!name.endsWith(".ts")) continue;
+    const text = fs.readFileSync(path.join(ITEMS_DIR, name), "utf8");
+    // Each entry is examQuestion({ ... }); split on the opener and inspect each
+    // body up to the next opener. Field values are simple quoted strings.
+    const chunks = text.split("examQuestion({").slice(1);
+    for (const chunk of chunks) {
+      const body = chunk.split("examQuestion({")[0];
+      if (!new RegExp(`promptLabel:\\s*"${KANJI_READING_LABEL}"`).test(body)) continue;
+      const id = body.match(/id:\s*"((?:[^"\\]|\\.)*)"/)?.[1];
+      const surface = body.match(/surface:\s*"((?:[^"\\]|\\.)*)"/)?.[1];
+      const expectedAnswer = body.match(/expectedAnswer:\s*"((?:[^"\\]|\\.)*)"/)?.[1];
+      const promptText = body.match(/promptText:\s*"((?:[^"\\]|\\.)*)"/)?.[1] ?? "";
+      // The tested word is what's between 「」 in the prompt (the conjugated
+      // form when applicable); fall back to surface if somehow unmarked.
+      const word = promptText.match(/「([^」]+)」/)?.[1] ?? surface;
+      if (id && surface && expectedAnswer) {
+        items.push({ id, surface, word, expectedAnswer, file: name });
+      }
+    }
+  }
+  return items;
+}
+
+function buildTokenizer() {
+  return new Promise((resolve, reject) => {
+    kuromoji.builder({ dicPath: DIC_PATH }).build((err, tokenizer) => {
+      if (err) reject(err);
+      else resolve(tokenizer);
+    });
+  });
+}
+
+// kuromoji reading of a whole surface (concatenate token readings, katakana).
+// Returns null when any token has no dictionary reading (unknown word) -- we
+// can't objectively validate those, so they're reported separately.
+function readingOf(tokenizer, surface) {
+  const tokens = tokenizer.tokenize(surface);
+  let reading = "";
+  for (const token of tokens) {
+    const r = token.reading;
+    if (!r || r === "*") return null;
+    reading += r;
+  }
+  return kataToHira(reading);
+}
+
+async function main() {
+  const items = collectKanjiReadingItems();
+  console.log(`Validating ${items.length} 漢字読み item(s) against kuromoji (IPADIC)...\n`);
+
+  const tokenizer = await buildTokenizer();
+  const mismatches = [];
+  const unknown = [];
+  let matched = 0;
+
+  for (const item of items) {
+    const got = readingOf(tokenizer, item.word);
+    if (got === null) {
+      unknown.push(item);
+    } else if (got === item.expectedAnswer) {
+      matched += 1;
+    } else {
+      mismatches.push({ ...item, got });
+    }
+  }
+
+  if (mismatches.length > 0) {
+    console.log(`⚠ ${mismatches.length} reading mismatch(es) -- review by hand`);
+    console.log(`  (kuromoji gives the single most-likely reading; an alternate`);
+    console.log(`   legitimate reading also lands here, so verify before changing)\n`);
+    for (const m of mismatches) {
+      console.log(`  ${m.id} (${m.file})  ${m.word}: item="${m.expectedAnswer}" vs kuromoji="${m.got}"`);
+    }
+    console.log("");
+  }
+
+  if (unknown.length > 0) {
+    console.log(`? ${unknown.length} word(s) kuromoji could not read (unknown to IPADIC) -- check manually`);
+    for (const u of unknown) {
+      console.log(`  ${u.id} (${u.file})  ${u.word}: item="${u.expectedAnswer}"`);
+    }
+    console.log("");
+  }
+
+  console.log(`Summary: ✓ ${matched} matched · ⚠ ${mismatches.length} to review · ? ${unknown.length} unknown · ${items.length} total`);
+  // Human-reference tool: never fail. Mismatches are flags for review, not errors.
+}
+
+main().catch((err) => {
+  console.error("check-readings failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 目標
品質鏈 **F**（A=#139 lint / B=#140 LLM-judge / F=本）：用開源 kuromoji.js（IPADIC）**客觀驗證** 漢字読み 題的 expectedAnswer 確為被考詞的合法讀音。

## 做了什麼
- 新增 `scripts/check-readings.mjs`（node, dev-only）：
  - 解析 `items/*.ts` 的 漢字読み 題，取 promptText **「」內被考詞**（活用形，非 surface 辭書形）。
  - kuromoji 斷詞取讀音 → 轉平假名 → 比對 expectedAnswer。
  - 印報告：✓ match / ⚠ 需人工複查 / ? kuromoji 不認得。
- `package.json`：加 `check:readings` script + kuromoji devDependency（**不進 app bundle**）。

## 關鍵設計
- 驗「」內被考詞而非 surface：考活用形時兩者不同（surface `滞る` vs 被考 `滞って`→`とどこおって`），驗被考詞才正確。
- **人工參考、不擋 CI**：永遠 exit 0；mismatch 是「請人看」而非「壞掉」（kuromoji 只回最可能讀音，合法異讀也會落在這）。

## 驗證
- 現有題庫 **71/71 漢字読み 讀音全 match**。
- 證明工具非 no-op：注入錯讀音（都合 つこう）→ 如期 flag「item=つこう vs kuromoji=つごう」→ 還原。
- build 綠（kuromoji 未被 src 引用，不影響 bundle）。

## 範圍外（in-script 註明）
kanjiOnyomi 單字音讀驗證、干擾是否也是合法讀音——需 KANJIDIC/JMdict 級資料，後續。

Dev 工具、TDD 豁免（同 importer）。Closes #141。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development tooling and npm script to support exam content validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->