### PR TITLE
feat(kanji): 音読み 表 +20 字（讀音 study list 擴充）

### DIFF
--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -4,7 +4,7 @@ import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
 import { SpeakButton } from "./SpeakButton";
 
-const LEVELS: Array<JlptLevel | "all"> = ["all", "N1", "N2"];
+const LEVELS: Array<JlptLevel | "all"> = ["all", "N1", "N2", "N3"];
 
 // 漢字音読み 速查表: browse kanji grouped by their primary 音読み
 // (homophone families -- the こう / しょう / せい ... that learners mix up),

--- a/src/domain/kanjiOnyomi.test.ts
+++ b/src/domain/kanjiOnyomi.test.ts
@@ -31,4 +31,14 @@ describe("kanjiOnyomi", () => {
       expect(examples[i].surface.length).toBeGreaterThanOrEqual(examples[i - 1].surface.length);
     }
   });
+
+  it("yields at least one example word for every entry", () => {
+    // kanjiExamples pulls from jlptVocabulary by surface-contains, so a kanji
+    // that appears in NO vocab word would render an empty card. Guard every
+    // entry -- this also catches a new kanji added without a backing compound.
+    const empty = kanjiOnyomi
+      .filter((entry) => kanjiExamples(entry.kanji).length === 0)
+      .map((entry) => entry.kanji);
+    expect(empty, `kanji with no example words: ${empty.join(", ")}`).toEqual([]);
+  });
 });

--- a/src/domain/kanjiOnyomi.ts
+++ b/src/domain/kanjiOnyomi.ts
@@ -48,7 +48,32 @@ export const kanjiOnyomi: KanjiOnyomiEntry[] = [
   { kanji: "情", onyomi: ["じょう"], meaningZh: "情感、情報", level: "N2" },
   { kanji: "状", onyomi: ["じょう"], meaningZh: "狀態、形狀", level: "N2" },
   // -- つう --------------------------------------------------------------
-  { kanji: "通", onyomi: ["つう"], meaningZh: "通過、普遍", level: "N2" }
+  { kanji: "通", onyomi: ["つう"], meaningZh: "通過、普遍", level: "N2" },
+  // -- こう --------------------------------------------------------------
+  { kanji: "効", onyomi: ["こう"], meaningZh: "效果、有效", level: "N3" },
+  { kanji: "工", onyomi: ["こう", "く"], meaningZh: "工程、工夫", level: "N3" },
+  { kanji: "交", onyomi: ["こう"], meaningZh: "交往、交叉", level: "N3" },
+  { kanji: "構", onyomi: ["こう"], meaningZh: "構造、構成", level: "N2" },
+  { kanji: "攻", onyomi: ["こう"], meaningZh: "攻擊、進攻", level: "N1" },
+  // -- しょう ------------------------------------------------------------
+  { kanji: "消", onyomi: ["しょう"], meaningZh: "消失、消費", level: "N3" },
+  { kanji: "招", onyomi: ["しょう"], meaningZh: "招待、招來", level: "N3" },
+  { kanji: "証", onyomi: ["しょう"], meaningZh: "證明、證據", level: "N2" },
+  // -- きょう ------------------------------------------------------------
+  { kanji: "教", onyomi: ["きょう"], meaningZh: "教導、教育", level: "N3" },
+  { kanji: "競", onyomi: ["きょう", "けい"], meaningZh: "競爭、競賽", level: "N2" },
+  { kanji: "強", onyomi: ["きょう", "ごう"], meaningZh: "強烈、強調", level: "N3" },
+  { kanji: "共", onyomi: ["きょう"], meaningZh: "共同、一起", level: "N3" },
+  // -- か ----------------------------------------------------------------
+  { kanji: "化", onyomi: ["か", "け"], meaningZh: "變化、化為", level: "N3" },
+  { kanji: "加", onyomi: ["か"], meaningZh: "增加、加入", level: "N3" },
+  { kanji: "価", onyomi: ["か"], meaningZh: "價值、價格", level: "N3" },
+  { kanji: "可", onyomi: ["か"], meaningZh: "可以、可能", level: "N3" },
+  { kanji: "過", onyomi: ["か"], meaningZh: "經過、過度", level: "N1" },
+  // -- げん --------------------------------------------------------------
+  { kanji: "減", onyomi: ["げん"], meaningZh: "減少、削減", level: "N3" },
+  { kanji: "限", onyomi: ["げん"], meaningZh: "限制、界限", level: "N2" },
+  { kanji: "現", onyomi: ["げん"], meaningZh: "出現、現在", level: "N2" }
 ];
 
 export type KanjiExample = { surface: string; reading: string; meaningZh: string };


### PR DESCRIPTION
## 目標
擴充「漢字音読み」study list（`kanjiOnyomi.ts`），從 21 字 → 41 字。這是品質鏈完成後、使用者指定的「後續增加讀音 study list」第一批。

## 新增 20 字（5 個同音家族）
| onyomi | 漢字 |
|---|---|
| こう | 効 工 交 構 攻 |
| しょう | 消 招 証 |
| きょう | 教 競 強 共 |
| か | 化 加 価 可 過 |
| げん | 減 限 現 |

以 N3 為主，搭配少量 N2/N1。

## 品質保證
- **候選經 subagent 對 `jlptVocabulary` 研究**：每字都在現有詞庫有例詞（否則卡片無例詞）。
- **讀音親審**：主讀音由例詞佐證（効果こうか…），次要讀音 工く／強ごう／競けい／化け 皆標準。
- **新增 guard 測試**：`kanjiOnyomi` 每個 entry 必須產出 ≥1 例詞（`kanjiExamples` 從 jlptVocabulary 撈）。
- 證明 guard 非 no-op：注入無詞漢字（朕）→ 如期 RED →還原。
- 既有 21 字也全數通過新 guard。

## 驗證
全測 203（+1 guard）、build 綠。kanjiOnyomi 不計入 CONTENT_STATS，無需同步。

Relates #97。後續：漢字読み 考題擴充（同讀音）。