### PR TITLE
feat(challenge): 挑戰分頁預設落地改「今日練習」（動詞變化 UX 調整）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -692,6 +692,20 @@ describe("App", () => {
     expect(screen.getAllByText(/N2＋N3 綜合題/).length).toBeGreaterThanOrEqual(2);
   });
 
+  it("opens 今日練習 by default when entering the challenge tab", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "挑戰" }));
+    await screen.findByRole("region", { name: "目前題目" });
+
+    // Entering the challenge tab lands on the guided 今日練習 mixed session,
+    // not the raw 基礎變化 setup cascade, so the learner is practising on
+    // arrival rather than configuring four selectors first.
+    expect(screen.getByRole("button", { name: /今日練習/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /基礎變化/ })).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("shows accuracy in the 今日戰報 stats block, not on the 錯題複習 heading", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,8 +65,11 @@ export default function App() {
     // learn / mock), so navigating in always mounts ChallengePanel fresh
     // and the seed applies. Don't call this with a non-undefined request
     // from INSIDE the challenge view -- the panel is already mounted, so
-    // the seed would be silently ignored. (The nav-bar 挑戰 button calls
-    // it with no request, which is a deliberate no-op when already there.)
+    // the seed would be silently ignored. (The nav-bar 挑戰 button seeds
+    // 今日練習 as the default landing -- the guided mixed session, so the
+    // learner practises on arrival instead of the raw 基礎變化 setup
+    // cascade; re-clicking it while already in the challenge view is a
+    // no-op since the mounted panel ignores re-seeds.)
     setLaunch(request);
     setAppView("challenge");
   };
@@ -154,7 +157,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "challenge" ? "selected" : ""}
-          onClick={() => openChallenge()}
+          onClick={() => openChallenge({ mode: "daily" })}
         >
           {t.challenge}
         </button>


### PR DESCRIPTION
## 背景
評估「動詞變化」UX 後，最大摩擦是：點「挑戰」分頁預設落在「基礎變化」的設定堆（詞性／重點／動詞分類／目標形 4 層選擇器），第一眼是設定而非練習。依使用者選擇「改善預設落地」、且依 UI 成長紀律（不刪選項、避免膨脹）做最低風險調整。

## 做了什麼
- 「挑戰」**導覽鍵**改為開啟 **今日練習**（guided 混合、冷啟也有題、有限回合友善）——`openChallenge({ mode: daily })`。
- **只改導覽鍵那一個入口**：hook 預設仍是 `basic`，所以 Learn drill／模擬考／首頁 CTA 等「省略 mode」的入口不受影響（這也是第一版誤改 hook 預設導致 11 個 Learn 測試掛掉、已修正的原因）。
- 「基礎變化」仍在模式列表一鍵可達，沒有刪任何能力。

## 驗證
- RED→GREEN：先加「挑戰預設落地＝今日練習」測試見其失敗，再改。
- 全測 **204 passed**（含回綠的 11 個 Learn drill 測試）、build 綠。
- （worker 啟動失敗是連跑太多次的資源耗盡，`--no-file-parallelism` 後全綠。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Challenge navigation now defaults to the "Today's Practice" guided session instead of launching without preset parameters.

* **Tests**
  * Added test coverage to verify the Challenge tab correctly defaults to "Today's Practice" with appropriate button state indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->