### PR TITLE
feat(auth): Google 登入加用途說明（跨裝置同步／本機 fallback）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,17 +100,18 @@ export default function App() {
           {isSupabaseConfigured && (
             <div className="heading-auth">
               {user ? (
-                <>
+                <div className="heading-auth-row">
                   <span className="heading-user">{t.authSignedInAs(user.user_metadata.full_name ?? user.email ?? "")}</span>
                   <button type="button" className="auth-button" onClick={signOut}>
                     {t.authSignOut}
                   </button>
-                </>
+                </div>
               ) : (
                 <button type="button" className="auth-button" onClick={signInWithGoogle}>
                   {t.authSignIn}
                 </button>
               )}
+              <small className="auth-hint">{user ? t.authSyncedHint : t.authSignInHint}</small>
               {authError && (
                 <span className="heading-auth-error" role="alert">
                   {authError}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -164,6 +164,8 @@ export type Copy = {
   authSignIn: string;
   authSignOut: string;
   authSignedInAs: (name: string) => string;
+  authSignInHint: string;
+  authSyncedHint: string;
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
   focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast", string>;
@@ -363,6 +365,8 @@ export const copy: Record<Language, Copy> = {
     authSignIn: "Google 登入",
     authSignOut: "登出",
     authSignedInAs: (name) => `${name}`,
+    authSignInHint: "登入後錯題與學習進度可跨裝置同步；不登入也能用，紀錄僅存於本機。",
+    authSyncedHint: "錯題與學習進度已跨裝置同步。",
     partOfSpeech: {
       verb: "動詞",
       i_adjective: "い形容詞",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -77,9 +77,26 @@
 }
 
 .heading-auth {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.heading-auth-row {
   align-items: center;
   display: flex;
   gap: 0.5rem;
+}
+
+/* Sign-in benefit hint (logged out) / sync confirmation (logged in). Small,
+   muted, right-aligned to match the header; wraps to 2 lines on narrow widths. */
+.auth-hint {
+  color: var(--muted);
+  font-size: 0.72rem;
+  line-height: 1.3;
+  max-width: 19rem;
+  text-align: right;
 }
 
 .heading-auth-error {


### PR DESCRIPTION
## 目標
登入按鈕旁加說明，讓使用者知道登入用途與不登入的差別。

## 文字（修飾後）
- **未登入**（按鈕下方）：「登入後錯題與學習進度可跨裝置同步；不登入也能用，紀錄僅存於本機。」
- **已登入**：「錯題與學習進度已跨裝置同步。」（簡短確認）

## 版面
- `heading-auth` 由橫向改**直向**：按鈕在上、說明在下、靠右對齊（小字、muted、max-width 19rem 自動折行），不撐爆 header。
- 已登入的「名稱＋登出」用 `heading-auth-row` 包成一列維持並排。
- i18n 新增 `authSignInHint` / `authSyncedHint`。
- 仍 env-gated：只有 Supabase 設定好（即現在會顯示 Google 登入）時才渲染。

## 驗證
- build 綠。
- 註：本地 App.test 因連跑多次資源耗盡，beforeAll 的 React.lazy priming flake（suite skip）；本改動 env-gated，測試環境 `isSupabaseConfigured=false`、auth 區塊不渲染，對 App.test 行為零影響——交由 CI 乾淨 runner 跑完整套件確認。