### PR TITLE
feat(domain): attempt-sync 合併邏輯（Part of #151, Phase 1）

### DIFF
--- a/src/domain/attemptSync.test.ts
+++ b/src/domain/attemptSync.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { attemptKey, mergeAttempts } from "./attemptSync";
+import type { Attempt } from "./types";
+
+// Build an Attempt fixture; override only the fields a test cares about.
+function att(over: Partial<Attempt> = {}): Attempt {
+  return {
+    vocabularyId: "v1",
+    targetForm: "te",
+    prompt: "p",
+    expectedAnswers: ["x"],
+    submittedAnswer: "x",
+    isCorrect: true,
+    timestamp: 1000,
+    responseTimeMs: 100,
+    ...over
+  };
+}
+
+describe("attemptKey", () => {
+  it("is identical for two records with the same identifying fields", () => {
+    expect(attemptKey(att())).toBe(attemptKey(att()));
+  });
+
+  it("differs when any identifying field differs", () => {
+    const base = attemptKey(att());
+    expect(attemptKey(att({ timestamp: 1001 }))).not.toBe(base);
+    expect(attemptKey(att({ vocabularyId: "v2" }))).not.toBe(base);
+    expect(attemptKey(att({ targetForm: "ta" }))).not.toBe(base);
+    expect(attemptKey(att({ submittedAnswer: "y" }))).not.toBe(base);
+    expect(attemptKey(att({ questionId: "q1" }))).not.toBe(base);
+  });
+});
+
+describe("mergeAttempts", () => {
+  it("unions disjoint lists", () => {
+    const a = att({ timestamp: 1 });
+    const b = att({ timestamp: 2, vocabularyId: "v2" });
+    expect(mergeAttempts([a], [b])).toEqual([a, b]);
+  });
+
+  it("dedupes an attempt present in both (union, no duplicate)", () => {
+    const a = att({ timestamp: 1 });
+    const b = att({ timestamp: 2, vocabularyId: "v2" });
+    const c = att({ timestamp: 3, vocabularyId: "v3" });
+    const merged = mergeAttempts([a, b], [b, c]);
+    expect(merged).toHaveLength(3);
+    expect(merged).toEqual([a, b, c]);
+  });
+
+  it("collapses identical lists to one copy", () => {
+    const a = att();
+    expect(mergeAttempts([a], [a])).toEqual([a]);
+  });
+
+  it("is idempotent: re-merging the remote set never grows the result", () => {
+    const local = [att({ timestamp: 1 }), att({ timestamp: 3, vocabularyId: "v3" })];
+    const remote = [att({ timestamp: 2, vocabularyId: "v2" })];
+    const once = mergeAttempts(local, remote);
+    expect(mergeAttempts(once, remote)).toEqual(once);
+  });
+
+  it("sorts the merged set by timestamp ascending", () => {
+    const merged = mergeAttempts(
+      [att({ timestamp: 30, vocabularyId: "c" })],
+      [att({ timestamp: 10, vocabularyId: "a" }), att({ timestamp: 20, vocabularyId: "b" })]
+    );
+    expect(merged.map((m) => m.timestamp)).toEqual([10, 20, 30]);
+  });
+
+  it("does not mutate its inputs", () => {
+    const local = [att({ timestamp: 2 })];
+    const remote = [att({ timestamp: 1, vocabularyId: "v2" })];
+    mergeAttempts(local, remote);
+    expect(local.map((a) => a.timestamp)).toEqual([2]);
+    expect(remote.map((a) => a.timestamp)).toEqual([1]);
+  });
+
+  it("handles empty inputs", () => {
+    const a = att();
+    expect(mergeAttempts([], [])).toEqual([]);
+    expect(mergeAttempts([a], [])).toEqual([a]);
+    expect(mergeAttempts([], [a])).toEqual([a]);
+  });
+});

--- a/src/domain/attemptSync.test.ts
+++ b/src/domain/attemptSync.test.ts
@@ -29,6 +29,7 @@ describe("attemptKey", () => {
     expect(attemptKey(att({ targetForm: "ta" }))).not.toBe(base);
     expect(attemptKey(att({ submittedAnswer: "y" }))).not.toBe(base);
     expect(attemptKey(att({ questionId: "q1" }))).not.toBe(base);
+    expect(attemptKey(att({ responseTimeMs: 200 }))).not.toBe(base);
   });
 });
 
@@ -66,6 +67,19 @@ describe("mergeAttempts", () => {
       [att({ timestamp: 10, vocabularyId: "a" }), att({ timestamp: 20, vocabularyId: "b" })]
     );
     expect(merged.map((m) => m.timestamp)).toEqual([10, 20, 30]);
+  });
+
+  it("keeps attempts differing only in responseTimeMs as distinct (no silent collapse)", () => {
+    const a = att({ timestamp: 1, responseTimeMs: 100 });
+    const b = att({ timestamp: 1, responseTimeMs: 250 });
+    expect(mergeAttempts([a], [b])).toHaveLength(2);
+  });
+
+  it("orders equal-timestamp attempts deterministically, independent of input order", () => {
+    const x = att({ timestamp: 5, vocabularyId: "a" });
+    const y = att({ timestamp: 5, vocabularyId: "b" });
+    expect(mergeAttempts([x], [y])).toEqual(mergeAttempts([y], [x]));
+    expect(mergeAttempts([y], [x])).toHaveLength(2);
   });
 
   it("does not mutate its inputs", () => {

--- a/src/domain/attemptSync.ts
+++ b/src/domain/attemptSync.ts
@@ -1,0 +1,43 @@
+import type { Attempt } from "./types";
+
+// Cross-device attempt sync -- Phase 1 (pure merge logic), Part of #151.
+//
+// Attempts are append-only practice records (see storage.ts). To sync them
+// across devices via Supabase we need a deterministic identity per attempt
+// (so the same record uploaded then re-downloaded de-dupes, and two devices
+// union without overwriting each other). This module is pure + offline: it
+// owns only the key + merge; the remote repo (Phase 2) and hook wiring
+// (Phase 3) build on it.
+
+// Deterministic identity for an attempt. Same logical record -> same key;
+// two genuinely different attempts (different word / form / time / answer)
+// -> different keys. JSON-encodes the identifying tuple so arbitrary answer
+// text can't collide via a separator char. Doubles as the DB row id (or its
+// hash) for the idempotent upsert in Phase 0/2.
+export function attemptKey(attempt: Attempt): string {
+  return JSON.stringify([
+    attempt.questionId ?? null,
+    attempt.vocabularyId,
+    attempt.targetForm,
+    attempt.timestamp,
+    attempt.submittedAnswer
+  ]);
+}
+
+// Union of two attempt lists, de-duplicated by attemptKey, sorted by
+// timestamp (ascending; key as a stable tiebreak). Pure -- inputs are not
+// mutated. First occurrence wins, and `local` is listed first so a local
+// record takes precedence over an identical remote one (never overwrites
+// local). Idempotent: merging in an already-merged remote set adds nothing.
+export function mergeAttempts(local: Attempt[], remote: Attempt[]): Attempt[] {
+  const byKey = new Map<string, Attempt>();
+  for (const attempt of [...local, ...remote]) {
+    const key = attemptKey(attempt);
+    if (!byKey.has(key)) {
+      byKey.set(key, attempt);
+    }
+  }
+  return [...byKey.values()].sort(
+    (a, b) => a.timestamp - b.timestamp || attemptKey(a).localeCompare(attemptKey(b))
+  );
+}

--- a/src/domain/attemptSync.ts
+++ b/src/domain/attemptSync.ts
@@ -10,25 +10,36 @@ import type { Attempt } from "./types";
 // (Phase 3) build on it.
 
 // Deterministic identity for an attempt. Same logical record -> same key;
-// two genuinely different attempts (different word / form / time / answer)
-// -> different keys. JSON-encodes the identifying tuple so arbitrary answer
-// text can't collide via a separator char. Doubles as the DB row id (or its
-// hash) for the idempotent upsert in Phase 0/2.
+// two genuinely different attempts -> different keys. The tuple includes
+// responseTimeMs as well as the timestamp: questionId is derived from
+// vocabularyId+targetForm (so it adds no entropy), and two distinct attempts
+// on the same word/form/answer can land in the same millisecond (e.g. a
+// double-fired MCQ keypress, or two devices), so timestamp alone is not
+// unique -- responseTimeMs makes a real collision effectively impossible,
+// preventing silent loss in the merge. JSON-encodes the tuple so arbitrary
+// answer text can't collide via a separator char. Doubles as the DB row id
+// (or, preferably, its hash -- see Phase 2) for the idempotent upsert.
 export function attemptKey(attempt: Attempt): string {
   return JSON.stringify([
     attempt.questionId ?? null,
     attempt.vocabularyId,
     attempt.targetForm,
     attempt.timestamp,
-    attempt.submittedAnswer
+    attempt.submittedAnswer,
+    attempt.responseTimeMs
   ]);
 }
 
 // Union of two attempt lists, de-duplicated by attemptKey, sorted by
-// timestamp (ascending; key as a stable tiebreak). Pure -- inputs are not
-// mutated. First occurrence wins, and `local` is listed first so a local
-// record takes precedence over an identical remote one (never overwrites
-// local). Idempotent: merging in an already-merged remote set adds nothing.
+// timestamp (ascending). Pure -- inputs are not mutated. First occurrence
+// wins, and `local` is listed first so a local record takes precedence over
+// an identical remote one (never overwrites local). Idempotent: merging in
+// an already-merged remote set adds nothing.
+//
+// The equal-timestamp tiebreak is a plain binary string compare on the key
+// (NOT localeCompare): the merged order must be identical on every device so
+// SRS, which replays same-timestamp attempts in array order, can't diverge
+// across devices.
 export function mergeAttempts(local: Attempt[], remote: Attempt[]): Attempt[] {
   const byKey = new Map<string, Attempt>();
   for (const attempt of [...local, ...remote]) {
@@ -37,7 +48,12 @@ export function mergeAttempts(local: Attempt[], remote: Attempt[]): Attempt[] {
       byKey.set(key, attempt);
     }
   }
-  return [...byKey.values()].sort(
-    (a, b) => a.timestamp - b.timestamp || attemptKey(a).localeCompare(attemptKey(b))
-  );
+  return [...byKey.values()].sort((a, b) => {
+    if (a.timestamp !== b.timestamp) {
+      return a.timestamp - b.timestamp;
+    }
+    const ka = attemptKey(a);
+    const kb = attemptKey(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
 }


### PR DESCRIPTION
跨裝置進度同步 #151 的 **Phase 1**：純合併邏輯，無網路、無相依，最安全先落地。

## 內容
`src/domain/attemptSync.ts`：
- `attemptKey(a)`：每筆 attempt 的 deterministic 身分（JSON 編碼 questionId/vocabularyId/targetForm/timestamp/submittedAnswer），供冪等 upsert／去重，亦可當 DB row id（或其 hash）。
- `mergeAttempts(local, remote)`：union + 依 key 去重 + 依 timestamp 升冪排序；**不改動輸入**、local 優先（同 key 不覆蓋本機）；**冪等**（重複併入 remote 不會增長）。

## TDD
先寫測試見 RED（模組不存在）→ 實作 GREEN。9 測：去重、union 不相交、相同折疊、冪等、排序、不變異、空輸入。build 綠。

## 範圍
純函式，目前無人 import——串接在後續 Phase：P0 建表(你跑 SQL)／P2 遠端 repo／P3 接 user+syncStatus／P5 文案（`authSyncedHint` 僅 `syncStatus===synced` 才顯示）。

Part of #151。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attempts can now be synchronized across your devices. Learning attempts are automatically merged with intelligent duplicate detection, ensuring consistency and preventing duplicate entries. Your attempt history is kept in sync and properly ordered across all devices.

* **Tests**
  * Added comprehensive unit tests for the new attempt synchronization and merging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->