### PR TITLE
feat(sync): attempts 表 schema + RLS（Part of #151, Phase 0）

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -4,7 +4,7 @@
 
 ## migrations
 
-- [`migrations/0001_create_attempts.sql`](migrations/0001_create_attempts.sql) — 建 `attempts` 表（每筆 attempt 一列、`id` 為 deterministic key／hash、append-only）＋ 開 RLS（每位使用者只能讀寫自己的列）。
+- [`migrations/0001_create_attempts.sql`](migrations/0001_create_attempts.sql) — 建 `attempts` 表（每筆 attempt 一列、**複合主鍵 `(user_id, id)`**、`id` 為 deterministic key／hash、append-only）＋ 開 RLS（每位使用者只能讀寫自己的列）。複合主鍵讓不同使用者的相同 attempt 不會撞鍵丟資料。
 
 ## 手動步驟（agent 無專案登入，需你執行）
 

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,17 @@
+# Supabase（跨裝置進度同步 / #151）
+
+本資料夾存放 Jabiko 跨裝置「錯題與進度（attempts）同步」用的資料庫結構。應用程式平時把資料存在本機 localStorage（`src/domain/storage.ts`），登入後才與這裡的 `attempts` 表雙向同步。
+
+## migrations
+
+- [`migrations/0001_create_attempts.sql`](migrations/0001_create_attempts.sql) — 建 `attempts` 表（每筆 attempt 一列、`id` 為 deterministic key／hash、append-only）＋ 開 RLS（每位使用者只能讀寫自己的列）。
+
+## 手動步驟（agent 無專案登入，需你執行）
+
+1. **建表**：把 `migrations/0001_create_attempts.sql` 全文貼到 Supabase Dashboard → SQL Editor → Run（或 `supabase db push`）。冪等、可重跑。
+2. **端到端驗證**（待同步程式碼 P2/P3 上線後）：真人 Google 登入（最好兩個瀏覽器/裝置）確認進度確實同步 —— 驗證通過後才會放行 P5 的「已同步」UI 文案。
+3. 確認 Supabase Auth 的 redirect / allowed URL 含你的部署網址（多半已 OK）。
+
+**不需**新環境變數或密鑰：anon key 已設定，存取一律靠 RLS ＋ 使用者 JWT。
+
+> 相關程式碼：`src/domain/attemptSync.ts`（合併邏輯, #153）、後續 `attemptRemote.ts`（P2 遠端 repo）、`useProgressAttempts.ts`（P3 串接）。追蹤見 issue #151。

--- a/supabase/migrations/0001_create_attempts.sql
+++ b/supabase/migrations/0001_create_attempts.sql
@@ -1,0 +1,40 @@
+-- Cross-device attempt sync — Phase 0 schema + RLS (Part of #151).
+--
+-- One row per practice attempt, owned by the authenticated user. The app's
+-- source of truth stays in localStorage (src/domain/storage.ts); this table
+-- is the sync backend. `id` is a deterministic key derived from the attempt
+-- (see src/domain/attemptSync.ts → attemptKey, hashed in the remote layer),
+-- so re-uploading the same attempt is an idempotent upsert (ON CONFLICT DO
+-- NOTHING) and two devices union without overwriting each other. Append-only:
+-- there is no UPDATE policy, so rows are immutable once written.
+--
+-- HOW TO RUN (manual — an agent has no Supabase project login):
+--   • Supabase Dashboard → SQL Editor → paste this whole file → Run, OR
+--   • supabase db push  (if the Supabase CLI is linked to the project).
+-- Idempotent: safe to re-run. No new env vars / keys needed (the anon key is
+-- already configured; access is gated by RLS + the user's JWT).
+
+create table if not exists public.attempts (
+  id          text        primary key,
+  user_id     uuid        not null default auth.uid() references auth.users (id) on delete cascade,
+  payload     jsonb       not null,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists attempts_user_id_idx on public.attempts (user_id);
+
+alter table public.attempts enable row level security;
+
+-- A user may only read / insert / delete their own rows. (No UPDATE policy:
+-- attempts are append-only; the client upserts with ON CONFLICT DO NOTHING.)
+drop policy if exists "attempts_select_own" on public.attempts;
+create policy "attempts_select_own" on public.attempts
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "attempts_insert_own" on public.attempts;
+create policy "attempts_insert_own" on public.attempts
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "attempts_delete_own" on public.attempts;
+create policy "attempts_delete_own" on public.attempts
+  for delete using (auth.uid() = user_id);

--- a/supabase/migrations/0001_create_attempts.sql
+++ b/supabase/migrations/0001_create_attempts.sql
@@ -3,25 +3,37 @@
 -- One row per practice attempt, owned by the authenticated user. The app's
 -- source of truth stays in localStorage (src/domain/storage.ts); this table
 -- is the sync backend. `id` is a deterministic key derived from the attempt
--- (see src/domain/attemptSync.ts → attemptKey, hashed in the remote layer),
--- so re-uploading the same attempt is an idempotent upsert (ON CONFLICT DO
--- NOTHING) and two devices union without overwriting each other. Append-only:
--- there is no UPDATE policy, so rows are immutable once written.
+-- (see src/domain/attemptSync.ts → attemptKey, hashed in the remote layer).
+--
+-- The primary key is COMPOSITE (user_id, id), not id alone: attemptKey is
+-- derived from attempt content only (no user_id), so two different users
+-- could in principle produce the same `id`. A global PK would let the first
+-- writer's row block the second user's insert (ON CONFLICT DO NOTHING) while
+-- RLS hides it from them — silently losing that attempt. Scoping the key to
+-- (user_id, id) keeps each user's attempts independent: re-uploading your own
+-- attempt is still an idempotent no-op, but two users never collide.
+-- Append-only: there is no UPDATE policy, so rows are immutable once written.
 --
 -- HOW TO RUN (manual — an agent has no Supabase project login):
 --   • Supabase Dashboard → SQL Editor → paste this whole file → Run, OR
 --   • supabase db push  (if the Supabase CLI is linked to the project).
 -- Idempotent: safe to re-run. No new env vars / keys needed (the anon key is
 -- already configured; access is gated by RLS + the user's JWT).
+--
+-- Phase-2 client writes with upsert(..., { onConflict: 'user_id,id',
+-- ignoreDuplicates: true }) and reads its own rows via select() (RLS-scoped).
 
 create table if not exists public.attempts (
-  id          text        primary key,
+  id          text        not null,
   user_id     uuid        not null default auth.uid() references auth.users (id) on delete cascade,
   payload     jsonb       not null,
-  created_at  timestamptz not null default now()
+  created_at  timestamptz not null default now(),
+  primary key (user_id, id)
 );
 
-create index if not exists attempts_user_id_idx on public.attempts (user_id);
+-- No separate user_id index needed: the composite primary key (user_id, id)
+-- already indexes user_id as its leading column, covering "select my rows"
+-- (where user_id = auth.uid()).
 
 alter table public.attempts enable row level security;
 


### PR DESCRIPTION
跨裝置進度同步 #151 的 **Phase 0**：資料庫結構，供你在 Supabase 後台執行。

## 內容
- `supabase/migrations/0001_create_attempts.sql`：建 `attempts` 表（每筆 attempt 一列；`id text primary key`＝attemptKey 的 hash（#153 review 建議，固定寬度）；`user_id uuid default auth.uid()`；`payload jsonb`；`created_at`）＋ 開 **RLS**：select/insert/delete 限 `auth.uid() = user_id`。
  - **無 UPDATE policy**＝append-only；client 用 upsert `ON CONFLICT DO NOTHING`，兩裝置 union 不互相覆蓋。
  - 冪等（if-not-exists + drop-policy-if-exists），可重跑。
- `supabase/README.md`：手動步驟（貼 Dashboard SQL Editor 或 `supabase db push`；端到端 OAuth 驗證後才放行 P5 文案）。

## 規範
SQL／文件，**TDD 豁免**（設定）。**需你手動執行**（agent 無專案登入）。不需新環境變數/密鑰（anon key 已設、靠 RLS＋JWT）。

Part of #151。下一步 P2（`attemptRemote.ts` 遠端 repo，把 attemptKey hash 成 id、upsert/select）。