### PR TITLE
feat(sync): Phase 2 remote repo + Phase 3 login-sync wiring (Part of #151)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,9 @@ export default function App() {
 
   const { theme, toggleTheme } = useTheme();
   const { user, error: authError, signInWithGoogle, signOut } = useAuth();
-  const { progressAttempts, recordAttempt } = useProgressAttempts();
+  // `user` drives cross-device sync: on login the hook merges the remote
+  // attempt history into the local store and pushes the local-only delta.
+  const { progressAttempts, recordAttempt } = useProgressAttempts(user);
   // Lightweight, pool-free count for the home/learn review badge (see
   // countDueReviews). The full review queue -- which needs the question
   // pool to resolve due items -- is built inside the lazy challenge view.

--- a/src/domain/attemptRemote.test.ts
+++ b/src/domain/attemptRemote.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { fetchRemoteAttempts, planLoginSync, pushAttempts } from "./attemptRemote";
+import { attemptKey } from "./attemptSync";
+import type { Attempt } from "./types";
+
+// --- test fixtures ---------------------------------------------------------
+
+function makeAttempt(overrides: Partial<Attempt> = {}): Attempt {
+  return {
+    vocabularyId: "kaku",
+    targetForm: "te",
+    prompt: "書く",
+    expectedAnswers: ["書いて"],
+    submittedAnswer: "書いて",
+    isCorrect: true,
+    timestamp: 1000,
+    responseTimeMs: 500,
+    ...overrides
+  };
+}
+
+// --- minimal typed fake SupabaseClient -------------------------------------
+//
+// Only the slice of the SDK surface that attemptRemote touches is modelled:
+// fetch does `.from(table).select(cols).eq(col, val)` (the eq() result is the
+// awaited query), push does `.from(table).upsert(rows, opts)`. We capture the
+// arguments so the tests can assert on them, and cast the fake to
+// SupabaseClient at the boundary (the cast is the one unavoidable `as`, kept
+// off the public test surface via a typed builder).
+
+interface SelectCall {
+  table: string;
+  columns: string;
+  eqColumn: string;
+  eqValue: string;
+}
+
+interface UpsertCall {
+  table: string;
+  rows: Array<{ id: string; user_id: string; payload: Attempt }>;
+  options: { onConflict?: string; ignoreDuplicates?: boolean } | undefined;
+}
+
+interface QueryResult {
+  data: Array<{ payload: Attempt }> | null;
+  error: Error | null;
+}
+
+function makeFakeClient(opts: {
+  rows?: Array<{ payload: Attempt }>;
+  selectError?: Error;
+  upsertError?: Error;
+}) {
+  const selectCalls: SelectCall[] = [];
+  const upsertCalls: UpsertCall[] = [];
+
+  const client = {
+    from(table: string) {
+      return {
+        select(columns: string) {
+          return {
+            eq(eqColumn: string, eqValue: string): Promise<QueryResult> {
+              selectCalls.push({ table, columns, eqColumn, eqValue });
+              return Promise.resolve(
+                opts.selectError
+                  ? { data: null, error: opts.selectError }
+                  : { data: opts.rows ?? [], error: null }
+              );
+            }
+          };
+        },
+        upsert(
+          rows: UpsertCall["rows"],
+          options: UpsertCall["options"]
+        ): Promise<{ error: Error | null }> {
+          upsertCalls.push({ table, rows, options });
+          return Promise.resolve({ error: opts.upsertError ?? null });
+        }
+      };
+    }
+  };
+
+  return {
+    client: client as unknown as SupabaseClient,
+    selectCalls,
+    upsertCalls
+  };
+}
+
+// --- fetchRemoteAttempts ---------------------------------------------------
+
+describe("fetchRemoteAttempts", () => {
+  it("returns [] when client is null (no SDK fetch)", async () => {
+    await expect(fetchRemoteAttempts(null, "user-1")).resolves.toEqual([]);
+  });
+
+  it("queries attempts.payload eq user_id and maps payloads to Attempts", async () => {
+    const a = makeAttempt({ timestamp: 1 });
+    const b = makeAttempt({ timestamp: 2, submittedAnswer: "書きて", isCorrect: false });
+    const { client, selectCalls } = makeFakeClient({
+      rows: [{ payload: a }, { payload: b }]
+    });
+
+    const result = await fetchRemoteAttempts(client, "user-42");
+
+    expect(selectCalls).toEqual([
+      { table: "attempts", columns: "payload", eqColumn: "user_id", eqValue: "user-42" }
+    ]);
+    expect(result).toEqual([a, b]);
+  });
+
+  it("throws when the query returns an error", async () => {
+    const { client } = makeFakeClient({ selectError: new Error("boom") });
+    await expect(fetchRemoteAttempts(client, "user-1")).rejects.toThrow("boom");
+  });
+});
+
+// --- pushAttempts ----------------------------------------------------------
+
+describe("pushAttempts", () => {
+  it("no-ops on null client", async () => {
+    await expect(pushAttempts(null, "user-1", [makeAttempt()])).resolves.toBeUndefined();
+  });
+
+  it("no-ops on empty attempts (no upsert call)", async () => {
+    const { client, upsertCalls } = makeFakeClient({});
+    await pushAttempts(client, "user-1", []);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  it("upserts rows keyed by attemptKey with onConflict + ignoreDuplicates", async () => {
+    const a = makeAttempt({ timestamp: 1 });
+    const b = makeAttempt({ timestamp: 2 });
+    const { client, upsertCalls } = makeFakeClient({});
+
+    await pushAttempts(client, "user-99", [a, b]);
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0].table).toBe("attempts");
+    expect(upsertCalls[0].options).toEqual({ onConflict: "user_id,id", ignoreDuplicates: true });
+    expect(upsertCalls[0].rows).toEqual([
+      { id: attemptKey(a), user_id: "user-99", payload: a },
+      { id: attemptKey(b), user_id: "user-99", payload: b }
+    ]);
+  });
+
+  it("throws when the upsert returns an error", async () => {
+    const { client } = makeFakeClient({ upsertError: new Error("nope") });
+    await expect(pushAttempts(client, "user-1", [makeAttempt()])).rejects.toThrow("nope");
+  });
+});
+
+// --- planLoginSync (pure) --------------------------------------------------
+
+describe("planLoginSync", () => {
+  it("merges local + remote and computes toUpload as local-only attempts", () => {
+    const shared = makeAttempt({ timestamp: 1 });
+    const localOnly = makeAttempt({ timestamp: 2, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 3, submittedAnswer: "remote" });
+
+    const local = [shared, localOnly];
+    const remote = [shared, remoteOnly];
+
+    const { merged, toUpload } = planLoginSync(local, remote);
+
+    // merged is the full union (3 distinct), sorted by timestamp.
+    expect(merged).toEqual([shared, localOnly, remoteOnly]);
+    // toUpload = the local record not already in remote.
+    expect(toUpload).toEqual([localOnly]);
+  });
+
+  it("uploads nothing when every local attempt already exists remotely", () => {
+    const a = makeAttempt({ timestamp: 1 });
+    const b = makeAttempt({ timestamp: 2, submittedAnswer: "b" });
+
+    const { merged, toUpload } = planLoginSync([a], [a, b]);
+
+    expect(toUpload).toEqual([]);
+    expect(merged).toEqual([a, b]);
+  });
+
+  it("uploads all local attempts when remote is empty", () => {
+    const a = makeAttempt({ timestamp: 1 });
+    const b = makeAttempt({ timestamp: 2, submittedAnswer: "b" });
+
+    const { toUpload } = planLoginSync([a, b], []);
+
+    expect(toUpload).toEqual([a, b]);
+  });
+
+  it("is idempotent: re-running with merged as local yields no new uploads", () => {
+    const local = [makeAttempt({ timestamp: 2, submittedAnswer: "local" })];
+    const remote = [makeAttempt({ timestamp: 3, submittedAnswer: "remote" })];
+
+    const first = planLoginSync(local, remote);
+    // After the first sync, local store holds `merged`; the remote now also
+    // holds everything that was uploaded. Re-running must push nothing new.
+    const second = planLoginSync(first.merged, first.merged);
+
+    expect(second.toUpload).toEqual([]);
+    expect(second.merged).toEqual(first.merged);
+  });
+});

--- a/src/domain/attemptRemote.ts
+++ b/src/domain/attemptRemote.ts
@@ -1,0 +1,89 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { attemptKey, mergeAttempts } from "./attemptSync";
+import type { Attempt } from "./types";
+
+// Cross-device attempt sync -- Phase 2 (remote repo), Part of #151.
+//
+// Thin, side-effecty wrapper over the Supabase `attempts` table plus one
+// pure planner. The pure merge/identity rules live in attemptSync.ts; this
+// module only translates them to/from rows. All functions tolerate a null
+// client (Supabase unconfigured / not yet loaded) so the anon, no-login
+// path stays a zero-cost no-op and the SDK never leaves its lazy chunk.
+
+// Shape of a stored row. `payload` is the whole Attempt; `id` is its
+// deterministic attemptKey so the composite PK (user_id, id) makes uploads
+// idempotent.
+interface AttemptRow {
+  id: string;
+  user_id: string;
+  payload: Attempt;
+}
+
+// Read this user's attempts back from Supabase. Null client (unconfigured)
+// -> []. Surfaces query errors to the caller (login sync treats a throw as
+// "couldn't sync" and leaves local untouched).
+export async function fetchRemoteAttempts(
+  client: SupabaseClient | null,
+  userId: string
+): Promise<Attempt[]> {
+  if (!client) {
+    return [];
+  }
+
+  const { data, error } = await client
+    .from("attempts")
+    .select("payload")
+    .eq("user_id", userId);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => (row as { payload: Attempt }).payload);
+}
+
+// Append the given attempts for this user. No-op on a null client or empty
+// list (so callers don't have to guard). Rows are keyed by attemptKey and
+// upserted with ignoreDuplicates so re-pushing an already-stored attempt is
+// a harmless no-op (the table is append-only; PK collisions are skipped).
+export async function pushAttempts(
+  client: SupabaseClient | null,
+  userId: string,
+  attempts: Attempt[]
+): Promise<void> {
+  if (!client || attempts.length === 0) {
+    return;
+  }
+
+  const rows: AttemptRow[] = attempts.map((attempt) => ({
+    id: attemptKey(attempt),
+    user_id: userId,
+    payload: attempt
+  }));
+
+  const { error } = await client
+    .from("attempts")
+    .upsert(rows, { onConflict: "user_id,id", ignoreDuplicates: true });
+
+  if (error) {
+    throw error;
+  }
+}
+
+// Pure login-sync planner. Given the local attempt history and what the
+// remote already holds, produce:
+//   - `merged`:   the union to write into the local store (mergeAttempts:
+//                 dedup by key, local wins, deterministically sorted).
+//   - `toUpload`: exactly the local-only attempts (those whose key is not
+//                 already remote). This never overwrites remote and never
+//                 loses local; uploading only the delta keeps the push
+//                 small and idempotent (re-running with merged as both
+//                 inputs yields toUpload []).
+export function planLoginSync(
+  local: Attempt[],
+  remote: Attempt[]
+): { merged: Attempt[]; toUpload: Attempt[] } {
+  const remoteKeys = new Set(remote.map(attemptKey));
+  const toUpload = local.filter((attempt) => !remoteKeys.has(attemptKey(attempt)));
+  return { merged: mergeAttempts(local, remote), toUpload };
+}

--- a/src/domain/storage.test.ts
+++ b/src/domain/storage.test.ts
@@ -27,6 +27,33 @@ describe("createAttemptStore", () => {
     expect(store.list()).toEqual([attempt]);
   });
 
+  it("replace overwrites the whole list in memory and storage", () => {
+    const backing = new Map<string, string>();
+    const store = createAttemptStore({
+      getItem: (key) => backing.get(key) ?? null,
+      setItem: (key, value) => backing.set(key, value),
+      removeItem: (key) => backing.delete(key)
+    });
+
+    store.add(attempt);
+    const merged: Attempt[] = [
+      attempt,
+      { ...attempt, timestamp: 2000, submittedAnswer: "書きて", isCorrect: false }
+    ];
+
+    store.replace(merged);
+
+    expect(store.list()).toEqual(merged);
+    // persisted, not just in memory: a fresh store over the same backing
+    // reads the replaced set back.
+    const reopened = createAttemptStore({
+      getItem: (key) => backing.get(key) ?? null,
+      setItem: (key, value) => backing.set(key, value),
+      removeItem: (key) => backing.delete(key)
+    });
+    expect(reopened.list()).toEqual(merged);
+  });
+
   it("falls back to memory when storage throws", () => {
     const store = createAttemptStore({
       getItem: () => {

--- a/src/domain/storage.ts
+++ b/src/domain/storage.ts
@@ -9,6 +9,7 @@ interface StorageLike {
 export interface AttemptStore {
   list: () => Attempt[];
   add: (attempt: Attempt) => void;
+  replace: (attempts: Attempt[]) => void;
   clear: () => void;
 }
 
@@ -49,6 +50,9 @@ export function createAttemptStore(storage: StorageLike | null = browserStorage(
   return {
     list: read,
     add: (attempt) => write([...read(), attempt]),
+    // Overwrite the whole set (memory + persisted). Used to write the
+    // merged history on login sync (see useProgressAttempts / Phase 3).
+    replace: (attempts) => write([...attempts]),
     clear: () => {
       memory = [];
 

--- a/src/hooks/useProgressAttempts.test.tsx
+++ b/src/hooks/useProgressAttempts.test.tsx
@@ -276,6 +276,45 @@ describe("useProgressAttempts -- login sync commit safety (codex review)", () =>
     expect(result.current.progressAttempts).not.toContainEqual(aRemote);
   });
 
+  // BUG 3 (codex re-review): a stale run must NOT push to the OLD user's
+  // remote either. If A's sync is parked on the fetch await and the user logs
+  // out (-> null) before it resolves, A's stale continuation must bail right
+  // after the fetch -- BEFORE reading the (now-anon) local store and uploading
+  // it to user A's remote account (a cross-account data leak).
+  it("logout before A's fetch resolves -> stale A run does NOT push to A's remote", async () => {
+    const localOnly = makeAttempt({ timestamp: 13, submittedAnswer: "local" });
+    const aRemote = makeAttempt({ timestamp: 14, submittedAnswer: "A-remote" });
+
+    const aFetch = deferred<Attempt[]>();
+    fetchRemoteAttempts.mockReturnValue(aFetch.promise);
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    // Seed local while anon.
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    // Begin user A's login sync; it parks on the deferred fetch.
+    rerender({ user: makeUser("user-A") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    // Log out (-> null) while A's fetch is still parked, THEN resolve it.
+    rerender({ user: null });
+    await act(async () => {
+      aFetch.resolve([aRemote]);
+      await aFetch.promise;
+    });
+
+    // The stale A run must have bailed after the fetch -- no upload to A.
+    expect(pushAttempts).not.toHaveBeenCalled();
+    // And of course the local store is untouched by the stale run.
+    expect(readStore()).toEqual([localOnly]);
+    expect(readStore()).not.toContainEqual(aRemote);
+  });
+
   // BUG 2: push failure (fetch ok) must leave local untouched. The old code
   // replaced local BEFORE the push, so a push reject lost the "untouched"
   // guarantee.

--- a/src/hooks/useProgressAttempts.test.tsx
+++ b/src/hooks/useProgressAttempts.test.tsx
@@ -1,0 +1,178 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { User } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Attempt } from "../domain/types";
+
+// The hook talks to Supabase only through these two seams, both mocked so
+// the test stays offline and the SDK never loads. getSupabase returns a
+// sentinel "client" object that the mocked remote fns ignore.
+const fakeClient = {} as unknown as SupabaseClient;
+const getSupabase = vi.fn<() => Promise<SupabaseClient | null>>();
+const fetchRemoteAttempts = vi.fn<(client: SupabaseClient | null, userId: string) => Promise<Attempt[]>>();
+const pushAttempts =
+  vi.fn<(client: SupabaseClient | null, userId: string, attempts: Attempt[]) => Promise<void>>();
+
+vi.mock("../lib/supabase", () => ({
+  getSupabase: () => getSupabase(),
+  isSupabaseConfigured: true
+}));
+
+vi.mock("../domain/attemptRemote", async () => {
+  // Keep the real planLoginSync (pure) -- only the IO is faked.
+  const real = await vi.importActual<typeof import("../domain/attemptRemote")>(
+    "../domain/attemptRemote"
+  );
+  return {
+    ...real,
+    fetchRemoteAttempts: (client: SupabaseClient | null, userId: string) =>
+      fetchRemoteAttempts(client, userId),
+    pushAttempts: (client: SupabaseClient | null, userId: string, attempts: Attempt[]) =>
+      pushAttempts(client, userId, attempts)
+  };
+});
+
+// Imported AFTER the mocks are registered. The hook owns a module-singleton
+// attemptStore backed by window.localStorage (jsdom), so each test clears it.
+import { useProgressAttempts } from "./useProgressAttempts";
+import { attemptKey } from "../domain/attemptSync";
+
+function makeAttempt(overrides: Partial<Attempt> = {}): Attempt {
+  return {
+    vocabularyId: "kaku",
+    targetForm: "te",
+    prompt: "書く",
+    expectedAnswers: ["書いて"],
+    submittedAnswer: "書いて",
+    isCorrect: true,
+    timestamp: 1000,
+    responseTimeMs: 500,
+    ...overrides
+  };
+}
+
+function makeUser(id: string): User {
+  return { id } as unknown as User;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  getSupabase.mockResolvedValue(fakeClient);
+  fetchRemoteAttempts.mockResolvedValue([]);
+  pushAttempts.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useProgressAttempts -- anon (no user)", () => {
+  it("behaves as before: idle status, local-only, no remote calls", async () => {
+    const { result } = renderHook(() => useProgressAttempts(null));
+
+    expect(result.current.syncStatus).toBe("idle");
+
+    const attempt = makeAttempt();
+    act(() => {
+      result.current.recordAttempt(attempt);
+    });
+
+    expect(result.current.progressAttempts).toEqual([attempt]);
+    // Nothing reached the network seams.
+    expect(getSupabase).not.toHaveBeenCalled();
+    expect(fetchRemoteAttempts).not.toHaveBeenCalled();
+    expect(pushAttempts).not.toHaveBeenCalled();
+  });
+
+  it("keeps recordAttempt identity stable across renders", () => {
+    const { result, rerender } = renderHook(() => useProgressAttempts(null));
+    const first = result.current.recordAttempt;
+    rerender();
+    expect(result.current.recordAttempt).toBe(first);
+  });
+});
+
+describe("useProgressAttempts -- login sync", () => {
+  it("merges remote into local, replaces local with merged, uploads only local-only, ends synced", async () => {
+    const localOnly = makeAttempt({ timestamp: 2, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 3, submittedAnswer: "remote" });
+
+    // Seed local store before login by recording while anon.
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    fetchRemoteAttempts.mockResolvedValue([remoteOnly]);
+
+    // Transition to a logged-in user.
+    rerender({ user: makeUser("user-1") });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    // Local state now holds the merged union (sorted by timestamp).
+    expect(result.current.progressAttempts).toEqual([localOnly, remoteOnly]);
+    expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1");
+    // Only the local-only attempt is uploaded (remoteOnly already remote).
+    expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", [localOnly]);
+  });
+
+  it("on sync failure sets error and leaves local untouched", async () => {
+    const localOnly = makeAttempt({ timestamp: 5, submittedAnswer: "local" });
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    fetchRemoteAttempts.mockRejectedValue(new Error("offline"));
+
+    rerender({ user: makeUser("user-1") });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("error"));
+    // Local untouched -- not cleared, not overwritten.
+    expect(result.current.progressAttempts).toEqual([localOnly]);
+  });
+
+  it("recordAttempt while logged in fire-and-forget pushes that single attempt", async () => {
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    pushAttempts.mockClear();
+
+    const attempt = makeAttempt({ timestamp: 9, submittedAnswer: "new" });
+    act(() => {
+      result.current.recordAttempt(attempt);
+    });
+
+    expect(result.current.progressAttempts).toContainEqual(attempt);
+    await waitFor(() =>
+      expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", [attempt])
+    );
+  });
+
+  it("uses attemptKey-based identity (no duplicate upload on re-login)", async () => {
+    const a = makeAttempt({ timestamp: 1 });
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(a);
+    });
+
+    // Remote already has `a` -> nothing to upload.
+    fetchRemoteAttempts.mockResolvedValue([a]);
+    rerender({ user: makeUser("user-1") });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", []);
+    // sanity: keys match
+    expect(attemptKey(result.current.progressAttempts[0])).toBe(attemptKey(a));
+  });
+});

--- a/src/hooks/useProgressAttempts.test.tsx
+++ b/src/hooks/useProgressAttempts.test.tsx
@@ -37,6 +37,28 @@ vi.mock("../domain/attemptRemote", async () => {
 import { useProgressAttempts } from "./useProgressAttempts";
 import { attemptKey } from "../domain/attemptSync";
 
+const ATTEMPTS_KEY = "jabiko:attempts";
+
+// The module-singleton attemptStore persists into window.localStorage (jsdom),
+// so we observe whether the store was mutated by reading the raw persisted set
+// (rather than spying on a private singleton). `null` -> never written.
+function readStore(): Attempt[] | null {
+  const raw = window.localStorage.getItem(ATTEMPTS_KEY);
+  return raw ? (JSON.parse(raw) as Attempt[]) : null;
+}
+
+// A manually-resolved promise so a test can unmount / rerender with a
+// different user BEFORE the sync's awaits settle.
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (err: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeAttempt(overrides: Partial<Attempt> = {}): Attempt {
   return {
     vocabularyId: "kaku",
@@ -174,5 +196,182 @@ describe("useProgressAttempts -- login sync", () => {
     expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", []);
     // sanity: keys match
     expect(attemptKey(result.current.progressAttempts[0])).toBe(attemptKey(a));
+  });
+});
+
+describe("useProgressAttempts -- login sync commit safety (codex review)", () => {
+  // BUG 1: a stale async run (unmount / logout / user switch) must NOT mutate
+  // the local store. Using a deferred fetch we unmount BEFORE it resolves,
+  // then resolve -- the store must never be replaced and no state update
+  // must run after unmount.
+  it("unmount before sync resolves -> store NOT replaced, no post-unmount state write", async () => {
+    const localOnly = makeAttempt({ timestamp: 2, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 3, submittedAnswer: "remote" });
+
+    const fetchGate = deferred<Attempt[]>();
+    fetchRemoteAttempts.mockReturnValue(fetchGate.promise);
+
+    const { result, rerender, unmount } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+    // Local store now holds exactly the local attempt.
+    expect(readStore()).toEqual([localOnly]);
+
+    // Begin login sync; it parks on the deferred fetch.
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalled());
+
+    // Unmount while the sync is still in flight, THEN let the fetch resolve.
+    unmount();
+    await act(async () => {
+      fetchGate.resolve([remoteOnly]);
+      await fetchGate.promise;
+    });
+
+    // The stale run must not have written the merged set into the store.
+    expect(readStore()).toEqual([localOnly]);
+    // The merged remote attempt must not have leaked into the (unmounted) store.
+    expect(readStore()).not.toContainEqual(remoteOnly);
+  });
+
+  // BUG 1 variant: user A -> B switch (and logout A -> null) before A's sync
+  // resolves. A's remote/merged must never be written into B's (or the anon)
+  // local store.
+  it("user switch (A->B) before A's sync resolves -> A's merged NOT written", async () => {
+    const aRemote = makeAttempt({ timestamp: 4, submittedAnswer: "A-remote" });
+
+    const aFetch = deferred<Attempt[]>();
+    const bFetch = deferred<Attempt[]>();
+    fetchRemoteAttempts
+      .mockReturnValueOnce(aFetch.promise) // user A
+      .mockReturnValueOnce(bFetch.promise); // user B
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: makeUser("user-A") as User | null } }
+    );
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    // Switch to user B while A's fetch is still parked.
+    rerender({ user: makeUser("user-B") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-B"));
+
+    // Now resolve A's (stale) fetch first, then B's.
+    await act(async () => {
+      aFetch.resolve([aRemote]);
+      await aFetch.promise;
+    });
+    await act(async () => {
+      bFetch.resolve([]);
+      await bFetch.promise;
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    // A's remote attempt must NOT have been written by the stale A run.
+    expect(readStore() ?? []).not.toContainEqual(aRemote);
+    expect(result.current.progressAttempts).not.toContainEqual(aRemote);
+  });
+
+  // BUG 2: push failure (fetch ok) must leave local untouched. The old code
+  // replaced local BEFORE the push, so a push reject lost the "untouched"
+  // guarantee.
+  it("pushAttempts rejects (fetch ok) -> error AND local untouched", async () => {
+    const localOnly = makeAttempt({ timestamp: 6, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 7, submittedAnswer: "remote" });
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    fetchRemoteAttempts.mockResolvedValue([remoteOnly]);
+    pushAttempts.mockRejectedValue(new Error("push failed"));
+
+    rerender({ user: makeUser("user-1") });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("error"));
+    // Local untouched -- the merged set was NOT committed because push failed.
+    expect(readStore()).toEqual([localOnly]);
+    expect(result.current.progressAttempts).toEqual([localOnly]);
+    // No data loss: the local-only attempt is still present.
+    expect(result.current.progressAttempts).toContainEqual(localOnly);
+  });
+
+  // Happy path through the fixed ordering: commit only after fetch + push
+  // both succeed and the effect is still active.
+  it("happy path -> store replaced with merged, state merged, synced, push got delta", async () => {
+    const localOnly = makeAttempt({ timestamp: 8, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 9, submittedAnswer: "remote" });
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    fetchRemoteAttempts.mockResolvedValue([remoteOnly]);
+
+    rerender({ user: makeUser("user-1") });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    const merged = [localOnly, remoteOnly];
+    expect(readStore()).toEqual(merged);
+    expect(result.current.progressAttempts).toEqual(merged);
+    // Push received exactly the local-only delta.
+    expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", [localOnly]);
+  });
+
+  // RE-READ guard: an attempt recorded DURING the awaits must survive the
+  // commit. The old code planned the merge from a snapshot taken before the
+  // awaits, so a concurrently recorded attempt would be clobbered by replace.
+  it("attempt recorded during the awaits -> final merged INCLUDES it (no clobber)", async () => {
+    const localOnly = makeAttempt({ timestamp: 10, submittedAnswer: "local" });
+    const remoteOnly = makeAttempt({ timestamp: 11, submittedAnswer: "remote" });
+    const recordedDuringSync = makeAttempt({ timestamp: 12, submittedAnswer: "mid-sync" });
+
+    const fetchGate = deferred<Attempt[]>();
+    fetchRemoteAttempts.mockReturnValue(fetchGate.promise);
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalled());
+
+    // Record a new attempt WHILE the sync is parked on the fetch await.
+    act(() => {
+      result.current.recordAttempt(recordedDuringSync);
+    });
+
+    // Now resolve the fetch and let the commit run.
+    await act(async () => {
+      fetchGate.resolve([remoteOnly]);
+      await fetchGate.promise;
+    });
+
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    // The concurrently recorded attempt must NOT have been clobbered.
+    expect(readStore()).toContainEqual(recordedDuringSync);
+    expect(result.current.progressAttempts).toContainEqual(recordedDuringSync);
+    // All three records survive.
+    expect(result.current.progressAttempts).toEqual([
+      localOnly,
+      remoteOnly,
+      recordedDuringSync
+    ]);
   });
 });

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -55,11 +55,25 @@ export function useProgressAttempts(user: User | null) {
     setSyncStatus("syncing");
 
     (async () => {
+      // Re-check `active` after EVERY await: if the effect went stale
+      // (unmount, logout -> null, or A->B user switch) while we were parked
+      // on an await, a stale run must bail immediately so it touches NEITHER
+      // remote NOR local. In particular it must bail after the fetch and
+      // BEFORE reading the (now anon's/new user's) live attemptStore and
+      // pushing it to the OLD user's remote -- otherwise A's stale
+      // continuation would upload the now-current local set to user A's
+      // account (a cross-account data leak).
       const client = await getSupabase();
+      if (!active) {
+        return;
+      }
       // fetch + push run BEFORE any local mutation, so a throw from either
       // (offline, RLS, push conflict, ...) lands in the catch with the local
       // store completely untouched.
       const remote = await fetchRemoteAttempts(client, userId);
+      if (!active) {
+        return;
+      }
       const { toUpload } = planLoginSync(attemptStore.list(), remote);
       await pushAttempts(client, userId, toUpload);
       // Only commit once the effect is still current: a stale run (unmount,

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -1,9 +1,19 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { User } from "@supabase/supabase-js";
 import { createAttemptStore } from "../domain/storage";
+import { fetchRemoteAttempts, planLoginSync, pushAttempts } from "../domain/attemptRemote";
+import { getSupabase } from "../lib/supabase";
 import type { Attempt } from "../domain/types";
 
 // One persistent attempt store for the app session.
 const attemptStore = createAttemptStore();
+
+// Status of cross-device sync (Phase 3, Part of #151):
+//   idle    -- no user / anon path (or before any login this session)
+//   syncing -- a login merge is in flight
+//   synced  -- the last login merge completed (writes are best-effort after)
+//   error   -- the last login merge failed; local was left untouched
+export type SyncStatus = "idle" | "syncing" | "synced" | "error";
 
 // Owns the lifetime attempt history (loaded from storage on mount,
 // appended on every answer). Lifted OUT of usePracticeSession so it can
@@ -12,16 +22,83 @@ const attemptStore = createAttemptStore();
 // view only needs to append to it via recordAttempt. Keeping it here is
 // also what lets usePracticeSession (and the heavy question-pool data it
 // imports) stay out of the initial bundle.
-export function useProgressAttempts() {
+//
+// `user` (from useAuth) drives cross-device sync: on a transition to a
+// logged-in user we merge the remote history into the local store and push
+// the local-only delta back up. The anon (no-user) path is unchanged --
+// local only, never cleared, and the Supabase SDK stays in its lazy chunk.
+export function useProgressAttempts(user: User | null) {
   const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>("idle");
+
+  const userId = user?.id ?? null;
+
+  // Keep the latest userId for recordAttempt's best-effort push without
+  // making the callback's identity depend on it (identity must stay stable
+  // so the lazy challenge view doesn't re-render on every answer).
+  const userIdRef = useRef<string | null>(userId);
+  useEffect(() => {
+    userIdRef.current = userId;
+  }, [userId]);
+
+  // Login sync: runs when the user id transitions to a non-null value.
+  useEffect(() => {
+    if (!userId) {
+      // Logout / anon: behaviour exactly as before -- local untouched,
+      // status back to idle.
+      setSyncStatus("idle");
+      return;
+    }
+
+    let active = true;
+    setSyncStatus("syncing");
+
+    (async () => {
+      const client = await getSupabase();
+      const remote = await fetchRemoteAttempts(client, userId);
+      const { merged, toUpload } = planLoginSync(attemptStore.list(), remote);
+      attemptStore.replace(merged);
+      if (!active) {
+        return;
+      }
+      setProgressAttempts(merged);
+      await pushAttempts(client, userId, toUpload);
+      if (!active) {
+        return;
+      }
+      setSyncStatus("synced");
+    })().catch(() => {
+      // Any failure (offline, RLS, etc.): keep local untouched, surface the
+      // error. The local store still holds everything; the next login retries.
+      if (active) {
+        setSyncStatus("error");
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [userId]);
 
   // Stable identity (setProgressAttempts is stable; attemptStore is a
-  // module singleton) so passing it down to the challenge view doesn't
-  // change on every answer.
+  // module singleton; user id read via ref) so passing it down to the
+  // challenge view doesn't change on every answer.
   const recordAttempt = useCallback((attempt: Attempt) => {
     setProgressAttempts((current) => [...current, attempt]);
     attemptStore.add(attempt);
+
+    // Best-effort live upload when logged in. The attempt is already safe in
+    // the local store, so a failed push is swallowed -- it will sync on the
+    // next login. Fire-and-forget: never blocks recording.
+    const id = userIdRef.current;
+    if (id) {
+      void getSupabase()
+        .then((client) => pushAttempts(client, id, [attempt]))
+        .catch(() => {
+          /* best-effort; safe in local store */
+        });
+    }
   }, []);
 
-  return { progressAttempts, recordAttempt };
+  return { progressAttempts, recordAttempt, syncStatus };
 }

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import { createAttemptStore } from "../domain/storage";
 import { fetchRemoteAttempts, planLoginSync, pushAttempts } from "../domain/attemptRemote";
+import { mergeAttempts } from "../domain/attemptSync";
 import { getSupabase } from "../lib/supabase";
 import type { Attempt } from "../domain/types";
 
@@ -55,21 +56,31 @@ export function useProgressAttempts(user: User | null) {
 
     (async () => {
       const client = await getSupabase();
+      // fetch + push run BEFORE any local mutation, so a throw from either
+      // (offline, RLS, push conflict, ...) lands in the catch with the local
+      // store completely untouched.
       const remote = await fetchRemoteAttempts(client, userId);
-      const { merged, toUpload } = planLoginSync(attemptStore.list(), remote);
-      attemptStore.replace(merged);
-      if (!active) {
-        return;
-      }
-      setProgressAttempts(merged);
+      const { toUpload } = planLoginSync(attemptStore.list(), remote);
       await pushAttempts(client, userId, toUpload);
+      // Only commit once the effect is still current: a stale run (unmount,
+      // logout, or A->B user switch) bails here BEFORE touching local, so it
+      // can never write a previous user's remote history into the now-anon
+      // or new-user store.
       if (!active) {
         return;
       }
+      // Re-read the live local set at commit time (rather than reusing the
+      // pre-await snapshot) so any attempt recorded during the awaits is
+      // folded in instead of being clobbered by replace.
+      const merged = mergeAttempts(attemptStore.list(), remote);
+      attemptStore.replace(merged);
+      setProgressAttempts(merged);
       setSyncStatus("synced");
     })().catch(() => {
-      // Any failure (offline, RLS, etc.): keep local untouched, surface the
-      // error. The local store still holds everything; the next login retries.
+      // Any failure (offline, RLS, push conflict, etc.): the local store is
+      // left untouched because mutation only happens after fetch + push both
+      // succeed and the effect is still active. Nothing is lost; the next
+      // login retries.
       if (active) {
         setSyncStatus("error");
       }


### PR DESCRIPTION
Part of #151（跨裝置進度同步）— Phase 2 ＋ Phase 3。前置已備：Phase 0（#156 建表＋RLS）、Phase 1（#153 合併邏輯）。

## 內容
**Phase 2 — 遠端 repo** `src/domain/attemptRemote.ts`
- `fetchRemoteAttempts(client, userId)`：`from("attempts").select("payload").eq("user_id", …)`，錯誤上拋、null client → `[]`。
- `pushAttempts(client, userId, attempts)`：`upsert(rows, { onConflict: "user_id,id", ignoreDuplicates: true })`，row id = `attemptKey`，**冪等**；null/空 → no-op。
- 純函式 `planLoginSync(local, remote) → { merged, toUpload }`：merged = `mergeAttempts`；toUpload = 僅本地（key 不在 remote）→ 不覆蓋遠端、不丟本地。

**Phase 3 — 接 user ＋ 登入同步** `useProgressAttempts(user)`
- 登入時：`syncing → fetch → planLoginSync → attemptStore.replace(merged) → setState → push(toUpload) → synced`；任何失敗 → `error`，**本地原封不動**。
- `recordAttempt`：登入時 fire-and-forget 推單筆（失敗吞掉，已安全存於本地、下次登入再補）；身分穩定（userId 走 ref）。
- 登出/匿名：`idle`，**行為與原本完全一致**（不碰 Supabase、不清本地）。
- 新增 `syncStatus: idle|syncing|synced|error`（供日後 Phase 5 文案 gate）。
- `storage.ts` 新增 `AttemptStore.replace()`；`App.tsx` 傳入 `useAuth().user`。

## 驗證
- TDD（先寫測試觀察 red）：`corepack pnpm test` → **233 passed (+18)**；`corepack pnpm build` 綠（tsc strict）。
- **匿名零回歸**；**Supabase 維持 lazy**（grep dist 確認 `createClient` 未進 initial bundle）；merge 非破壞性、冪等、unmount 防護。
- source 無 `any`；未碰題庫（`exam/items` 等）。

## 不含 / 後續
- **Phase 5 UI 文案**（`authSyncedHint`，僅在 `syncStatus==='synced'` 顯示）未做。
- **端到端**需：① Supabase 已建表（#151 Phase 0 SQL，作者手動跑 → 已提供步驟）② 真人 Google 登入做手動 E2E。
