### PR TITLE
feat(practice): 可設定的練習回合上限（closes #154）

### DIFF
--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -40,6 +40,7 @@ function partOfSpeechLabel(partOfSpeech: PartOfSpeech, language: Language): stri
 export function DrillPanel({
   language,
   questionIndex,
+  sessionTotal,
   selectedChoice,
   feedback,
   attempts,
@@ -61,6 +62,7 @@ export function DrillPanel({
 }: Pick<
   PracticeSession,
   | "questionIndex"
+  | "sessionTotal"
   | "selectedChoice"
   | "feedback"
   | "attempts"
@@ -80,6 +82,34 @@ export function DrillPanel({
   | "handleDrillKeyDown"
 > & { language: Language; onExit: () => void }) {
   const t = copy[language];
+
+  // Completion-screen copy: daily / review have their own wording; every
+  // other (capped, #154) finite session uses the generic "這組完成" set.
+  const wrongCount = attempts.length - correctCount;
+  const doneTitle =
+    practiceMode === "daily"
+      ? t.dailyDoneTitle
+      : practiceMode === "review"
+        ? t.reviewDoneTitle
+        : t.sessionDoneTitle;
+  const doneBody =
+    practiceMode === "daily"
+      ? t.dailyDoneBody(correctCount, wrongCount)
+      : practiceMode === "review"
+        ? t.reviewDoneBody(correctCount, wrongCount)
+        : t.sessionDoneBody(correctCount, wrongCount);
+  const doneAgain =
+    practiceMode === "daily"
+      ? t.dailyDoneAgain
+      : practiceMode === "review"
+        ? t.reviewDoneAgain
+        : t.sessionDoneAgain;
+  const doneExit =
+    practiceMode === "daily"
+      ? t.dailyDoneExit
+      : practiceMode === "review"
+        ? t.reviewDoneExit
+        : t.sessionDoneExit;
 
   // Container-level answer state for embedded AI / browser automation:
   // collapse feedback into one result string so .drill-panel exposes the
@@ -107,7 +137,11 @@ export function DrillPanel({
       {currentQuestion ? (
         <>
           <div className="prompt-header">
-            <span>{t.questionNumber(questionIndex + 1)}</span>
+            <span>
+              {sessionTotal != null
+                ? t.questionProgress(questionIndex + 1, sessionTotal)
+                : t.questionNumber(questionIndex + 1)}
+            </span>
             <strong>{currentQuestion.promptLabel ?? t.targetForms[currentQuestion.targetForm]}</strong>
           </div>
 
@@ -192,19 +226,15 @@ export function DrillPanel({
       ) : sessionExhausted ? (
         <div className="empty-state review-done">
           <DarumaSpot />
-          <h2>{practiceMode === "daily" ? t.dailyDoneTitle : t.reviewDoneTitle}</h2>
-          <p>
-            {practiceMode === "daily"
-              ? t.dailyDoneBody(correctCount, attempts.length - correctCount)
-              : t.reviewDoneBody(correctCount, attempts.length - correctCount)}
-          </p>
+          <h2>{doneTitle}</h2>
+          <p>{doneBody}</p>
           <div className="review-done-actions">
             <button className="next-button" type="button" onClick={resetSession}>
               <RotateCcw aria-hidden="true" />
-              {practiceMode === "daily" ? t.dailyDoneAgain : t.reviewDoneAgain}
+              {doneAgain}
             </button>
             <button className="ghost-button" type="button" onClick={onExit}>
-              {practiceMode === "daily" ? t.dailyDoneExit : t.reviewDoneExit}
+              {doneExit}
             </button>
           </div>
         </div>

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -2,7 +2,7 @@ import { BookOpen, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
 import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../../domain/levelRange";
-import type { PracticeMode, PracticeSession } from "../../hooks/usePracticeSession";
+import { SESSION_LENGTH_OPTIONS, type PracticeMode, type PracticeSession } from "../../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
 
@@ -62,6 +62,8 @@ export function ModePicker({
   practiceMode,
   levelRange,
   showLevelRange,
+  sessionLength,
+  showSessionLength,
   selectedForm,
   setVerbGroup,
   setTargetForm,
@@ -76,6 +78,7 @@ export function ModePicker({
   handlePracticeFocusChange,
   applyModePreset,
   handleLevelRangeChange,
+  handleSessionLengthChange,
   resetSession
 }: Pick<
   PracticeSession,
@@ -85,6 +88,8 @@ export function ModePicker({
   | "practiceMode"
   | "levelRange"
   | "showLevelRange"
+  | "sessionLength"
+  | "showSessionLength"
   | "selectedForm"
   | "setVerbGroup"
   | "setTargetForm"
@@ -99,6 +104,7 @@ export function ModePicker({
   | "handlePracticeFocusChange"
   | "applyModePreset"
   | "handleLevelRangeChange"
+  | "handleSessionLengthChange"
   | "resetSession"
 > & { language: Language }) {
   const t = copy[language];
@@ -162,6 +168,29 @@ export function ModePicker({
                 {t.levelRangeOptions[range]}
               </button>
             ))}
+          </div>
+        </fieldset>
+      ) : null}
+
+      {showSessionLength ? (
+        <fieldset>
+          <legend>{t.sessionLength}</legend>
+          <div className="segmented">
+            {SESSION_LENGTH_OPTIONS.map((option) => {
+              const key = option ?? "all";
+              const active = sessionLength === option;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  className={active ? "selected" : ""}
+                  aria-pressed={active}
+                  onClick={() => handleSessionLengthChange(option)}
+                >
+                  {option === null ? t.sessionLengthAll : String(option)}
+                </button>
+              );
+            })}
           </div>
         </fieldset>
       ) : null}

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -263,3 +263,46 @@ describe("buildQuestionPool part-of-speech handling (#60)", () => {
     expect(drills).toEqual([]);
   });
 });
+
+describe("buildPracticeQuestions session-length cap (#154)", () => {
+  it("caps the basic-drill pool to sessionLength", () => {
+    const full = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "verb", verbGroup: "godan", targetForms: ["te"] })
+    );
+    expect(full.length).toBeGreaterThan(20);
+
+    const capped = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "verb", verbGroup: "godan", targetForms: ["te"], sessionLength: 20 })
+    );
+    expect(capped.length).toBe(20);
+  });
+
+  it("caps the exam pool to sessionLength", () => {
+    const capped = buildPracticeQuestions(
+      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: 20 })
+    );
+    expect(capped.length).toBe(20);
+  });
+
+  it("treats null sessionLength as no cap (full pool)", () => {
+    const full = buildPracticeQuestions(
+      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: null })
+    );
+    expect(full.length).toBe(buildExamQuestionPool("all").length);
+  });
+
+  it("does NOT cap review mode (clears the whole due queue)", () => {
+    const due = buildExamQuestionPool("all").slice(0, 25);
+    const questions = buildPracticeQuestions(
+      poolParams({ isReviewFocus: true, reviewQueue: due, sessionLength: 20 })
+    );
+    expect(questions.length).toBe(25);
+  });
+
+  it("does NOT shrink 今日練習 below its own target via sessionLength", () => {
+    const daily = buildPracticeQuestions(
+      poolParams({ isDailyFocus: true, reviewQueue: [], sessionLength: 5 })
+    );
+    expect(daily.length).toBeGreaterThan(5);
+  });
+});

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -144,6 +144,12 @@ export type PracticePoolParams = {
   // review and 今日練習 branches. The hook passes the value captured when
   // its `questions` memo last ran (mode change / explicit reset).
   reviewQueue: PracticeQuestion[];
+  // Cap for the endless drill modes (exam / cloze / pattern / vocab /
+  // basic): the learner picks a session length (#154) and we slice the
+  // shuffled pool down to it so the session is finite. null / undefined /
+  // <=0 means no cap (the old endless behaviour). review (clears the whole
+  // due queue) and 今日練習 (already a fixed ~20 set) are NEVER capped.
+  sessionLength?: number | null;
 };
 
 // Derives the active question pool for the current mode. This is the body
@@ -165,8 +171,16 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     verbGroup,
     targetForms,
     levelRange,
-    reviewQueue
+    reviewQueue,
+    sessionLength
   } = params;
+
+  // Cap the endless drill modes to the chosen session length (#154). A
+  // null / non-positive length leaves the pool whole (old behaviour).
+  // Applied only to the cappable branches below; review / 今日練習 return
+  // without it.
+  const cap = (pool: PracticeQuestion[]): PracticeQuestion[] =>
+    sessionLength != null && sessionLength > 0 ? pool.slice(0, sessionLength) : pool;
 
   if (isExamFocus) {
     // Section-filtered when launched from the 模擬考 picker; the
@@ -174,24 +188,24 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     // mixes every section.
     const section = examSection;
     if (section) {
-      return shuffleQuestions(
-        buildExamQuestionPool(section.level).filter(
-          (question) => question.promptLabel === section.promptLabel
+      return cap(
+        shuffleQuestions(
+          buildExamQuestionPool(section.level).filter(
+            (question) => question.promptLabel === section.promptLabel
+          )
         )
       );
     }
     // 綜合考題庫: optionally narrowed to a level range (N1+N2 / N2+N3).
-    return shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"));
+    return cap(shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all")));
   }
 
   if (isClozeFocus) {
-    return shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary));
+    return cap(shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary)));
   }
 
   if (isPatternFocus) {
-    return shuffleQuestions(
-      buildSentencePatternPool({ patternIds })
-    );
+    return cap(shuffleQuestions(buildSentencePatternPool({ patternIds })));
   }
 
   if (isReviewFocus) {
@@ -228,9 +242,11 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     // have different-length answers -> different distractor bands ->
     // no "same options twice in a row" feel even when the random
     // shuffle clusters same-length words together.
-    return reduceAdjacentClusters(
-      vocabPool,
-      (question) => String(question.expectedAnswers[0]?.length ?? 0)
+    return cap(
+      reduceAdjacentClusters(
+        vocabPool,
+        (question) => String(question.expectedAnswers[0]?.length ?? 0)
+      )
     );
   }
 
@@ -240,11 +256,13 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     return composeDailySet(reviewQueue);
   }
 
-  return shuffleQuestions(
-    buildQuestionPool(vocabulary, {
-      partOfSpeech,
-      verbGroup,
-      targetForms
-    })
+  return cap(
+    shuffleQuestions(
+      buildQuestionPool(vocabulary, {
+        partOfSpeech,
+        verbGroup,
+        targetForms
+      })
+    )
   );
 }

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -17,8 +17,26 @@ import {
   uniqueForms
 } from "../domain/sessionPools";
 import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
+import { readStored, writeStored } from "../domain/safeStorage";
 import { copy, type Language } from "../i18n";
 import type { Feedback } from "../components/types";
+
+// Configurable practice-session length (#154). The endless drill modes
+// (exam / cloze / pattern / vocab / basic) are capped to this many
+// questions so a session is finite; `null` means "全部" (no cap, the old
+// endless behaviour). review (clears the whole due queue) and 今日練習
+// (already a fixed ~20 set) ignore it. Persisted across sessions.
+const SESSION_LENGTH_KEY = "jabiko.sessionLength";
+const DEFAULT_SESSION_LENGTH = 20;
+export const SESSION_LENGTH_OPTIONS: ReadonlyArray<number | null> = [10, 20, 30, 50, null];
+
+function readSessionLength(): number | null {
+  const raw = readStored(SESSION_LENGTH_KEY);
+  if (raw === null) return DEFAULT_SESSION_LENGTH;
+  if (raw === "all") return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_SESSION_LENGTH;
+}
 
 export type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast";
 export type PracticeMode = "basic" | "cloze" | "daily" | "pattern" | "exam" | "review" | "vocab";
@@ -97,6 +115,7 @@ export function usePracticeSession({
   const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "basic");
   const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>(init?.filter ?? {});
   const [levelRange, setLevelRange] = useState<LevelRange>(init?.levelRange ?? "all");
+  const [sessionLength, setSessionLength] = useState<number | null>(() => readSessionLength());
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
@@ -122,6 +141,11 @@ export function usePracticeSession({
   const isDailyFocus = practiceMode === "daily";
   const isCuratedFocus =
     isExamFocus || isClozeFocus || isPatternFocus || isReviewFocus || isVocabFocus || isDailyFocus;
+  // The session-length picker applies to the endless drill modes (exam /
+  // cloze / pattern / vocab / basic). review clears the whole due queue
+  // and 今日練習 is already a fixed ~20 set, so neither is capped.
+  const showSessionLength = !isReviewFocus && !isDailyFocus;
+  const isCapped = showSessionLength && sessionLength != null;
   // The level-range picker applies to the 綜合考題庫 (exam with no fixed
   // section) and 単字 pools -- the two banks with JLPT-tagged items. A
   // mock-launched exam section already fixes the level, so hide it there.
@@ -200,7 +224,8 @@ export function usePracticeSession({
         verbGroup,
         targetForms,
         levelRange,
-        reviewQueue
+        reviewQueue,
+        sessionLength
       });
     },
     // INTENTIONALLY excluding `reviewQueue` from deps. The live queue
@@ -229,6 +254,7 @@ export function usePracticeSession({
       targetForms,
       verbGroup,
       levelRange,
+      sessionLength,
       sessionSeed
     ]
   );
@@ -238,13 +264,19 @@ export function usePracticeSession({
   // Looping review would re-show items the learner just cleared -- exactly
   // the "錯題一直輪迴" report. Correctly-answered items leave the SRS due
   // set (next session), wrong ones reset to box 0 and return next session.
-  const isFinitePass = isReviewFocus || isDailyFocus;
+  // A capped endless mode (#154) also becomes a finite pass: walk the
+  // sliced pool once, then show the completion screen ("再來一組" reshuffles
+  // a fresh capped set via resetSession).
+  const isFinitePass = isReviewFocus || isDailyFocus || isCapped;
   const currentQuestion = isFinitePass
     ? questions[questionIndex] ?? null
     : selectQuestion(questions, questionIndex);
   const reviewEmpty = isReviewFocus && questions.length === 0;
   const sessionExhausted =
     isFinitePass && questions.length > 0 && questionIndex >= questions.length;
+  // Total for the "N / total" progress readout: known for finite passes
+  // (capped / review / 今日練習), null for the remaining endless modes.
+  const sessionTotal = isFinitePass ? questions.length : null;
   const choiceOptions = useMemo(
     () => (currentQuestion ? buildChoiceOptions(currentQuestion, questions, questionIndex) : []),
     [currentQuestion, questionIndex, questions]
@@ -287,6 +319,13 @@ export function usePracticeSession({
   const handleLevelRangeChange = (nextRange: LevelRange) => {
     if (nextRange === levelRange) return;
     setLevelRange(nextRange);
+    resetSession();
+  };
+
+  const handleSessionLengthChange = (nextLength: number | null) => {
+    if (nextLength === sessionLength) return;
+    setSessionLength(nextLength);
+    writeStored(SESSION_LENGTH_KEY, nextLength === null ? "all" : String(nextLength));
     resetSession();
   };
 
@@ -382,6 +421,9 @@ export function usePracticeSession({
     practiceMode,
     levelRange,
     showLevelRange,
+    sessionLength,
+    showSessionLength,
+    sessionTotal,
     selectedForm,
     questionIndex,
     selectedChoice,
@@ -412,6 +454,7 @@ export function usePracticeSession({
     handlePracticeFocusChange,
     applyModePreset,
     handleLevelRangeChange,
+    handleSessionLengthChange,
     handleChoiceSubmit,
     nextQuestion,
     resetSession,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -110,6 +110,8 @@ export type Copy = {
   practiceMode: string;
   levelRange: string;
   levelRangeOptions: { all: string; n1n2: string; n2n3: string; n4n5: string };
+  sessionLength: string;
+  sessionLengthAll: string;
   practiceFocus: string;
   verbGroup: string;
   targetForm: string;
@@ -120,6 +122,7 @@ export type Copy = {
   resetSession: string;
   currentQuestion: string;
   questionNumber: (value: number) => string;
+  questionProgress: (value: number, total: number) => string;
   answerOptions: string;
   revealAnswer: string;
   nextQuestion: string;
@@ -160,6 +163,10 @@ export type Copy = {
   dailyDoneBody: (cleared: number, remaining: number) => string;
   dailyDoneAgain: string;
   dailyDoneExit: string;
+  sessionDoneTitle: string;
+  sessionDoneBody: (cleared: number, remaining: number) => string;
+  sessionDoneAgain: string;
+  sessionDoneExit: string;
   speakAriaLabel: string;
   authSignIn: string;
   authSignOut: string;
@@ -297,6 +304,8 @@ export const copy: Record<Language, Copy> = {
     practiceMode: "練習模式",
     levelRange: "題庫範圍",
     levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n4n5: "N4＋N5" },
+    sessionLength: "每組題數",
+    sessionLengthAll: "全部",
     practiceFocus: "練習重點",
     verbGroup: "動詞類別",
     targetForm: "目標形",
@@ -307,6 +316,7 @@ export const copy: Record<Language, Copy> = {
     resetSession: "重設本次",
     currentQuestion: "目前題目",
     questionNumber: (value) => `第 ${value} 題`,
+    questionProgress: (value, total) => `第 ${value} / ${total} 題`,
     answerOptions: "答案選項",
     revealAnswer: "看答案",
     nextQuestion: "下一題",
@@ -359,6 +369,11 @@ export const copy: Record<Language, Copy> = {
       `今天練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，下次複習時會再出現。`,
     dailyDoneAgain: "再練一組",
     dailyDoneExit: "回首頁",
+    sessionDoneTitle: "這組練完了！",
+    sessionDoneBody: (cleared, remaining) =>
+      `這一組練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，下次複習時會再出現。`,
+    sessionDoneAgain: "再來一組",
+    sessionDoneExit: "回首頁",
     speakAriaLabel: "朗讀日文",
     authSignIn: "Google 登入",
     authSignOut: "登出",


### PR DESCRIPTION
## 摘要
非 daily/review 的練習模式（綜合考題庫／句中填空／句型／單字讀音／基礎變化）原本**無上限、會一直出題**。本 PR 加上可設定的「每組題數」。

## 行為
- 左欄新增「每組題數」segmented：**10／20／30／50／全部**，預設 **20**，localStorage 持久化。
- 選定數量後，這些模式變成**有限回合**：出完該組 → 顯示完成畫面「這組練完了！」＋「再來一組」（重洗一組）。選「全部」＝維持原本無限模式。
- 作答進度由「第 N 題」改為「第 N / 總 題」。
- **review**（清空整個錯題 due queue）與**今日練習**（固定 ~20）不受影響。

## 實作（TDD）
- `sessionPools.buildPracticeQuestions` 加 `sessionLength` 參數（null=不 cap），cap 五個 endless 分支；新增 5 個單元測試（先 RED 後 GREEN）。
- `usePracticeSession`：sessionLength state + 持久化 + 把 capped 模式納入 isFinitePass + sessionTotal。
- `ModePicker`（每組題數控制）、`DrillPanel`（N/總 進度 + 通用完成文案）、i18n。

## 驗證
- test 244 passed（含新 cap 測試）、build 綠、tsc 通過；examBlocks 仍 lazy、initial chunk 不變。

closes #154