### PR TITLE
feat(grammar): 答題回饋的文法說明頁（closes #137）

### DIFF
--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { FeedbackPanel } from "./FeedbackPanel";
 import { buildQuestionPool } from "../domain/practice";
@@ -7,6 +7,7 @@ import { examStyleQuestions } from "../domain/examBlocks";
 import { buildSentencePatternPool } from "../domain/sentencePatterns";
 import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
+import { grammarNotes } from "../domain/grammarNotes";
 
 const readingPool = buildQuestionPool(jlptVocabulary, {
   partOfSpeech: "mixed",
@@ -165,5 +166,76 @@ describe("FeedbackPanel distractor gloss", () => {
       expect(hasGloss, `promptLabel=${testCase.question.promptLabel ?? "(none)"}`).toBe(testCase.gloss);
       unmount();
     }
+  });
+});
+
+describe("FeedbackPanel grammar note (#137)", () => {
+  const grammarBase = examStyleQuestions.find((q) => q.promptLabel === "文法形式選擇")!;
+  // Override the surface so the lookup hit is independent of which exact
+  // grammar items happen to be in the bank.
+  const grammarWithSurface = (surface: string) => ({
+    ...grammarBase,
+    vocabulary: { ...grammarBase.vocabulary, surface }
+  });
+
+  it("shows a collapsed 看文法說明 entry for a grammar item whose point has a note", () => {
+    const question = grammarWithSurface("ばかりに");
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={question.options ?? []}
+      />
+    );
+    const toggle = container.querySelector(".grammar-note-toggle");
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    // Collapsed by default -> the note card is not rendered yet.
+    expect(container.querySelector(".grammar-note")).toBeNull();
+  });
+
+  it("expands the note on click, showing the point's meaning", () => {
+    const question = grammarWithSurface("ばかりに");
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={question.options ?? []}
+      />
+    );
+    fireEvent.click(container.querySelector(".grammar-note-toggle")!);
+    const note = container.querySelector(".grammar-note");
+    expect(note).not.toBeNull();
+    expect(container.querySelector(".grammar-note-toggle")?.getAttribute("aria-expanded")).toBe("true");
+    expect(note?.textContent).toContain(grammarNotes["ばかりに"].meaningZh);
+  });
+
+  it("hides the entry for a grammar point with no note yet (no error)", () => {
+    const question = grammarWithSurface("そんな文法点はない");
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={question.options ?? []}
+      />
+    );
+    expect(container.querySelector(".grammar-note-block")).toBeNull();
+  });
+
+  it("does not show the entry for non-grammar items even if the surface collides", () => {
+    // A reading drill (no grammar promptLabel) whose surface happens to be a
+    // noted point must NOT surface the grammar-note entry.
+    const question = {
+      ...readingPool[0],
+      vocabulary: { ...readingPool[0].vocabulary, surface: "ばかりに" }
+    };
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    expect(container.querySelector(".grammar-note-block")).toBeNull();
   });
 });

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -1,7 +1,10 @@
-import { CheckCircle2, XCircle } from "lucide-react";
+import { useState } from "react";
+import { BookOpen, CheckCircle2, XCircle } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
+import { lookupGrammarNote } from "../domain/grammarNotes";
+import { GrammarNoteCard } from "./GrammarNoteCard";
 import type { Feedback } from "./types";
 
 // Post-answer panel: shows correct/incorrect/revealed status, the
@@ -18,6 +21,7 @@ export function FeedbackPanel({
   options: string[];
 }) {
   const t = copy[language];
+  const [showGrammarNote, setShowGrammarNote] = useState(false);
   const isCorrect = feedback.status === "correct";
   const isRevealed = feedback.status === "revealed";
   const title = isCorrect ? t.correct : isRevealed ? t.revealed : t.incorrect;
@@ -41,6 +45,14 @@ export function FeedbackPanel({
     promptLabel === "漢字読み" || (promptLabel === "" && feedback.question.targetForm === "reading");
   // Grammar-form items: options are patterns, so show each pattern's gloss.
   const isGrammarGloss = promptLabel === "文法形式選擇" || promptLabel === "文章脈絡";
+  // Full reference note (#137) for grammar items, opened behind a "看文法說明"
+  // toggle to close the wrong -> learn loop. Gated on grammar promptLabels;
+  // a point with no note yet just hides the entry point (never an error).
+  const isGrammarItem =
+    promptLabel === "文法形式選擇" || promptLabel === "語順組合" || promptLabel === "文章脈絡";
+  const grammarNote = isGrammarItem
+    ? lookupGrammarNote(feedback.question.vocabulary.surface)
+    : null;
 
   // One gloss string PER distractor, rendered one-per-line, so a long
   // option list stays readable on mobile instead of wrapping mid-item.
@@ -89,6 +101,20 @@ export function FeedbackPanel({
           {feedback.question.vocabulary.examples[0].japanese}
           <span>{feedback.question.vocabulary.examples[0].meaningZh}</span>
         </p>
+      ) : null}
+      {grammarNote ? (
+        <div className="grammar-note-block">
+          <button
+            type="button"
+            className="grammar-note-toggle"
+            aria-expanded={showGrammarNote}
+            onClick={() => setShowGrammarNote((open) => !open)}
+          >
+            <BookOpen aria-hidden="true" />
+            {showGrammarNote ? t.grammarNoteHide : t.grammarNoteCta}
+          </button>
+          {showGrammarNote ? <GrammarNoteCard note={grammarNote} language={language} /> : null}
+        </div>
       ) : null}
     </section>
   );

--- a/src/components/GrammarNoteCard.tsx
+++ b/src/components/GrammarNoteCard.tsx
@@ -1,0 +1,53 @@
+import { copy, type Language } from "../i18n";
+import type { GrammarNote } from "../domain/grammarNotes";
+
+// Reusable presentation for one grammar-point reference note (issue #137):
+// meaning / formation / usage / examples / easily-confused points. Pure
+// presentation over a GrammarNote -- used inside the post-answer feedback
+// (the wrong -> learn loop) and reusable by the #97 exam-prep learning
+// tier. Carries no data lookup of its own.
+export function GrammarNoteCard({ note, language }: { note: GrammarNote; language: Language }) {
+  const t = copy[language];
+  return (
+    <div className="grammar-note">
+      <div className="grammar-note-head">
+        <strong>{note.surface}</strong>
+        {note.jlptLevel ? (
+          <span className="grammar-note-level" aria-label={`JLPT ${note.jlptLevel}`}>
+            {note.jlptLevel}
+          </span>
+        ) : null}
+      </div>
+      <p className="grammar-note-meaning">{note.meaningZh}</p>
+      <dl className="grammar-note-fields">
+        <dt>{t.grammarNoteFormation}</dt>
+        <dd>{note.formation}</dd>
+        <dt>{t.grammarNoteUsage}</dt>
+        <dd>{note.usageZh}</dd>
+      </dl>
+      {note.examples.length > 0 ? (
+        <div className="grammar-note-examples">
+          <p className="grammar-note-label">{t.grammarNoteExamples}</p>
+          <ul>
+            {note.examples.map((example) => (
+              <li key={example.ja}>
+                {example.ja}
+                <span>{example.zh}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {note.confusions.length > 0 ? (
+        <div className="grammar-note-confusions">
+          <p className="grammar-note-label">{t.grammarNoteConfusions}</p>
+          <ul>
+            {note.confusions.map((confusion) => (
+              <li key={confusion}>{confusion}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/domain/grammarNotes.test.ts
+++ b/src/domain/grammarNotes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { grammarNotes, lookupGrammarNote } from "./grammarNotes";
+
+describe("lookupGrammarNote", () => {
+  it("returns the full note for a seeded grammar point", () => {
+    const note = lookupGrammarNote("ばかりに");
+    expect(note).not.toBeNull();
+    expect(note?.surface).toBe("ばかりに");
+    expect(note?.meaningZh.length).toBeGreaterThan(0);
+    expect(note?.formation.length).toBeGreaterThan(0);
+    expect(note?.usageZh.length).toBeGreaterThan(0);
+    expect(note?.examples.length).toBeGreaterThan(0);
+    expect(note?.examples[0]?.ja.length).toBeGreaterThan(0);
+    expect(note?.examples[0]?.zh.length).toBeGreaterThan(0);
+  });
+
+  it("returns null for a point with no note yet (no error)", () => {
+    expect(lookupGrammarNote("これは存在しない文法")).toBeNull();
+    expect(lookupGrammarNote("")).toBeNull();
+  });
+
+  it("keys every entry by its own surface (consistent map)", () => {
+    for (const [key, note] of Object.entries(grammarNotes)) {
+      expect(note.surface).toBe(key);
+      // confusions list each name a different pattern, never empty strings
+      expect(note.confusions.every((c) => c.trim().length > 0)).toBe(true);
+    }
+  });
+});

--- a/src/domain/grammarNotes.ts
+++ b/src/domain/grammarNotes.ts
@@ -1,0 +1,111 @@
+// Reusable grammar-point reference notes (issue #137): meaning / formation
+// / usage / examples / easily-confused points for a 文法点, keyed by its
+// `surface` (the exam item's surface, e.g. "ばかりに"). Looked up from the
+// post-answer feedback to close the wrong -> learn loop, and reused by the
+// #97 exam-prep learning tier -- so this stays a neutral data module with
+// NO React / UI / heavy-data imports. It is pulled only inside the lazy
+// challenge chunk (via FeedbackPanel), same layer as examBlocks, so it
+// never drags weight into the initial bundle.
+//
+// Content is added in small batches; an un-noted point simply has no entry
+// (lookup returns null and the feedback entry point is hidden -- never an
+// error). Explanations are original rewrites, not copied from textbooks.
+import type { JlptLevel } from "./types";
+
+export type GrammarNoteExample = { ja: string; zh: string };
+
+export type GrammarNote = {
+  /** Grammar-point surface; matches the exam item's `vocabulary.surface`. */
+  surface: string;
+  jlptLevel: JlptLevel | null;
+  meaningZh: string;
+  /** 接續 — how the pattern attaches to the preceding word. */
+  formation: string;
+  /** 用法 / 語感 — when and why it's used, the nuance it carries. */
+  usageZh: string;
+  examples: GrammarNoteExample[];
+  /** 易混點 — nearby patterns and how this one differs. */
+  confusions: string[];
+};
+
+export const grammarNotes: Record<string, GrammarNote> = {
+  ばかりに: {
+    surface: "ばかりに",
+    jlptLevel: "N2",
+    meaningZh: "就因為…（才導致不好的結果）",
+    formation: "動詞・い形容詞普通形＋ばかりに；な形＋な／名詞＋である＋ばかりに",
+    usageZh: "強調『正是因為這個原因』才招致後面（多為負面、令人懊悔）的結果，帶後悔、不甘的語氣。",
+    examples: [
+      { ja: "よけいな一言を言ったばかりに、彼を怒らせてしまった。", zh: "就因為多說了一句話，把他給惹火了。" }
+    ],
+    confusions: [
+      "だけあって：是正面評價（不愧是…），方向相反",
+      "せいで：單純歸咎於負面原因，沒有『正因如此』的強調與懊悔語氣"
+    ]
+  },
+  だけあって: {
+    surface: "だけあって",
+    jlptLevel: "N2",
+    meaningZh: "不愧是…、正因為…（所以理所當然地出色）",
+    formation: "名詞／動詞・い形容詞普通形＋だけあって；な形＋な＋だけあって",
+    usageZh: "表『正因為有某身分、經歷或條件，結果自然如此』，後接與前提相稱的（多為正面、令人佩服的）評價。",
+    examples: [
+      { ja: "さすが一流ホテルだけあって、サービスが行き届いている。", zh: "不愧是一流飯店，服務無微不至。" }
+    ],
+    confusions: [
+      "ばかりに：是負面後果、帶懊悔，方向相反",
+      "おかげで：單純歸功於某原因，沒有『名實相符、理所當然』的語感"
+    ]
+  },
+  なり: {
+    surface: "なり",
+    jlptLevel: "N1",
+    meaningZh: "一…就（立刻）…",
+    formation: "動詞辭書形＋なり",
+    usageZh: "表前一個動作才剛發生、緊接著（往往出乎意料地）就做了後項；前後為同一主語，後項常是說話者目睹的意外舉動。",
+    examples: [
+      { ja: "彼は席に着くなり、堰を切ったように話し始めた。", zh: "他一坐下，就像決堤般滔滔不絕地說了起來。" }
+    ],
+    confusions: [
+      "たとたん：一…就…，但『なり』更強調同一人緊接著的下一個動作",
+      "次第：一…就…，語感較鄭重、事務性，後項多為意志性安排"
+    ]
+  },
+  あげく: {
+    surface: "あげく",
+    jlptLevel: "N2",
+    meaningZh: "…到最後（結果卻，多為負面）",
+    formation: "動詞た形＋あげく；名詞＋の＋あげく",
+    usageZh: "表經過一番（長時間或反覆的）折騰之後，最終落得某個（通常不好的）結果。",
+    examples: [
+      { ja: "さんざん迷ったあげく、結局何も買わずに帰った。", zh: "猶豫了老半天，結果什麼都沒買就回去了。" }
+    ],
+    confusions: [
+      "すえに：經過…最後得到結果，但結果可正可負、語感較鄭重",
+      "結果：中性陳述，沒有『折騰一番』的辛苦語感"
+    ]
+  },
+  っぱなし: {
+    surface: "っぱなし",
+    jlptLevel: "N2",
+    meaningZh: "一直…著（放著不管，多含疏忽／負面）",
+    formation: "動詞ます形（去ます）＋っぱなし",
+    usageZh: "表某動作做了之後、該收尾卻放著不處理，使狀態一直持續，常帶『沒做該做的後續』的負面語感。",
+    examples: [
+      { ja: "水を出しっぱなしにして、歯を磨いていた。", zh: "開著水龍頭沒關就在刷牙。" }
+    ],
+    confusions: [
+      "たまま：只是保持某狀態不變、語感中性；『っぱなし』帶『該收而沒收』的責備意味",
+      "ておく：為某目的『刻意』保持狀態，是有意圖的，與放任不管不同"
+    ]
+  }
+};
+
+/**
+ * Full reference note for a grammar point if the bank has one, else null.
+ * Points without a note are not an error -- the feedback entry point is
+ * simply hidden, and notes are filled in batch by batch.
+ */
+export function lookupGrammarNote(surface: string): GrammarNote | null {
+  return grammarNotes[surface] ?? null;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -138,6 +138,12 @@ export type Copy = {
   feedbackNoWord: string;
   showHint: string;
   hideHint: string;
+  grammarNoteCta: string;
+  grammarNoteHide: string;
+  grammarNoteFormation: string;
+  grammarNoteUsage: string;
+  grammarNoteExamples: string;
+  grammarNoteConfusions: string;
   keyboardHint: string;
   focusSummaryEmpty: string;
   modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
@@ -332,6 +338,12 @@ export const copy: Record<Language, Copy> = {
     feedbackNoWord: "無對應詞",
     showHint: "提示",
     hideHint: "隱藏提示",
+    grammarNoteCta: "看文法說明",
+    grammarNoteHide: "收起說明",
+    grammarNoteFormation: "接續",
+    grammarNoteUsage: "用法",
+    grammarNoteExamples: "例句",
+    grammarNoteConfusions: "易混點",
     keyboardHint: "桌面快捷：按 1–4 選答、Enter 進下一題",
     focusSummaryEmpty: "目前重點沒有可用形",
     modeOptions: {


### PR DESCRIPTION
## 摘要
為文法點建立可重用說明，並從**答題後回饋**連過去——答錯文法題 →「看文法說明」→ 讀 意思／接續／用法／例句／易混點，閉合「錯→學→複習」迴圈。infra 第一刀，內容分批補。

## 內容
- `src/domain/grammarNotes.ts`：`GrammarNote` 資料模型（surface/jlptLevel/meaningZh/formation/usageZh/examples/confusions）+ `lookupGrammarNote`；seed 5 條（ばかりに／だけあって／なり／あげく／っぱなし，原創改寫）。資料中性、供 #97 exam-prep 學習層共用。
- `GrammarNoteCard`：可重用說明卡。
- `FeedbackPanel`：文法題（文法形式選擇／語順組合／文章脈絡）依 `surface` 命中才顯示可展開「看文法說明」入口；**無條目不顯示、不報錯**。

## 品質
- code-reviewer 過（正確性／bundle 分割／型別／a11y／seed 內容皆通過），並依其意見補齊 FeedbackPanel toggle 的 TDD 測試。
- grammarNotes + GrammarNoteCard 只在 lazy challenge chunk 載入，**初始 bundle 不回退**（index 257.99kB 不變、examBlocks 仍 lazy）。
- test 251 passed（grammarNotes 3 + FeedbackPanel toggle 4 新）、build 綠。

closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable grammar note card for supported grammar questions, showing explanations, usage, examples, and related confusions.
  * Added Traditional Chinese text for the new grammar note controls and labels.

* **Bug Fixes**
  * Grammar notes now stay hidden for questions without matching reference content.
  * Non-grammar questions are unaffected, even when their text overlaps with a grammar note topic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->