### PR TITLE
feat(home): 進度／熟練度總覽（closes #133）

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -3,6 +3,7 @@ import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
+import { computeProgressStats } from "../domain/stats";
 
 // Content-volume snapshot rendered above the entry cards. The exam /
 // pattern / vocab counts come from CONTENT_STATS (hardcoded, drift-
@@ -66,6 +67,11 @@ export function HomePanel({
   const nextIncompleteChapter = trackableChapters.find(
     (block) => !isLearningBlockComplete(progressAttempts, block)
   );
+
+  // Progress / mastery overview (#133): streak + due + mastered + per-level
+  // accuracy, all aggregated from attempts (+ SRS state) with no heavy bank
+  // import. Only shown once the learner has a history.
+  const progress = computeProgressStats(progressAttempts);
 
   return (
     <section className="home-panel" aria-label={t.home}>
@@ -153,6 +159,38 @@ export function HomePanel({
             <small>{t.homeStatsChapters}</small>
           </div>
         </div>
+      ) : null}
+
+      {totalAttempts > 0 ? (
+        <section className="home-progress" aria-label={t.homeProgressLabel}>
+          <div className="home-stats-strip">
+            <div className="home-stats-cell">
+              <strong>{progress.streakDays}</strong>
+              <small>{t.homeStatsStreak}</small>
+            </div>
+            <div className="home-stats-cell">
+              <strong>{reviewCount}</strong>
+              <small>{t.homeStatsDue}</small>
+            </div>
+            <div className="home-stats-cell">
+              <strong>{progress.masteredCount}</strong>
+              <small>{t.homeStatsMastered}</small>
+            </div>
+          </div>
+
+          {progress.perLevel.length > 0 ? (
+            <div className="home-stats-strip" aria-label={t.homeLevelLabel}>
+              {progress.perLevel.map((stat) => (
+                <div className="home-stats-cell" key={stat.level}>
+                  <strong>{stat.accuracy}%</strong>
+                  <small>
+                    {stat.level}・{t.homeLevelAnswered(stat.answered)}
+                  </small>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </section>
       ) : null}
 
       <div className="home-grid">

--- a/src/domain/stats.test.ts
+++ b/src/domain/stats.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeProgressStats,
+  computeStreakDays,
+  levelFromQuestionId,
+  MASTERY_BOX
+} from "./stats";
+import type { Attempt } from "./types";
+
+const DAY = 86_400_000;
+// A clean day boundary + a few seconds, so "now" sits inside day index 100.
+const NOW = 100 * DAY + 5_000;
+
+function attempt(over: Partial<Attempt>): Attempt {
+  return {
+    questionId: "n1-grammar-x",
+    vocabularyId: "v",
+    targetForm: "reading",
+    prompt: "",
+    expectedAnswers: ["a"],
+    submittedAnswer: "a",
+    isCorrect: true,
+    timestamp: NOW,
+    responseTimeMs: 100,
+    ...over
+  };
+}
+
+describe("levelFromQuestionId", () => {
+  it("reads the JLPT level from the exam item id prefix", () => {
+    expect(levelFromQuestionId("n1-grammar-toaimatte")).toBe("N1");
+    expect(levelFromQuestionId("n3-vocab-hakkaku")).toBe("N3");
+    expect(levelFromQuestionId("n5-grammar-x")).toBe("N5");
+  });
+
+  it("returns null for non-exam ids and missing ids", () => {
+    expect(levelFromQuestionId("食べる:te")).toBeNull();
+    expect(levelFromQuestionId("")).toBeNull();
+    expect(levelFromQuestionId(undefined)).toBeNull();
+  });
+});
+
+describe("computeStreakDays", () => {
+  it("counts consecutive active days ending today", () => {
+    const attempts = [100, 99, 98].map((day) => attempt({ timestamp: day * DAY + 1_000 }));
+    expect(computeStreakDays(attempts, NOW)).toBe(3);
+  });
+
+  it("counts a streak that ends yesterday (today not yet active)", () => {
+    const attempts = [99, 98].map((day) => attempt({ timestamp: day * DAY + 1_000 }));
+    expect(computeStreakDays(attempts, NOW)).toBe(2);
+  });
+
+  it("stops at the first gap", () => {
+    const attempts = [100, 98].map((day) => attempt({ timestamp: day * DAY + 1_000 }));
+    expect(computeStreakDays(attempts, NOW)).toBe(1);
+  });
+
+  it("is 0 when the last activity is older than yesterday, or there is none", () => {
+    expect(computeStreakDays([attempt({ timestamp: 97 * DAY })], NOW)).toBe(0);
+    expect(computeStreakDays([], NOW)).toBe(0);
+  });
+});
+
+describe("computeProgressStats", () => {
+  it("aggregates overall and per-level accuracy from the id prefix", () => {
+    const attempts = [
+      attempt({ questionId: "n1-grammar-a", isCorrect: true }),
+      attempt({ questionId: "n1-grammar-b", isCorrect: false }),
+      attempt({ questionId: "n3-vocab-c", isCorrect: true })
+    ];
+    const stats = computeProgressStats(attempts, NOW);
+
+    expect(stats.totalAnswered).toBe(3);
+    expect(stats.totalCorrect).toBe(2);
+    expect(stats.overallAccuracy).toBe(67); // 2/3
+
+    const n1 = stats.perLevel.find((s) => s.level === "N1");
+    expect(n1).toEqual({ level: "N1", answered: 2, correct: 1, accuracy: 50 });
+    const n3 = stats.perLevel.find((s) => s.level === "N3");
+    expect(n3).toEqual({ level: "N3", answered: 1, correct: 1, accuracy: 100 });
+    // Levels with no attempts are omitted.
+    expect(stats.perLevel.some((s) => s.level === "N2")).toBe(false);
+  });
+
+  it("counts a missed-then-recovered item as mastered (SRS box >= threshold)", () => {
+    // First wrong seeds box 0; three corrects promote 0->1->2->3 (= MASTERY_BOX).
+    const id = "n2-grammar-bakarini";
+    const attempts = [
+      attempt({ questionId: id, isCorrect: false, timestamp: 90 * DAY }),
+      attempt({ questionId: id, isCorrect: true, timestamp: 91 * DAY }),
+      attempt({ questionId: id, isCorrect: true, timestamp: 95 * DAY }),
+      attempt({ questionId: id, isCorrect: true, timestamp: 99 * DAY })
+    ];
+    const stats = computeProgressStats(attempts, NOW);
+    expect(MASTERY_BOX).toBe(3);
+    expect(stats.masteredCount).toBe(1);
+    // Box 3 -> 7-day interval from the last (day 99) attempt -> not due yet at day 100.
+    expect(stats.dueCount).toBe(0);
+  });
+
+  it("counts a freshly-missed item as due", () => {
+    const attempts = [attempt({ questionId: "n1-grammar-z", isCorrect: false, timestamp: NOW })];
+    const stats = computeProgressStats(attempts, NOW);
+    expect(stats.dueCount).toBe(1);
+    expect(stats.masteredCount).toBe(0);
+  });
+
+  it("is all-zero for an empty history", () => {
+    const stats = computeProgressStats([], NOW);
+    expect(stats).toEqual({
+      totalAnswered: 0,
+      totalCorrect: 0,
+      overallAccuracy: 0,
+      perLevel: [],
+      masteredCount: 0,
+      dueCount: 0,
+      streakDays: 0
+    });
+  });
+});

--- a/src/domain/stats.ts
+++ b/src/domain/stats.ts
@@ -1,0 +1,102 @@
+// Progress / mastery aggregation for the home dashboard (issue #133).
+//
+// Everything here is derived from `attempts` + the SRS box state, both of
+// which are LIGHTWEIGHT (attempts are the learner's own history; srs.ts
+// replays them with no question-bank dependency). It deliberately imports
+// only srs + types -- NEVER the exam bank / vocabulary -- so the eager
+// home view can show progress without dragging examBlocks into the initial
+// bundle. Per-level is read from the exam item id prefix (n1-… → N1), so
+// no bank lookup is needed to know an attempt's JLPT level.
+import { computeReviewStates, countDueReviews } from "./srs";
+import type { Attempt, JlptLevel } from "./types";
+
+const MS_PER_DAY = 86_400_000;
+
+// "Mastered" = a previously-missed item drilled up to a high SRS box.
+// (Items answered correctly on the first try never enter the SRS queue, so
+// this measures recovered weak points rather than total knowledge.) Box 3
+// is the 7-day interval -- solidly remembered, not yet fully graduated.
+export const MASTERY_BOX = 3;
+
+const LEVELS: JlptLevel[] = ["N1", "N2", "N3", "N4", "N5"];
+
+export type LevelStat = {
+  level: JlptLevel;
+  answered: number;
+  correct: number;
+  accuracy: number;
+};
+
+export type ProgressStats = {
+  totalAnswered: number;
+  totalCorrect: number;
+  overallAccuracy: number;
+  perLevel: LevelStat[];
+  masteredCount: number;
+  dueCount: number;
+  streakDays: number;
+};
+
+/** JLPT level of an attempt from its exam item id prefix (n1-… → N1), or
+ *  null for non-exam items (basic drills / vocab) that carry no level. */
+export function levelFromQuestionId(questionId: string | undefined): JlptLevel | null {
+  if (!questionId) return null;
+  const match = /^n([1-5])-/.exec(questionId);
+  return match ? (`N${match[1]}` as JlptLevel) : null;
+}
+
+/** Consecutive calendar days (UTC buckets) with at least one attempt,
+ *  ending today or yesterday; 0 if the streak is broken or no attempts. */
+export function computeStreakDays(attempts: Attempt[], now: number = Date.now()): number {
+  if (attempts.length === 0) return 0;
+  const dayOf = (ts: number) => Math.floor(ts / MS_PER_DAY);
+  const activeDays = new Set(attempts.map((attempt) => dayOf(attempt.timestamp)));
+  const today = dayOf(now);
+  // A streak only counts if it reaches today or yesterday; otherwise it's
+  // been broken.
+  let cursor = activeDays.has(today) ? today : activeDays.has(today - 1) ? today - 1 : null;
+  if (cursor === null) return 0;
+  let streak = 0;
+  while (activeDays.has(cursor)) {
+    streak++;
+    cursor--;
+  }
+  return streak;
+}
+
+/** Aggregate the learner's progress: overall + per-level accuracy, mastered
+ *  count (SRS box ≥ threshold), due count, and the activity streak. Pure;
+ *  `now` is injectable for tests. */
+export function computeProgressStats(attempts: Attempt[], now: number = Date.now()): ProgressStats {
+  const totalAnswered = attempts.length;
+  const totalCorrect = attempts.filter((attempt) => attempt.isCorrect).length;
+  const overallAccuracy =
+    totalAnswered > 0 ? Math.round((totalCorrect / totalAnswered) * 100) : 0;
+
+  const perLevel = LEVELS.map((level) => {
+    const inLevel = attempts.filter((attempt) => levelFromQuestionId(attempt.questionId) === level);
+    const correct = inLevel.filter((attempt) => attempt.isCorrect).length;
+    return {
+      level,
+      answered: inLevel.length,
+      correct,
+      accuracy: inLevel.length > 0 ? Math.round((correct / inLevel.length) * 100) : 0
+    };
+  }).filter((stat) => stat.answered > 0);
+
+  const states = computeReviewStates(attempts);
+  let masteredCount = 0;
+  for (const state of states.values()) {
+    if (state.box >= MASTERY_BOX) masteredCount++;
+  }
+
+  return {
+    totalAnswered,
+    totalCorrect,
+    overallAccuracy,
+    perLevel,
+    masteredCount,
+    dueCount: countDueReviews(attempts, now),
+    streakDays: computeStreakDays(attempts, now)
+  };
+}

--- a/src/domain/stats.ts
+++ b/src/domain/stats.ts
@@ -7,7 +7,7 @@
 // home view can show progress without dragging examBlocks into the initial
 // bundle. Per-level is read from the exam item id prefix (n1-… → N1), so
 // no bank lookup is needed to know an attempt's JLPT level.
-import { computeReviewStates, countDueReviews } from "./srs";
+import { computeReviewStates } from "./srs";
 import type { Attempt, JlptLevel } from "./types";
 
 const MS_PER_DAY = 86_400_000;
@@ -84,10 +84,15 @@ export function computeProgressStats(attempts: Attempt[], now: number = Date.now
     };
   }).filter((stat) => stat.answered > 0);
 
+  // One SRS replay covers both mastered (box ≥ threshold) and due
+  // (dueAt ≤ now) -- same definition countDueReviews uses, without a
+  // second pass over the attempts.
   const states = computeReviewStates(attempts);
   let masteredCount = 0;
+  let dueCount = 0;
   for (const state of states.values()) {
     if (state.box >= MASTERY_BOX) masteredCount++;
+    if (state.dueAt <= now) dueCount++;
   }
 
   return {
@@ -96,7 +101,7 @@ export function computeProgressStats(attempts: Attempt[], now: number = Date.now
     overallAccuracy,
     perLevel,
     masteredCount,
-    dueCount: countDueReviews(attempts, now),
+    dueCount,
     streakDays: computeStreakDays(attempts, now)
   };
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -36,6 +36,12 @@ export type Copy = {
   homeStatsAttempts: string;
   homeStatsAccuracy: string;
   homeStatsChapters: string;
+  homeProgressLabel: string;
+  homeStatsStreak: string;
+  homeStatsDue: string;
+  homeStatsMastered: string;
+  homeLevelLabel: string;
+  homeLevelAnswered: (count: number) => string;
   homeCardLearnTitle: string;
   homeCardLearnSub: string;
   homeCardLearnMeta: (completed: number, total: number) => string;
@@ -221,6 +227,12 @@ export const copy: Record<Language, Copy> = {
     homeStatsAttempts: "累積已答",
     homeStatsAccuracy: "總正答率",
     homeStatsChapters: "完成章節",
+    homeProgressLabel: "學習進度",
+    homeStatsStreak: "連續天數",
+    homeStatsDue: "待複習",
+    homeStatsMastered: "已熟練",
+    homeLevelLabel: "各級正答率",
+    homeLevelAnswered: (count) => `${count} 題`,
     homeCardLearnTitle: "學習",
     homeCardLearnSub: "章節式變化與句型解說，先看規則再練。",
     homeCardLearnMeta: (completed, total) => `已完成 ${completed} / ${total} 章`,


### PR DESCRIPTION
## 摘要
首頁新增「學習進度」區塊：**連續天數(streak)、待複習數、已熟練數**，以及**各級正答率**。

## 資料來源（輕量、不碰題庫）
- 全部從 `attempts`(+ SRS box 狀態) 聚合；per-level 由 `questionId` 前綴（`n1-…`→N1）解析，無需題庫 lookup。
- `src/domain/stats.ts` 只 import `srs`（已 eager-safe，App 既用）。

## 內容
- `computeProgressStats` / `computeStreakDays` / `levelFromQuestionId`（+10 單元測試）。
- HomePanel 在有作答紀錄時顯示進度區塊（重用既有 stats-cell 樣式，數字優先、圖表後續）。

## 品質
- code-reviewer 過：bundle 隔離完整（examBlocks 仍 lazy、index 僅 +~2KB 輕量邏輯）、streak 邊界/level 解析/空 history 皆正確。依其意見將 `computeReviewStates` 收斂為單次 replay（mastered+due 一次算完）。
- test 261 passed、build 綠。

closes #133