### PR TITLE
feat(sync): 同步狀態說明文案，收尾跨裝置同步（closes #151）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,7 +46,9 @@ export default function App() {
   const { user, error: authError, signInWithGoogle, signOut } = useAuth();
   // `user` drives cross-device sync: on login the hook merges the remote
   // attempt history into the local store and pushes the local-only delta.
-  const { progressAttempts, recordAttempt } = useProgressAttempts(user);
+  // `syncStatus` feeds the honest auth hint below (never says "synced"
+  // until a login merge has actually completed -- #151).
+  const { progressAttempts, recordAttempt, syncStatus } = useProgressAttempts(user);
   // Lightweight, pool-free count for the home/learn review badge (see
   // countDueReviews). The full review queue -- which needs the question
   // pool to resolve due items -- is built inside the lazy challenge view.
@@ -102,20 +104,30 @@ export default function App() {
           {isSupabaseConfigured && (
             <div className="heading-auth">
               {user ? (
-                <>
+                <div className="heading-auth-row">
                   <span className="heading-user">{t.authSignedInAs(user.user_metadata.full_name ?? user.email ?? "")}</span>
                   <button type="button" className="auth-button" onClick={signOut}>
                     {t.authSignOut}
                   </button>
-                </>
+                </div>
               ) : (
                 <button type="button" className="auth-button" onClick={signInWithGoogle}>
                   {t.authSignIn}
                 </button>
               )}
-              {authError && (
+              {authError ? (
                 <span className="heading-auth-error" role="alert">
                   {authError}
+                </span>
+              ) : (
+                <span className="auth-hint">
+                  {!user
+                    ? t.authSignInHint
+                    : syncStatus === "error"
+                      ? t.authSyncErrorHint
+                      : syncStatus === "synced"
+                        ? t.authSyncedHint
+                        : t.authSyncingHint}
                 </span>
               )}
             </div>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -183,6 +183,10 @@ export type Copy = {
   authSignIn: string;
   authSignOut: string;
   authSignedInAs: (name: string) => string;
+  authSignInHint: string;
+  authSyncingHint: string;
+  authSyncedHint: string;
+  authSyncErrorHint: string;
   partOfSpeech: Record<PartOfSpeech | "mixed", string>;
   verbGroups: Record<VerbGroup | "all", string>;
   focusOptions: Record<"single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast", string>;
@@ -402,6 +406,10 @@ export const copy: Record<Language, Copy> = {
     authSignIn: "Google 登入",
     authSignOut: "登出",
     authSignedInAs: (name) => `${name}`,
+    authSignInHint: "登入後錯題與學習進度可跨裝置同步；不登入也能用，紀錄僅存於本機。",
+    authSyncingHint: "同步中…",
+    authSyncedHint: "錯題與學習進度已跨裝置同步。",
+    authSyncErrorHint: "同步失敗，本機紀錄仍在；下次登入會再試。",
     partOfSpeech: {
       verb: "動詞",
       i_adjective: "い形容詞",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -77,14 +77,31 @@
 }
 
 .heading-auth {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.heading-auth-row {
   align-items: center;
   display: flex;
   gap: 0.5rem;
 }
 
+.auth-hint {
+  color: var(--muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  max-width: 19rem;
+  text-align: right;
+}
+
 .heading-auth-error {
   color: var(--danger, #c0392b);
   font-size: 0.75rem;
+  max-width: 19rem;
+  text-align: right;
 }
 
 .view-switch {


### PR DESCRIPTION
## 摘要
P1/P2/P3 同步邏輯已於 [#184](https://github.com/nurockplayer/Jabiko/pull/184) 上線（attemptSync 合併／attemptRemote 上傳下載／useProgressAttempts 登入合併＋best-effort 上傳＋syncStatus）。**SQL 建表（#181）已由作者執行**，故本 PR 補上最後一塊讓 #151 端到端可用：把同步狀態說明文案接到登入區。

## 行為（誠實文案）
- 未登入：「登入後錯題與學習進度可跨裝置同步；不登入也能用，紀錄僅存於本機。」
- 登入：依 `syncStatus` → 同步中／**已同步**／同步失敗（本機仍在，下次再試）。
- ⚠「已同步」只在 `syncStatus === 'synced'`（登入合併真的完成）時出現——符合 issue「同步真能用前不得宣稱已同步」。

## 變更
- App.tsx：取 `syncStatus`，依登入＋狀態渲染 `.auth-hint`；名稱+登出包進 `.heading-auth-row`。
- i18n：authSignInHint / authSyncingHint / authSyncedHint / authSyncErrorHint。
- layout.css：heading-auth 改直向靠右、新增 .auth-hint。

## 品質
- test 261 綠、build 綠、tsc 通過；Supabase SDK 仍動態載入（initial bundle 不含）、examBlocks 仍 lazy。
- 端到端真實驗證（Google OAuth 雙裝置）由作者進行。

closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer authentication status messages, showing whether syncing is in progress, complete, or has an error.
  * Expanded translated text for sign-in and sync-related hints.

* **Style**
  * Improved the authentication header layout and spacing.
  * Refined helper and error text styling for better alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->