### PR TITLE
refactor(learning): 整理學習頁排版（分組左欄、縮標題、例詞網格自適應）

### DIFF
--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -49,6 +49,21 @@ export function LearningPanel({
   const activeCard = blockCards.find((card) => card.block.id === selectedBlockId) ?? recommended;
   const active = activeCard.block;
 
+  // Group chapters by category so the rail reads as a few labelled sections
+  // instead of one long flat list where every card repeats a coloured kicker
+  // tag. First-seen category order is preserved.
+  const groupOrder: string[] = [];
+  const groupMap = new Map<string, typeof blockCards>();
+  for (const card of blockCards) {
+    const category = card.block.category;
+    if (!groupMap.has(category)) {
+      groupMap.set(category, []);
+      groupOrder.push(category);
+    }
+    groupMap.get(category)!.push(card);
+  }
+  const chapterGroups = groupOrder.map((category) => ({ category, cards: groupMap.get(category)! }));
+
   // Resolve the drill button label from the i18n copy table. The schema
   // stores a plain string key so new drill labels don't require schema
   // updates.
@@ -110,29 +125,39 @@ export function LearningPanel({
           </div>
 
           <div className="chapter-list">
-            {blockCards.map(({ block, complete, incompletePrereqs }) => (
-              <button
-                key={block.id}
-                type="button"
-                className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
-                aria-label={`查看：${block.title}`}
-                aria-pressed={block.id === active.id}
-                onClick={() => setSelectedBlockId(block.id)}
-              >
-                <span>
-                  {block.completionMode === "reference"
+            {chapterGroups.map(({ category, cards }) => (
+              <div className="chapter-group" key={category}>
+                <p className="chapter-group-title">{category}</p>
+                {cards.map(({ block, complete, incompletePrereqs }) => {
+                  // Card no longer carries the category kicker (the group
+                  // header owns it); keep only a status marker when relevant.
+                  // Reference chapters always read "參考" (they're material,
+                  // not drillable), even once their prereqs are done.
+                  const status = block.completionMode === "reference"
                     ? "參考"
                     : complete
                     ? "完成"
-                    : block.kicker ?? block.category}
-                </span>
-                <strong>{block.title}</strong>
-                <small>
-                  {incompletePrereqs.length > 0
-                    ? `建議先看：${incompletePrereqs.map(blockTitleById).join("、")}`
-                    : block.subtitle}
-                </small>
-              </button>
+                    : null;
+                  return (
+                    <button
+                      key={block.id}
+                      type="button"
+                      className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
+                      aria-label={`查看：${block.title}`}
+                      aria-pressed={block.id === active.id}
+                      onClick={() => setSelectedBlockId(block.id)}
+                    >
+                      {status ? <span>{status}</span> : null}
+                      <strong>{block.title}</strong>
+                      <small>
+                        {incompletePrereqs.length > 0
+                          ? `建議先看：${incompletePrereqs.map(blockTitleById).join("、")}`
+                          : block.subtitle}
+                      </small>
+                    </button>
+                  );
+                })}
+              </div>
             ))}
           </div>
 

--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -46,7 +46,24 @@
 .chapter-list {
   align-content: start;
   display: grid;
-  gap: 0.6rem;
+  gap: 1.15rem;
+}
+
+/* Chapters grouped by category: a quiet section label, then the cards. The
+ * card-level kicker tag is dropped (the header carries the category), so
+ * the rail reads as a few sections instead of one long flat list. */
+.chapter-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.chapter-group-title {
+  color: var(--muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding-left: 0.1rem;
 }
 
 .chapter-list-button {
@@ -106,8 +123,12 @@
 .chapter-content-head h3 {
   color: var(--ink);
   font-family: var(--font-japanese-display);
-  font-size: clamp(2.1rem, 5vw, 4.2rem);
-  line-height: 1.05;
+  /* Was clamp(2.1rem, 5vw, 4.2rem) -- the 4.2rem cap turned short chapter
+   * titles into oversized billboards with a void beneath, and wrapped long
+   * sentence-style titles into giant multi-line blocks. Keep the display
+   * font, dial the size down to a heading. */
+  font-size: clamp(1.7rem, 3vw, 2.5rem);
+  line-height: 1.1;
 }
 
 .chapter-actions {
@@ -520,7 +541,12 @@
 .pipeline-grid {
   display: grid;
   gap: 0.75rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  /* Was a fixed 4-column grid: with variable-height cards (some carry a
+   * note, some don't) and an example count that isn't a multiple of 4, it
+   * left ragged rows + a half-empty trailing row. Auto-fill reflows by
+   * width and items stretch to an even row height. */
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  align-items: stretch;
 }
 
 .pipeline-card code {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -24,8 +24,14 @@
     padding: 0 0 1rem;
   }
 
-  .chapter-list {
+  /* Chapters are grouped now: keep the groups stacked, but lay each
+   * group's cards out 2-up with its title spanning the row. */
+  .chapter-group {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chapter-group-title {
+    grid-column: 1 / -1;
   }
 
   .learning-hero {


### PR DESCRIPTION
## 摘要
學習頁（LearningPanel）排版整理——保留原本的調性（日文 display 大標、柔色卡片），把「酷但有點亂」收乾淨。

## 改動
- **左欄章節按 category 分組**：加小節標題（形容詞/名詞 修飾、動詞變化、句型…），卡片**移除每張的 kicker eyebrow**、只保留「完成／參考」狀態 → 一長條平鋪變成幾個可掃的小節。
- **右欄標題** font-size 由 `clamp(2.1rem, 5vw, 4.2rem)` 改 `clamp(1.7rem, 3vw, 2.5rem)`：消除短標題下的巨型空洞、長標題不再洗版（保留日文 display 字體）。
- **例詞網格** 由寫死 `repeat(4, minmax(0,1fr))` 改 `repeat(auto-fill, minmax(170px, 1fr))` + 等高：去除參差與殘列空白。
- 行動版連帶：分組卡片改組內 2 欄、小節標題跨欄。

## 驗證
- reference 章節「參考」優先邏輯保留；test 261 綠、build 綠、initial bundle 不變（examBlocks 仍 lazy）。
- 實機重截學習頁確認三處都收乾淨。

動到：`src/components/LearningPanel.tsx`、`src/styles/learning.css`、`src/styles/responsive.css`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Learning content is now organized into labeled category sections for easier browsing.
  * Chapter navigation now uses a more responsive layout, improving how cards flow across screen sizes.

* **UI Improvements**
  * Card labels now show only completion or reference status, reducing visual clutter.
  * Section headings and spacing were refined for clearer hierarchy and readability.
  * Pipeline example cards now resize more naturally and align evenly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->