### PR TITLE
Make attempts table GRANT explicit (#151)

### DIFF
--- a/supabase/migrations/0001_create_attempts.sql
+++ b/supabase/migrations/0001_create_attempts.sql
@@ -50,3 +50,13 @@ create policy "attempts_insert_own" on public.attempts
 drop policy if exists "attempts_delete_own" on public.attempts;
 create policy "attempts_delete_own" on public.attempts
   for delete using (auth.uid() = user_id);
+
+-- Table-level privileges, made explicit. RLS policies above decide WHICH rows
+-- a role may touch, but PostgreSQL first checks the role holds the privilege at
+-- all; without it a query returns 42501 "permission denied for table attempts"
+-- regardless of RLS. On Supabase the `authenticated` role usually inherits this
+-- via the project's default privileges, but relying on that makes the migration
+-- non-self-contained: a fresh DB (or `supabase db reset`) without those defaults
+-- would deny logged-in users. Grant exactly the CRUD the policies scope to own
+-- rows. `anon` is intentionally NOT granted: only logged-in users sync.
+grant select, insert, delete on public.attempts to authenticated;


### PR DESCRIPTION
## What

Append an explicit `grant select, insert, delete on public.attempts to authenticated;` to the #151 sync migration (`supabase/migrations/0001_create_attempts.sql`).

## Why

The migration created the table, enabled RLS, and added own-row select/insert/delete policies — but left the **table-level** grant to Supabase's implicit default privileges. RLS gates *which rows* a role sees; PostgreSQL checks the privilege *first*. Relying on the implicit default makes the migration non-self-contained: a fresh DB or `supabase db reset` outside Supabase's default-privileges setup would deny logged-in users with `42501 permission denied`.

`anon` is intentionally left ungranted — only authenticated users sync.

## Verified live (prod)

- `information_schema.role_table_grants`: `authenticated` holds `SELECT/INSERT/DELETE`; `anon` does **not**.
- Prod client (jabiko.pages.dev) shows **錯題與學習進度已跨裝置同步**, and `public.attempts` holds **1065 rows / 1 user** — exactly matching the user's local 累積已答. End-to-end sync confirmed.

Idempotent; safe to re-run. No code change, no new keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access settings so signed-in users can read, add, and remove their own attempt records as expected, while keeping data restricted to each user’s rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->