### PR TITLE
feat: 全站可選難度 — fresh 池吃目標級別偏好 (Closes #199)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import { isSupabaseConfigured } from "./lib/supabase";
 import { useAuth } from "./hooks/useAuth";
 import { useProgressAttempts } from "./hooks/useProgressAttempts";
 import type { SessionInit } from "./hooks/usePracticeSession";
+import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
+import type { LevelRange } from "./domain/levelRange";
 import "./styles.css";
 
 // Lazy routes. The challenge view owns the practice engine, which
@@ -63,6 +65,14 @@ export default function App() {
   // basic drill. Read once when ChallengePanel mounts (it owns the
   // session), so changing it while already in the challenge is a no-op.
   const [launch, setLaunch] = useState<SessionInit | undefined>(undefined);
+  // Global target-level preference (#199), read once at startup. Seeds the
+  // fresh-pool level range (今日練習 / 綜合 / 単字) and drives the first-run
+  // onboarding card; the home card persists it.
+  const [targetLevel, setTargetLevel] = useState<LevelRange | null>(() => readLevelPreference());
+  const handleChooseLevel = (range: LevelRange) => {
+    writeLevelPreference(range);
+    setTargetLevel(range);
+  };
 
   const themeToggleLabel = theme === "dark" ? t.themeLight : t.themeDark;
   const ThemeIcon = theme === "dark" ? Sun : Moon;
@@ -209,6 +219,8 @@ export default function App() {
           onStartReview={() => openChallenge({ mode: "review" })}
           onStartVocab={() => openChallenge({ mode: "vocab" })}
           onStartDaily={() => openChallenge({ mode: "daily" })}
+          targetLevel={targetLevel}
+          onChooseLevel={handleChooseLevel}
         />
       ) : appView === "learn" ? (
         <LearningPanel
@@ -242,6 +254,7 @@ export default function App() {
             progressAttempts={progressAttempts}
             recordAttempt={recordAttempt}
             language={language}
+            targetLevel={targetLevel}
             onExit={() => setAppView("home")}
           />
         </Suspense>

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -1,5 +1,6 @@
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
+import type { LevelRange } from "../domain/levelRange";
 import { usePracticeSession, type SessionInit } from "../hooks/usePracticeSession";
 import { ModePicker } from "./challenge/ModePicker";
 import { DrillPanel } from "./challenge/DrillPanel";
@@ -23,16 +24,20 @@ export function ChallengePanel({
   progressAttempts,
   recordAttempt,
   language,
+  targetLevel = null,
   onExit
 }: {
   init?: SessionInit;
   progressAttempts: Attempt[];
   recordAttempt: (attempt: Attempt) => void;
   language: Language;
+  // The learner's global target-level preference (#199), forwarded to the
+  // session hook to seed the daily / 綜合 / 単字 level range.
+  targetLevel?: LevelRange | null;
   onExit: () => void;
 }) {
   const t = copy[language];
-  const session = usePracticeSession({ language, init, progressAttempts, recordAttempt });
+  const session = usePracticeSession({ language, init, progressAttempts, recordAttempt, targetLevel });
 
   return (
     <section className="practice-layout" aria-label="Jabiko practice">

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HomePanel } from "./HomePanel";
+import type { Attempt } from "../domain/types";
+
+const noop = () => {};
+
+const sampleAttempt: Attempt = {
+  vocabularyId: "seed",
+  targetForm: "reading",
+  prompt: "seed",
+  expectedAnswers: ["seed"],
+  submittedAnswer: "seed",
+  isCorrect: true,
+  timestamp: 1,
+  responseTimeMs: 100
+};
+
+function renderHome(overrides: Partial<Parameters<typeof HomePanel>[0]> = {}) {
+  const props = {
+    language: "zh-Hant" as const,
+    progressAttempts: [] as Attempt[],
+    reviewCount: 0,
+    onNavigate: noop,
+    onStartReview: noop,
+    onStartVocab: noop,
+    onStartDaily: noop,
+    targetLevel: null,
+    onChooseLevel: vi.fn(),
+    ...overrides
+  };
+  render(<HomePanel {...props} />);
+  return props;
+}
+
+describe("HomePanel level onboarding (#199)", () => {
+  it("shows the choose-your-level card for a brand-new learner (no pref, no attempts)", () => {
+    renderHome();
+    expect(screen.getByText("選擇你的程度")).toBeInTheDocument();
+  });
+
+  it("choosing 初級 calls onChooseLevel with the n4n5 band", () => {
+    const props = renderHome();
+    fireEvent.click(screen.getByRole("button", { name: /初級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n4n5");
+  });
+
+  it("maps 中級 -> n2n3 and 高級 -> n1n2", () => {
+    const props = renderHome();
+    fireEvent.click(screen.getByRole("button", { name: /中級/ }));
+    fireEvent.click(screen.getByRole("button", { name: /高級/ }));
+    expect(props.onChooseLevel).toHaveBeenNthCalledWith(1, "n2n3");
+    expect(props.onChooseLevel).toHaveBeenNthCalledWith(2, "n1n2");
+  });
+
+  it("hides the card once a preference exists", () => {
+    renderHome({ targetLevel: "n2n3" });
+    expect(screen.queryByText("選擇你的程度")).not.toBeInTheDocument();
+  });
+
+  it("hides the card for a returning learner with attempts (even without a preference)", () => {
+    renderHome({ progressAttempts: [sampleAttempt] });
+    expect(screen.queryByText("選擇你的程度")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, ArrowRight, BookOpen, CalendarCheck } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
+import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
@@ -37,7 +38,9 @@ export function HomePanel({
   onNavigate,
   onStartReview,
   onStartVocab,
-  onStartDaily
+  onStartDaily,
+  targetLevel,
+  onChooseLevel
 }: {
   language: Language;
   progressAttempts: Attempt[];
@@ -46,8 +49,24 @@ export function HomePanel({
   onStartReview: () => void;
   onStartVocab: () => void;
   onStartDaily: () => void;
+  // Global target-level preference (#199): null = not chosen yet. Drives the
+  // first-run onboarding card; selecting a band persists it via onChooseLevel.
+  targetLevel: LevelRange | null;
+  onChooseLevel: (range: LevelRange) => void;
 }) {
   const t = copy[language];
+
+  // First-run "choose your level" card: only for a brand-new learner -- no
+  // saved preference AND no answer history -- so it's a one-time nudge, never
+  // shown to returning learners. Selecting a band stores it and the card
+  // disappears (targetLevel becomes non-null). 初級/中級/高級 map to the
+  // existing LevelRange bands (n4n5 / n2n3 / n1n2); easy → hard order.
+  const showLevelOnboarding = targetLevel === null && progressAttempts.length === 0;
+  const onboardingOptions: { range: LevelRange; label: string; hint: string }[] = [
+    { range: "n4n5", label: t.levelOnboarding.beginner, hint: t.levelOnboarding.beginnerHint },
+    { range: "n2n3", label: t.levelOnboarding.intermediate, hint: t.levelOnboarding.intermediateHint },
+    { range: "n1n2", label: t.levelOnboarding.advanced, hint: t.levelOnboarding.advancedHint }
+  ];
 
   const totalAttempts = progressAttempts.length;
   const correctAttempts = progressAttempts.filter((attempt) => attempt.isCorrect).length;
@@ -75,6 +94,28 @@ export function HomePanel({
 
   return (
     <section className="home-panel" aria-label={t.home}>
+      {showLevelOnboarding ? (
+        <div className="home-level-card" role="group" aria-label={t.levelOnboarding.title}>
+          <div className="home-level-card-copy">
+            <strong>{t.levelOnboarding.title}</strong>
+            <small>{t.levelOnboarding.subtitle}</small>
+          </div>
+          <div className="home-level-card-options">
+            {onboardingOptions.map((option) => (
+              <button
+                key={option.range}
+                type="button"
+                className="home-level-option"
+                onClick={() => onChooseLevel(option.range)}
+              >
+                <strong>{option.label}</strong>
+                <small>{option.hint}</small>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <header className="home-hero">
         {/* Decorative hero -- the heading below carries the actual
             message, so alt is intentionally empty (avoids the screen

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -140,7 +140,7 @@ export function ModePicker({
                 type="button"
                 className={`mode-card${selected ? " selected" : ""}`}
                 aria-pressed={selected}
-                onClick={() => applyModePreset(preset.mode, preset.levelRange ?? "all")}
+                onClick={() => applyModePreset(preset.mode, preset.levelRange)}
               >
                 <strong>{t.modeOptions[preset.id].title}</strong>
                 <small>{t.modeOptions[preset.id].subtitle}</small>

--- a/src/domain/levelPreference.test.ts
+++ b/src/domain/levelPreference.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readLevelPreference, writeLevelPreference } from "./levelPreference";
+
+const KEY = "jabiko:targetLevel";
+
+describe("levelPreference", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("returns null when nothing has been chosen", () => {
+    expect(readLevelPreference()).toBeNull();
+  });
+
+  it("reads a stored valid range", () => {
+    localStorage.setItem(KEY, "n2n3");
+    expect(readLevelPreference()).toBe("n2n3");
+  });
+
+  it("treats an invalid stored value as null (no preference)", () => {
+    localStorage.setItem(KEY, "definitely-not-a-range");
+    expect(readLevelPreference()).toBeNull();
+  });
+
+  it("round-trips every valid LevelRange through write -> read", () => {
+    for (const range of ["n4n5", "n2n3", "n1n2", "all"] as const) {
+      writeLevelPreference(range);
+      expect(readLevelPreference()).toBe(range);
+    }
+  });
+
+  it("persists the latest choice (overwrite)", () => {
+    writeLevelPreference("n1n2");
+    writeLevelPreference("n4n5");
+    expect(readLevelPreference()).toBe("n4n5");
+  });
+});

--- a/src/domain/levelPreference.ts
+++ b/src/domain/levelPreference.ts
@@ -1,0 +1,39 @@
+import { LEVEL_RANGE_OPTIONS, type LevelRange } from "./levelRange";
+
+// The learner's single global "target level" preference (#199), chosen once
+// (e.g. the first-run home card) and applied as the DEFAULT level range for
+// every fresh pool (今日練習 / 単字 / 綜合考題庫). Stored locally only -- v1
+// does not sync it (Supabase #151 syncs attempts only).
+//
+// Deliberately tiny and dependency-light: it imports ONLY the LevelRange
+// type + the options constant from levelRange.ts (no question banks), so the
+// eager HomePanel can read it without dragging heavy data into the initial
+// bundle (see [[jabiko-bundle-codesplit]]). Crash-safe like safeStorage:
+// any storage failure or unrecognised value reads back as null (= "not
+// chosen yet"), so a blocked storage costs persistence, not the app.
+const TARGET_LEVEL_KEY = "jabiko:targetLevel";
+
+function isLevelRange(value: string | null): value is LevelRange {
+  return value !== null && (LEVEL_RANGE_OPTIONS as readonly string[]).includes(value);
+}
+
+// The stored target level, or null when the learner hasn't chosen one (or
+// storage is unavailable / holds a stale invalid value).
+export function readLevelPreference(): LevelRange | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const raw = window.localStorage.getItem(TARGET_LEVEL_KEY);
+    return isLevelRange(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLevelPreference(range: LevelRange): void {
+  try {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(TARGET_LEVEL_KEY, range);
+  } catch {
+    // Persistence unavailable -- ignore so the caller still works.
+  }
+}

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -181,6 +181,14 @@ describe("buildPracticeQuestions", () => {
     ).toBe(true);
   });
 
+  it("vocab mode (n4n5 has no JLPT vocab): falls back to a non-empty reading pool (#199)", () => {
+    // 単字 only has N1/N2 jlpt entries. A global n4n5 preference must not
+    // empty the 単字 pool -- it falls back to the full reading deck.
+    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "n4n5" }));
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.targetForm === "reading")).toBe(true);
+  });
+
   it("vocab mode (range all): keeps the whole JLPT vocab reading pool", () => {
     const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "all" }));
     const expected = buildQuestionPool(jlptVocabulary, {
@@ -202,6 +210,16 @@ describe("buildPracticeQuestions", () => {
     const dueIds = new Set(due.map((q) => q.id));
     const leading = questions.slice(0, due.length);
     expect(leading.every((q) => dueIds.has(q.id))).toBe(true);
+  });
+
+  it("daily mode: threads the level range into the composed set (n4n5 -> N4/N5) (#199)", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({ isDailyFocus: true, reviewQueue: [], levelRange: "n4n5" })
+    );
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.every((q) => q.vocabulary.level === "N4" || q.vocabulary.level === "N5")
+    ).toBe(true);
   });
 });
 
@@ -245,6 +263,43 @@ describe("composeDailySet", () => {
     // With an empty due queue the set is entirely fresh and reserves at
     // least one vocab reading item (DAILY_VOCAB_MIN floor).
     expect(set.some((q) => q.targetForm === "reading")).toBe(true);
+  });
+
+  it("targets the chosen band: n1n2 yields N1/N2 fresh items only (#199)", () => {
+    const set = composeDailySet([], "n1n2");
+    expect(set.length).toBeGreaterThan(0);
+    expect(set.every((q) => q.vocabulary.level === "N1" || q.vocabulary.level === "N2")).toBe(true);
+  });
+
+  it("targets the chosen band: n2n3 narrows to N2/N3 and still reserves a vocab item (#199)", () => {
+    const set = composeDailySet([], "n2n3");
+    expect(set.length).toBeGreaterThan(0);
+    expect(set.every((q) => q.vocabulary.level === "N2" || q.vocabulary.level === "N3")).toBe(true);
+    // jlptVocabulary has N2 entries, so the reserved vocab reading slot fills
+    // (a non-exam_style item -- exam items also carry targetForm "reading").
+    expect(set.some((q) => !q.vocabulary.tags?.includes("exam_style"))).toBe(true);
+  });
+
+  it("初級 n4n5: jlptVocabulary has no N4/N5, so the set fills entirely with N4/N5 exam (no vocab gap) (#199)", () => {
+    const set = composeDailySet([], "n4n5");
+    expect(set.length).toBeGreaterThan(0);
+    expect(set.every((q) => q.vocabulary.level === "N4" || q.vocabulary.level === "N5")).toBe(true);
+    // The empty vocab slots roll into N4/N5 exam (which carry their own 4
+    // baked options), so EVERY item is exam_style -- no short-option 漢字読み.
+    expect(set.every((q) => q.vocabulary.tags?.includes("exam_style"))).toBe(true);
+  });
+
+  it("defaults to the prior all-levels behaviour when no range is passed (#199)", () => {
+    // No range arg == "all" == the old N1/N2-focused default, so an
+    // existing learner with no preference is unaffected. (Both random
+    // sets reserve a vocab reading item and are not band-restricted.)
+    const set = composeDailySet([]);
+    expect(set.some((q) => q.targetForm === "reading")).toBe(true);
+    // "all" is not narrowed to a single band: N1 items are eligible.
+    const everN1 = Array.from({ length: 5 }, () => composeDailySet([])).some((s) =>
+      s.some((q) => q.vocabulary.level === "N1")
+    );
+    expect(everN1).toBe(true);
   });
 });
 

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -46,7 +46,10 @@ const DAILY_VOCAB_MIN = Math.floor(DAILY_TARGET / 4);
 // completion screen, same as review mode. v1 is an even mix; weighting
 // toward the learner's weak sections is a follow-up (needs attempt
 // metadata).
-export function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
+export function composeDailySet(
+  due: PracticeQuestion[],
+  range: LevelRange = "all"
+): PracticeQuestion[] {
   const dueTake = due.slice(0, Math.ceil(DAILY_TARGET / 2));
   // Exclude EVERY due item from the fresh pools -- not just the capped
   // slice -- so an over-cap due item can't slip back in mislabelled as a
@@ -55,14 +58,27 @@ export function composeDailySet(due: PracticeQuestion[]): PracticeQuestion[] {
   const isFresh = (question: PracticeQuestion) => !dueIds.has(question.id);
   const freshSlots = DAILY_TARGET - dueTake.length;
 
+  // Narrow the fresh pools to the learner's target band (#199). `null`
+  // (range "all") keeps each bank's own default mix -- the prior behaviour,
+  // so a learner with no preference is unaffected.
+  const levels = levelsForRange(range);
+  const vocabSource = levels
+    ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
+    : jlptVocabulary;
+
   const vocabFresh = shuffleQuestions(
-    buildQuestionPool(jlptVocabulary, {
+    buildQuestionPool(vocabSource, {
       partOfSpeech: "mixed",
       verbGroup: "all",
       targetForms: ["reading"]
     }).filter(isFresh)
   ).slice(0, Math.min(DAILY_VOCAB_MIN, freshSlots));
-  const examFresh = shuffleQuestions(buildExamQuestionPool().filter(isFresh)).slice(
+  // 初級 (n4n5) hole: jlptVocabulary is N1/N2 only, so vocabSource is empty
+  // there -> vocabFresh is empty and its reserved slots roll into exam. Exam
+  // items each carry their own 4 baked options, so the band still fills a full
+  // set with no short-option 漢字読み. DAILY_VOCAB_MIN keeps its "reserve a
+  // vocab floor" meaning only where vocab actually exists.
+  const examFresh = shuffleQuestions(buildExamQuestionPool(levels ?? "all").filter(isFresh)).slice(
     0,
     freshSlots - vocabFresh.length
   );
@@ -228,9 +244,14 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
     // 詞彙用法 sections -- which is the authentic way to test it.
     const levels = levelsForRange(levelRange);
-    const vocabSource = levels
+    const narrowed = levels
       ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
       : jlptVocabulary;
+    // 単字 only has N1/N2 jlpt entries (VOCAB_LEVEL_RANGE_OPTIONS excludes
+    // n4n5 for this reason). A global n4n5 preference would narrow this to an
+    // empty pool, so fall back to the full reading deck rather than show an
+    // empty 単字 session (#199).
+    const vocabSource = narrowed.length > 0 ? narrowed : jlptVocabulary;
     const vocabPool = shuffleQuestions(
       buildQuestionPool(vocabSource, {
         partOfSpeech: "mixed",
@@ -252,8 +273,9 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
 
   if (isDailyFocus) {
     // Snapshot the current due queue at session start (same as review
-    // mode); the live reviewQueue stays excluded from the deps below.
-    return composeDailySet(reviewQueue);
+    // mode); the live reviewQueue stays excluded from the deps below. The
+    // fresh portion is narrowed to the learner's target band (#199).
+    return composeDailySet(reviewQueue, levelRange);
   }
 
   return cap(

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -1,5 +1,44 @@
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { initialLevelRange } from "./usePracticeSession";
+import { initialLevelRange, usePracticeSession } from "./usePracticeSession";
+
+const baseHookArgs = {
+  language: "zh-Hant" as const,
+  progressAttempts: [],
+  recordAttempt: () => {}
+};
+
+// applyModePreset must keep honouring the global target preference when a
+// mode is picked from the in-session picker -- not only on first mount.
+// Modes with no explicit range (daily / 単字 / basic …) inherit the
+// preference; the exam 備考 cards still pass an explicit range that wins.
+describe("usePracticeSession applyModePreset preference (#199)", () => {
+  it("re-selecting 今日練習 in the picker keeps the global preference (not reset to 'all')", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({ ...baseHookArgs, init: { mode: "daily" }, targetLevel: "n4n5" })
+    );
+    expect(result.current.levelRange).toBe("n4n5");
+    act(() => result.current.applyModePreset("basic"));
+    act(() => result.current.applyModePreset("daily"));
+    expect(result.current.levelRange).toBe("n4n5");
+  });
+
+  it("clamps the preference for 単字 when re-selected (n4n5 has no jlpt vocab -> all)", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({ ...baseHookArgs, init: { mode: "basic" }, targetLevel: "n4n5" })
+    );
+    act(() => result.current.applyModePreset("vocab"));
+    expect(result.current.levelRange).toBe("all");
+  });
+
+  it("an explicit exam range (備考 cards) still overrides the preference", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({ ...baseHookArgs, init: { mode: "basic" }, targetLevel: "n4n5" })
+    );
+    act(() => result.current.applyModePreset("exam", "n1n2"));
+    expect(result.current.levelRange).toBe("n1n2");
+  });
+});
 
 // The pure seed logic for a session's starting level range (#199): an
 // explicit launch request wins; otherwise the global target preference,

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { initialLevelRange } from "./usePracticeSession";
+
+// The pure seed logic for a session's starting level range (#199): an
+// explicit launch request wins; otherwise the global target preference,
+// clamped so 単字 never starts on a band its picker can't show.
+describe("initialLevelRange (#199)", () => {
+  it("uses an explicit init.levelRange over the global preference", () => {
+    expect(initialLevelRange({ mode: "exam", levelRange: "n1n2" }, "n4n5")).toBe("n1n2");
+  });
+
+  it("falls back to the global target preference when init has none", () => {
+    expect(initialLevelRange({ mode: "daily" }, "n4n5")).toBe("n4n5");
+    expect(initialLevelRange({ mode: "exam" }, "n2n3")).toBe("n2n3");
+  });
+
+  it("defaults to 'all' when there is no preference", () => {
+    expect(initialLevelRange(undefined, null)).toBe("all");
+    expect(initialLevelRange({ mode: "daily" }, null)).toBe("all");
+  });
+
+  it("clamps an n4n5 preference to 'all' for 単字 mode (no n4n5 jlpt vocab)", () => {
+    expect(initialLevelRange({ mode: "vocab" }, "n4n5")).toBe("all");
+  });
+
+  it("keeps a vocab-valid preference for 単字 mode", () => {
+    expect(initialLevelRange({ mode: "vocab" }, "n2n3")).toBe("n2n3");
+    expect(initialLevelRange({ mode: "vocab" }, "n1n2")).toBe("n1n2");
+  });
+});

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ADJECTIVE_FORMS, VERB_FORMS } from "../domain/conjugation";
-import { type LevelRange } from "../domain/levelRange";
+import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../domain/levelRange";
 import type { MockExamLevel } from "../domain/mockExam";
 import { type SentencePatternId } from "../domain/sentencePatterns";
 import {
@@ -63,6 +63,25 @@ export type SessionInit = {
   levelRange?: LevelRange;
 };
 
+// The level range a session starts in (#199). An explicit launch request
+// (init.levelRange) always wins; otherwise it inherits the learner's global
+// target preference. 単字 has no n4n5 jlpt vocab, so an n4n5 preference is
+// clamped to "all" for that mode -- its picker can't show n4n5 and the pool
+// would be empty (the composeDailySet / vocab-branch fallbacks cover the
+// data side; this keeps the picker selection valid). Pure so it can be
+// unit-tested without mounting the hook.
+export function initialLevelRange(
+  init: SessionInit | undefined,
+  targetLevel: LevelRange | null
+): LevelRange {
+  if (init?.levelRange) return init.levelRange;
+  const preferred = targetLevel ?? "all";
+  if (init?.mode === "vocab" && !VOCAB_LEVEL_RANGE_OPTIONS.includes(preferred)) {
+    return "all";
+  }
+  return preferred;
+}
+
 const focusOptions: Array<{ value: PracticeFocus; targetForms: TargetForm[]; verbOnly?: boolean }> = [
   { value: "single", targetForms: [] },
   { value: "teTa", targetForms: ["te", "ta"], verbOnly: true },
@@ -101,12 +120,17 @@ export function usePracticeSession({
   language,
   init,
   progressAttempts,
-  recordAttempt
+  recordAttempt,
+  targetLevel = null
 }: {
   language: Language;
   init?: SessionInit;
   progressAttempts: Attempt[];
   recordAttempt: (attempt: Attempt) => void;
+  // The learner's global target-level preference (#199). Seeds the level
+  // range for the daily / 綜合 / 単字 pools when the launch request doesn't
+  // pin one; a per-session picker change still overrides it.
+  targetLevel?: LevelRange | null;
 }) {
   const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | "mixed">(init?.partOfSpeech ?? "verb");
   const [verbGroup, setVerbGroup] = useState<VerbGroup | "all">(init?.verbGroup ?? "godan");
@@ -114,7 +138,7 @@ export function usePracticeSession({
   const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>(init?.practiceFocus ?? "single");
   const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "basic");
   const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>(init?.filter ?? {});
-  const [levelRange, setLevelRange] = useState<LevelRange>(init?.levelRange ?? "all");
+  const [levelRange, setLevelRange] = useState<LevelRange>(() => initialLevelRange(init, targetLevel));
   const [sessionLength, setSessionLength] = useState<number | null>(() => readSessionLength());
   const [questionIndex, setQuestionIndex] = useState(0);
   const [sessionSeed, setSessionSeed] = useState(0);

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -332,10 +332,14 @@ export function usePracticeSession({
   // level range at once. Non-exam presets pass "all" (a no-op for the
   // modes that ignore levelRange). Clearing the filter keeps the picker a
   // "fresh mix" (a chapter drill button is what sets a patternIds filter).
-  const applyModePreset = (nextMode: PracticeMode, nextRange: LevelRange = "all") => {
-    if (nextMode === practiceMode && nextRange === levelRange) return;
+  const applyModePreset = (nextMode: PracticeMode, nextRange?: LevelRange) => {
+    // An explicit range (the exam 綜合 / 備考 cards) wins; otherwise inherit
+    // the global target preference, so daily / 単字 keep honouring it when
+    // re-picked from the in-session picker -- not only on first mount (#199).
+    const resolvedRange = nextRange ?? initialLevelRange({ mode: nextMode }, targetLevel);
+    if (nextMode === practiceMode && resolvedRange === levelRange) return;
     setPracticeMode(nextMode);
-    setLevelRange(nextRange);
+    setLevelRange(resolvedRange);
     setPracticeFilter({});
     resetSession();
   };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -118,6 +118,16 @@ export type Copy = {
   practiceMode: string;
   levelRange: string;
   levelRangeOptions: { all: string; n1n2: string; n2n3: string; n4n5: string };
+  levelOnboarding: {
+    title: string;
+    subtitle: string;
+    beginner: string;
+    beginnerHint: string;
+    intermediate: string;
+    intermediateHint: string;
+    advanced: string;
+    advancedHint: string;
+  };
   sessionLength: string;
   sessionLengthAll: string;
   practiceFocus: string;
@@ -330,6 +340,16 @@ export const copy: Record<Language, Copy> = {
     practiceMode: "練習模式",
     levelRange: "題庫範圍",
     levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n4n5: "N4＋N5" },
+    levelOnboarding: {
+      title: "選擇你的程度",
+      subtitle: "設定今日練習與各題庫的預設難度，之後隨時可改。",
+      beginner: "初級",
+      beginnerHint: "N4・N5",
+      intermediate: "中級",
+      intermediateHint: "N2・N3",
+      advanced: "高級",
+      advancedHint: "N1・N2"
+    },
     sessionLength: "每組題數",
     sessionLengthAll: "全部",
     practiceFocus: "練習重點",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -263,3 +263,56 @@
     gap: 0.6rem;
   }
 }
+
+/* First-run "choose your level" card (#199): a light paper card with three
+   band options (初級/中級/高級), shown only to brand-new learners. */
+.home-level-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.95rem;
+  background: var(--paper);
+}
+
+.home-level-card-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.home-level-card-copy strong {
+  font-size: 1.05rem;
+  color: var(--ink);
+}
+
+.home-level-card-copy small {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.home-level-card-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.6rem;
+}
+
+.home-level-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.7rem 0.5rem;
+}
+
+.home-level-option small {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 560px) {
+  .home-level-card-options {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
Closes #199.

New users used to land straight in the N1/N2-heavy default exam pool. This adds a single global **target level** that every fresh pool (今日練習 / 単字 / 綜合考題庫) inherits, plus a one-time onboarding nudge.

## Changes
- **`src/domain/levelPreference.ts`** (+test): tiny crash-safe `localStorage` module (`jabiko:targetLevel`) → `LevelRange | null`. Imports only the `LevelRange` type/options — **no question banks** — so the eager HomePanel reads it without bloating the initial bundle.
- **`composeDailySet(due, range)`**: fresh exam `buildExamQuestionPool(levelsForRange(range) ?? "all")`; fresh vocab filtered by band. **初級(n4n5) vocab hole** — `jlptVocabulary` is N1/N2 only — the reserved vocab slots roll into N4/N5 exam (each carries its own 4 options, so no short-option 漢字読み gap). No range arg `== "all" ==` the prior default, so **returning users with no preference are unaffected**.
- **`usePracticeSession`**: new `targetLevel` prop seeds the daily / 綜合 / 単字 level range; the per-session picker still overrides. `initialLevelRange()` is a pure, unit-tested helper; 単字 clamps an n4n5 preference (its picker has no n4n5) and the vocab branch falls back to the full deck rather than empty.
- **`HomePanel`**: first-run「選擇你的程度」card (初級/中級/高級 = n4n5/n2n3/n1n2), shown only when there's **no preference AND no attempts**; choosing persists it and the card disappears. `App` owns the preference state, feeds both HomePanel and ChallengePanel.
- **i18n** + light card CSS.

## Acceptance (#199)
- New learner (no pref, no attempts) → asked once; choice persists across reloads; card then hidden. ✓ (HomePanel.test)
- 初級 learner's 今日練習 fresh items are N4/N5, not N1/N2. ✓ (sessionPools.test)
- 初級 vocab fallback: no empty pool / no short options. ✓
- 綜合/単字 default = preference, per-session override still works; n4n5 → 単字 safe fallback. ✓ (initialLevelRange + vocab-branch tests)
- Returning learner unaffected: SRS due still first; no-pref daily unchanged. ✓
- Bundle: `examBlocks`/`furiganaData` stay lazy; initial `index` chunk unchanged (~263KB). ✓

## Gates
TDD throughout. `pnpm check:exam` (13) · `pnpm test` (321) · `pnpm build` all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-time level selection flow so new learners can choose a starting difficulty.
  * Your chosen level is now remembered and used to personalize future practice sessions.

* **Bug Fixes**
  * Practice sessions now better respect the selected level across home and challenge screens.
  * Daily and vocab practice more consistently stay within the intended difficulty band, with safer fallback behavior when needed.

* **Documentation**
  * Added updated Traditional Chinese copy for the new onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->