### PR TITLE
refactor(challenge): 每組題數 picker 移到右欄頂端

### DIFF
--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -6,6 +6,7 @@ import { ModePicker } from "./challenge/ModePicker";
 import { DrillPanel } from "./challenge/DrillPanel";
 import { ScoreReport } from "./challenge/ScoreReport";
 import { ReviewList } from "./challenge/ReviewList";
+import { SessionLengthPicker } from "./challenge/SessionLengthPicker";
 
 // The challenge workspace: the three-column practice layout (mode/setup
 // controls, the active drill, and the running mistake list). This is the
@@ -46,6 +47,13 @@ export function ChallengePanel({
       <DrillPanel language={language} onExit={onExit} {...session} />
 
       <aside className="review-panel" aria-label={t.mistakesLabel}>
+        {session.showSessionLength ? (
+          <SessionLengthPicker
+            language={language}
+            sessionLength={session.sessionLength}
+            onChange={session.handleSessionLengthChange}
+          />
+        ) : null}
         <ScoreReport
           language={language}
           attempts={session.attempts}

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -2,7 +2,7 @@ import { BookOpen, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
 import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../../domain/levelRange";
-import { SESSION_LENGTH_OPTIONS, type PracticeMode, type PracticeSession } from "../../hooks/usePracticeSession";
+import { type PracticeMode, type PracticeSession } from "../../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
 
@@ -62,8 +62,6 @@ export function ModePicker({
   practiceMode,
   levelRange,
   showLevelRange,
-  sessionLength,
-  showSessionLength,
   selectedForm,
   setVerbGroup,
   setTargetForm,
@@ -78,7 +76,6 @@ export function ModePicker({
   handlePracticeFocusChange,
   applyModePreset,
   handleLevelRangeChange,
-  handleSessionLengthChange,
   resetSession
 }: Pick<
   PracticeSession,
@@ -88,8 +85,6 @@ export function ModePicker({
   | "practiceMode"
   | "levelRange"
   | "showLevelRange"
-  | "sessionLength"
-  | "showSessionLength"
   | "selectedForm"
   | "setVerbGroup"
   | "setTargetForm"
@@ -104,7 +99,6 @@ export function ModePicker({
   | "handlePracticeFocusChange"
   | "applyModePreset"
   | "handleLevelRangeChange"
-  | "handleSessionLengthChange"
   | "resetSession"
 > & { language: Language }) {
   const t = copy[language];
@@ -168,29 +162,6 @@ export function ModePicker({
                 {t.levelRangeOptions[range]}
               </button>
             ))}
-          </div>
-        </fieldset>
-      ) : null}
-
-      {showSessionLength ? (
-        <fieldset>
-          <legend>{t.sessionLength}</legend>
-          <div className="segmented">
-            {SESSION_LENGTH_OPTIONS.map((option) => {
-              const key = option ?? "all";
-              const active = sessionLength === option;
-              return (
-                <button
-                  key={key}
-                  type="button"
-                  className={active ? "selected" : ""}
-                  aria-pressed={active}
-                  onClick={() => handleSessionLengthChange(option)}
-                >
-                  {option === null ? t.sessionLengthAll : String(option)}
-                </button>
-              );
-            })}
           </div>
         </fieldset>
       ) : null}

--- a/src/components/challenge/SessionLengthPicker.test.tsx
+++ b/src/components/challenge/SessionLengthPicker.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SessionLengthPicker } from "./SessionLengthPicker";
+
+describe("SessionLengthPicker", () => {
+  it("renders every session-length option, including 全部", () => {
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={20} onChange={() => {}} />);
+    for (const label of ["10", "20", "30", "50", "全部"]) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("marks the active length pressed", () => {
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={30} onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "30" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "20" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("calls onChange with the number, and null for 全部", () => {
+    const onChange = vi.fn();
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={20} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "50" }));
+    fireEvent.click(screen.getByRole("button", { name: "全部" }));
+    expect(onChange).toHaveBeenNthCalledWith(1, 50);
+    expect(onChange).toHaveBeenNthCalledWith(2, null);
+  });
+});

--- a/src/components/challenge/SessionLengthPicker.tsx
+++ b/src/components/challenge/SessionLengthPicker.tsx
@@ -1,0 +1,41 @@
+import { copy, type Language } from "../../i18n";
+import { SESSION_LENGTH_OPTIONS } from "../../hooks/usePracticeSession";
+
+// The 每組題數 (session length) segmented control (#154). Moved out of the
+// left mode/setup column to the top of the right-hand column so it sits high
+// and stays visible instead of being pushed below the mode cards (#199
+// follow-up). Pure presentation over the session's length state + handler.
+export function SessionLengthPicker({
+  language,
+  sessionLength,
+  onChange
+}: {
+  language: Language;
+  sessionLength: number | null;
+  onChange: (length: number | null) => void;
+}) {
+  const t = copy[language];
+
+  return (
+    <fieldset className="session-length-picker">
+      <legend>{t.sessionLength}</legend>
+      <div className="segmented">
+        {SESSION_LENGTH_OPTIONS.map((option) => {
+          const key = option ?? "all";
+          const active = sessionLength === option;
+          return (
+            <button
+              key={key}
+              type="button"
+              className={active ? "selected" : ""}
+              aria-pressed={active}
+              onClick={() => onChange(option)}
+            >
+              {option === null ? t.sessionLengthAll : String(option)}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}


### PR DESCRIPTION
使用者回饋：挑戰頁的「每組題數」(10/20/30/50/全部) 原本在左欄 mode 卡下方、太低容易看不到。移到**右欄頂端**(今日戰報上方),維持高處可見。

## 改動
- 新增 presentational `SessionLengthPicker`(+test),從 ModePicker 抽出。
- `ChallengePanel`：在右欄 aside 最上方渲染,沿用 `showSessionLength`(review / 今日練習 仍隱藏,行為不變)。
- `ModePicker`：移除該 fieldset 與不再使用的 session-length props（destructure + Pick + `SESSION_LENGTH_OPTIONS` import）。

純位置搬移,無行為改變。沿用既有全域 `fieldset`/`legend`/`.segmented` 樣式,無需新 CSS。

## 驗證
`pnpm test` (327) · tsc · `pnpm build` 全綠；examBlocks/furiganaData 仍 lazy、初始 chunk 不變。