### PR TITLE
feat(level): N3 備考 (N3+N4) 題庫區 + mode preset

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -702,9 +702,11 @@ describe("App", () => {
     const exam = screen.getByRole("button", { name: /綜合考題庫/ });
     const n1 = screen.getByRole("button", { name: /N1 備考/ });
     const n2 = screen.getByRole("button", { name: /N2 備考/ });
+    const n3 = screen.getByRole("button", { name: /N3 備考/ });
     expect(exam).toBeInTheDocument();
     expect(n1).toBeInTheDocument();
     expect(n2).toBeInTheDocument();
+    expect(n3).toBeInTheDocument();
     expect(screen.queryByText("題庫範圍")).toBeNull();
 
     // Picking N2 備考 activates it (exam mode + N2+N3 range) and deselects
@@ -717,6 +719,12 @@ describe("App", () => {
     // 「N2＋N3 綜合題」), not the generic 綜合 text -- so that copy now
     // appears on BOTH the N2 備考 card and the summary (>= 2 occurrences).
     expect(screen.getAllByText(/N2＋N3 綜合題/).length).toBeGreaterThanOrEqual(2);
+
+    // The new N3 備考 (N3+N4) preset (#195 follow-up) activates the same way.
+    await user.click(n3);
+    expect(n3).toHaveAttribute("aria-pressed", "true");
+    expect(n2).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getAllByText(/N3＋N4 綜合題/).length).toBeGreaterThanOrEqual(2);
   });
 
   it("opens 今日練習 by default when entering the challenge tab", async () => {

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -33,7 +33,7 @@ const formOptions: TargetForm[] = [
 // presets -- 綜合考題庫 (all levels) plus N1 備考 (N1+N2) and N2 備考
 // (N2+N3) -- so the備考 ranges are first-class picks rather than a filter
 // hidden inside the exam mode. `id` doubles as the i18n / count key.
-type ModePresetId = PracticeMode | "examN1" | "examN2" | "examN4";
+type ModePresetId = PracticeMode | "examN1" | "examN2" | "examN3" | "examN4";
 type ModePreset = { id: ModePresetId; mode: PracticeMode; levelRange?: LevelRange };
 const modePresetOrder: ModePreset[] = [
   { id: "daily", mode: "daily" },
@@ -43,6 +43,7 @@ const modePresetOrder: ModePreset[] = [
   { id: "exam", mode: "exam", levelRange: "all" },
   { id: "examN1", mode: "exam", levelRange: "n1n2" },
   { id: "examN2", mode: "exam", levelRange: "n2n3" },
+  { id: "examN3", mode: "exam", levelRange: "n3n4" },
   { id: "examN4", mode: "exam", levelRange: "n4n5" },
   { id: "vocab", mode: "vocab" },
   { id: "review", mode: "review" }

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -7,12 +7,13 @@ describe("levelsForRange", () => {
     expect(levelsForRange("all")).toBeNull();
     expect(levelsForRange("n1n2")).toEqual(["N1", "N2"]);
     expect(levelsForRange("n2n3")).toEqual(["N2", "N3"]);
+    expect(levelsForRange("n3n4")).toEqual(["N3", "N4"]);
     expect(levelsForRange("n4n5")).toEqual(["N4", "N5"]);
   });
 
-  it("offers 全部 first, then the target bands", () => {
+  it("offers 全部 first, then the target bands high→low", () => {
     expect(LEVEL_RANGE_OPTIONS[0]).toBe("all");
-    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n4n5"]);
+    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n3n4", "n4n5"]);
   });
 
   it("excludes n4n5 from the vocab picker (no N4/N5 jlpt words)", () => {
@@ -36,6 +37,14 @@ describe("buildExamQuestionPool level range", () => {
     const n3InRange = pool.filter((q) => q.vocabulary.level === "N3").length;
     const n3InAll = buildExamQuestionPool().filter((q) => q.vocabulary.level === "N3").length;
     expect(n3InRange).toBeGreaterThan(n3InAll);
+  });
+
+  it("N3+N4 keeps only N3/N4 items (the new N3 備考 band)", () => {
+    const pool = buildExamQuestionPool(["N3", "N4"]);
+    expect(pool.length).toBeGreaterThan(0);
+    expect(pool.every((q) => q.vocabulary.level === "N3" || q.vocabulary.level === "N4")).toBe(true);
+    expect(pool.some((q) => q.vocabulary.level === "N3")).toBe(true);
+    expect(pool.some((q) => q.vocabulary.level === "N4")).toBe(true);
   });
 
   it("does not regress the single-level and all behaviour", () => {

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -5,19 +5,21 @@ import type { JlptLevel } from "./types";
 // FILTER only -- the level never appears on the question itself (no
 // visible promptLabel); it just narrows which bank items are in play.
 // "all" keeps each pool's own default behaviour (no level narrowing).
-export type LevelRange = "all" | "n1n2" | "n2n3" | "n4n5";
+export type LevelRange = "all" | "n1n2" | "n2n3" | "n3n4" | "n4n5";
 
 // Order shown in the picker (全部 first, then the target bands high→low).
-export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n4n5"];
+export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5"];
 
-// Vocab (単字讀音) only has N1/N2 jlpt entries, so its segmented picker
-// must NOT offer n4n5 (it would filter jlptVocabulary down to an empty
-// pool). Exam reaches N4/N5 via the examN4 mode preset, not this picker.
+// Vocab (単字讀音) only has N1/N2 jlpt entries, so its segmented picker must
+// NOT offer the lower bands (they would filter jlptVocabulary down to an
+// empty pool). Exam reaches N3/N4/N5 via the examN3 / examN4 mode presets,
+// not this picker.
 export const VOCAB_LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3"];
 
 const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
   n1n2: ["N1", "N2"],
   n2n3: ["N2", "N3"],
+  n3n4: ["N3", "N4"],
   n4n5: ["N4", "N5"]
 };
 

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -53,6 +53,7 @@ describe("buildModeCounts", () => {
     // counts come from the matching level RANGE pools, never the default.
     expect(counts.examN1).toBe(buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length);
     expect(counts.examN2).toBe(buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length);
+    expect(counts.examN3).toBe(buildExamQuestionPool(levelsForRange("n3n4") ?? "all").length);
     expect(counts.examN4).toBe(buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length);
     expect(counts.vocab).toBe(
       buildQuestionPool(jlptVocabulary, {
@@ -71,6 +72,17 @@ describe("buildModeCounts", () => {
     expect(counts.examN4).toBe(n4n5.length);
     expect(
       n4n5.every((q) => q.vocabulary.level === "N4" || q.vocabulary.level === "N5")
+    ).toBe(true);
+  });
+
+  it("derives the examN3 preset from the n3n4 range (N3/N4 only)", () => {
+    const counts = buildModeCounts();
+    const n3n4 = buildExamQuestionPool(levelsForRange("n3n4") ?? "all");
+
+    expect(counts.examN3).toBeGreaterThan(0);
+    expect(counts.examN3).toBe(n3n4.length);
+    expect(
+      n3n4.every((q) => q.vocabulary.level === "N3" || q.vocabulary.level === "N4")
     ).toBe(true);
   });
 });

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -107,6 +107,7 @@ export function buildModeCounts() {
     exam: buildExamQuestionPool().length,
     examN1: buildExamQuestionPool(levelsForRange("n1n2") ?? "all").length,
     examN2: buildExamQuestionPool(levelsForRange("n2n3") ?? "all").length,
+    examN3: buildExamQuestionPool(levelsForRange("n3n4") ?? "all").length,
     examN4: buildExamQuestionPool(levelsForRange("n4n5") ?? "all").length,
     vocab: buildQuestionPool(jlptVocabulary, {
       partOfSpeech: "mixed",

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -216,15 +216,17 @@ export function usePracticeSession({
   // / N2 備考). Map the active mode+range to the matching copy key so the
   // summary + mode description reflect the chosen 備考 preset, not the
   // generic 綜合考題庫 text.
-  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" | "examN4" =
+  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" | "examN3" | "examN4" =
     practiceMode === "exam"
       ? levelRange === "n1n2"
         ? "examN1"
         : levelRange === "n2n3"
           ? "examN2"
-          : levelRange === "n4n5"
-            ? "examN4"
-            : "exam"
+          : levelRange === "n3n4"
+            ? "examN3"
+            : levelRange === "n4n5"
+              ? "examN4"
+              : "exam"
       : practiceMode;
   const focusSummary = isCuratedFocus
     ? t.modeOptions[activeModeCopyKey].subtitle

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -122,7 +122,7 @@ export type Copy = {
   practiceType: string;
   practiceMode: string;
   levelRange: string;
-  levelRangeOptions: { all: string; n1n2: string; n2n3: string; n4n5: string };
+  levelRangeOptions: { all: string; n1n2: string; n2n3: string; n3n4: string; n4n5: string };
   levelOnboarding: {
     title: string;
     subtitle: string;
@@ -169,7 +169,7 @@ export type Copy = {
   grammarNoteConfusions: string;
   keyboardHint: string;
   focusSummaryEmpty: string;
-  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
+  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN3" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
   homeCardVocabTitle: string;
   homeCardVocabSub: string;
@@ -349,7 +349,7 @@ export const copy: Record<Language, Copy> = {
     practiceType: "練習類型",
     practiceMode: "練習模式",
     levelRange: "題庫範圍",
-    levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n4n5: "N4＋N5" },
+    levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
     levelOnboarding: {
       title: "選擇你的程度",
       subtitle: "設定今日練習與各題庫的預設難度，之後隨時可改。",
@@ -404,6 +404,7 @@ export const copy: Record<Language, Copy> = {
       exam: { title: "綜合考題庫", subtitle: "N1〜N3 為主 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
       examN1: { title: "N1 備考", subtitle: "N1＋N2 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
       examN2: { title: "N2 備考", subtitle: "N2＋N3 綜合題 · 文法 / 語順 / 短文 / 詞彙 / 漢字読み" },
+      examN3: { title: "N3 備考", subtitle: "N3＋N4 綜合題 · 文法 / 短文 / 詞彙 / 漢字読み" },
       examN4: { title: "N4 備考", subtitle: "N4＋N5 綜合題 · 助詞 / 基礎文法 / 詞彙 / 漢字読み" },
       vocab: { title: "単字讀音", subtitle: "N1/N2 漢字詞 · 選正確讀音（よみ）" },
       review: { title: "弱點複習", subtitle: "把上次答錯的題目重練到對為止" }


### PR DESCRIPTION
Adds an **N3 備考** exam preset (N3+N4), mirroring the existing 綜合 / N1 / N2 / N4 備考 presets.

- New `n3n4` LevelRange → `[N3, N4]` (in LEVEL_RANGE_OPTIONS; not the vocab picker — no N3/N4 jlpt words).
- `examN3` mode-picker preset; wired through `usePracticeSession` (activeModeCopyKey), `buildModeCounts`, i18n (`modeOptions.examN3` = N3＋N4 綜合題, `levelRangeOptions.n3n4`).
- The band already pulls ~226 items (N3 174 + N4 52); a follow-up content loop will fatten the N4 side.

Tests: `levelsForRange("n3n4")` + n3n4 pool, `buildModeCounts.examN3`, App preset-pick. `pnpm check:exam` + `pnpm test` (334) + `tsc` + `build` green; exam pool stays lazy.