### PR TITLE
首頁：hero 加「使用說明書」按鈕（導流到部落格教學）

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -63,3 +63,18 @@ describe("HomePanel level onboarding (#199)", () => {
     expect(screen.queryByText("選擇你的程度")).not.toBeInTheDocument();
   });
 });
+
+describe("HomePanel guide link", () => {
+  it("renders a 使用說明書 link to the blog that opens safely in a new tab", () => {
+    renderHome();
+    const link = screen.getByRole("link", { name: /使用說明書/ });
+    expect(link).toHaveAttribute("href", "https://hanayukii.dev/blog/jabiko-jlpt-app");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel") ?? "").toContain("noopener");
+  });
+
+  it("shows the guide link for returning learners too", () => {
+    renderHome({ targetLevel: "n2n3", progressAttempts: [sampleAttempt] });
+    expect(screen.getByRole("link", { name: /使用說明書/ })).toBeInTheDocument();
+  });
+});

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,5 +1,9 @@
 import { AlertTriangle, ArrowRight, BookOpen, CalendarCheck } from "lucide-react";
 import { copy, type Language } from "../i18n";
+
+// External walkthrough / 使用說明書: the author's blog post about Jabiko.
+// Surfaced in the hero so first-time visitors can read how to use the app.
+const GUIDE_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
 import type { Attempt } from "../domain/types";
 import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
@@ -130,6 +134,15 @@ export function HomePanel({
         <div className="home-hero-text">
           <h1>{t.homeHeroTitle}</h1>
           <p>{t.homeHeroIntro}</p>
+          <a
+            className="home-hero-guide"
+            href={GUIDE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <BookOpen aria-hidden="true" />
+            {t.homeGuideLink}
+          </a>
         </div>
       </header>
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,6 +22,7 @@ export type Copy = {
   challenge: string;
   homeHeroTitle: string;
   homeHeroIntro: string;
+  homeGuideLink: string;
   homeContentStats: (chapters: number, examItems: number, n1Grammar: number, patternChecks: number, vocab: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
@@ -233,6 +234,7 @@ export const copy: Record<Language, Copy> = {
     mockExam: "模擬考",
     homeHeroTitle: "今天想練什麼？",
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",
+    homeGuideLink: "使用說明書",
     homeContentStats: (chapters, examItems, n1Grammar, patternChecks, vocab) =>
       `${chapters} 章節 · ${examItems} 綜合題 · ${n1Grammar} N1 句型 · ${patternChecks} 句型判斷 · ${vocab} N1/N2 單字`,
     homeCardStageLearn: "學",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -59,6 +59,35 @@
   line-height: 1.6;
 }
 
+/* 使用說明書: outlined pill linking out to the author's walkthrough blog.
+   Sits just under the hero intro as a low-key, self-aligned secondary CTA. */
+.home-hero-guide {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--paper);
+  color: var(--teal-dark);
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-decoration: none;
+  transition: box-shadow 0.16s ease, border-color 0.16s ease;
+}
+
+.home-hero-guide:hover {
+  border-color: var(--teal-dark);
+  box-shadow: var(--button-hover-shadow);
+}
+
+.home-hero-guide svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 @media (max-width: 720px) {
   .home-hero-image {
     max-height: 200px;


### PR DESCRIPTION
## 摘要
在首頁 hero intro 下方加一顆「使用說明書」外連 pill，連到作者的 Jabiko 教學文，讓新訪客先看怎麼用。

連結：`https://hanayukii.dev/blog/jabiko-jlpt-app`（`target="_blank"` + `rel="noopener noreferrer"`）。

## 變更
- `src/components/HomePanel.tsx`：hero 內加 `<a class="home-hero-guide">`（BookOpen 圖示 + 文字）。
- `src/i18n.ts`：加 `homeGuideLink: "使用說明書"`。
- `src/styles/home.css`：`.home-hero-guide` outlined pill（沿用 --teal-dark / --panel-border / --paper / hover shadow）。
- `src/components/HomePanel.test.tsx`：TDD 測試（href、target、rel；新舊訪客都顯示）。

## 驗證
- HomePanel 測試 7 passed、tsc 0、build：app `index` 265 kB（+0.2 kB），bundle 不受影響。