### PR TITLE
首頁全站題數自動加總 + 每組題數自訂輸入

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { HomePanel } from "./HomePanel";
 import type { Attempt } from "../domain/types";
+import { CONTENT_STATS } from "../domain/contentStats";
 
 const noop = () => {};
 
@@ -76,5 +77,17 @@ describe("HomePanel guide link", () => {
   it("shows the guide link for returning learners too", () => {
     renderHome({ targetLevel: "n2n3", progressAttempts: [sampleAttempt] });
     expect(screen.getByRole("link", { name: /使用說明書/ })).toBeInTheDocument();
+  });
+});
+
+describe("HomePanel content total", () => {
+  it("renders the grand total of exam + vocab + kanji-readings + patterns", () => {
+    renderHome();
+    const total =
+      CONTENT_STATS.examItems +
+      CONTENT_STATS.vocab +
+      CONTENT_STATS.kanjiReadings +
+      CONTENT_STATS.patternChecks;
+    expect(screen.getByText(new RegExp(total.toLocaleString()))).toBeInTheDocument();
   });
 });

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -20,10 +20,20 @@ import { computeProgressStats } from "../domain/stats";
 const HOME_CONTENT_STATS = {
   chapters: learningBlocks.filter((block) => block.group === "basic").length,
   examItems: CONTENT_STATS.examItems,
-  n1Grammar: CONTENT_STATS.n1Grammar,
   patternChecks: CONTENT_STATS.patternChecks,
-  vocab: CONTENT_STATS.vocab
+  vocab: CONTENT_STATS.vocab,
+  kanjiReadings: CONTENT_STATS.kanjiReadings
 };
+
+// Authoritative site-wide question total, summed from the drift-guarded
+// CONTENT_STATS so it can never go stale as content batches land. n1Grammar
+// is deliberately excluded -- it's a subset of examItems, not a separate
+// pool -- and chapters are learning units, listed but not counted as 題.
+const HOME_CONTENT_TOTAL =
+  HOME_CONTENT_STATS.examItems +
+  HOME_CONTENT_STATS.vocab +
+  HOME_CONTENT_STATS.kanjiReadings +
+  HOME_CONTENT_STATS.patternChecks;
 
 // First view the learner lands on. Three layers:
 //   1. Context-aware banner ("review N items" if any, else "continue
@@ -164,11 +174,12 @@ export function HomePanel({
           honest whenever a content batch lands. */}
       <p className="home-content-stats">
         {t.homeContentStats(
-          HOME_CONTENT_STATS.chapters,
+          HOME_CONTENT_TOTAL,
           HOME_CONTENT_STATS.examItems,
-          HOME_CONTENT_STATS.n1Grammar,
+          HOME_CONTENT_STATS.vocab,
+          HOME_CONTENT_STATS.kanjiReadings,
           HOME_CONTENT_STATS.patternChecks,
-          HOME_CONTENT_STATS.vocab
+          HOME_CONTENT_STATS.chapters
         )}
       </p>
 

--- a/src/components/challenge/SessionLengthPicker.test.tsx
+++ b/src/components/challenge/SessionLengthPicker.test.tsx
@@ -24,4 +24,26 @@ describe("SessionLengthPicker", () => {
     expect(onChange).toHaveBeenNthCalledWith(1, 50);
     expect(onChange).toHaveBeenNthCalledWith(2, null);
   });
+
+  it("renders a 自訂 number input and calls onChange with the typed value", () => {
+    const onChange = vi.fn();
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={20} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton", { name: /自訂/ });
+    fireEvent.change(input, { target: { value: "7" } });
+    expect(onChange).toHaveBeenCalledWith(7);
+  });
+
+  it("shows a non-preset length in the 自訂 input", () => {
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={7} onChange={() => {}} />);
+    expect(screen.getByRole("spinbutton", { name: /自訂/ })).toHaveValue(7);
+    // a non-preset value must not light up any preset button
+    expect(screen.getByRole("button", { name: "10" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("ignores zero / non-positive custom input", () => {
+    const onChange = vi.fn();
+    render(<SessionLengthPicker language="zh-Hant" sessionLength={20} onChange={onChange} />);
+    fireEvent.change(screen.getByRole("spinbutton", { name: /自訂/ }), { target: { value: "0" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/challenge/SessionLengthPicker.tsx
+++ b/src/components/challenge/SessionLengthPicker.tsx
@@ -16,6 +16,11 @@ export function SessionLengthPicker({
 }) {
   const t = copy[language];
 
+  // A length that isn't one of the presets (and isn't 全部) is a manual
+  // choice -- surface it in the 自訂 field so it stays visible/editable and
+  // no preset button lights up.
+  const isCustom = sessionLength != null && !SESSION_LENGTH_OPTIONS.includes(sessionLength);
+
   return (
     <fieldset className="session-length-picker">
       <legend>{t.sessionLength}</legend>
@@ -36,6 +41,22 @@ export function SessionLengthPicker({
           );
         })}
       </div>
+      <label className={`session-length-custom${isCustom ? " selected" : ""}`}>
+        <span>{t.sessionLengthCustom}</span>
+        <input
+          type="number"
+          min={1}
+          max={999}
+          inputMode="numeric"
+          aria-label={t.sessionLengthCustom}
+          placeholder={t.sessionLengthCustomPlaceholder}
+          value={isCustom ? sessionLength : ""}
+          onChange={(event) => {
+            const next = Math.floor(Number(event.target.value));
+            if (Number.isFinite(next) && next > 0) onChange(next);
+          }}
+        />
+      </label>
     </fieldset>
   );
 }

--- a/src/domain/contentStats.test.ts
+++ b/src/domain/contentStats.test.ts
@@ -3,6 +3,7 @@ import { CONTENT_STATS } from "./contentStats";
 import { buildExamQuestionPool } from "./examBlocks";
 import { buildSentencePatternPool } from "./sentencePatterns";
 import { jlptVocabulary } from "./vocabulary-jlpt";
+import { kanjiOnyomi } from "./kanjiOnyomi";
 
 // Drift guard: CONTENT_STATS is hardcoded so the home view doesn't have
 // to import the heavy data modules (see contentStats.ts). This test is
@@ -32,5 +33,9 @@ describe("CONTENT_STATS", () => {
 
   it("matches the live JLPT vocabulary count", () => {
     expect(CONTENT_STATS.vocab).toBe(jlptVocabulary.length);
+  });
+
+  it("matches the live kanji-reading entry count", () => {
+    expect(CONTENT_STATS.kanjiReadings).toBe(kanjiOnyomi.length);
   });
 });

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -16,5 +16,6 @@ export const CONTENT_STATS = {
   examItems: 1113,
   n1Grammar: 265,
   patternChecks: 32,
-  vocab: 579
+  vocab: 579,
+  kanjiReadings: 671
 } as const;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -23,7 +23,7 @@ export type Copy = {
   homeHeroTitle: string;
   homeHeroIntro: string;
   homeGuideLink: string;
-  homeContentStats: (chapters: number, examItems: number, n1Grammar: number, patternChecks: number, vocab: number) => string;
+  homeContentStats: (total: number, examItems: number, vocab: number, kanjiReadings: number, patternChecks: number, chapters: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
   homeCardStageVocab: string;
@@ -136,6 +136,8 @@ export type Copy = {
   };
   sessionLength: string;
   sessionLengthAll: string;
+  sessionLengthCustom: string;
+  sessionLengthCustomPlaceholder: string;
   practiceFocus: string;
   verbGroup: string;
   targetForm: string;
@@ -235,8 +237,8 @@ export const copy: Record<Language, Copy> = {
     homeHeroTitle: "今天想練什麼？",
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",
     homeGuideLink: "使用說明書",
-    homeContentStats: (chapters, examItems, n1Grammar, patternChecks, vocab) =>
-      `${chapters} 章節 · ${examItems} 綜合題 · ${n1Grammar} N1 句型 · ${patternChecks} 句型判斷 · ${vocab} N1/N2 單字`,
+    homeContentStats: (total, examItems, vocab, kanjiReadings, patternChecks, chapters) =>
+      `全站 ${total.toLocaleString()} 題 · 檢定題 ${examItems} · 單字 ${vocab} · 漢字讀音 ${kanjiReadings} · 句型 ${patternChecks} · ${chapters} 學習章節`,
     homeCardStageLearn: "學",
     homeCardStageChallenge: "練",
     homeCardStageVocab: "背",
@@ -364,6 +366,8 @@ export const copy: Record<Language, Copy> = {
     },
     sessionLength: "每組題數",
     sessionLengthAll: "全部",
+    sessionLengthCustom: "自訂",
+    sessionLengthCustomPlaceholder: "題數",
     practiceFocus: "練習重點",
     verbGroup: "動詞類別",
     targetForm: "目標形",

--- a/src/styles/challenge.css
+++ b/src/styles/challenge.css
@@ -100,6 +100,32 @@ legend,
   grid-template-columns: 1fr;
 }
 
+/* 自訂題數: manual count entry below the session-length presets. */
+.session-length-custom {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.42rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.session-length-custom input {
+  width: 5rem;
+  padding: 0.32rem 0.5rem;
+  border: 1px solid var(--field-border);
+  border-radius: 0.5rem;
+  background: var(--field-bg);
+  color: var(--button-text);
+  font: inherit;
+}
+
+.session-length-custom.selected input {
+  border-color: var(--matcha-dark);
+  background: var(--matcha);
+  color: var(--selected-text);
+}
+
 select {
   background: linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 95%, var(--indigo) 5%), var(--field-bg));
   border: 1px solid var(--field-border);


### PR DESCRIPTION
## 摘要
回應使用者兩個需求。

### 1. 首頁自動算總數
- 首頁內容統計列改成 **自動加總全站題數**：`全站 2,395 題 · 檢定題 1113 · 單字 579 · 漢字讀音 671 · 句型 32 · N 學習章節`。
- 總數＝examItems＋vocab＋kanjiReadings＋patternChecks，由 **drift-guarded** `CONTENT_STATS` 算出，**永遠不會隨內容擴充過期**（n1Grammar 是 examItems 子集，刻意不重複計）。
- 新增 `CONTENT_STATS.kanjiReadings`(671) + `contentStats.test.ts` drift guard（對齊 `kanjiOnyomi.length`）。
- 不影響 bundle：首頁只 import `CONTENT_STATS`（純數字），不 eager-import kanjiOnyomi。

### 2. 每組題數自訂
- `SessionLengthPicker` 在預設 10/20/30/50/全部 之外加一個「自訂」數字輸入，可手動指定任意題數。
- 非預設值會顯示在自訂框並高亮、預設按鈕不亮；忽略 0／負數。
- 資料層 `readSessionLength` 早已接受非預設正整數，故能正常持久化。

## 驗證
- TDD：3 個檔新增 7 個測試，全測 **341 passed**、tsc 0。
- build：app eager `index` 265 kB（≈不變）、`examBlocks` 仍 lazy。

備註：給文案用的權威數字是 **2,395 題**（檢定 1113＋單字 579＋漢字讀音 671＋句型 32）。