### PR TITLE
首頁：使用說明書按鈕做明顯一點

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -59,33 +59,38 @@
   line-height: 1.6;
 }
 
-/* 使用說明書: outlined pill linking out to the author's walkthrough blog.
-   Sits just under the hero intro as a low-key, self-aligned secondary CTA. */
+/* 使用說明書: teal-tinted pill linking out to the author's walkthrough blog.
+   A filled (not outlined) secondary CTA sitting under the hero intro -- a
+   notch more prominent than a plain border, but still clearly below the
+   primary 今日練習 banner. Theme-safe: tint mixes onto --paper and text
+   uses --teal-dark, both of which adapt in dark mode. */
 .home-hero-guide {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  margin-top: 0.35rem;
-  padding: 0.4rem 0.85rem;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1.05rem;
   border-radius: 999px;
-  border: 1px solid var(--panel-border);
-  background: var(--paper);
+  border: 1px solid color-mix(in srgb, var(--teal) 55%, var(--panel-border));
+  background: color-mix(in srgb, var(--teal) 18%, var(--paper));
   color: var(--teal-dark);
-  font-weight: 600;
-  font-size: 0.92rem;
+  font-weight: 700;
+  font-size: 0.96rem;
   text-decoration: none;
-  transition: box-shadow 0.16s ease, border-color 0.16s ease;
+  box-shadow: 0 1px 4px color-mix(in srgb, var(--teal) 22%, transparent);
+  transition: box-shadow 0.16s ease, border-color 0.16s ease, background 0.16s ease;
 }
 
 .home-hero-guide:hover {
   border-color: var(--teal-dark);
+  background: color-mix(in srgb, var(--teal) 28%, var(--paper));
   box-shadow: var(--button-hover-shadow);
 }
 
 .home-hero-guide svg {
-  width: 1rem;
-  height: 1rem;
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
把首頁 hero 的「使用說明書」連結從白底外框 pill 改成 **teal tint 填色** + 加粗(700) + 略放大(0.96rem/更大 padding) + 淡陰影，比原本顯眼一些，但仍明顯低於主 CTA「今日練習」。

- theme-safe：tint 用 `color-mix(--teal, --paper)`、文字 `--teal-dark`，深淺色模式都通過。
- 純 CSS 變更，連結邏輯與既有測試不變；build 通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the home page guide call-to-action to a more prominent filled pill design.
  * Improved spacing, typography, and icon sizing for a cleaner, more balanced appearance.
  * Refined hover behavior for a smoother interactive feel with updated background and shadow effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->