### PR TITLE
品牌：加 Jabiko 達摩吉祥物到頂部品牌列

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
 import { copy, type Language } from "./i18n";
 import { HomePanel, LearningPanel, RulesPanel } from "./components";
+import { JabikoMark } from "./components/JabikoMark";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
 import { useFurigana } from "./hooks/useFurigana";
@@ -111,9 +112,12 @@ export default function App() {
   return (
     <main className="app-shell">
       <div className="app-heading" aria-label={t.appIntroLabel}>
-        <div>
-          <p className="eyebrow">Minna no Nihongo practice</p>
-          <h1>{t.appTitle}</h1>
+        <div className="app-brand">
+          <JabikoMark className="app-brand-mark" />
+          <div>
+            <p className="eyebrow">Minna no Nihongo practice</p>
+            <h1>{t.appTitle}</h1>
+          </div>
         </div>
         <div className="heading-actions">
           <p>{t.appTagline}</p>

--- a/src/components/JabikoMark.test.tsx
+++ b/src/components/JabikoMark.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { JabikoMark } from "./JabikoMark";
+
+describe("JabikoMark", () => {
+  it("renders an accessible Jabiko brand mark", () => {
+    render(<JabikoMark />);
+    expect(screen.getByRole("img", { name: "Jabiko" })).toBeInTheDocument();
+  });
+
+  it("passes through a custom className", () => {
+    const { container } = render(<JabikoMark className="x-mark" />);
+    expect(container.querySelector("svg.x-mark")).not.toBeNull();
+  });
+});

--- a/src/components/JabikoMark.tsx
+++ b/src/components/JabikoMark.tsx
@@ -1,0 +1,36 @@
+// Jabiko mascot — 合格ちゃん, a matcha-green daruma (the Japanese
+// pass-your-exam talisman). Used as the brand mark in the app heading and the
+// practice side-panel lockup. Inline SVG so it stays crisp at any size; the
+// brand palette is hardcoded because the mark must read identically in light
+// and dark mode (it is not a theme-tinted UI element). Refined from the
+// generated concept: friendly raised brows (not a frown), unified dark-matcha
+// features for contrast, and no tiny details that vanish at ~28px.
+export function JabikoMark({ className, title = "Jabiko" }: { className?: string; title?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={title}
+    >
+      <path
+        d="M32 7c12 0 19 11 19 26 0 13-7 23-19 23S13 46 13 33C13 18 20 7 32 7Z"
+        fill="#647c5c"
+        stroke="#4f6549"
+        strokeWidth="3"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M32 48c8 0 13.5-4.2 13.5-4.2C45 51 39 56 32 56s-13-5-13.5-12.2C18.5 43.8 24 48 32 48Z"
+        fill="#4f6549"
+      />
+      <ellipse cx="32" cy="31" rx="14.5" ry="13" fill="#fdfdf7" stroke="#4f6549" strokeWidth="2.5" />
+      <path d="M22 24q4-2.5 8 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
+      <path d="M34 24q4-2.5 8 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
+      <circle cx="26" cy="31" r="3.1" fill="#4f6549" />
+      <circle cx="38" cy="31" r="3.1" fill="#4f6549" />
+      <path d="M27 38q5 4 10 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -1,5 +1,6 @@
-import { BookOpen, RotateCcw } from "lucide-react";
+import { RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
+import { JabikoMark } from "../JabikoMark";
 import type { PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
 import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../../domain/levelRange";
 import { type PracticeMode, type PracticeSession } from "../../hooks/usePracticeSession";
@@ -107,7 +108,7 @@ export function ModePicker({
   return (
     <aside className="controls-panel" aria-label={t.settingsLabel}>
       <div className="brand-lockup">
-        <BookOpen aria-hidden="true" />
+        <JabikoMark />
         <div>
           <p>Jabiko</p>
           <h2>{t.todayPractice}</h2>

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -22,6 +22,18 @@
   margin: 0;
 }
 
+.app-brand {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.app-brand-mark {
+  flex-shrink: 0;
+  height: 3rem;
+  width: 3rem;
+}
+
 .app-heading h1 {
   color: var(--ink);
   font-family: var(--font-title);


### PR DESCRIPTION
## 摘要
新增 Jabiko 吉祥物「合格ちゃん」（抹茶綠達摩，祈求合格意象），放在：
- **app 頂部標題列** 標題左側 —— 每頁可見的固定品牌列。
- **練習側欄 brand-lockup** —— 取代原本通用的 lucide BookOpen 圖示，品牌一致。

## 設計流程
Workflow 平行生成 6 款方向（擬人書本／文鳥／貓＋書／柴犬／貓頭鷹／達摩）→ 評審排序 → 選達摩（主題最貼、小尺寸最清楚）→ 精修：友善彎眉（修掉原本的皺眉）、統一深抹茶五官拉對比、去掉 ~28px 會消失的細節。

## 實作
- `src/components/JabikoMark.tsx`：inline SVG 元件，品牌色硬編（深淺色模式都讀得清楚），可傳 className/title。
- `App.tsx`：標題列加 `.app-brand` 群組（mark + 標題）。
- `ModePicker.tsx`：brand-lockup 改用 `<JabikoMark>`。
- `layout.css`：`.app-brand` / `.app-brand-mark`(3rem)。

## 驗證
TDD：JabikoMark 測試 2 passed、全測 **343 passed**、tsc 0；build：app `index` 266 kB（+1KB inline SVG）、bundle 不受影響。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new branded mascot/icon to the app header and challenge mode picker.
  * Updated the main heading layout to show the brand mark alongside the existing app title.
* **Style**
  * Adjusted spacing and alignment for the header branding area to keep the logo and text properly aligned.
* **Tests**
  * Added coverage for the new brand icon’s accessibility and custom styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->