### PR TITLE
插圖：新增 3 款和風線稿 spot + 補進漢字/學習頁

### DIFF
--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -3,6 +3,7 @@ import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
 import { SpeakButton } from "./SpeakButton";
+import { InkstoneSpot, MagnifierKanjiSpot } from "../illustrations";
 
 const LEVELS: Array<JlptLevel | "all"> = ["all", "N5", "N4", "N3", "N2", "N1"];
 type ReadingType = "on" | "kun";
@@ -59,6 +60,7 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
   return (
     <section className="kanji-panel" aria-label={t.kanjiTitle}>
       <header className="kanji-head">
+        <InkstoneSpot className="panel-header-spot" />
         <h2>{t.kanjiTitle}</h2>
         <p>{t.kanjiIntro}</p>
       </header>
@@ -176,7 +178,10 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
           </div>
         ))
       ) : (
-        <p className="kanji-empty">{t.kanjiSearchEmpty}</p>
+        <div className="empty-state empty-state-illustrated kanji-empty">
+          <MagnifierKanjiSpot />
+          <p>{t.kanjiSearchEmpty}</p>
+        </div>
       )}
     </section>
   );

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -9,6 +9,7 @@ import {
   type LearningBlockDrillPreset
 } from "../domain/learningBlocks";
 import type { SentencePatternId } from "../domain/sentencePatterns";
+import { SproutSpot, TeaCupSpot } from "../illustrations";
 
 // Chapter index + active-chapter detail (the "學習" view). Reads learner
 // progress to mark chapter completion and surface a review nudge, but
@@ -94,6 +95,7 @@ export function LearningPanel({
       <div className="chapter-shell">
         <aside className="chapter-index" aria-label="學習章節">
           <div className="dashboard-card" aria-label={t.dashboardEyebrow}>
+            <SproutSpot size={48} className="dashboard-spot" />
             <p className="eyebrow">{t.dashboardEyebrow}</p>
             {reviewCount > 0 ? (
               <button
@@ -108,7 +110,10 @@ export function LearningPanel({
                 <span className="dashboard-review-action">{t.dashboardReviewCta}</span>
               </button>
             ) : (
-              <p className="dashboard-review-empty">{t.dashboardReviewEmpty}</p>
+              <p className="dashboard-review-empty">
+                <TeaCupSpot size={40} />
+                {t.dashboardReviewEmpty}
+              </p>
             )}
             {dashboardTotalAttempts > 0 ? (
               <div className="dashboard-stats">

--- a/src/illustrations.tsx
+++ b/src/illustrations.tsx
@@ -119,3 +119,47 @@ export function BrushSpot({ size = 56, className }: SpotProps) {
     </svg>
   );
 }
+
+/** Inkstone (硯) with a brush dipping in -- "kanji / writing" motif.
+ *  Used on the kanji-reading reference header. */
+export function InkstoneSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M18 54 Q18 46 27 46 L73 46 Q82 46 82 54 L82 76 Q82 84 73 84 L27 84 Q18 84 18 76 Z" fill="var(--paper-deep)" />
+      <path {...stroke} d="M28 56 L70 56 Q74 56 73 60 L70 73 Q69 76 65 76 L35 76 Q31 76 30 73 L27 60 Q26 56 28 56 Z" fill="var(--paper)" />
+      <path {...stroke} d="M37 62 H63" stroke="var(--matcha)" strokeWidth="3" fill="none" />
+      <path d="M50 67 Q54 71 50 74 Q46 71 50 67 Z" fill="currentColor" />
+      <path {...stroke} d="M30 14 L52 36" stroke="var(--gold)" strokeWidth="8" fill="none" />
+      <path {...stroke} d="M52 36 L62 46" strokeWidth="5" fill="none" />
+    </svg>
+  );
+}
+
+/** Magnifying glass over a half-written kanji card -- "search / no match"
+ *  motif for the kanji lookup empty state. */
+export function MagnifierKanjiSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <rect {...stroke} x="20" y="18" width="44" height="48" rx="4" fill="var(--paper)" />
+      <path {...stroke} d="M32 32 H52" stroke="var(--matcha)" strokeWidth="3" fill="none" />
+      <path {...stroke} d="M42 30 V50" strokeWidth="3" fill="none" />
+      <circle {...stroke} cx="60" cy="60" r="17" fill="var(--paper-deep)" />
+      <path {...stroke} d="M72 72 L86 86" strokeWidth="5" fill="none" />
+    </svg>
+  );
+}
+
+/** Two-leaf sprout rising from a pot -- "learning / growth" motif.
+ *  Used on the learn dashboard header. */
+export function SproutSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M22 74 Q50 66 78 74 L72 84 Q50 88 28 84 Z" fill="var(--paper-deep)" />
+      <path {...stroke} d="M50 74 V42" fill="none" />
+      <path {...stroke} d="M50 54 C40 52 26 44 22 30 C36 26 48 34 50 48 Z" fill="var(--paper)" />
+      <path {...stroke} d="M50 46 C60 42 74 32 80 18 C64 16 50 26 50 40 Z" fill="var(--paper)" />
+      <path {...stroke} d="M50 50 Q40 45 30 36" stroke="var(--matcha)" strokeWidth="2" fill="none" />
+      <path {...stroke} d="M50 42 Q62 37 71 27" stroke="var(--matcha)" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -208,6 +208,12 @@
   color: var(--muted);
 }
 
+.kanji-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 .kanji-empty {
   color: var(--muted);
 }

--- a/src/styles/rules.css
+++ b/src/styles/rules.css
@@ -54,6 +54,9 @@
 }
 
 .dashboard-review-empty {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
   margin: 0;
   padding: 0.55rem 0.7rem;
   background: var(--summary-bg);
@@ -61,6 +64,10 @@
   border-radius: 0.65rem;
   color: var(--summary-text);
   font-size: 0.9rem;
+}
+
+.dashboard-review-empty .spot-illustration {
+  flex-shrink: 0;
 }
 
 .dashboard-stats {


### PR DESCRIPTION
## 摘要
延續既有 `illustrations.tsx` 線稿系統（currentColor + `--matcha/--vermilion/--gold/--paper`，深淺色自適應），新增 3 款並補進原本沒插圖的位置。

| 新插圖 | 放在 |
|---|---|
| `InkstoneSpot`（硯與筆）| 漢字速查表標題 |
| `MagnifierKanjiSpot`（放大鏡）| 漢字「查無結果」空狀態 |
| `SproutSpot`（嫩芽·成長）| 學習儀表板標題 |
| `TeaCupSpot`（沿用既有）| 學習儀表板「沒有錯題可複習」 |

## 設計
Workflow 平行生成 6 款和風 motif（提灯/御守/嫩芽/放大鏡/鳥居/硯台）→ 評審排序 → 挑出最對位的擺放並精修（葉脈/卷鬚收細、放大鏡單層鏡片）。提灯/御守/鳥居先留作備用，日後可放首頁/祝賀畫面。

## 驗證
全測 343 passed、tsc 0；build：app `index` 268 kB、`examBlocks` 仍 lazy 不受影響。插圖皆 `aria-hidden` 裝飾性、不影響互動。