### PR TITLE
插圖：首頁加和風結尾（鳥居·御守·提灯 + 祝福語）

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -9,6 +9,7 @@ import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
+import { ToriiSpot, OmamoriSpot, LanternSpot } from "../illustrations";
 
 // Content-volume snapshot rendered above the entry cards. The exam /
 // pattern / vocab counts come from CONTENT_STATS (hardcoded, drift-
@@ -305,6 +306,15 @@ export function HomePanel({
           <ArrowRight className="home-card-arrow" aria-hidden="true" />
         </button>
       </div>
+
+      <footer className="home-footer">
+        <div className="home-footer-spots" aria-hidden="true">
+          <ToriiSpot size={40} />
+          <OmamoriSpot size={40} />
+          <LanternSpot size={40} />
+        </div>
+        <p>{t.homeFooterWish}</p>
+      </footer>
     </section>
   );
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -23,6 +23,7 @@ export type Copy = {
   homeHeroTitle: string;
   homeHeroIntro: string;
   homeGuideLink: string;
+  homeFooterWish: string;
   homeContentStats: (total: number, examItems: number, vocab: number, kanjiReadings: number, patternChecks: number, chapters: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
@@ -237,6 +238,7 @@ export const copy: Record<Language, Copy> = {
     homeHeroTitle: "今天想練什麼？",
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",
     homeGuideLink: "使用說明書",
+    homeFooterWish: "一步一步來，祝你考試順利合格。",
     homeContentStats: (total, examItems, vocab, kanjiReadings, patternChecks, chapters) =>
       `全站 ${total.toLocaleString()} 題 · 檢定題 ${examItems} · 單字 ${vocab} · 漢字讀音 ${kanjiReadings} · 句型 ${patternChecks} · ${chapters} 學習章節`,
     homeCardStageLearn: "學",

--- a/src/illustrations.tsx
+++ b/src/illustrations.tsx
@@ -163,3 +163,48 @@ export function SproutSpot({ size = 60, className }: SpotProps) {
     </svg>
   );
 }
+
+/** Paper lantern (提灯) -- wafuu evening / festival ambience. */
+export function LanternSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M50 8 L50 18" fill="none" />
+      <rect {...stroke} x="36" y="18" width="28" height="8" rx="2" fill="var(--paper-deep)" />
+      <path {...stroke} d="M40 26 C24 36 24 64 40 74 L60 74 C76 64 76 36 60 26 Z" fill="var(--paper)" />
+      <path {...stroke} d="M28 38 H72" fill="none" />
+      <path {...stroke} d="M24.5 50 H75.5" fill="none" />
+      <path {...stroke} d="M28 62 H72" fill="none" />
+      <circle {...stroke} cx="50" cy="50" r="5" fill="var(--vermilion)" />
+      <rect {...stroke} x="36" y="74" width="28" height="8" rx="2" fill="var(--paper-deep)" />
+      <path {...stroke} d="M44 82 V88 M56 82 V88" strokeWidth="3" fill="none" />
+    </svg>
+  );
+}
+
+/** Omamori (合格御守) -- a pass-the-exam talisman. Good-luck / celebration motif. */
+export function OmamoriSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M50 18 L50 30" fill="none" />
+      <path {...stroke} d="M42 24 Q50 14 58 24 Q63 30 56 31 L44 31 Q37 30 42 24 Z" fill="var(--gold)" />
+      <path {...stroke} d="M34 34 Q50 26 66 34 L72 78 Q72 86 64 86 L36 86 Q28 86 28 78 Z" fill="var(--vermilion)" />
+      <path {...stroke} d="M31 44 L69 44" fill="none" />
+      <path d="M44 58 L56 58" stroke="var(--gold)" strokeWidth="5" strokeLinecap="round" fill="none" />
+      <path d="M50 54 L50 70" stroke="var(--gold)" strokeWidth="5" strokeLinecap="round" fill="none" />
+      <path {...stroke} d="M44 86 L42 94 M56 86 L58 94 M50 86 L50 95" strokeWidth="3" fill="none" />
+    </svg>
+  );
+}
+
+/** Torii gate (鳥居) -- a wafuu gateway / landmark motif. */
+export function ToriiSpot({ size = 60, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M16 26 Q50 18 84 26 L84 32 Q50 25 16 32 Z" fill="var(--vermilion)" />
+      <path {...stroke} d="M22 44 L78 44 L78 52 L22 52 Z" fill="var(--paper)" />
+      <path {...stroke} d="M30 32 L30 86" strokeWidth="5" fill="none" />
+      <path {...stroke} d="M70 32 L70 86" strokeWidth="5" fill="none" />
+      <path d="M50 44 L50 52" stroke="var(--vermilion)" strokeWidth="3" strokeLinecap="round" fill="none" />
+    </svg>
+  );
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -9,6 +9,31 @@
   width: 100%;
 }
 
+/* 和風 footer: a quiet trio of line-art spots + an encouraging line,
+   closing the home page with some warmth. */
+.home-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 0.6rem;
+  padding-top: 1.3rem;
+  border-top: 1px solid var(--rule);
+  text-align: center;
+}
+
+.home-footer-spots {
+  display: flex;
+  align-items: flex-end;
+  gap: 1.4rem;
+}
+
+.home-footer p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
 .home-hero {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 摘要
把先前生成、暫存備用的 3 款線稿插圖正式落地，並在首頁底部加一個低調的「和風結尾」。

- `illustrations.tsx` 新增 `LanternSpot`（提灯）/ `OmamoriSpot`（合格御守）/ `ToriiSpot`（鳥居），沿用既有 currentColor + `--matcha/--vermilion/--gold/--paper` 慣例，深淺色自適應。
- 首頁底部 `.home-footer`：鳥居·御守·提灯 三款並排（各 40px）+ 一句「一步一步來，祝你考試順利合格。」純氛圍收尾，不擾動既有版面。

## 驗證
全測 343 passed、tsc 0；build：app `index` 270 kB、`examBlocks` 仍 lazy 不受影響。插圖 `aria-hidden`、祝福語可被螢幕報讀。