### PR TITLE
插圖：首頁五張卡的單字徽章換成同款線稿插圖

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -9,7 +9,16 @@ import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
-import { ToriiSpot, OmamoriSpot, LanternSpot } from "../illustrations";
+import {
+  ToriiSpot,
+  OmamoriSpot,
+  LanternSpot,
+  BooksSpot,
+  BrushSpot,
+  SpeechSpot,
+  ExamPaperSpot,
+  TargetSpot
+} from "../illustrations";
 
 // Content-volume snapshot rendered above the entry cards. The exam /
 // pattern / vocab counts come from CONTENT_STATS (hardcoded, drift-
@@ -267,7 +276,7 @@ export function HomePanel({
             independently entry-able -- a returning learner who only
             wants today's mock exam can still jump straight to 考. */}
         <button type="button" className="home-card" onClick={() => onNavigate("learn")}>
-          <span className="home-card-stage" aria-hidden="true">{t.homeCardStageLearn}</span>
+          <BooksSpot className="home-card-spot" />
           <h2>{t.homeCardLearnTitle}</h2>
           <p>{t.homeCardLearnSub}</p>
           <span className="home-card-meta">
@@ -276,28 +285,28 @@ export function HomePanel({
           <ArrowRight className="home-card-arrow" aria-hidden="true" />
         </button>
         <button type="button" className="home-card" onClick={() => onNavigate("challenge")}>
-          <span className="home-card-stage" aria-hidden="true">{t.homeCardStageChallenge}</span>
+          <BrushSpot className="home-card-spot" />
           <h2>{t.homeCardChallengeTitle}</h2>
           <p>{t.homeCardChallengeSub}</p>
           <span className="home-card-meta">{t.homeCardChallengeMeta}</span>
           <ArrowRight className="home-card-arrow" aria-hidden="true" />
         </button>
         <button type="button" className="home-card" onClick={onStartVocab}>
-          <span className="home-card-stage" aria-hidden="true">{t.homeCardStageVocab}</span>
+          <SpeechSpot className="home-card-spot" />
           <h2>{t.homeCardVocabTitle}</h2>
           <p>{t.homeCardVocabSub}</p>
           <span className="home-card-meta">{t.homeCardVocabMeta}</span>
           <ArrowRight className="home-card-arrow" aria-hidden="true" />
         </button>
         <button type="button" className="home-card" onClick={() => onNavigate("mock")}>
-          <span className="home-card-stage" aria-hidden="true">{t.homeCardStageMock}</span>
+          <ExamPaperSpot className="home-card-spot" />
           <h2>{t.homeCardMockTitle}</h2>
           <p>{t.homeCardMockSub}</p>
           <span className="home-card-meta">{t.homeCardMockMeta}</span>
           <ArrowRight className="home-card-arrow" aria-hidden="true" />
         </button>
         <button type="button" className="home-card" onClick={onStartReview}>
-          <span className="home-card-stage" aria-hidden="true">{t.homeCardStageReview}</span>
+          <TargetSpot className="home-card-spot" />
           <h2>{t.homeCardReviewTitle}</h2>
           <p>
             {reviewCount > 0 ? t.homeCardReviewSubActive(reviewCount) : t.homeCardReviewSubEmpty}

--- a/src/illustrations.tsx
+++ b/src/illustrations.tsx
@@ -208,3 +208,40 @@ export function ToriiSpot({ size = 60, className }: SpotProps) {
     </svg>
   );
 }
+
+/** Speech bubble with sound waves -- "pronunciation / vocab reading" motif. */
+export function SpeechSpot({ size = 56, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path {...stroke} d="M22 26 H62 Q68 26 68 32 L68 58 Q68 64 62 64 L40 64 L28 74 L30 64 L22 64 Q16 64 16 58 L16 32 Q16 26 22 26 Z" fill="var(--paper)" />
+      <path {...stroke} d="M28 40 H50" stroke="var(--matcha)" strokeWidth="3" fill="none" />
+      <path {...stroke} d="M28 50 H44" stroke="var(--matcha)" strokeWidth="3" fill="none" />
+      <path {...stroke} d="M76 38 Q83 45 76 52" fill="none" />
+      <path {...stroke} d="M82 32 Q94 45 82 58" fill="none" />
+    </svg>
+  );
+}
+
+/** Clipboard with a red maru (○) -- "mock exam / graded test" motif. */
+export function ExamPaperSpot({ size = 56, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <rect {...stroke} x="26" y="22" width="48" height="62" rx="5" fill="var(--paper)" />
+      <rect {...stroke} x="40" y="16" width="20" height="11" rx="3" fill="var(--paper-deep)" />
+      <circle {...stroke} cx="50" cy="54" r="15" stroke="var(--vermilion)" strokeWidth="4" fill="none" />
+    </svg>
+  );
+}
+
+/** Bullseye with an arrow -- "review weak points / aim" motif. */
+export function TargetSpot({ size = 56, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <circle {...stroke} cx="44" cy="56" r="28" fill="var(--paper)" />
+      <circle {...stroke} cx="44" cy="56" r="16" fill="none" />
+      <circle cx="44" cy="56" r="6" fill="var(--vermilion)" />
+      <path {...stroke} d="M86 22 L52 50" stroke="var(--gold)" strokeWidth="4" fill="none" />
+      <path {...stroke} d="M86 22 L78 23 M86 22 L85 30" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -278,6 +278,16 @@
   line-height: 1;
 }
 
+/* Per-card wafuu spot illustration, replacing the single-CJK stage badge.
+   Sits in the same grid "icon" slot, sized down from the spot default. */
+.home-card-spot {
+  grid-area: icon;
+  align-self: start;
+  width: 2.7rem;
+  height: 2.7rem;
+  margin-top: 0.05rem;
+}
+
 .home-card h2 {
   grid-area: title;
   margin: 0;


### PR DESCRIPTION
## 摘要
把首頁五張入口卡左上的單字徽章（學/練/背/考/補）換成同款和風線稿插圖。

| 卡片 | 插圖 |
|---|---|
| 學習 | 書本 BooksSpot |
| 挑戰 | 毛筆 BrushSpot |
| 單字讀音 | 發音泡泡 SpeechSpot（新） |
| 模擬考 | 試卷＋紅圈 ExamPaperSpot（新） |
| 弱點複習 | 標靶＋箭 TargetSpot（新） |

新增 3 款沿用既有 `illustrations.tsx` 慣例（currentColor + `--matcha/--vermilion/--gold/--paper`，深淺色自適應）。沿用原本 grid 的 icon 槽位、`.home-card-spot` 控制尺寸。

## 驗證
全測 343 passed、tsc 0；build：app `index` 271 kB、`examBlocks` 仍 lazy。插圖 `aria-hidden`、卡片標題仍可報讀。