### PR TITLE
首頁：許願 + 問題回報入口（導向 GitHub issue）

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -80,6 +80,21 @@ describe("HomePanel guide link", () => {
   });
 });
 
+describe("HomePanel feedback links", () => {
+  it("renders 許願 + 問題回報 links to GitHub issues, opening safely in a new tab", () => {
+    renderHome();
+    const wish = screen.getByRole("link", { name: /許願/ });
+    const bug = screen.getByRole("link", { name: /回報/ });
+    expect(wish.getAttribute("href") ?? "").toContain("/issues/new");
+    expect(wish.getAttribute("href") ?? "").toContain("labels=enhancement");
+    expect(bug.getAttribute("href") ?? "").toContain("labels=bug");
+    for (const link of [wish, bug]) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel") ?? "").toContain("noopener");
+    }
+  });
+});
+
 describe("HomePanel content total", () => {
   it("renders the grand total of exam + vocab + kanji-readings + patterns", () => {
     renderHome();

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,9 +1,15 @@
-import { AlertTriangle, ArrowRight, BookOpen, CalendarCheck } from "lucide-react";
+import { AlertTriangle, ArrowRight, BookOpen, Bug, CalendarCheck, Sparkles } from "lucide-react";
 import { copy, type Language } from "../i18n";
 
 // External walkthrough / 使用說明書: the author's blog post about Jabiko.
 // Surfaced in the hero so first-time visitors can read how to use the app.
 const GUIDE_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
+
+// 許願 / 問題回報: deep-link to a prefilled GitHub issue (the repo is public
+// with issues enabled). enhancement = feature wish, bug = problem report.
+const ISSUE_NEW = "https://github.com/nurockplayer/Jabiko/issues/new";
+const WISH_URL = `${ISSUE_NEW}?labels=enhancement&title=${encodeURIComponent("[許願] ")}`;
+const BUG_URL = `${ISSUE_NEW}?labels=bug&title=${encodeURIComponent("[Bug] ")}`;
 import type { Attempt } from "../domain/types";
 import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
@@ -323,6 +329,16 @@ export function HomePanel({
           <LanternSpot size={40} />
         </div>
         <p>{t.homeFooterWish}</p>
+        <div className="home-feedback">
+          <a className="home-feedback-link" href={WISH_URL} target="_blank" rel="noopener noreferrer">
+            <Sparkles aria-hidden="true" />
+            {t.feedbackWish}
+          </a>
+          <a className="home-feedback-link" href={BUG_URL} target="_blank" rel="noopener noreferrer">
+            <Bug aria-hidden="true" />
+            {t.feedbackBug}
+          </a>
+        </div>
       </footer>
     </section>
   );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -24,6 +24,8 @@ export type Copy = {
   homeHeroIntro: string;
   homeGuideLink: string;
   homeFooterWish: string;
+  feedbackWish: string;
+  feedbackBug: string;
   homeContentStats: (total: number, examItems: number, vocab: number, kanjiReadings: number, patternChecks: number, chapters: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
@@ -239,6 +241,8 @@ export const copy: Record<Language, Copy> = {
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",
     homeGuideLink: "使用說明書",
     homeFooterWish: "一步一步來，祝你考試順利合格。",
+    feedbackWish: "許願功能",
+    feedbackBug: "回報問題",
     homeContentStats: (total, examItems, vocab, kanjiReadings, patternChecks, chapters) =>
       `全站 ${total.toLocaleString()} 題 · 檢定題 ${examItems} · 單字 ${vocab} · 漢字讀音 ${kanjiReadings} · 句型 ${patternChecks} · ${chapters} 學習章節`,
     homeCardStageLearn: "學",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -34,6 +34,38 @@
   font-size: 0.9rem;
 }
 
+.home-feedback {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 0.1rem;
+}
+
+.home-feedback-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--paper);
+  color: var(--teal-dark);
+  font-size: 0.85rem;
+  text-decoration: none;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.home-feedback-link svg {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.home-feedback-link:hover {
+  border-color: var(--teal-dark);
+  box-shadow: var(--button-hover-shadow);
+}
+
 .home-hero {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Closes #218

## 摘要
回應 Discord 敲碗：首頁頁尾（祝福語下方）加兩顆意見回饋按鈕。

- **許願功能** → `issues/new?labels=enhancement`（標題預填 `[許願] `）
- **回報問題** → `issues/new?labels=bug`（標題預填 `[Bug] `）

外連 `target=_blank` + `rel=noopener noreferrer`，沿用既有 guide-link 樣式（outlined pill、teal）。repo 為 public、issues 已開，所以連結可直接開票。

## 之後可選
若要降低門檻（免 GitHub 帳號）：可改導 Discord 頻道，或做 Supabase 後端的 app 內表單 — 改 URL 常數即可。

## 驗證
TDD（href/labels/target/rel）；全測 344 passed、tsc 0；build：app `index` 273 kB、`examBlocks` 仍 lazy。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new feedback section on the Home panel with two links for sending wish requests and bug reports.
  * These links open in a new tab and include matching icons for clearer recognition.

* **Bug Fixes**
  * Updated link handling to ensure external feedback links use safer new-tab behavior.

* **Style**
  * Added styling for the feedback section and its pill-shaped link buttons to match the existing home page design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->