### PR TITLE
意見回饋：站內匿名表單（Google-Form 式，寫進 Supabase）

### DIFF
--- a/src/components/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FeedbackForm } from "./FeedbackForm";
+
+describe("FeedbackForm", () => {
+  it("preselects the given category", () => {
+    render(<FeedbackForm language="zh-Hant" category="bug" onClose={() => {}} submit={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "回報問題", pressed: true })).toBeInTheDocument();
+  });
+
+  it("disables submit until a message is typed", () => {
+    render(<FeedbackForm language="zh-Hant" category="wish" onClose={() => {}} submit={vi.fn()} />);
+    const send = screen.getByRole("button", { name: /送出/ });
+    expect(send).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText(/想許什麼願/), { target: { value: "想要夜間模式" } });
+    expect(send).toBeEnabled();
+  });
+
+  it("submits trimmed input and shows a thank-you", async () => {
+    const submit = vi.fn().mockResolvedValue(undefined);
+    render(<FeedbackForm language="zh-Hant" category="wish" onClose={() => {}} submit={submit} />);
+    fireEvent.change(screen.getByPlaceholderText(/想許什麼願/), { target: { value: "  想要夜間模式  " } });
+    fireEvent.click(screen.getByRole("button", { name: /送出/ }));
+    await waitFor(() => expect(screen.getByText(/謝謝你的回饋/)).toBeInTheDocument());
+    expect(submit).toHaveBeenCalledWith({ category: "wish", message: "想要夜間模式", contact: undefined });
+  });
+
+  it("shows a GitHub fallback link when submit fails", async () => {
+    const submit = vi.fn().mockRejectedValue(new Error("boom"));
+    render(<FeedbackForm language="zh-Hant" category="bug" onClose={() => {}} submit={submit} />);
+    fireEvent.change(screen.getByPlaceholderText(/想許什麼願/), { target: { value: "壞了" } });
+    fireEvent.click(screen.getByRole("button", { name: /送出/ }));
+    const link = await screen.findByRole("link", { name: /GitHub/ });
+    expect(link.getAttribute("href") ?? "").toContain("labels=bug");
+  });
+});

--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -1,0 +1,136 @@
+import { useState, type FormEvent } from "react";
+import { Send, X } from "lucide-react";
+import { copy, type Language } from "../i18n";
+import { getSupabase } from "../lib/supabase";
+import {
+  submitFeedback,
+  CONTACT_MAX,
+  FEEDBACK_MAX,
+  type FeedbackCategory,
+  type FeedbackInput
+} from "../domain/feedbackRemote";
+
+// Anonymous feedback form (#218 follow-up). A small in-app "suggestion box":
+// pick a kind (許願 / 問題 / 其他), type a message, optionally leave a contact,
+// submit anonymously to Supabase (no login). On failure (e.g. table not
+// migrated yet, or Supabase unconfigured) it falls back to opening a GitHub
+// issue. `submit` is injectable so the UI can be tested without Supabase.
+
+const ISSUE_NEW = "https://github.com/nurockplayer/Jabiko/issues/new";
+const GH_FALLBACK: Record<FeedbackCategory, string> = {
+  wish: `${ISSUE_NEW}?labels=enhancement&title=${encodeURIComponent("[許願] ")}`,
+  bug: `${ISSUE_NEW}?labels=bug&title=${encodeURIComponent("[Bug] ")}`,
+  other: ISSUE_NEW
+};
+
+async function defaultSubmit(input: FeedbackInput): Promise<void> {
+  const client = await getSupabase();
+  await submitFeedback(client, input);
+}
+
+type Status = "idle" | "sending" | "done" | "error";
+
+const KINDS: FeedbackCategory[] = ["wish", "bug", "other"];
+
+export function FeedbackForm({
+  language,
+  category,
+  onClose,
+  submit = defaultSubmit
+}: {
+  language: Language;
+  category: FeedbackCategory;
+  onClose: () => void;
+  submit?: (input: FeedbackInput) => Promise<void>;
+}) {
+  const t = copy[language];
+  const [kind, setKind] = useState<FeedbackCategory>(category);
+  const [message, setMessage] = useState("");
+  const [contact, setContact] = useState("");
+  const [status, setStatus] = useState<Status>("idle");
+
+  const trimmed = message.trim();
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!trimmed || status === "sending") return;
+    setStatus("sending");
+    try {
+      await submit({ category: kind, message: trimmed, contact: contact.trim() || undefined });
+      setStatus("done");
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  if (status === "done") {
+    return (
+      <div className="feedback-form feedback-done" role="status">
+        <p>{t.feedbackThanks}</p>
+        <button type="button" className="ghost-button" onClick={onClose}>
+          {t.feedbackClose}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form className="feedback-form" onSubmit={handleSubmit} aria-label={t.feedbackTitle}>
+      <div className="feedback-head">
+        <strong>{t.feedbackTitle}</strong>
+        <button type="button" className="feedback-close" aria-label={t.feedbackClose} onClick={onClose}>
+          <X aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="segmented feedback-kind">
+        {KINDS.map((option) => (
+          <button
+            key={option}
+            type="button"
+            className={kind === option ? "selected" : ""}
+            aria-pressed={kind === option}
+            onClick={() => setKind(option)}
+          >
+            {t.feedbackKind[option]}
+          </button>
+        ))}
+      </div>
+
+      <textarea
+        className="feedback-message"
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+        placeholder={t.feedbackPlaceholder}
+        rows={4}
+        maxLength={FEEDBACK_MAX}
+        aria-label={t.feedbackTitle}
+      />
+      <input
+        className="feedback-contact"
+        type="text"
+        value={contact}
+        onChange={(event) => setContact(event.target.value)}
+        placeholder={t.feedbackContact}
+        maxLength={CONTACT_MAX}
+      />
+      <p className="feedback-anon">{t.feedbackAnon}</p>
+
+      {status === "error" ? (
+        <p className="feedback-error" role="alert">
+          {t.feedbackError}{" "}
+          <a href={GH_FALLBACK[kind]} target="_blank" rel="noopener noreferrer">
+            {t.feedbackFallback}
+          </a>
+        </p>
+      ) : null}
+
+      <div className="feedback-actions">
+        <button type="submit" className="next-button" disabled={!trimmed || status === "sending"}>
+          <Send aria-hidden="true" />
+          {status === "sending" ? t.feedbackSending : t.feedbackSend}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -80,18 +80,12 @@ describe("HomePanel guide link", () => {
   });
 });
 
-describe("HomePanel feedback links", () => {
-  it("renders 許願 + 問題回報 links to GitHub issues, opening safely in a new tab", () => {
+describe("HomePanel feedback entry", () => {
+  it("opens the anonymous feedback form from a footer button", () => {
     renderHome();
-    const wish = screen.getByRole("link", { name: /許願/ });
-    const bug = screen.getByRole("link", { name: /回報/ });
-    expect(wish.getAttribute("href") ?? "").toContain("/issues/new");
-    expect(wish.getAttribute("href") ?? "").toContain("labels=enhancement");
-    expect(bug.getAttribute("href") ?? "").toContain("labels=bug");
-    for (const link of [wish, bug]) {
-      expect(link).toHaveAttribute("target", "_blank");
-      expect(link.getAttribute("rel") ?? "").toContain("noopener");
-    }
+    expect(screen.queryByText("意見回饋")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /許願功能/ }));
+    expect(screen.getByText("意見回饋")).toBeInTheDocument();
   });
 });
 

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,20 +1,17 @@
+import { useState } from "react";
 import { AlertTriangle, ArrowRight, BookOpen, Bug, CalendarCheck, Sparkles } from "lucide-react";
 import { copy, type Language } from "../i18n";
-
-// External walkthrough / 使用說明書: the author's blog post about Jabiko.
-// Surfaced in the hero so first-time visitors can read how to use the app.
-const GUIDE_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
-
-// 許願 / 問題回報: deep-link to a prefilled GitHub issue (the repo is public
-// with issues enabled). enhancement = feature wish, bug = problem report.
-const ISSUE_NEW = "https://github.com/nurockplayer/Jabiko/issues/new";
-const WISH_URL = `${ISSUE_NEW}?labels=enhancement&title=${encodeURIComponent("[許願] ")}`;
-const BUG_URL = `${ISSUE_NEW}?labels=bug&title=${encodeURIComponent("[Bug] ")}`;
 import type { Attempt } from "../domain/types";
 import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
+import { FeedbackForm } from "./FeedbackForm";
+import type { FeedbackCategory } from "../domain/feedbackRemote";
+
+// External walkthrough / 使用說明書: the author's blog post about Jabiko.
+// Surfaced in the hero so first-time visitors can read how to use the app.
+const GUIDE_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
 import {
   ToriiSpot,
   OmamoriSpot,
@@ -121,6 +118,10 @@ export function HomePanel({
   // accuracy, all aggregated from attempts (+ SRS state) with no heavy bank
   // import. Only shown once the learner has a history.
   const progress = computeProgressStats(progressAttempts);
+
+  // 許願 / 問題回報: which feedback form is open (null = closed). Opened by the
+  // footer buttons; the form submits anonymously to Supabase.
+  const [feedbackKind, setFeedbackKind] = useState<FeedbackCategory | null>(null);
 
   return (
     <section className="home-panel" aria-label={t.home}>
@@ -330,15 +331,22 @@ export function HomePanel({
         </div>
         <p>{t.homeFooterWish}</p>
         <div className="home-feedback">
-          <a className="home-feedback-link" href={WISH_URL} target="_blank" rel="noopener noreferrer">
+          <button type="button" className="home-feedback-link" onClick={() => setFeedbackKind("wish")}>
             <Sparkles aria-hidden="true" />
             {t.feedbackWish}
-          </a>
-          <a className="home-feedback-link" href={BUG_URL} target="_blank" rel="noopener noreferrer">
+          </button>
+          <button type="button" className="home-feedback-link" onClick={() => setFeedbackKind("bug")}>
             <Bug aria-hidden="true" />
             {t.feedbackBug}
-          </a>
+          </button>
         </div>
+        {feedbackKind ? (
+          <FeedbackForm
+            language={language}
+            category={feedbackKind}
+            onClose={() => setFeedbackKind(null)}
+          />
+        ) : null}
       </footer>
     </section>
   );

--- a/src/domain/feedbackRemote.test.ts
+++ b/src/domain/feedbackRemote.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { submitFeedback } from "./feedbackRemote";
+
+function fakeClient(insert: (row: unknown) => { error: unknown }) {
+  return {
+    from: (table: string) => {
+      expect(table).toBe("feedback");
+      return { insert: (row: unknown) => Promise.resolve(insert(row)) };
+    }
+  } as unknown as Parameters<typeof submitFeedback>[0];
+}
+
+describe("submitFeedback", () => {
+  it("inserts a trimmed, capped row and resolves on success", async () => {
+    let captured: any;
+    const client = fakeClient((row) => {
+      captured = row;
+      return { error: null };
+    });
+    await submitFeedback(client, { category: "wish", message: "  想要夜間模式  ", contact: " a@b.c " });
+    expect(captured).toEqual({ category: "wish", message: "想要夜間模式", contact: "a@b.c" });
+  });
+
+  it("stores null contact when blank", async () => {
+    let captured: any;
+    const client = fakeClient((row) => {
+      captured = row;
+      return { error: null };
+    });
+    await submitFeedback(client, { category: "bug", message: "壞了", contact: "   " });
+    expect(captured.contact).toBeNull();
+  });
+
+  it("throws 'empty' on a blank message without touching the client", async () => {
+    const insert = vi.fn();
+    const client = fakeClient(insert as never);
+    await expect(submitFeedback(client, { category: "other", message: "   " })).rejects.toThrow("empty");
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("throws 'unconfigured' on a null client", async () => {
+    await expect(submitFeedback(null, { category: "wish", message: "hi" })).rejects.toThrow("unconfigured");
+  });
+
+  it("propagates a Supabase error (e.g. table not migrated)", async () => {
+    const client = fakeClient(() => ({ error: new Error("relation does not exist") }));
+    await expect(submitFeedback(client, { category: "bug", message: "x" })).rejects.toThrow("relation");
+  });
+});

--- a/src/domain/feedbackRemote.ts
+++ b/src/domain/feedbackRemote.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Anonymous feedback submit (#218 follow-up). Thin wrapper over the Supabase
+// `feedback` table -- a write-only suggestion box (anon may INSERT, nobody may
+// SELECT via the API; see supabase/migrations/0002_create_feedback.sql).
+// No login required, so feedback can be fully anonymous.
+
+export type FeedbackCategory = "wish" | "bug" | "other";
+
+export interface FeedbackInput {
+  category: FeedbackCategory;
+  message: string;
+  contact?: string;
+}
+
+export const FEEDBACK_MAX = 4000;
+export const CONTACT_MAX = 200;
+
+// Insert one feedback row. Throws on an empty message ("empty"), an
+// unconfigured client ("unconfigured"), or a Supabase error (e.g. the table
+// not migrated yet) -- the caller surfaces these as a friendly retry / fallback.
+export async function submitFeedback(
+  client: SupabaseClient | null,
+  input: FeedbackInput
+): Promise<void> {
+  const message = input.message.trim();
+  if (!message) {
+    throw new Error("empty");
+  }
+  if (!client) {
+    throw new Error("unconfigured");
+  }
+
+  const contact = input.contact?.trim();
+  const { error } = await client.from("feedback").insert({
+    category: input.category,
+    message: message.slice(0, FEEDBACK_MAX),
+    contact: contact ? contact.slice(0, CONTACT_MAX) : null
+  });
+
+  if (error) {
+    throw error;
+  }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -26,6 +26,17 @@ export type Copy = {
   homeFooterWish: string;
   feedbackWish: string;
   feedbackBug: string;
+  feedbackTitle: string;
+  feedbackKind: { wish: string; bug: string; other: string };
+  feedbackPlaceholder: string;
+  feedbackContact: string;
+  feedbackAnon: string;
+  feedbackSend: string;
+  feedbackSending: string;
+  feedbackThanks: string;
+  feedbackClose: string;
+  feedbackError: string;
+  feedbackFallback: string;
   homeContentStats: (total: number, examItems: number, vocab: number, kanjiReadings: number, patternChecks: number, chapters: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
@@ -243,6 +254,17 @@ export const copy: Record<Language, Copy> = {
     homeFooterWish: "一步一步來，祝你考試順利合格。",
     feedbackWish: "許願功能",
     feedbackBug: "回報問題",
+    feedbackTitle: "意見回饋",
+    feedbackKind: { wish: "許願功能", bug: "回報問題", other: "其他" },
+    feedbackPlaceholder: "想許什麼願、遇到什麼問題，都可以直接說（匿名）…",
+    feedbackContact: "聯絡方式（選填，想收到回覆再留）",
+    feedbackAnon: "匿名送出，不需登入。",
+    feedbackSend: "送出",
+    feedbackSending: "送出中…",
+    feedbackThanks: "收到了，謝謝你的回饋！",
+    feedbackClose: "關閉",
+    feedbackError: "送出失敗，請稍後再試，或",
+    feedbackFallback: "改用 GitHub 回報",
     homeContentStats: (total, examItems, vocab, kanjiReadings, patternChecks, chapters) =>
       `全站 ${total.toLocaleString()} 題 · 檢定題 ${examItems} · 單字 ${vocab} · 漢字讀音 ${kanjiReadings} · 句型 ${patternChecks} · ${chapters} 學習章節`,
     homeCardStageLearn: "學",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -51,7 +51,9 @@
   border: 1px solid var(--panel-border);
   background: var(--paper);
   color: var(--teal-dark);
+  font: inherit;
   font-size: 0.85rem;
+  cursor: pointer;
   text-decoration: none;
   transition: border-color 0.16s ease, box-shadow 0.16s ease;
 }
@@ -64,6 +66,85 @@
 .home-feedback-link:hover {
   border-color: var(--teal-dark);
   box-shadow: var(--button-hover-shadow);
+}
+
+/* Anonymous feedback form (opened by the footer buttons). */
+.feedback-form {
+  width: 100%;
+  max-width: 32rem;
+  margin: 0.6rem auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem 1.1rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.85rem;
+  background: var(--paper);
+  text-align: left;
+}
+
+.feedback-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.feedback-head strong {
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.feedback-close {
+  display: inline-flex;
+  padding: 0.25rem;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.feedback-close svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.feedback-message,
+.feedback-contact {
+  width: 100%;
+  padding: 0.55rem 0.7rem;
+  border: 1px solid var(--field-border);
+  border-radius: 0.5rem;
+  background: var(--field-bg);
+  color: var(--button-text);
+  font: inherit;
+  resize: vertical;
+}
+
+.feedback-anon {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.feedback-error {
+  margin: 0;
+  color: var(--vermilion);
+  font-size: 0.85rem;
+}
+
+.feedback-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.feedback-done {
+  align-items: center;
+  text-align: center;
+}
+
+.feedback-done p {
+  margin: 0;
+  color: var(--ink);
 }
 
 .home-hero {

--- a/supabase/migrations/0002_create_feedback.sql
+++ b/supabase/migrations/0002_create_feedback.sql
@@ -1,0 +1,45 @@
+-- Anonymous feedback box (#218 follow-up): 許願 / 問題回報 / 其他.
+--
+-- A write-only "suggestion box". ANYONE -- anonymous (anon) or logged-in
+-- (authenticated) -- may INSERT a row; NOBODY may SELECT / UPDATE / DELETE
+-- through the API. The owner reads submissions in the Supabase Dashboard
+-- (the service_role bypasses RLS). No login required, so feedback can be
+-- fully anonymous.
+--
+-- HOW TO RUN (manual -- an agent has no Supabase project login):
+--   • Supabase Dashboard → SQL Editor → paste this whole file → Run, OR
+--   • supabase db push  (if the Supabase CLI is linked to the project).
+-- Idempotent: safe to re-run. No new env vars / keys needed (uses the
+-- existing anon key; access is gated by RLS + the grants below).
+
+create table if not exists public.feedback (
+  id          uuid        not null default gen_random_uuid() primary key,
+  category    text        not null default 'other',
+  message     text        not null,
+  contact     text,
+  created_at  timestamptz not null default now()
+);
+
+alter table public.feedback enable row level security;
+
+-- INSERT-only policy (applies to every role -- anon + authenticated). The
+-- WITH CHECK doubles as light server-side validation / abuse bound: a
+-- non-empty, length-capped message and a known category.
+drop policy if exists "feedback_insert_any" on public.feedback;
+create policy "feedback_insert_any" on public.feedback
+  for insert
+  with check (
+    char_length(message) between 1 and 4000
+    and char_length(coalesce(contact, '')) <= 200
+    and category in ('wish', 'bug', 'other')
+  );
+
+-- Deliberately NO select / update / delete policies: with RLS on and no such
+-- policy, the anon & authenticated roles can neither read nor modify rows via
+-- the API. Only the Dashboard (service_role, which bypasses RLS) can read the
+-- inbox. So submissions are write-only from the app and never publicly listable.
+
+-- Table-level privileges, made explicit (don't rely on Supabase's implicit
+-- default grants -- a fresh DB / `supabase db reset` may lack them). Grant
+-- INSERT only; never SELECT/UPDATE/DELETE to anon/authenticated.
+grant insert on public.feedback to anon, authenticated;


### PR DESCRIPTION
相關 #218

## 摘要
把「許願 / 回報」從 GitHub 連結改成 **站內匿名意見表單**（Google-Form 式，免登入、可匿名）。

- 首頁頁尾兩顆按鈕（許願功能 / 回報問題）→ 開表單：分類（許願/問題/其他）＋ 留言 ＋ 選填聯絡方式。
- **匿名送出、不需登入**。
- 送出失敗（表還沒建、或 Supabase 未設定）會自動退回「改用 GitHub 回報」連結，不會卡死。

## 後端（write-only 意見箱）
`supabase/migrations/0002_create_feedback.sql`：`feedback` 表 + RLS。
- `anon` / `authenticated` 可 **INSERT**（policy 帶長度/分類驗證），**沒有 SELECT/UPDATE/DELETE policy** → 任何人能投、沒人能透過 API 讀。
- 你在 **Supabase Dashboard**（service_role 繞過 RLS）讀收件匣。
- 明確 `grant insert ... to anon, authenticated`（不靠隱性 default grant，沿用 #196 教訓）。

## ⚠ 上線前要做一件事
到 **Supabase Dashboard → SQL Editor**，貼上 `0002_create_feedback.sql` 跑一次，表單才會真的寫入（在那之前送出會走 GitHub 退路）。

## 驗證
TDD：feedbackRemote 5 + FeedbackForm 4 + HomePanel 入口 1；全測 **353 passed**、tsc 0；build：Supabase SDK 仍 lazy（不進首屏）、`examBlocks` 仍 lazy、eager `index` +3KB。