### PR TITLE
fix(發音)：iOS 指定日文 voice，修中文語音念漢字

### DIFF
--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -1,5 +1,6 @@
 import { Volume2 } from "lucide-react";
 import { copy, type Language } from "../i18n";
+import { getJapaneseVoice } from "../lib/speech";
 
 // Small inline button that reads its `text` aloud via the browser's
 // built-in SpeechSynthesis API. No external TTS service or audio asset
@@ -23,6 +24,10 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
     try {
       window.speechSynthesis.cancel();
       const utterance = new window.SpeechSynthesisUtterance(text);
+      // iOS/iPadOS ignores `lang` alone and may read kanji with a Chinese
+      // voice -- pin an explicit ja-* voice when one is available.
+      const jaVoice = getJapaneseVoice();
+      if (jaVoice) utterance.voice = jaVoice;
       utterance.lang = "ja-JP";
       utterance.rate = 0.95;
       window.speechSynthesis.speak(utterance);

--- a/src/lib/speech.test.ts
+++ b/src/lib/speech.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { pickJapaneseVoice } from "./speech";
+
+// Minimal SpeechSynthesisVoice stand-ins.
+function voice(lang: string, name = lang, localService = true): SpeechSynthesisVoice {
+  return { lang, name, localService, default: false, voiceURI: name } as SpeechSynthesisVoice;
+}
+
+describe("pickJapaneseVoice", () => {
+  it("returns null when there is no Japanese voice", () => {
+    expect(pickJapaneseVoice([voice("zh-CN"), voice("en-US")])).toBeNull();
+  });
+
+  it("picks a ja-JP voice over zh / en (the iOS Chinese-voice bug)", () => {
+    const picked = pickJapaneseVoice([voice("zh-CN", "Tingting"), voice("ja-JP", "Kyoko"), voice("en-US")]);
+    expect(picked?.lang).toBe("ja-JP");
+    expect(picked?.name).toBe("Kyoko");
+  });
+
+  it("matches case-insensitively and on the ja- prefix", () => {
+    expect(pickJapaneseVoice([voice("JA-JP", "X")])?.lang).toBe("JA-JP");
+    expect(pickJapaneseVoice([voice("ja")])?.lang).toBe("ja");
+  });
+
+  it("does not mistake non-ja langs (e.g. jamo/java-ish) for Japanese", () => {
+    expect(pickJapaneseVoice([voice("jv-ID"), voice("en-JM")])).toBeNull();
+  });
+
+  it("prefers a local ja-JP voice over a remote one", () => {
+    const remote = voice("ja-JP", "Cloud", false);
+    const local = voice("ja-JP", "Kyoko", true);
+    expect(pickJapaneseVoice([remote, local])?.name).toBe("Kyoko");
+  });
+});

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -1,0 +1,62 @@
+// Japanese TTS voice selection.
+//
+// Bug (iPhone / iPad): the speak button read Japanese with a CHINESE voice.
+// iOS Safari ignores `utterance.lang = "ja-JP"` on its own and falls back to
+// the default voice -- and a Chinese TTS voice will happily read kanji, so the
+// listener hears Mandarin. The fix is to set `utterance.voice` to an explicit
+// ja-* SpeechSynthesisVoice (Windows / Android honour `lang`, hence "正常").
+//
+// getVoices() can be empty until the async 'voiceschanged' event fires
+// (notably on Safari), so we prime it once on load and re-query on each use.
+
+function isJapanese(v: SpeechSynthesisVoice): boolean {
+  const lang = (v.lang ?? "").toLowerCase();
+  return lang === "ja" || lang.startsWith("ja-") || lang.startsWith("ja_");
+}
+
+// Pure picker (unit-tested): prefer a local ja-JP voice (e.g. Kyoko), then any
+// ja-JP, then any local Japanese voice, then any Japanese voice. null if none.
+export function pickJapaneseVoice(voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null {
+  const ja = voices.filter(isJapanese);
+  if (ja.length === 0) return null;
+  const isJaJp = (v: SpeechSynthesisVoice) => (v.lang ?? "").toLowerCase() === "ja-jp";
+  return (
+    ja.find((v) => isJaJp(v) && v.localService) ??
+    ja.find(isJaJp) ??
+    ja.find((v) => v.localService) ??
+    ja[0]
+  );
+}
+
+function speechSynth(): SpeechSynthesis | null {
+  if (typeof window === "undefined" || !("speechSynthesis" in window)) return null;
+  return window.speechSynthesis;
+}
+
+// Prime the voice list once: some browsers only populate getVoices() after the
+// first call and/or the 'voiceschanged' event. Safe no-op when unsupported.
+function primeVoices() {
+  const synth = speechSynth();
+  if (!synth) return;
+  try {
+    synth.getVoices();
+    synth.addEventListener?.("voiceschanged", () => {
+      synth.getVoices();
+    });
+  } catch {
+    // ignore -- worst case the first click has no voice and falls back to lang
+  }
+}
+primeVoices();
+
+// Current best Japanese voice, or null. Re-queried each call so it reflects
+// voices that loaded after the initial prime.
+export function getJapaneseVoice(): SpeechSynthesisVoice | null {
+  const synth = speechSynth();
+  if (!synth) return null;
+  try {
+    return pickJapaneseVoice(synth.getVoices());
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 回報
> 使用 iPhone 和 iPad mini 會用中文語音輸出，但 Windows 和 Android 正常

## 根因
SpeakButton 只設了 `utterance.lang = "ja-JP"`，沒指定 `voice`。iOS/iPadOS Safari 會忽略 `lang`、用預設 voice，而中文 TTS 也能念漢字 → 聽起來變中文。Windows/Android honour `lang`，所以正常。

## 修法
明確挑一個 `ja-*` 的 `SpeechSynthesisVoice` 設到 `utterance.voice`。
- 新 `src/lib/speech.ts`：`pickJapaneseVoice()` 純函式（偏好本機 `ja-JP`，如 Kyoko → 任何 `ja-JP` → 任何本機日文 → 任何日文），`getJapaneseVoice()`，以及 voices 預熱（Safari 的 `getVoices()` 初期常為空、要等 `voiceschanged`）。
- `SpeakButton` 點擊時設 `utterance.voice`（找不到日文 voice 才退回只設 `lang`）。

## 驗證
TDD：`pickJapaneseVoice` 5 測試（含 zh/en 排除、ja-JP 優先、大小寫、本機優先、不誤判 jv/en-JM）。全測 **358 passed**、tsc 0；SpeakButton 仍為獨立 lazy chunk。

備註：實機需有日文語音資料（iOS 內建 Kyoko）；在日本的 iOS 裝置通常已具備。