### PR TITLE
fix(意見回饋)：表單改成置中 modal

### DIFF
--- a/src/components/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm.test.tsx
@@ -25,6 +25,29 @@ describe("FeedbackForm", () => {
     expect(submit).toHaveBeenCalledWith({ category: "wish", message: "想要夜間模式", contact: undefined });
   });
 
+  it("closes when the backdrop is clicked", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <FeedbackForm language="zh-Hant" category="wish" onClose={onClose} submit={vi.fn()} />
+    );
+    fireEvent.click(container.querySelector(".feedback-overlay")!);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not close when clicking inside the form", () => {
+    const onClose = vi.fn();
+    render(<FeedbackForm language="zh-Hant" category="wish" onClose={onClose} submit={vi.fn()} />);
+    fireEvent.click(screen.getByPlaceholderText(/想許什麼願/));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    render(<FeedbackForm language="zh-Hant" category="wish" onClose={onClose} submit={vi.fn()} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it("shows a GitHub fallback link when submit fails", async () => {
     const submit = vi.fn().mockRejectedValue(new Error("boom"));
     render(<FeedbackForm language="zh-Hant" category="bug" onClose={() => {}} submit={submit} />);

--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { Send, X } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { getSupabase } from "../lib/supabase";
@@ -51,6 +51,24 @@ export function FeedbackForm({
 
   const trimmed = message.trim();
 
+  // Modal behaviour: Escape closes, and the background page is locked from
+  // scrolling while open (the form pops centered over the viewport so the
+  // learner never has to scroll down to find it).
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [onClose]);
+
+  const stopClose = (event: { stopPropagation: () => void }) => event.stopPropagation();
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!trimmed || status === "sending") return;
@@ -65,17 +83,33 @@ export function FeedbackForm({
 
   if (status === "done") {
     return (
-      <div className="feedback-form feedback-done" role="status">
-        <p>{t.feedbackThanks}</p>
-        <button type="button" className="ghost-button" onClick={onClose}>
-          {t.feedbackClose}
-        </button>
+      <div className="feedback-overlay" role="presentation" onClick={onClose}>
+        <div
+          className="feedback-form feedback-done"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t.feedbackTitle}
+          onClick={stopClose}
+        >
+          <p>{t.feedbackThanks}</p>
+          <button type="button" className="ghost-button" onClick={onClose}>
+            {t.feedbackClose}
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
-    <form className="feedback-form" onSubmit={handleSubmit} aria-label={t.feedbackTitle}>
+    <div className="feedback-overlay" role="presentation" onClick={onClose}>
+      <form
+        className="feedback-form"
+        role="dialog"
+        aria-modal="true"
+        onSubmit={handleSubmit}
+        aria-label={t.feedbackTitle}
+        onClick={stopClose}
+      >
       <div className="feedback-head">
         <strong>{t.feedbackTitle}</strong>
         <button type="button" className="feedback-close" aria-label={t.feedbackClose} onClick={onClose}>
@@ -131,6 +165,7 @@ export function FeedbackForm({
           {status === "sending" ? t.feedbackSending : t.feedbackSend}
         </button>
       </div>
-    </form>
+      </form>
+    </div>
   );
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -68,11 +68,24 @@
   box-shadow: var(--button-hover-shadow);
 }
 
-/* Anonymous feedback form (opened by the footer buttons). */
+/* Anonymous feedback form -- a centered modal opened by the footer buttons
+   (so the learner never has to scroll down to find it). */
+.feedback-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(23, 33, 38, 0.5);
+}
+
 .feedback-form {
   width: 100%;
   max-width: 32rem;
-  margin: 0.6rem auto 0;
+  max-height: 90vh;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
@@ -80,6 +93,7 @@
   border: 1px solid var(--panel-border);
   border-radius: 0.85rem;
   background: var(--paper);
+  box-shadow: 0 12px 40px rgba(23, 33, 38, 0.28);
   text-align: left;
 }
 


### PR DESCRIPTION
## 回報
> 按了之後還要往下滑才看得到，UI 有點不直覺

(之前「按了沒反應」其實也是這個 —— 表單開在頁面最底、捲動範圍外，沒注意到。)

## 修法
意見回饋表單從「頁尾內嵌」改成 **置中彈出的 modal**：
- `position: fixed` 半透明遮罩 + 卡片置中，點哪顆按鈕都在畫面中央跳出,**不用捲動**。
- 點背景 / 按 Esc 關閉;開啟時鎖住背景捲動。

## 驗證(真瀏覽器 preview)
- scrollY=1205(頁面中段)時,表單 rect 仍完整落在視窗內(top 88 / bottom 529, vh 617)、overlay `position:fixed` z-index 1000。
- 點背景會關閉、關閉後解鎖捲動。
- 全測 **361 passed**、tsc 0;新增 modal 行為測試(背景關閉 / Esc / 點內部不關)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Converted the feedback form into a centered modal overlay with a dimmed background.
  * Added easy close actions: click outside the dialog or press **Esc**.
  * Improved dialog behavior by preventing background page scrolling while the modal is open.
  * Updated the feedback experience with clearer dialog semantics and better in-modal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->