### PR TITLE
fix(同步)：fetch 分頁，突破 PostgREST 1000 列上限

### DIFF
--- a/src/domain/attemptRemote.test.ts
+++ b/src/domain/attemptRemote.test.ts
@@ -60,13 +60,22 @@ function makeFakeClient(opts: {
       return {
         select(columns: string) {
           return {
-            eq(eqColumn: string, eqValue: string): Promise<QueryResult> {
+            // fetch paginates: .eq(...).order(...).range(from, to). The eq()
+            // result is a chainable builder whose range() resolves a page.
+            eq(eqColumn: string, eqValue: string) {
               selectCalls.push({ table, columns, eqColumn, eqValue });
-              return Promise.resolve(
-                opts.selectError
-                  ? { data: null, error: opts.selectError }
-                  : { data: opts.rows ?? [], error: null }
-              );
+              const builder = {
+                order() {
+                  return builder;
+                },
+                range(from: number, to: number): Promise<QueryResult> {
+                  if (opts.selectError) {
+                    return Promise.resolve({ data: null, error: opts.selectError });
+                  }
+                  return Promise.resolve({ data: (opts.rows ?? []).slice(from, to + 1), error: null });
+                }
+              };
+              return builder;
             }
           };
         },
@@ -113,6 +122,17 @@ describe("fetchRemoteAttempts", () => {
   it("throws when the query returns an error", async () => {
     const { client } = makeFakeClient({ selectError: new Error("boom") });
     await expect(fetchRemoteAttempts(client, "user-1")).rejects.toThrow("boom");
+  });
+
+  it("paginates past the PostgREST 1000-row cap (fetches every page)", async () => {
+    const rows = Array.from({ length: 1500 }, (_, i) => ({ payload: makeAttempt({ timestamp: i }) }));
+    const { client, selectCalls } = makeFakeClient({ rows });
+
+    const result = await fetchRemoteAttempts(client, "user-1");
+
+    expect(result).toHaveLength(1500);
+    // more than one page was fetched (1000 + 500), so the 1000 cap can't truncate.
+    expect(selectCalls.length).toBeGreaterThanOrEqual(2);
   });
 });
 

--- a/src/domain/attemptRemote.ts
+++ b/src/domain/attemptRemote.ts
@@ -30,16 +30,32 @@ export async function fetchRemoteAttempts(
     return [];
   }
 
-  const { data, error } = await client
-    .from("attempts")
-    .select("payload")
-    .eq("user_id", userId);
+  // PostgREST caps a single select at ~1000 rows (the project's max-rows),
+  // so a heavy learner's full history wouldn't all come back on a fresh
+  // device. Page through with .range() (ordered by the stable PK column `id`
+  // so pages don't overlap or skip) until a short page signals the end.
+  const PAGE = 1000;
+  const attempts: Attempt[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await client
+      .from("attempts")
+      .select("payload")
+      .eq("user_id", userId)
+      .order("id", { ascending: true })
+      .range(from, from + PAGE - 1);
 
-  if (error) {
-    throw error;
+    if (error) {
+      throw error;
+    }
+
+    const rows = data ?? [];
+    attempts.push(...rows.map((row) => (row as { payload: Attempt }).payload));
+    if (rows.length < PAGE) {
+      break;
+    }
   }
 
-  return (data ?? []).map((row) => (row as { payload: Attempt }).payload);
+  return attempts;
 }
 
 // Append the given attempts for this user. No-op on a null client or empty


### PR DESCRIPTION
## 問題
使用者問到「跨裝置 DB 是否有 1000 上限」—— 確實有，在**讀取**路徑。

`fetchRemoteAttempts` 之前是單次 `select`，PostgREST 預設一次最多回 ~1000 列。
- **上傳(push/upsert)無此限** → 雲端資料完整(先前實測雲端 1065 吻合本機)。
- **讀取(fetch)只回前 1000** → 答題數 >1000 的使用者，在**全新/重灌/清快取**的裝置同步回來時，超過 1000 的部分抓不回來。

## 修法
fetch 改成 `.order("id").range(from, to)` 分頁迴圈，逐頁抓到不足一頁為止 → 任意筆數都完整。用 PK 欄位 `id` 排序，分頁不重疊/不漏。

## 驗證
TDD：新增「1500 筆分頁」測試(驗證抓滿 1500、至少兩頁);全測 **362 passed**、tsc 0。純前端讀取修正，不需改 Supabase 設定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote attempt loading now fetches results in pages, so larger histories are returned completely instead of stopping at an initial limit.
  * Results are now ordered consistently, improving reliability when viewing many attempts.

* **Tests**
  * Added coverage for paginated loading to confirm large result sets are retrieved across multiple requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->