### PR TITLE
fix: Cloudflare 快取規則 _headers + robots.txt (#240)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,36 @@
+# Cloudflare Pages headers (issue #240). Vite copies public/_headers -> dist/_headers.
+# Rule precedence: when several rules match one path, a header set later in the
+# file wins. So list the broad extension rules first, then /assets/* and the
+# named root files last, so /assets/* stays immutable and the entry/SW files
+# always revalidate.
+
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+
+# Unhashed images/icons in public/ (change rarely): cache a day at the edge,
+# keep serving stale up to a week while revalidating in the background.
+/*.webp
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+/*.png
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+/*.svg
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+# Vite content-hashed build output — the filename changes on every change,
+# so these are safe to cache forever (this is the main cache-hit-rate fix).
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Entry document + service-worker control files — must revalidate so the PWA
+# (registerType "autoUpdate") can ship new versions instead of pinning stale ones.
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+/manifest.webmanifest
+  Cache-Control: public, max-age=0, must-revalidate
+/sw.js
+  Cache-Control: public, max-age=0, must-revalidate
+/registerSW.js
+  Cache-Control: public, max-age=0, must-revalidate
+/workbox-*.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
修 Cloudflare Cache Hit Rate 0.18%(issue #240)。根因:`public/` 無 `_headers`,hashed 資源完全沒被邊緣快取、一直回源。

## 變更
- **`public/_headers`**(Vite 複製到 `dist/_headers`):
  - `/assets/*` → `max-age=31536000, immutable`(content-hash,主要修正)
  - root 未 hash 圖示(webp/png/svg)→ `max-age=86400, stale-while-revalidate=604800`
  - `index.html`/`manifest.webmanifest`/`sw.js`/`registerSW.js`/`workbox-*.js` → `max-age=0, must-revalidate`(保住 PWA autoUpdate)
  - 全站 `X-Content-Type-Options: nosniff`、`Referrer-Policy`
  - 排序:廣域副檔名規則在前、`/assets/*` 與具名 root 檔在後(Cloudflare 後者覆蓋前者)
- **`public/robots.txt`**:allow-all(目前無 sitemap.xml,先不掛 Sitemap 行)

## 驗證
- build 後確認 `dist/_headers`、`dist/robots.txt` 都生成於 root ✓
- merge+重佈後:`curl -I .../assets/<hash>.js` 應見 immutable、重抓 `cf-cache-status: HIT`;`curl -I .../sw.js` 應為 must-revalidate

Closes #240