### PR TITLE
fix(srs): rest a missed item ~1h before it resurfaces

### DIFF
--- a/src/domain/practice.test.ts
+++ b/src/domain/practice.test.ts
@@ -13,7 +13,12 @@ import {
   scoreAttempt,
   shuffleQuestions
 } from "./practice";
+import { SRS_INTERVAL_DAYS } from "./srs";
 import type { VocabularyItem } from "./types";
+
+// Box-0 relearn cooldown in ms -- a just-missed item is due only after this
+// elapses (see srs.ts). Tests add it to the miss timestamp to reach "due".
+const BOX0_MS = SRS_INTERVAL_DAYS[0] * 24 * 60 * 60 * 1000;
 
 describe("buildClozeQuestionPool", () => {
   it("turns seed sentences into PracticeQuestion objects with curated options", () => {
@@ -768,9 +773,12 @@ describe("getReviewQueue", () => {
     expect(getReviewQueue([], pool, 10000)).toEqual([]);
   });
 
-  it("includes a question whose only attempt was wrong (box 0 due now)", () => {
+  it("rests a just-missed item, then surfaces it after the box-0 cooldown", () => {
     const wrong = scoreAttempt(pool[0], "wrong", 1000, 1500);
-    expect(getReviewQueue([wrong], pool, 1500)).toEqual([pool[0]]);
+    // Not due in the same session (would just train answer-memorisation) ...
+    expect(getReviewQueue([wrong], pool, 1500)).toEqual([]);
+    // ... due once the ~1-hour box-0 cooldown elapses.
+    expect(getReviewQueue([wrong], pool, 1500 + BOX0_MS)).toEqual([pool[0]]);
   });
 
   it("defers a correctly-answered question past its 1-day interval", () => {
@@ -786,7 +794,8 @@ describe("getReviewQueue", () => {
   it("re-adds a question that was answered correctly then missed again", () => {
     const right = scoreAttempt(pool[0], pool[0].expectedAnswers[0], 1000, 1300);
     const wrong = scoreAttempt(pool[0], "wrong", 2000, 2500);
-    expect(getReviewQueue([right, wrong], pool, 2500)).toEqual([pool[0]]);
+    // Back in box 0 -> due after the cooldown, not immediately.
+    expect(getReviewQueue([right, wrong], pool, 2500 + BOX0_MS)).toEqual([pool[0]]);
   });
 
   it("orders the queue with the most overdue item first", () => {
@@ -796,13 +805,14 @@ describe("getReviewQueue", () => {
     // ordering -- SRS prioritises items most at risk of being forgotten.)
     const olderMiss = scoreAttempt(pool[0], "wrong", 1000, 1500);
     const newerMiss = scoreAttempt(pool[1], "wrong", 3000, 3500);
-    const queue = getReviewQueue([olderMiss, newerMiss], pool, 4000);
+    // Past both box-0 cooldowns so both are due; older miss = smaller dueAt = first.
+    const queue = getReviewQueue([olderMiss, newerMiss], pool, 3500 + BOX0_MS);
     expect(queue.map((q) => q.id)).toEqual([pool[0].id, pool[1].id]);
   });
 
   it("deduplicates a question that has been missed multiple times", () => {
     const miss1 = scoreAttempt(pool[0], "wrong", 1000, 1500);
     const miss2 = scoreAttempt(pool[0], "wrong-again", 2000, 2500);
-    expect(getReviewQueue([miss1, miss2], pool, 2500)).toEqual([pool[0]]);
+    expect(getReviewQueue([miss1, miss2], pool, 2500 + BOX0_MS)).toEqual([pool[0]]);
   });
 });

--- a/src/domain/srs.test.ts
+++ b/src/domain/srs.test.ts
@@ -65,12 +65,15 @@ describe("computeReviewStates", () => {
     expect(states.size).toBe(0);
   });
 
-  it("seeds a first-wrong item in box 0 due immediately", () => {
+  it("seeds a first-wrong item in box 0 with a relearn rest before it's due", () => {
     const states = computeReviewStates([makeAttempt("q1", false, 5000)]);
     const state = states.get("q1");
     expect(state).toBeDefined();
     expect(state!.box).toBe(0);
     expect(state!.lastAttemptAt).toBe(5000);
+    // Box 0 rests SRS_INTERVAL_DAYS[0] days (~1 hour) instead of resurfacing
+    // immediately -- otherwise the learner just memorises the answer in the
+    // same session rather than recalling it.
     expect(state!.dueAt).toBe(5000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY);
   });
 
@@ -102,7 +105,8 @@ describe("computeReviewStates", () => {
     const state = states.get("q1")!;
     expect(state.box).toBe(0);
     expect(state.lastAttemptAt).toBe(5000);
-    expect(state.dueAt).toBe(5000); // box-0 interval is 0 days
+    // Reset goes back to the box-0 relearn rest, not "due now".
+    expect(state.dueAt).toBe(5000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY);
   });
 
   it("sorts unordered input chronologically before replay", () => {
@@ -135,52 +139,60 @@ describe("getDueQuestions", () => {
     expect(getDueQuestions([], pool, 10000)).toEqual([]);
   });
 
-  it("returns box-0 items as due right after a miss", () => {
+  it("rests a just-missed item until its box-0 interval, then makes it due", () => {
     const attempts = [makeAttempt("q1", false, 5000)];
-    expect(getDueQuestions(attempts, pool, 5000)).toEqual([pool[0]]);
-    expect(getDueQuestions(attempts, pool, 5100)).toEqual([pool[0]]);
+    const due = 5000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY;
+    // NOT due right after the miss (no same-session answer-cramming) ...
+    expect(getDueQuestions(attempts, pool, 5000)).toEqual([]);
+    expect(getDueQuestions(attempts, pool, due - 1)).toEqual([]);
+    // ... due once the box-0 relearn rest elapses.
+    expect(getDueQuestions(attempts, pool, due)).toEqual([pool[0]]);
   });
 
-  it("defers a correctly-answered question past its 1-day interval", () => {
-    // wrong at 1500, right at 2300 -> box 1, due at 2300 + 1 day.
+  it("defers a correctly-answered question past its box-1 interval", () => {
+    // wrong at 1500, right at 2300 -> box 1, due at 2300 + box-1 interval.
     const attempts = [
       makeAttempt("q1", false, 1500),
       makeAttempt("q1", true, 2300)
     ];
-    expect(getDueQuestions(attempts, pool, 2400)).toEqual([]);
-    expect(getDueQuestions(attempts, pool, 2300 + MS_PER_DAY - 1)).toEqual([]);
-    expect(getDueQuestions(attempts, pool, 2300 + MS_PER_DAY)).toEqual([pool[0]]);
+    const due = 2300 + SRS_INTERVAL_DAYS[1] * MS_PER_DAY;
+    expect(getDueQuestions(attempts, pool, due - 1)).toEqual([]);
+    expect(getDueQuestions(attempts, pool, due)).toEqual([pool[0]]);
   });
 
   it("re-includes the question once the interval elapses (overdue)", () => {
-    // wrong at 1500, right at 2300 (box 1). 3 days later it's overdue.
+    // wrong at 1500, right at 2300 (box 1). Well past the interval -> overdue.
     const attempts = [
       makeAttempt("q1", false, 1500),
       makeAttempt("q1", true, 2300)
     ];
-    const now = 2300 + 3 * MS_PER_DAY;
+    const now = 2300 + (SRS_INTERVAL_DAYS[1] + 2) * MS_PER_DAY;
     expect(getDueQuestions(attempts, pool, now)).toEqual([pool[0]]);
   });
 
-  it("re-adds an item to box 0 when missed after promotion", () => {
-    // Promote to box 2, then miss again. Should be due immediately.
+  it("re-adds a missed-after-promotion item to box 0 (rests, then due)", () => {
+    // Promote to box 2, then miss again -> back to box 0's relearn rest.
     const attempts = [
       makeAttempt("q1", false, 1000),
       makeAttempt("q1", true, 2000),
       makeAttempt("q1", true, 3000),
       makeAttempt("q1", false, 4000)
     ];
-    expect(getDueQuestions(attempts, pool, 4000)).toEqual([pool[0]]);
+    expect(getDueQuestions(attempts, pool, 4000)).toEqual([]); // resting
+    expect(
+      getDueQuestions(attempts, pool, 4000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY)
+    ).toEqual([pool[0]]);
   });
 
   it("orders due items most-overdue first", () => {
-    // q1 missed older, q2 missed more recently. Both box 0, both due.
-    // q1 is more overdue (smaller dueAt), so it comes first.
+    // q1 missed older, q2 missed more recently. Both box 0; check once both
+    // have passed the box-0 rest. q1 is more overdue (smaller dueAt) -> first.
     const attempts = [
       makeAttempt("q1", false, 1000),
       makeAttempt("q2", false, 5000)
     ];
-    const queue = getDueQuestions(attempts, pool, 9000);
+    const now = 5000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY + 1000;
+    const queue = getDueQuestions(attempts, pool, now);
     expect(queue.map((q) => q.id)).toEqual(["q1", "q2"]);
   });
 
@@ -190,7 +202,8 @@ describe("getDueQuestions", () => {
       makeAttempt("q1", false, 2000),
       makeAttempt("q1", false, 3000)
     ];
-    expect(getDueQuestions(attempts, pool, 3000)).toEqual([pool[0]]);
+    const now = 3000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY;
+    expect(getDueQuestions(attempts, pool, now)).toEqual([pool[0]]);
   });
 
   it("excludes items whose pool entry is missing", () => {
@@ -203,8 +216,8 @@ describe("getDueQuestions", () => {
 
 describe("countUpcoming", () => {
   it("counts items scheduled to become due within the window", () => {
-    // q1 -> box 1, due at 2300 + 1 day = 2300 + 86400000
-    // q2 -> box 2, due at 4000 + 3 days = 4000 + 259200000
+    // q1 -> box 1 (due ~SRS_INTERVAL_DAYS[1] days from 2300)
+    // q2 -> box 2 (due ~SRS_INTERVAL_DAYS[2] days from 4000)
     const attempts = [
       makeAttempt("q1", false, 1500),
       makeAttempt("q1", true, 2300),
@@ -212,16 +225,17 @@ describe("countUpcoming", () => {
       makeAttempt("q2", true, 2000),
       makeAttempt("q2", true, 4000)
     ];
-    // From t=0, looking 2 days ahead: only q1 fits (its dueAt is ~1 day).
-    expect(countUpcoming(attempts, 2, 0)).toBe(1);
-    // 5 days ahead: both q1 and q2 fit.
-    expect(countUpcoming(attempts, 5, 0)).toBe(2);
+    // From t=0, a window just past box-1's interval catches q1 but not q2.
+    expect(countUpcoming(attempts, SRS_INTERVAL_DAYS[1] + 1, 0)).toBe(1);
+    // A wide window catches both.
+    expect(countUpcoming(attempts, SRS_INTERVAL_DAYS[2] + 2, 0)).toBe(2);
   });
 
   it("excludes items already due (those go to getDueQuestions)", () => {
     const attempts = [makeAttempt("q1", false, 1000)];
-    // q1 is due at 1000 (box 0), and now=5000, so it's already due ->
-    // NOT counted as "upcoming".
-    expect(countUpcoming(attempts, 7, 5000)).toBe(0);
+    // Pick now AFTER q1's box-0 due time so it's already due -> NOT counted
+    // as "upcoming".
+    const now = 1000 + SRS_INTERVAL_DAYS[0] * MS_PER_DAY + 1;
+    expect(countUpcoming(attempts, 7, now)).toBe(0);
   });
 });

--- a/src/domain/srs.ts
+++ b/src/domain/srs.ts
@@ -7,14 +7,17 @@
 // weeks. JLPT prep runs 3-6 months, so we need item resurfacing.
 //
 // SRS rules implemented here:
-//   - First incorrect attempt seeds the item in box 0 (due now).
+//   - First incorrect attempt seeds the item in box 0. Box 0 is a short
+//     ~1-hour relearn cooldown (NOT 0) -- just long enough that a missed
+//     item won't resurface in the SAME study session (which only trains
+//     answer-memorisation, not recall -- learner feedback), while still
+//     coming back soon rather than days later.
 //   - Each subsequent CORRECT attempt promotes one box, growing the
-//     interval (0 -> 1 -> 3 -> 7 -> 14 days).
-//   - Any INCORRECT attempt resets to box 0.
-//   - Items capped at MAX_BOX (14-day interval). Going further (30 /
-//     60 days) is a one-line constant change if needed; capping at 14
-//     matches a typical JLPT-prep cadence where exam day is the goal,
-//     not lifelong retention.
+//     interval (1h -> 1 -> 3 -> 7 -> 14 days).
+//   - Any INCORRECT attempt resets to box 0 (back to the ~1-hour cooldown).
+//   - Items capped at MAX_BOX (14-day interval). Going further (30 / 60
+//     days) is a one-line constant change; capping at 14 matches a typical
+//     JLPT-prep cadence where exam day is the goal, not lifelong retention.
 //   - dueAt = lastAttemptAt + boxInterval. "Due" means dueAt <= now.
 //
 // State is DERIVED from the existing Attempt[] each call. No schema
@@ -29,7 +32,9 @@ import type { Attempt, PracticeQuestion } from "./types";
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-export const SRS_INTERVAL_DAYS = [0, 1, 3, 7, 14] as const;
+// Box 0 = 1/24 day (~1 hour): a relearn cooldown that just clears the
+// current session, not a multi-day wait. Boxes 1+ are the real spacing.
+export const SRS_INTERVAL_DAYS = [1 / 24, 1, 3, 7, 14] as const;
 export const SRS_MAX_BOX = SRS_INTERVAL_DAYS.length - 1;
 
 export interface ReviewItemState {

--- a/src/domain/stats.test.ts
+++ b/src/domain/stats.test.ts
@@ -5,6 +5,7 @@ import {
   levelFromQuestionId,
   MASTERY_BOX
 } from "./stats";
+import { SRS_INTERVAL_DAYS } from "./srs";
 import type { Attempt } from "./types";
 
 const DAY = 86_400_000;
@@ -99,9 +100,12 @@ describe("computeProgressStats", () => {
     expect(stats.dueCount).toBe(0);
   });
 
-  it("counts a freshly-missed item as due", () => {
+  it("rests a freshly-missed item, then counts it due after the box-0 interval", () => {
     const attempts = [attempt({ questionId: "n1-grammar-z", isCorrect: false, timestamp: NOW })];
-    const stats = computeProgressStats(attempts, NOW);
+    // Just missed -> resting, NOT due yet (no same-session answer-cramming).
+    expect(computeProgressStats(attempts, NOW).dueCount).toBe(0);
+    // Due once the box-0 relearn cooldown (~1 hour) elapses.
+    const stats = computeProgressStats(attempts, NOW + SRS_INTERVAL_DAYS[0] * DAY);
     expect(stats.dueCount).toBe(1);
     expect(stats.masteredCount).toBe(0);
   });

--- a/src/domain/stats.ts
+++ b/src/domain/stats.ts
@@ -15,7 +15,8 @@ const MS_PER_DAY = 86_400_000;
 // "Mastered" = a previously-missed item drilled up to a high SRS box.
 // (Items answered correctly on the first try never enter the SRS queue, so
 // this measures recovered weak points rather than total knowledge.) Box 3
-// is the 7-day interval -- solidly remembered, not yet fully graduated.
+// is the 7-day interval -- three correct reps after a miss, solidly
+// remembered but not yet fully graduated.
 export const MASTERY_BOX = 3;
 
 const LEVELS: JlptLevel[] = ["N1", "N2", "N3", "N4", "N5"];


### PR DESCRIPTION
## 問題
答錯的題目原本 box-0 間隔是 **0 天**，會立刻變成 due，可能在**同一回合**就再出現——這樣只是在背答案，不是真的回想（使用者回饋）。

## 修法
box-0 改成 **~1 小時的 relearn 冷卻**（`SRS_INTERVAL_DAYS[0] = 1/24` 天）：剛好離開當前回合，但又不會等到好幾天後才回來。box 1+ 維持原本 **1 / 3 / 7 / 14 天** 間隔，所以升級行為與精熟門檻（box 3 = 7 天）都不變。

## 測試
`srs` / `stats` / `practice` 三檔測試改為 **interval-agnostic**（直接對 `SRS_INTERVAL_DAYS` 斷言），並驗證剛答錯的題目**不會立刻 due**、而是在 box-0 冷卻後才浮現。

- ✅ `vitest run` 362/362
- ✅ `tsc --noEmit`
- ✅ `vite build`（`index` 仍 210.64 kB，`examBlocks` / `ChallengePanel` 維持 lazy chunk）