### PR TITLE
feat(mock): 模擬考新增 N3

### DIFF
--- a/src/components/MockExamPanel.tsx
+++ b/src/components/MockExamPanel.tsx
@@ -43,7 +43,7 @@ export function MockExamPanel({
       <fieldset className="mock-level-picker">
         <legend>{t.mockExamLevelLabel}</legend>
         <div className="segmented">
-          {(["N2", "N1"] as MockExamLevel[]).map((option) => (
+          {(["N3", "N2", "N1"] as MockExamLevel[]).map((option) => (
             <button
               key={option}
               type="button"

--- a/src/domain/mockExam.test.ts
+++ b/src/domain/mockExam.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getMockExamBlueprint, N1_BLUEPRINT, N2_BLUEPRINT } from "./mockExam";
+import { getMockExamBlueprint, N1_BLUEPRINT, N2_BLUEPRINT, N3_BLUEPRINT } from "./mockExam";
 
 // 模擬考 is now a section picker built on these blueprints (the timed
 // full-paper composer was removed). These tests pin the section metadata:
@@ -20,8 +20,22 @@ describe("getMockExamBlueprint", () => {
     expect(total).toBe(66);
   });
 
+  it("returns the N3 blueprint with the official 74-question total", () => {
+    const bp = getMockExamBlueprint("N3");
+    const total = bp.sections.reduce((sum, s) => sum + s.targetCount, 0);
+    expect(bp).toBe(N3_BLUEPRINT);
+    expect(total).toBe(74);
+    // N3 has NO 語形成 / 統合理解 / 主張理解 sections (those are N1/N2 only);
+    // its long reading is plain 内容理解（長文）.
+    const ids = bp.sections.map((s) => s.id);
+    expect(ids).not.toContain("go-keisei");
+    expect(ids).not.toContain("togo");
+    expect(ids).not.toContain("shucho");
+    expect(ids).toContain("dokkai-long");
+  });
+
   it("gives every section a non-empty promptLabel and stable id", () => {
-    for (const bp of [N1_BLUEPRINT, N2_BLUEPRINT]) {
+    for (const bp of [N1_BLUEPRINT, N2_BLUEPRINT, N3_BLUEPRINT]) {
       const ids = bp.sections.map((s) => s.id);
       expect(new Set(ids).size).toBe(ids.length); // ids unique within a level
       for (const section of bp.sections) {

--- a/src/domain/mockExam.ts
+++ b/src/domain/mockExam.ts
@@ -13,7 +13,7 @@
 // full-paper mode is ever wanted again.)
 import type { JlptLevel } from "./types";
 
-export type MockExamLevel = Extract<JlptLevel, "N1" | "N2">;
+export type MockExamLevel = Extract<JlptLevel, "N1" | "N2" | "N3">;
 
 export interface MockExamSection {
   /** Stable id used internally (e.g. "kanji-yomi"). */
@@ -83,6 +83,33 @@ export const N1_BLUEPRINT: MockExamBlueprint = {
   ]
 };
 
+// N3 言語知識（文字・語彙）・（文法）・読解 (聴解 is out of scope). N3 differs
+// from N2/N1: NO 語形成, and its long reading is plain 内容理解（長文） rather
+// than 統合理解 / 主張理解. The 文字・語彙 (30 min) + 文法・読解 (70 min) papers are
+// merged here into one section list, matching the N1/N2 blueprint shape.
+// promptLabels mirror the strings authored for N3 in examBlocks.ts; sections
+// with no authored items yet (表記 / 語順組合 / 読解) render as "準備中".
+export const N3_BLUEPRINT: MockExamBlueprint = {
+  level: "N3",
+  totalMinutes: 100,
+  sections: [
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", promptLabel: "漢字読み", targetCount: 8 },
+    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", promptLabel: "表記", targetCount: 6 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", promptLabel: "詞彙填空", targetCount: 11 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", promptLabel: "類義替換", targetCount: 5 },
+    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", promptLabel: "詞彙用法", targetCount: 5 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", promptLabel: "文法形式選擇", targetCount: 13 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", promptLabel: "語順組合", targetCount: 5 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", promptLabel: "文章脈絡", targetCount: 5 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", promptLabel: "内容理解（短文）", targetCount: 4 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", promptLabel: "内容理解（中文）", targetCount: 6 },
+    { id: "dokkai-long", labelJa: "内容理解（長文）", labelZh: "長文閱讀", promptLabel: "内容理解（長文）", targetCount: 4 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", promptLabel: "情報検索", targetCount: 2 }
+  ]
+};
+
 export function getMockExamBlueprint(level: MockExamLevel): MockExamBlueprint {
-  return level === "N1" ? N1_BLUEPRINT : N2_BLUEPRINT;
+  if (level === "N1") return N1_BLUEPRINT;
+  if (level === "N3") return N3_BLUEPRINT;
+  return N2_BLUEPRINT;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -295,7 +295,7 @@ export const copy: Record<Language, Copy> = {
     homeCardChallengeSub: "四種模式：基礎變化 · 句中填空 · 句型判斷 · 綜合考題庫。",
     homeCardChallengeMeta: "自由選詞類、目標形、JLPT 等級",
     homeCardMockTitle: "模擬考",
-    homeCardMockSub: "JLPT N1 / N2 整卷抽題，計時 + 結果分析。",
+    homeCardMockSub: "JLPT N1〜N3 題型分區，照官方結構逐區攻略。",
     homeCardMockMeta: "依官方題型結構",
     homeCardReviewTitle: "弱點複習",
     homeCardReviewSubActive: (count) => `${count} 題等你重練到對。`,


### PR DESCRIPTION
## 需求
使用者回饋:「希望未來能新增 N3 模擬考」。模擬考(題型分區練習)原本只開放 N1/N2。

## 內容
N3 題庫已有 6 個分區、共 351 題,完全夠開:

| 分區 | N3 題數 |
|---|---|
| 文法形式選擇 | 113 |
| 詞彙填空（文脈規定） | 101 |
| 漢字読み | 58 |
| 詞彙用法 | 30 |
| 類義替換 | 28 |
| 文章脈絡 | 21 |

## 改動
- **mockExam.ts**:`MockExamLevel` 加 N3;新增 `N3_BLUEPRINT`(N3 官方 言語知識・読解 結構——**無**語形成/統合理解/主張理解,長文為 内容理解（長文）);`getMockExamBlueprint` 支援 N3。
- **MockExamPanel.tsx**:等級選擇加 N3(N3 | N2 | N1)。
- **i18n.ts**:首頁卡文案原為「N1 / N2 整卷抽題,計時 + 結果分析」——同時舊在兩點(沒 N3、且現在是分區練習非計時整卷),改為「N1〜N3 題型分區,照官方結構逐區攻略」。

表記 / 語順組合 / 閱讀類目前無題,沿用既有「準備中」列(與 N1/N2 空分區一致)。

## 驗證
- ✅ `vitest` 363/363(新增 N3 blueprint 測試:total 74、無 語形成/統合/主張、有 内容理解長文)
- ✅ `tsc --noEmit`、`vite build`(`index` 210.64 kB,MockExamPanel 維持 lazy chunk)
- ✅ 瀏覽器端到端:N3 等級可選 → 分區題數正確(58/101/28/30/113/21)+ 空區準備中 → 點 漢字読み 真的開出 N3 題(`n3-kanji-koutsuu`)

## 後續(非本 PR)
表記 / 語順組合 可用既有出題 pipeline 補(各 ~5–8 題);長閱讀依現有「不做長閱讀/聽力」方針維持準備中。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the JLPT N3 mock exam level in the level picker and exam setup.
  * Expanded mock exam content to include an N3 blueprint with its own section breakdown.

* **Bug Fixes**
  * Updated mock exam selection so N3 now loads the correct question set and section structure.

* **Documentation**
  * Refined Traditional Chinese copy to reflect JLPT N1–N3 mock exam coverage and section-based practice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->