### PR TITLE
feat(home): 學習儀表板 v1（正答率環 + 各級長條 + 每日趨勢）#243

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -6,6 +6,10 @@ import type { LevelRange } from "../domain/levelRange";
 import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlocks";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
+import { computeActivityTrend } from "../domain/analytics/trend";
+import { AccuracyRing } from "./dashboard/AccuracyRing";
+import { LevelBars } from "./dashboard/LevelBars";
+import { ActivityTrend } from "./dashboard/ActivityTrend";
 import { FeedbackForm } from "./FeedbackForm";
 import type { FeedbackCategory } from "../domain/feedbackRemote";
 
@@ -47,6 +51,10 @@ const HOME_CONTENT_TOTAL =
   HOME_CONTENT_STATS.vocab +
   HOME_CONTENT_STATS.kanjiReadings +
   HOME_CONTENT_STATS.patternChecks;
+
+// Window for the home activity-trend strip (#243). Two weeks reads as a
+// glanceable "recent habit" without crowding the home page.
+const TREND_DAYS = 14;
 
 // First view the learner lands on. Three layers:
 //   1. Context-aware banner ("review N items" if any, else "continue
@@ -118,6 +126,8 @@ export function HomePanel({
   // accuracy, all aggregated from attempts (+ SRS state) with no heavy bank
   // import. Only shown once the learner has a history.
   const progress = computeProgressStats(progressAttempts);
+  // Daily practice volume for the last fortnight (dashboard v1, #243).
+  const activityTrend = computeActivityTrend(progressAttempts, TREND_DAYS);
 
   // 許願 / 問題回報: which feedback form is open (null = closed). Opened by the
   // footer buttons; the form submits anonymously to Supabase.
@@ -260,18 +270,21 @@ export function HomePanel({
             </div>
           </div>
 
-          {progress.perLevel.length > 0 ? (
-            <div className="home-stats-strip" aria-label={t.homeLevelLabel}>
-              {progress.perLevel.map((stat) => (
-                <div className="home-stats-cell" key={stat.level}>
-                  <strong>{stat.accuracy}%</strong>
-                  <small>
-                    {stat.level}・{t.homeLevelAnswered(stat.answered)}
-                  </small>
-                </div>
-              ))}
-            </div>
-          ) : null}
+          <div className="home-overview-row">
+            <AccuracyRing percent={progress.overallAccuracy} caption={t.homeStatsAccuracy} />
+            <LevelBars
+              levels={progress.perLevel}
+              caption={t.homeLevelLabel}
+              answeredLabel={t.homeLevelAnswered}
+            />
+          </div>
+
+          <ActivityTrend
+            points={activityTrend}
+            title={t.homeTrendTitle}
+            rangeLabel={t.homeTrendRange(TREND_DAYS)}
+            dayLabel={t.homeTrendDay}
+          />
         </section>
       ) : null}
 

--- a/src/components/dashboard/AccuracyRing.tsx
+++ b/src/components/dashboard/AccuracyRing.tsx
@@ -1,0 +1,31 @@
+// Overall-accuracy donut for the home dashboard (#243). Pure presentational:
+// takes a 0-100 percent + a caption and draws an SVG ring. Colours come from
+// CSS tokens (home.css) so dark mode is automatic; no chart library.
+const RADIUS = 52;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function AccuracyRing({ percent, caption }: { percent: number; caption: string }) {
+  const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+  const filled = (clamped / 100) * CIRCUMFERENCE;
+
+  return (
+    <div className="accuracy-ring" role="img" aria-label={`${caption}: ${clamped}%`}>
+      <svg viewBox="0 0 120 120" className="accuracy-ring-svg" aria-hidden="true">
+        <circle className="accuracy-ring-track" cx="60" cy="60" r={RADIUS} />
+        {/* rotate -90 so the arc starts at 12 o'clock and grows clockwise */}
+        <circle
+          className="accuracy-ring-fill"
+          cx="60"
+          cy="60"
+          r={RADIUS}
+          strokeDasharray={`${filled} ${CIRCUMFERENCE}`}
+          transform="rotate(-90 60 60)"
+        />
+      </svg>
+      <div className="accuracy-ring-center">
+        <strong>{clamped}%</strong>
+        <small>{caption}</small>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/ActivityTrend.tsx
+++ b/src/components/dashboard/ActivityTrend.tsx
@@ -1,0 +1,46 @@
+// Daily practice-volume bar strip for the home dashboard (#243). Pure
+// presentational: takes the dense TrendPoint[] from computeActivityTrend and
+// draws one bar per day, height scaled to the busiest day. Honest label:
+// this is attempts-per-day (題數), not study time. Tokenised colours; no deps.
+import type { TrendPoint } from "../../domain/analytics/trend";
+
+export function ActivityTrend({
+  points,
+  title,
+  rangeLabel,
+  dayLabel
+}: {
+  points: TrendPoint[];
+  title: string;
+  rangeLabel: string;
+  /** Builds the per-bar tooltip, e.g. (date, count) => "2026-06-27：8 題". */
+  dayLabel: (date: string, count: number) => string;
+}) {
+  if (points.length === 0) return null;
+
+  // Scale against the busiest day; floor at 1 so an all-zero week doesn't /0.
+  const peak = Math.max(1, ...points.map((p) => p.attempts));
+
+  return (
+    <div className="activity-trend" role="group" aria-label={title}>
+      <div className="activity-trend-head">
+        <span className="activity-trend-title">{title}</span>
+        <span className="activity-trend-range">{rangeLabel}</span>
+      </div>
+      <ol className="activity-trend-bars">
+        {points.map((point) => (
+          <li
+            key={point.dayBucket}
+            className={`activity-trend-bar${point.attempts === 0 ? " is-empty" : ""}`}
+            title={dayLabel(point.date, point.attempts)}
+          >
+            <span
+              className="activity-trend-bar-fill"
+              style={{ height: `${(point.attempts / peak) * 100}%` }}
+            />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/components/dashboard/LevelBars.tsx
+++ b/src/components/dashboard/LevelBars.tsx
@@ -1,0 +1,43 @@
+// Per-JLPT-level accuracy bars for the home dashboard (#243). Pure
+// presentational: takes the perLevel slice of computeProgressStats and draws
+// one labelled horizontal bar per level. Tokenised colours (home.css); no deps.
+import type { LevelStat } from "../../domain/stats";
+
+export function LevelBars({
+  levels,
+  caption,
+  answeredLabel
+}: {
+  levels: LevelStat[];
+  caption: string;
+  answeredLabel: (count: number) => string;
+}) {
+  if (levels.length === 0) return null;
+
+  return (
+    <div className="level-bars" role="group" aria-label={caption}>
+      <p className="level-bars-caption">{caption}</p>
+      <ul className="level-bars-list">
+        {levels.map((stat) => (
+          <li className="level-bar-row" key={stat.level}>
+            <span className="level-bar-tag">{stat.level}</span>
+            <span
+              className="level-bar-track"
+              role="progressbar"
+              aria-valuenow={stat.accuracy}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${stat.level} ${stat.accuracy}%`}
+            >
+              <span className="level-bar-fill" style={{ width: `${stat.accuracy}%` }} />
+            </span>
+            <span className="level-bar-value">
+              {stat.accuracy}%
+              <small>{answeredLabel(stat.answered)}</small>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/domain/analytics/trend.test.ts
+++ b/src/domain/analytics/trend.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { computeActivityTrend } from "./trend";
+import type { Attempt } from "../types";
+
+const MS_PER_DAY = 86_400_000;
+// A clean day boundary + a few seconds so "now" sits inside one day bucket.
+const NOW = 20_300 * MS_PER_DAY + 5_000;
+
+function attempt(over: Partial<Attempt>): Attempt {
+  return {
+    questionId: "n3-grammar-x",
+    vocabularyId: "v",
+    targetForm: "reading",
+    prompt: "",
+    expectedAnswers: ["a"],
+    submittedAnswer: "a",
+    isCorrect: true,
+    timestamp: NOW,
+    responseTimeMs: 100,
+    ...over
+  };
+}
+
+describe("computeActivityTrend", () => {
+  it("returns a dense, zero-filled range of `days` buckets ending today", () => {
+    const trend = computeActivityTrend([], 7, NOW);
+    expect(trend).toHaveLength(7);
+    const todayBucket = Math.floor(NOW / MS_PER_DAY);
+    // Oldest first, today last.
+    expect(trend[0].dayBucket).toBe(todayBucket - 6);
+    expect(trend[6].dayBucket).toBe(todayBucket);
+    // Empty history -> every bucket is zero (not an empty array).
+    for (const point of trend) {
+      expect(point.attempts).toBe(0);
+      expect(point.correct).toBe(0);
+      expect(point.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("buckets attempts by day and counts correct separately", () => {
+    const attempts = [
+      attempt({ timestamp: NOW, isCorrect: true }), // today
+      attempt({ timestamp: NOW - 1000, isCorrect: false }), // also today
+      attempt({ timestamp: NOW - 2 * MS_PER_DAY, isCorrect: true }) // 2 days ago
+    ];
+    const trend = computeActivityTrend(attempts, 7, NOW);
+    const today = trend[6];
+    expect(today.attempts).toBe(2);
+    expect(today.correct).toBe(1);
+    const twoAgo = trend[4];
+    expect(twoAgo.attempts).toBe(1);
+    expect(twoAgo.correct).toBe(1);
+  });
+
+  it("excludes attempts older than the window", () => {
+    const attempts = [attempt({ timestamp: NOW - 30 * MS_PER_DAY })];
+    const trend = computeActivityTrend(attempts, 7, NOW);
+    const total = trend.reduce((sum, p) => sum + p.attempts, 0);
+    expect(total).toBe(0);
+  });
+
+  it("includes an attempt on the oldest in-window day", () => {
+    const attempts = [attempt({ timestamp: NOW - 6 * MS_PER_DAY })];
+    const trend = computeActivityTrend(attempts, 7, NOW);
+    expect(trend[0].attempts).toBe(1);
+  });
+
+  it("returns an empty array for a non-positive window", () => {
+    expect(computeActivityTrend([attempt({})], 0, NOW)).toEqual([]);
+    expect(computeActivityTrend([attempt({})], -3, NOW)).toEqual([]);
+  });
+});

--- a/src/domain/analytics/trend.ts
+++ b/src/domain/analytics/trend.ts
@@ -1,0 +1,70 @@
+// Daily activity trend for the home dashboard (#243).
+//
+// A pure aggregator over the persisted Attempt[] history: it buckets
+// attempts by UTC day and returns a DENSE, zero-filled series of the last
+// `days` days ending today. "Dense" matters for the chart -- a day with no
+// practice must still be a zero-height bar, not a gap, so streaks read
+// honestly.
+//
+// NOTE on labelling: this is attempts-PER-DAY (題數), NOT study time. The
+// Attempt schema has responseTimeMs per answer but no session/idle data, so
+// a real "study duration" would overstate; the UI calls this 每日練習量.
+//
+// Like the rest of the analytics layer this imports ONLY ./types, so it is
+// safe to use from the eager home bundle (no exam-bank / vocabulary pull).
+import type { Attempt } from "../types";
+
+const MS_PER_DAY = 86_400_000;
+
+export interface TrendPoint {
+  /** UTC day index, Math.floor(timestamp / MS_PER_DAY). */
+  dayBucket: number;
+  /** ISO yyyy-mm-dd for the bucket (UTC), for labels/tooltips. */
+  date: string;
+  /** Attempts answered that day. */
+  attempts: number;
+  /** Correct attempts that day (<= attempts). */
+  correct: number;
+}
+
+function bucketToISO(dayBucket: number): string {
+  return new Date(dayBucket * MS_PER_DAY).toISOString().slice(0, 10);
+}
+
+/**
+ * Daily attempt counts for the last `days` days ending on today's bucket.
+ * Oldest day first, today last. Always returns exactly `days` points
+ * (zero-filled), or [] when `days` < 1. `now` is injectable for tests.
+ */
+export function computeActivityTrend(
+  attempts: Attempt[],
+  days: number,
+  now: number = Date.now()
+): TrendPoint[] {
+  if (days < 1) return [];
+
+  const todayBucket = Math.floor(now / MS_PER_DAY);
+  const startBucket = todayBucket - (days - 1);
+
+  const points: TrendPoint[] = [];
+  const byBucket = new Map<number, TrendPoint>();
+  for (let bucket = startBucket; bucket <= todayBucket; bucket++) {
+    const point: TrendPoint = {
+      dayBucket: bucket,
+      date: bucketToISO(bucket),
+      attempts: 0,
+      correct: 0
+    };
+    points.push(point);
+    byBucket.set(bucket, point);
+  }
+
+  for (const attempt of attempts) {
+    const point = byBucket.get(Math.floor(attempt.timestamp / MS_PER_DAY));
+    if (!point) continue; // outside the window
+    point.attempts += 1;
+    if (attempt.isCorrect) point.correct += 1;
+  }
+
+  return points;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -59,6 +59,9 @@ export type Copy = {
   homeStatsMastered: string;
   homeLevelLabel: string;
   homeLevelAnswered: (count: number) => string;
+  homeTrendTitle: string;
+  homeTrendRange: (days: number) => string;
+  homeTrendDay: (date: string, count: number) => string;
   homeCardLearnTitle: string;
   homeCardLearnSub: string;
   homeCardLearnMeta: (completed: number, total: number) => string;
@@ -288,6 +291,9 @@ export const copy: Record<Language, Copy> = {
     homeStatsMastered: "已熟練",
     homeLevelLabel: "各級正答率",
     homeLevelAnswered: (count) => `${count} 題`,
+    homeTrendTitle: "每日練習量",
+    homeTrendRange: (days) => `近 ${days} 天`,
+    homeTrendDay: (date, count) => `${date}：${count} 題`,
     homeCardLearnTitle: "學習",
     homeCardLearnSub: "章節式變化與句型解說，先看規則再練。",
     homeCardLearnMeta: (completed, total) => `已完成 ${completed} / ${total} 章`,

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -351,6 +351,204 @@
   letter-spacing: 0.02em;
 }
 
+/* ── Home dashboard v1 (#243) ──────────────────────────────────────────
+   Lightweight progress visuals layered into the existing .home-progress
+   section: an overall-accuracy ring + per-level bars (one row) and a daily
+   practice-volume strip below. All hand-rolled SVG/CSS, tokenised so dark
+   mode comes free; no chart library (keeps the eager bundle untouched). */
+.home-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+.home-overview-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.1rem;
+  padding: 1rem 1.1rem;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 0.85rem;
+}
+
+/* Accuracy ring */
+.accuracy-ring {
+  position: relative;
+  flex: 0 0 auto;
+  width: 120px;
+  height: 120px;
+}
+
+.accuracy-ring-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.accuracy-ring-track {
+  fill: none;
+  stroke: var(--rule);
+  stroke-width: 10;
+}
+
+.accuracy-ring-fill {
+  fill: none;
+  stroke: var(--matcha);
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dasharray 0.45s ease;
+}
+
+.accuracy-ring-center {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+}
+
+.accuracy-ring-center strong {
+  font-size: 1.7rem;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.accuracy-ring-center small {
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+/* Per-level accuracy bars */
+.level-bars {
+  flex: 1 1 220px;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.level-bars-caption {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.02em;
+}
+
+.level-bars-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.level-bar-row {
+  display: grid;
+  grid-template-columns: 1.7rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.level-bar-tag {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.level-bar-track {
+  display: block;
+  height: 0.5rem;
+  background: var(--rule);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.level-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--matcha);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.level-bar-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.level-bar-value small {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+/* Daily practice-volume strip */
+.activity-trend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.9rem 1.1rem;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 0.85rem;
+}
+
+.activity-trend-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.activity-trend-title {
+  font-size: 0.9rem;
+  color: var(--ink);
+}
+
+.activity-trend-range {
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.activity-trend-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.25rem;
+  height: 64px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.activity-trend-bar {
+  display: flex;
+  flex: 1 1 0;
+  align-items: flex-end;
+  min-width: 0;
+  height: 100%;
+}
+
+.activity-trend-bar-fill {
+  display: block;
+  width: 100%;
+  min-height: 2px;
+  background: var(--matcha);
+  border-radius: 3px 3px 0 0;
+  transition: height 0.3s ease;
+}
+
+.activity-trend-bar.is-empty .activity-trend-bar-fill {
+  background: var(--rule);
+}
+
 .home-grid {
   /* auto-fit so 4 cards stay 2×2 on desktop, 5 cards lay out as 2/2/1
    * (or 3/2 at wider viewports), and mobile drops to 1 column. */


### PR DESCRIPTION
#243 學習進度儀表板的**第一刀(陽春版)**,直接擴充首頁進度區(不新增分頁)。採 **foundation-first**:資料層是純 domain 模組、可單元測試,之後階段(題型弱點分析、成就徽章/目標、#242 個人化)能直接接、不用重寫。

> 與使用者對齊的範圍:入口=擴充首頁進度區;v1=總覽(KPI + 正答率環 + 各級長條)+ 每日練習量趨勢條。弱點分析/徽章/2D 熱圖/雲端持久化留後續階段。

## 改動
**資料層(TDD)**
- `src/domain/analytics/trend.ts` — `computeActivityTrend(attempts, days, now?)` 回傳**密集、補零**的每日序列(到今天為止)。只 import `./types`,eager 安全(不拉題庫)。

**UI(手刻 SVG/CSS,零新依賴,全用 token → 深色模式免費)**
- `AccuracyRing` — 總正答率環圈(重用 `computeProgressStats`)。
- `LevelBars` — N1–N5 各級正答率長條(`perLevel`,`role=progressbar`)。
- `ActivityTrend` — 近 14 天練習量長條。
- `HomePanel` 將三者接入 `.home-progress`;`computeProgressStats` 仍只算一次;原本各級的純文字格升級成長條。

**誠實標示**:趨勢是「每日**題數**(每日練習量)」非學習時長(無時長欄位);「已熟練」/正答率沿用既有 SRS 定義。

## 驗證
- ✅ `vitest` 368/368(含 5 個新 trend 測試)
- ✅ `tsc --noEmit`、`vite build`:eager entry +2.5KB、Supabase/examBlocks chunk **不變**、無題庫洩漏
- ✅ 瀏覽器(注入 12 天 N1–N5 模擬紀錄):環 79%、各級長條 54→100%、14 根趨勢條高度正確、無 console error
  - 註:截圖工具當下逾時,改以 DOM 斷言驗證數值與結構

## 後續階段(非本 PR)
弱點分析(題型/詞類 → 需 `questionTypeOf` 解碼器)、成就徽章 + 每日目標、2D 等級×題型熱圖、徽章/目標雲端持久化(歸 #242)。