### PR TITLE
feat(home): 儀表板 Phase 2 — 題型弱點分析 #243

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -7,9 +7,11 @@ import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlock
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
 import { computeActivityTrend } from "../domain/analytics/trend";
+import { computeErrorsByQuestionType } from "../domain/analytics/weakness";
 import { AccuracyRing } from "./dashboard/AccuracyRing";
 import { LevelBars } from "./dashboard/LevelBars";
 import { ActivityTrend } from "./dashboard/ActivityTrend";
+import { TypeBars } from "./dashboard/TypeBars";
 import { FeedbackForm } from "./FeedbackForm";
 import type { FeedbackCategory } from "../domain/feedbackRemote";
 
@@ -128,6 +130,8 @@ export function HomePanel({
   const progress = computeProgressStats(progressAttempts);
   // Daily practice volume for the last fortnight (dashboard v1, #243).
   const activityTrend = computeActivityTrend(progressAttempts, TREND_DAYS);
+  // Per-question-type accuracy, weakest first (dashboard phase 2, #243).
+  const typeWeakness = computeErrorsByQuestionType(progressAttempts);
 
   // 許願 / 問題回報: which feedback form is open (null = closed). Opened by the
   // footer buttons; the form submits anonymously to Supabase.
@@ -284,6 +288,13 @@ export function HomePanel({
             title={t.homeTrendTitle}
             rangeLabel={t.homeTrendRange(TREND_DAYS)}
             dayLabel={t.homeTrendDay}
+          />
+
+          <TypeBars
+            stats={typeWeakness}
+            caption={t.homeTypeWeaknessTitle}
+            label={(type) => t.questionTypeLabels[type]}
+            answeredLabel={t.homeLevelAnswered}
           />
         </section>
       ) : null}

--- a/src/components/dashboard/TypeBars.tsx
+++ b/src/components/dashboard/TypeBars.tsx
@@ -1,0 +1,55 @@
+// Per-question-type weakness bars for the home dashboard (#243, phase 2).
+// Pure presentational: takes the weakest-first QuestionTypeStat[] and draws a
+// labelled bar per type, colour-banded by accuracy (weak = vermilion, mid =
+// gold, strong = matcha) so the soft spots pop. Tokenised colours; no deps.
+import type { QuestionTypeStat } from "../../domain/analytics/weakness";
+import type { QuestionType } from "../../domain/analytics/questionType";
+
+function band(accuracy: number): string {
+  if (accuracy < 60) return "is-weak";
+  if (accuracy < 80) return "is-mid";
+  return "is-strong";
+}
+
+export function TypeBars({
+  stats,
+  caption,
+  label,
+  answeredLabel
+}: {
+  stats: QuestionTypeStat[];
+  caption: string;
+  label: (type: QuestionType) => string;
+  answeredLabel: (count: number) => string;
+}) {
+  if (stats.length === 0) return null;
+
+  return (
+    <div className="type-bars" role="group" aria-label={caption}>
+      <p className="type-bars-caption">{caption}</p>
+      <ul className="type-bars-list">
+        {stats.map((stat) => (
+          <li className="type-bar-row" key={stat.type}>
+            <span className="type-bar-tag">{label(stat.type)}</span>
+            <span
+              className="type-bar-track"
+              role="progressbar"
+              aria-valuenow={stat.accuracy}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${label(stat.type)} ${stat.accuracy}%`}
+            >
+              <span
+                className={`type-bar-fill ${band(stat.accuracy)}`}
+                style={{ width: `${stat.accuracy}%` }}
+              />
+            </span>
+            <span className="type-bar-value">
+              {stat.accuracy}%<small>{answeredLabel(stat.answered)}</small>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/domain/analytics/questionType.test.ts
+++ b/src/domain/analytics/questionType.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { questionTypeOf, QUESTION_TYPES } from "./questionType";
+import type { Attempt } from "../types";
+
+function withId(questionId: string | undefined): Attempt {
+  return {
+    questionId,
+    vocabularyId: "v",
+    targetForm: "reading",
+    prompt: "",
+    expectedAnswers: ["a"],
+    submittedAnswer: "a",
+    isCorrect: true,
+    timestamp: 0,
+    responseTimeMs: 1
+  };
+}
+
+describe("questionTypeOf", () => {
+  it("decodes every exam id 2nd segment", () => {
+    const cases: Record<string, string> = {
+      "n1-grammar-bakari": "grammar",
+      "n3-vocab-koutsuu": "vocab",
+      "n3-kanji-koutsuu": "kanji",
+      "n2-syn-aaa": "syn",
+      "n1-usage-bbb": "usage",
+      "n3-context-ccc": "context",
+      "n2-read-ddd": "read",
+      "n1-order-eee": "order",
+      "n2-text-fff": "text"
+    };
+    for (const [id, expected] of Object.entries(cases)) {
+      expect(questionTypeOf(withId(id))).toBe(expected);
+    }
+  });
+
+  it("buckets the non-exam practice modes by id namespace", () => {
+    expect(questionTypeOf(withId("cloze:te-form-001"))).toBe("cloze");
+    expect(questionTypeOf(withId("pattern-te-kudasai-001"))).toBe("pattern");
+    // basic conjugation / vocab-reading drills use the `vocabId:targetForm` id
+    expect(questionTypeOf(withId("kaku:te"))).toBe("basic");
+    // missing id (legacy attempts keyed by vocabularyId:targetForm) -> basic
+    expect(questionTypeOf(withId(undefined))).toBe("basic");
+  });
+
+  it("falls back to basic for an unrecognised id shape", () => {
+    expect(questionTypeOf(withId("n9-foo-bar"))).toBe("basic");
+    expect(questionTypeOf(withId("totally-unknown"))).toBe("basic");
+  });
+
+  it("lists exam types before the practice-mode buckets", () => {
+    // exam types first (so a worst-first sort still reads sensibly), basic last
+    expect(QUESTION_TYPES[0]).toBe("grammar");
+    expect(QUESTION_TYPES[QUESTION_TYPES.length - 1]).toBe("basic");
+    expect(new Set(QUESTION_TYPES).size).toBe(QUESTION_TYPES.length);
+  });
+});

--- a/src/domain/analytics/questionType.ts
+++ b/src/domain/analytics/questionType.ts
@@ -1,0 +1,56 @@
+// Question-type decoder for the dashboard weakness view (#243, phase 2).
+//
+// Mirrors stats.ts levelFromQuestionId: it reads the TYPE from an attempt's
+// id rather than needing the question bank, so it stays eager-safe (imports
+// only ./types). Exam items are id'd `n{1-5}-{type}-…` (grammar/vocab/kanji/
+// syn/usage/context/read/order/text); the non-exam practice modes use their
+// own id namespaces (cloze:… / pattern-… / `vocabId:targetForm`).
+//
+// This is the single type decoder the weakness metrics build on, and the same
+// brick a future 2-D level×type heatmap / #242 recommendation layer will reuse.
+import type { Attempt } from "../types";
+
+/** Exam-item question types, in display order (matches the id 2nd segment). */
+export const EXAM_QUESTION_TYPES = [
+  "grammar",
+  "vocab",
+  "kanji",
+  "syn",
+  "usage",
+  "context",
+  "read",
+  "order",
+  "text"
+] as const;
+
+export type ExamQuestionType = (typeof EXAM_QUESTION_TYPES)[number];
+
+/** All buckets: the 9 exam types, then the non-exam practice modes. */
+export type QuestionType = ExamQuestionType | "cloze" | "pattern" | "basic";
+
+export const QUESTION_TYPES: readonly QuestionType[] = [
+  ...EXAM_QUESTION_TYPES,
+  "cloze",
+  "pattern",
+  "basic"
+];
+
+const EXAM_TYPE_SET = new Set<string>(EXAM_QUESTION_TYPES);
+const EXAM_ID = /^n[1-5]-([a-z]+)/;
+
+/**
+ * Classify an attempt into a question-type bucket from its id. Exam ids map to
+ * their 2nd segment; cloze:/pattern- ids map to those modes; everything else
+ * (the `vocabId:targetForm` basic/vocab drills, missing ids, or any
+ * unrecognised shape) falls back to "basic".
+ */
+export function questionTypeOf(attempt: Attempt): QuestionType {
+  const id = attempt.questionId;
+  if (id) {
+    const match = EXAM_ID.exec(id);
+    if (match && EXAM_TYPE_SET.has(match[1])) return match[1] as ExamQuestionType;
+    if (id.startsWith("cloze:")) return "cloze";
+    if (id.startsWith("pattern-") || id.startsWith("pattern:")) return "pattern";
+  }
+  return "basic";
+}

--- a/src/domain/analytics/weakness.test.ts
+++ b/src/domain/analytics/weakness.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { computeErrorsByQuestionType } from "./weakness";
+import type { Attempt } from "../types";
+
+function ans(questionId: string, isCorrect: boolean): Attempt {
+  return {
+    questionId,
+    vocabularyId: "v",
+    targetForm: "reading",
+    prompt: "",
+    expectedAnswers: ["a"],
+    submittedAnswer: isCorrect ? "a" : "b",
+    isCorrect,
+    timestamp: 0,
+    responseTimeMs: 1
+  };
+}
+
+describe("computeErrorsByQuestionType", () => {
+  it("groups attempts by question type with accuracy", () => {
+    const stats = computeErrorsByQuestionType([
+      ans("n1-grammar-a", true),
+      ans("n1-grammar-b", false),
+      ans("n3-kanji-c", true),
+      ans("n3-kanji-d", true)
+    ]);
+    const grammar = stats.find((s) => s.type === "grammar");
+    const kanji = stats.find((s) => s.type === "kanji");
+    expect(grammar).toMatchObject({ answered: 2, correct: 1, accuracy: 50 });
+    expect(kanji).toMatchObject({ answered: 2, correct: 2, accuracy: 100 });
+  });
+
+  it("sorts weakest (lowest accuracy) first", () => {
+    const stats = computeErrorsByQuestionType([
+      ans("n3-kanji-a", true),
+      ans("n3-kanji-b", true),
+      ans("n1-grammar-c", false),
+      ans("n1-grammar-d", true),
+      ans("n2-vocab-e", false),
+      ans("n2-vocab-f", false)
+    ]);
+    expect(stats.map((s) => s.type)).toEqual(["vocab", "grammar", "kanji"]);
+  });
+
+  it("counts revealed answers as wrong, like the overall accuracy ring", () => {
+    // usePracticeSession records a reveal as { isCorrect:false }, so it must
+    // pull the type's accuracy DOWN -- the per-type bars stay consistent with
+    // computeProgressStats.overallAccuracy.
+    const reveal = { ...ans("n1-grammar-a", false), submittedAnswer: "(revealed)" };
+    const stats = computeErrorsByQuestionType([ans("n1-grammar-b", true), reveal]);
+    expect(stats.find((s) => s.type === "grammar")).toMatchObject({
+      answered: 2,
+      correct: 1,
+      accuracy: 50
+    });
+  });
+
+  it("excludes types with no attempts and returns [] for empty input", () => {
+    expect(computeErrorsByQuestionType([])).toEqual([]);
+    const stats = computeErrorsByQuestionType([ans("n1-grammar-a", true)]);
+    expect(stats).toHaveLength(1);
+    expect(stats.every((s) => s.answered > 0)).toBe(true);
+  });
+});

--- a/src/domain/analytics/weakness.ts
+++ b/src/domain/analytics/weakness.ts
@@ -1,0 +1,43 @@
+// Per-question-type accuracy for the dashboard weakness view (#243, phase 2).
+//
+// Pure aggregator over Attempt[]: groups by questionTypeOf and reports
+// answered / correct / accuracy per type, sorted weakest-first so the learner
+// sees where to focus. Every attempt is counted uniformly (a revealed answer
+// is isCorrect:false, so it lowers accuracy exactly like it does in
+// computeProgressStats -- the per-type bars stay consistent with the overall
+// accuracy ring). Imports only ./questionType + ./types -> eager-safe.
+import type { Attempt } from "../types";
+import { questionTypeOf, type QuestionType } from "./questionType";
+
+export interface QuestionTypeStat {
+  type: QuestionType;
+  answered: number;
+  correct: number;
+  /** Rounded percentage, 0-100. */
+  accuracy: number;
+}
+
+/**
+ * Accuracy per question type, weakest (lowest accuracy) first; ties broken by
+ * most-answered first (a 50% over 20 questions is a louder signal than 50%
+ * over 2). Types with no attempts are omitted; returns [] for empty input.
+ */
+export function computeErrorsByQuestionType(attempts: Attempt[]): QuestionTypeStat[] {
+  const byType = new Map<QuestionType, { answered: number; correct: number }>();
+
+  for (const attempt of attempts) {
+    const type = questionTypeOf(attempt);
+    const bucket = byType.get(type) ?? { answered: 0, correct: 0 };
+    bucket.answered += 1;
+    if (attempt.isCorrect) bucket.correct += 1;
+    byType.set(type, bucket);
+  }
+
+  const stats: QuestionTypeStat[] = [];
+  for (const [type, { answered, correct }] of byType) {
+    stats.push({ type, answered, correct, accuracy: Math.round((correct / answered) * 100) });
+  }
+
+  stats.sort((a, b) => a.accuracy - b.accuracy || b.answered - a.answered);
+  return stats;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,5 @@
 import type { PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
+import type { QuestionType } from "./domain/analytics/questionType";
 
 export type Language = "zh-Hant";
 
@@ -62,6 +63,8 @@ export type Copy = {
   homeTrendTitle: string;
   homeTrendRange: (days: number) => string;
   homeTrendDay: (date: string, count: number) => string;
+  homeTypeWeaknessTitle: string;
+  questionTypeLabels: Record<QuestionType, string>;
   homeCardLearnTitle: string;
   homeCardLearnSub: string;
   homeCardLearnMeta: (completed: number, total: number) => string;
@@ -294,6 +297,21 @@ export const copy: Record<Language, Copy> = {
     homeTrendTitle: "每日練習量",
     homeTrendRange: (days) => `近 ${days} 天`,
     homeTrendDay: (date, count) => `${date}：${count} 題`,
+    homeTypeWeaknessTitle: "題型弱點",
+    questionTypeLabels: {
+      grammar: "文法",
+      vocab: "詞彙",
+      kanji: "漢字読み",
+      syn: "類義",
+      usage: "用法",
+      context: "文脈",
+      read: "閱讀",
+      order: "語順",
+      text: "文章",
+      cloze: "句中填空",
+      pattern: "句型",
+      basic: "基礎・單字"
+    },
     homeCardLearnTitle: "學習",
     homeCardLearnSub: "章節式變化與句型解說，先看規則再練。",
     homeCardLearnMeta: (completed, total) => `已完成 ${completed} / ${total} 章`,

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -549,6 +549,88 @@
   background: var(--rule);
 }
 
+/* Per-question-type weakness bars (#243 phase 2). Same paper-card frame as
+   the trend strip; bars are accuracy-banded so soft spots read at a glance. */
+.type-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.9rem 1.1rem;
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 0.85rem;
+}
+
+.type-bars-caption {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink);
+}
+
+.type-bars-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.type-bar-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.type-bar-tag {
+  font-size: 0.8rem;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.type-bar-track {
+  display: block;
+  height: 0.5rem;
+  background: var(--rule);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.type-bar-fill {
+  display: block;
+  height: 100%;
+  background: var(--matcha);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.type-bar-fill.is-weak {
+  background: var(--vermilion);
+}
+
+.type-bar-fill.is-mid {
+  background: var(--gold);
+}
+
+.type-bar-fill.is-strong {
+  background: var(--matcha);
+}
+
+.type-bar-value {
+  display: flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.type-bar-value small {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
 .home-grid {
   /* auto-fit so 4 cards stay 2×2 on desktop, 5 cards lay out as 2/2/1
    * (or 3/2 at wider viewports), and mobile drops to 1 column. */


### PR DESCRIPTION
#243 儀表板 **Phase 2**:接在 v1 總覽之後,回答「**我哪裡弱、該練什麼?**」。延續 foundation-first:純解碼器 + 弱點聚合器,之後 2D 熱圖與 #242 推薦都會重用。

## 改動
**資料層(TDD,eager 安全,只 import `./types`)**
- `analytics/questionType.ts` — `questionTypeOf(attempt)` 由 id 解出題型:考檢題取 `n{1-5}-{type}-…` 第 2 段(grammar/vocab/kanji/syn/usage/context/read/order/text),`cloze:`/`pattern-` 依命名空間,其餘 → `basic`。比照 `levelFromQuestionId`。
- `analytics/weakness.ts` — `computeErrorsByQuestionType` 依題型算正答率,**最弱排前**(平手以題數多者優先)。**revealed 算答錯**(`isCorrect:false`),所以題型 bar 與 v1 總正答率環一致、不會各說各話。

**UI(手刻、零依賴、tokenised)**
- `TypeBars` — 依正答率**色帶**(弱=朱 / 中=金 / 強=綠)讓弱點一眼跳出;`role=progressbar`。接進首頁進度區(趨勢條下方),標籤用新增的 i18n `questionTypeLabels`。

## 驗證
- ✅ `vitest` 376/376(+8:4 questionType + 4 weakness)
- ✅ `tsc --noEmit`、`vite build`:eager entry +1.9KB、Supabase/examBlocks chunk **不變**、無題庫洩漏
- ✅ 瀏覽器(注入各題型紀錄):9 條題型 bar 最弱排前、正答率/色帶/平手序皆正確
  - 註:截圖工具當下逾時,改以 DOM 斷言驗證(文法 50%朱 → … → 文脈 100%綠)

## 後續(非本 PR)
成就徽章 + 每日目標(Phase 3,門檻待你定)、2D 等級×題型熱圖、徽章/目標雲端持久化(歸 #242)。