### PR TITLE
refactor(home): UI review 後的儀表板清理 #243

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -58,6 +58,10 @@ const HOME_CONTENT_TOTAL =
 // glanceable "recent habit" without crowding the home page.
 const TREND_DAYS = 14;
 
+// Cap the weakness breakdown to the few weakest types -- a "weakness" callout
+// is the soft spots, not an exhaustive list of every type practised.
+const TYPE_WEAKNESS_ROWS = 5;
+
 // First view the learner lands on. Three layers:
 //   1. Context-aware banner ("review N items" if any, else "continue
 //      chapter XX" if there's an incomplete one). Suppressed entirely
@@ -106,9 +110,6 @@ export function HomePanel({
   ];
 
   const totalAttempts = progressAttempts.length;
-  const correctAttempts = progressAttempts.filter((attempt) => attempt.isCorrect).length;
-  const accuracyPercent =
-    totalAttempts === 0 ? 0 : Math.round((correctAttempts / totalAttempts) * 100);
 
   // Only count "trackable" basic chapters towards the X / Y badge --
   // reference chapters (verb-types + the four sentence-pattern reading
@@ -239,27 +240,21 @@ export function HomePanel({
       ) : null}
 
       {totalAttempts > 0 ? (
-        <div className="home-stats-strip" aria-label={t.homeStatsLabel}>
-          <div className="home-stats-cell">
-            <strong>{totalAttempts}</strong>
-            <small>{t.homeStatsAttempts}</small>
-          </div>
-          <div className="home-stats-cell">
-            <strong>{accuracyPercent}%</strong>
-            <small>{t.homeStatsAccuracy}</small>
-          </div>
-          <div className="home-stats-cell">
-            <strong>
-              {completedChapters} / {trackableChapters.length}
-            </strong>
-            <small>{t.homeStatsChapters}</small>
-          </div>
-        </div>
-      ) : null}
-
-      {totalAttempts > 0 ? (
-        <section className="home-progress" aria-label={t.homeProgressLabel}>
-          <div className="home-stats-strip">
+        <section className="home-progress">
+          {/* One headed stats group: overall accuracy lives in the ring below,
+              so it's intentionally NOT repeated as a tile here. */}
+          <h2 className="home-progress-title">{t.homeProgressLabel}</h2>
+          <div className="home-stats-strip is-wrap" aria-label={t.homeStatsLabel}>
+            <div className="home-stats-cell">
+              <strong>{totalAttempts}</strong>
+              <small>{t.homeStatsAttempts}</small>
+            </div>
+            <div className="home-stats-cell">
+              <strong>
+                {completedChapters} / {trackableChapters.length}
+              </strong>
+              <small>{t.homeStatsChapters}</small>
+            </div>
             <div className="home-stats-cell">
               <strong>{progress.streakDays}</strong>
               <small>{t.homeStatsStreak}</small>
@@ -287,14 +282,16 @@ export function HomePanel({
             points={activityTrend}
             title={t.homeTrendTitle}
             rangeLabel={t.homeTrendRange(TREND_DAYS)}
+            peakLabel={t.homeTrendPeak}
             dayLabel={t.homeTrendDay}
           />
 
           <TypeBars
-            stats={typeWeakness}
+            stats={typeWeakness.slice(0, TYPE_WEAKNESS_ROWS)}
             caption={t.homeTypeWeaknessTitle}
             label={(type) => t.questionTypeLabels[type]}
             answeredLabel={t.homeLevelAnswered}
+            bandLabels={t.typeBandLabels}
           />
         </section>
       ) : null}

--- a/src/components/dashboard/ActivityTrend.tsx
+++ b/src/components/dashboard/ActivityTrend.tsx
@@ -8,24 +8,32 @@ export function ActivityTrend({
   points,
   title,
   rangeLabel,
+  peakLabel,
   dayLabel
 }: {
   points: TrendPoint[];
   title: string;
   rangeLabel: string;
+  /** Header magnitude anchor, e.g. (n) => "最多 n 題/日". Bars normalise to the
+   *  busiest day, so without this the absolute scale is invisible on touch. */
+  peakLabel: (count: number) => string;
   /** Builds the per-bar tooltip, e.g. (date, count) => "2026-06-27：8 題". */
   dayLabel: (date: string, count: number) => string;
 }) {
   if (points.length === 0) return null;
 
+  const busiest = Math.max(0, ...points.map((p) => p.attempts));
   // Scale against the busiest day; floor at 1 so an all-zero week doesn't /0.
-  const peak = Math.max(1, ...points.map((p) => p.attempts));
+  const peak = Math.max(1, busiest);
 
   return (
     <div className="activity-trend" role="group" aria-label={title}>
       <div className="activity-trend-head">
         <span className="activity-trend-title">{title}</span>
-        <span className="activity-trend-range">{rangeLabel}</span>
+        <span className="activity-trend-range">
+          {busiest > 0 ? `${peakLabel(busiest)} · ` : ""}
+          {rangeLabel}
+        </span>
       </div>
       <ol className="activity-trend-bars">
         {points.map((point) => (

--- a/src/components/dashboard/TypeBars.tsx
+++ b/src/components/dashboard/TypeBars.tsx
@@ -15,18 +15,29 @@ export function TypeBars({
   stats,
   caption,
   label,
-  answeredLabel
+  answeredLabel,
+  bandLabels
 }: {
   stats: QuestionTypeStat[];
   caption: string;
   label: (type: QuestionType) => string;
   answeredLabel: (count: number) => string;
+  /** Legend text for the three accuracy bands, low → high. */
+  bandLabels: { weak: string; mid: string; strong: string };
 }) {
   if (stats.length === 0) return null;
 
   return (
     <div className="type-bars" role="group" aria-label={caption}>
-      <p className="type-bars-caption">{caption}</p>
+      <div className="type-bars-head">
+        <p className="type-bars-caption">{caption}</p>
+        {/* Legend so the colour bands aren't a colour-only signal. */}
+        <ul className="type-bars-legend" aria-hidden="true">
+          <li className="is-weak">{bandLabels.weak}</li>
+          <li className="is-mid">{bandLabels.mid}</li>
+          <li className="is-strong">{bandLabels.strong}</li>
+        </ul>
+      </div>
       <ul className="type-bars-list">
         {stats.map((stat) => (
           <li className="type-bar-row" key={stat.type}>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -62,8 +62,10 @@ export type Copy = {
   homeLevelAnswered: (count: number) => string;
   homeTrendTitle: string;
   homeTrendRange: (days: number) => string;
+  homeTrendPeak: (count: number) => string;
   homeTrendDay: (date: string, count: number) => string;
   homeTypeWeaknessTitle: string;
+  typeBandLabels: { weak: string; mid: string; strong: string };
   questionTypeLabels: Record<QuestionType, string>;
   homeCardLearnTitle: string;
   homeCardLearnSub: string;
@@ -296,8 +298,10 @@ export const copy: Record<Language, Copy> = {
     homeLevelAnswered: (count) => `${count} 題`,
     homeTrendTitle: "每日練習量",
     homeTrendRange: (days) => `近 ${days} 天`,
+    homeTrendPeak: (count) => `最多 ${count} 題/日`,
     homeTrendDay: (date, count) => `${date}：${count} 題`,
     homeTypeWeaknessTitle: "題型弱點",
+    typeBandLabels: { weak: "待加強", mid: "普通", strong: "熟練" },
     questionTypeLabels: {
       grammar: "文法",
       vocab: "詞彙",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -362,6 +362,20 @@
   gap: 0.7rem;
 }
 
+.home-progress-title {
+  margin: 0 0 -0.1rem;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+}
+
+/* The merged lifetime+SRS metric strip carries 5 cells; auto-fit keeps them
+   even and wraps gracefully on narrow screens (vs the fixed 3-col default). */
+.home-stats-strip.is-wrap {
+  grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
+}
+
 .home-overview-row {
   display: flex;
   flex-wrap: wrap;
@@ -561,10 +575,56 @@
   border-radius: 0.85rem;
 }
 
+.type-bars-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem 0.8rem;
+}
+
 .type-bars-caption {
   margin: 0;
   font-size: 0.9rem;
   color: var(--ink);
+}
+
+/* Inline legend so the accuracy bands aren't a colour-only signal. */
+.type-bars-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.type-bars-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.type-bars-legend li::before {
+  content: "";
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--rule);
+}
+
+.type-bars-legend li.is-weak::before {
+  background: var(--vermilion);
+}
+
+.type-bars-legend li.is-mid::before {
+  background: var(--gold);
+}
+
+.type-bars-legend li.is-strong::before {
+  background: var(--matcha);
 }
 
 .type-bars-list {
@@ -578,7 +638,7 @@
 
 .type-bar-row {
   display: grid;
-  grid-template-columns: 4.5rem 1fr auto;
+  grid-template-columns: minmax(4.5rem, max-content) 1fr auto;
   align-items: center;
   gap: 0.5rem;
 }
@@ -587,6 +647,8 @@
   font-size: 0.8rem;
   color: var(--ink);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .type-bar-track {


### PR DESCRIPTION
做了一次**多視角 UI review**(clutter / 直覺 / 一致性 / a11y / 手機)。結論:**整體不算太亂、做得不錯**(主 CTA 仍在最上、全 token 化、a11y/誠實標示到位、無水平溢出),但有**真實但很窄的冗餘**。本 PR 套用 review 建議的 quick wins:

- **總正答率印了兩次**(KPI 格 + 環圈,同標籤)→ 拿掉重複的格子,環圈成為唯一出處(順手移除不再用到的 accuracyPercent 計算)。
- **兩條一模一樣的 3 格 strip 疊著、中間無標題** → 合併成**一條**(累積已答 / 完成章節 / 連續天數 / 待複習 / 已熟練,auto-fit),並把「學習進度」從 aria-label **升為可見標題**。
- **題型弱點無上限**(最多 12 列)→ 取**最弱 5 項**,回到「弱點」語意。
- **色帶是純顏色訊號** → 加 `待加強 / 普通 / 熟練` 圖例。
- **趨勢量級只在 hover tooltip**(手機點不到)→ 表頭加「最多 N 題/日」。
- type 標籤欄 `minmax(4.5rem,max-content)+ellipsis`,長標籤(基礎・單字)不再溢出。

**保留不動**(review 認定良好):儀表板位置、僅在有紀錄時顯示、無圖表函式庫、token 化深色、誠實文案、a11y。

## 成效
home-progress 676→**605px**、整頁 2346→**2169px**。

## 驗證
- ✅ `vitest` 376/376、`tsc`、`build`(eager chunk 不變)
- ✅ 瀏覽器:strip 只剩一條(含標題)、總正答率全頁只 1 次、題型 5 列 + 圖例、趨勢顯示峰值;無 console error
  - 註:截圖工具本 session 持續逾時,改以 DOM 量測驗證(統計上更準)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer progress headings and a more responsive stats layout on the home dashboard.
  * Added a text legend for performance bands, making the weakness breakdown easier to understand without relying on color alone.
  * Enhanced activity trend labels to show the busiest-day count in the header.

* **Bug Fixes**
  * Improved trend chart handling for days with no activity.
  * Limited the weakness breakdown to the top 5 question types for a cleaner view.
  * Simplified the stats strip to show only the most relevant progress metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->