### PR TITLE
refactor(home): 入口卡片移到統計資料上方

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -239,6 +239,56 @@ export function HomePanel({
         </button>
       ) : null}
 
+      <div className="home-grid">
+        {/* Each card carries a single-CJK "stage badge" (學 / 練 / 背 /
+            考 / 補) instead of a lucide-react icon. The icons read as
+            tech-product chrome; the kanji read as editorial. Stages
+            suggest a natural progression but the cards stay
+            independently entry-able -- a returning learner who only
+            wants today's mock exam can still jump straight to 考. */}
+        <button type="button" className="home-card" onClick={() => onNavigate("learn")}>
+          <BooksSpot className="home-card-spot" />
+          <h2>{t.homeCardLearnTitle}</h2>
+          <p>{t.homeCardLearnSub}</p>
+          <span className="home-card-meta">
+            {t.homeCardLearnMeta(completedChapters, trackableChapters.length)}
+          </span>
+          <ArrowRight className="home-card-arrow" aria-hidden="true" />
+        </button>
+        <button type="button" className="home-card" onClick={() => onNavigate("challenge")}>
+          <BrushSpot className="home-card-spot" />
+          <h2>{t.homeCardChallengeTitle}</h2>
+          <p>{t.homeCardChallengeSub}</p>
+          <span className="home-card-meta">{t.homeCardChallengeMeta}</span>
+          <ArrowRight className="home-card-arrow" aria-hidden="true" />
+        </button>
+        <button type="button" className="home-card" onClick={onStartVocab}>
+          <SpeechSpot className="home-card-spot" />
+          <h2>{t.homeCardVocabTitle}</h2>
+          <p>{t.homeCardVocabSub}</p>
+          <span className="home-card-meta">{t.homeCardVocabMeta}</span>
+          <ArrowRight className="home-card-arrow" aria-hidden="true" />
+        </button>
+        <button type="button" className="home-card" onClick={() => onNavigate("mock")}>
+          <ExamPaperSpot className="home-card-spot" />
+          <h2>{t.homeCardMockTitle}</h2>
+          <p>{t.homeCardMockSub}</p>
+          <span className="home-card-meta">{t.homeCardMockMeta}</span>
+          <ArrowRight className="home-card-arrow" aria-hidden="true" />
+        </button>
+        <button type="button" className="home-card" onClick={onStartReview}>
+          <TargetSpot className="home-card-spot" />
+          <h2>{t.homeCardReviewTitle}</h2>
+          <p>
+            {reviewCount > 0 ? t.homeCardReviewSubActive(reviewCount) : t.homeCardReviewSubEmpty}
+          </p>
+          <span className="home-card-meta">{t.homeCardReviewMeta}</span>
+          <ArrowRight className="home-card-arrow" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* Stats sit BELOW the entry cards: the actionable cards are the
+          headline; the progress dashboard is a glance-down afterthought. */}
       {totalAttempts > 0 ? (
         <section className="home-progress">
           {/* One headed stats group: overall accuracy lives in the ring below,
@@ -295,54 +345,6 @@ export function HomePanel({
           />
         </section>
       ) : null}
-
-      <div className="home-grid">
-        {/* Each card carries a single-CJK "stage badge" (學 / 練 / 背 /
-            考 / 補) instead of a lucide-react icon. The icons read as
-            tech-product chrome; the kanji read as editorial. Stages
-            suggest a natural progression but the cards stay
-            independently entry-able -- a returning learner who only
-            wants today's mock exam can still jump straight to 考. */}
-        <button type="button" className="home-card" onClick={() => onNavigate("learn")}>
-          <BooksSpot className="home-card-spot" />
-          <h2>{t.homeCardLearnTitle}</h2>
-          <p>{t.homeCardLearnSub}</p>
-          <span className="home-card-meta">
-            {t.homeCardLearnMeta(completedChapters, trackableChapters.length)}
-          </span>
-          <ArrowRight className="home-card-arrow" aria-hidden="true" />
-        </button>
-        <button type="button" className="home-card" onClick={() => onNavigate("challenge")}>
-          <BrushSpot className="home-card-spot" />
-          <h2>{t.homeCardChallengeTitle}</h2>
-          <p>{t.homeCardChallengeSub}</p>
-          <span className="home-card-meta">{t.homeCardChallengeMeta}</span>
-          <ArrowRight className="home-card-arrow" aria-hidden="true" />
-        </button>
-        <button type="button" className="home-card" onClick={onStartVocab}>
-          <SpeechSpot className="home-card-spot" />
-          <h2>{t.homeCardVocabTitle}</h2>
-          <p>{t.homeCardVocabSub}</p>
-          <span className="home-card-meta">{t.homeCardVocabMeta}</span>
-          <ArrowRight className="home-card-arrow" aria-hidden="true" />
-        </button>
-        <button type="button" className="home-card" onClick={() => onNavigate("mock")}>
-          <ExamPaperSpot className="home-card-spot" />
-          <h2>{t.homeCardMockTitle}</h2>
-          <p>{t.homeCardMockSub}</p>
-          <span className="home-card-meta">{t.homeCardMockMeta}</span>
-          <ArrowRight className="home-card-arrow" aria-hidden="true" />
-        </button>
-        <button type="button" className="home-card" onClick={onStartReview}>
-          <TargetSpot className="home-card-spot" />
-          <h2>{t.homeCardReviewTitle}</h2>
-          <p>
-            {reviewCount > 0 ? t.homeCardReviewSubActive(reviewCount) : t.homeCardReviewSubEmpty}
-          </p>
-          <span className="home-card-meta">{t.homeCardReviewMeta}</span>
-          <ArrowRight className="home-card-arrow" aria-hidden="true" />
-        </button>
-      </div>
 
       <footer className="home-footer">
         <div className="home-footer-spots" aria-hidden="true">


### PR DESCRIPTION
依使用者回饋:5 張入口卡(學習 / 挑戰 / 単字讀音 / 模擬考 / 弱點複習)是首頁的主要動作,但儀表板(#246/#247)把它們擠到很長的統計區下面。本 PR 把卡片移到統計上方,統計儀表板改成往下滑才看到的次要資訊。純 JSX 重排,無邏輯變動。

驗證:tsc / build 過;瀏覽器 DOM 順序確認 hero → banner → **入口卡** → 統計儀表板 → footer。