### PR TITLE
feat(about): 新增「關於」分頁（名字由來 + 作者簡介）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
 import { copy, type Language } from "./i18n";
-import { HomePanel, LearningPanel, RulesPanel } from "./components";
+import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { JabikoMark } from "./components/JabikoMark";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
@@ -36,7 +36,7 @@ const KanjiOnyomiPanel = lazy(() =>
   import("./components/KanjiOnyomiPanel").then((module) => ({ default: module.KanjiOnyomiPanel }))
 );
 
-type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock";
+type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about";
 type DrillPreset = LearningBlockDrillPreset;
 
 export default function App() {
@@ -211,6 +211,13 @@ export default function App() {
         >
           {t.mockExam}
         </button>
+        <button
+          type="button"
+          className={appView === "about" ? "selected" : ""}
+          onClick={() => setAppView("about")}
+        >
+          {t.about}
+        </button>
       </nav>
 
       <FuriganaContext.Provider value={{ enabled: furiganaEnabled }}>
@@ -238,6 +245,8 @@ export default function App() {
         />
       ) : appView === "rules" ? (
         <RulesPanel language={language} />
+      ) : appView === "about" ? (
+        <AboutPanel language={language} />
       ) : appView === "kanji" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
           <KanjiOnyomiPanel language={language} />

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,0 +1,42 @@
+import { copy, type Language } from "../i18n";
+import { BooksSpot } from "../illustrations";
+
+// The author's blog (same destination as the home hero's guide link).
+const BLOG_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
+
+// 關於 view: a quiet reading page -- where the name came from, how the app
+// grew, and a short note about who made it. Static text only (no learner
+// state, no heavy data), so it's an eager panel like RulesPanel.
+export function AboutPanel({ language }: { language: Language }) {
+  const t = copy[language];
+
+  return (
+    <section className="about-panel" aria-label={t.about}>
+      <header className="about-hero">
+        <BooksSpot className="panel-header-spot" />
+        <p className="eyebrow">{t.about}</p>
+        <h1>{t.aboutTitle}</h1>
+        <p className="about-tagline">{t.aboutTagline}</p>
+      </header>
+
+      <article className="about-section">
+        <h2>{t.aboutNameTitle}</h2>
+        <p>{t.aboutNameBody}</p>
+      </article>
+
+      <article className="about-section">
+        <h2>{t.aboutStoryTitle}</h2>
+        <p>{t.aboutStoryBody}</p>
+      </article>
+
+      <article className="about-section about-author">
+        <h2>{t.aboutAuthorTitle}</h2>
+        <p className="about-author-name">{t.aboutAuthorName}</p>
+        <p>{t.aboutAuthorBody}</p>
+        <a className="about-link" href={BLOG_URL} target="_blank" rel="noopener noreferrer">
+          {t.aboutAuthorLink}
+        </a>
+      </article>
+    </section>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,3 +13,4 @@
 export { HomePanel } from "./HomePanel";
 export { LearningPanel } from "./LearningPanel";
 export { RulesPanel } from "./RulesPanel";
+export { AboutPanel } from "./AboutPanel";

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -81,6 +81,17 @@ export type Copy = {
   homeCardReviewSubEmpty: string;
   homeCardReviewMeta: string;
   mockExam: string;
+  about: string;
+  aboutTitle: string;
+  aboutTagline: string;
+  aboutNameTitle: string;
+  aboutNameBody: string;
+  aboutStoryTitle: string;
+  aboutStoryBody: string;
+  aboutAuthorTitle: string;
+  aboutAuthorName: string;
+  aboutAuthorBody: string;
+  aboutAuthorLink: string;
   mockExamLevelLabel: string;
   mockSectionTitle: string;
   mockSectionIntro: string;
@@ -259,6 +270,20 @@ export const copy: Record<Language, Copy> = {
     rulesPanelIntro: "考試 / 練習中忘了形變化，直接翻這頁。涵蓋動詞三類分類、ます／て・た、可能・意向・受身・使役、形容詞與名詞變化、必要過去 step-by-step，以及 N5-N4 基礎句型 cheat sheet。",
     challenge: "挑戰",
     mockExam: "模擬考",
+    about: "關於",
+    aboutTitle: "關於 Jabiko",
+    aboutTagline: "Master Japanese verbs, one step at a time.",
+    aboutNameTitle: "名字由來",
+    aboutNameBody:
+      "Jabiko（ジャビ子）最初只是想做一個「把日語動詞變化練到熟」的小工具。名字拆開看：JA 是 Japanese、bi 取自動詞變化、ko 是日文裡那個可愛的「子」。於是有了 ジャビ子——一隻頭上頂著動詞變化表小書本的助理機器人，陪你 one step at a time，把ます形、て形、可能形一個一個記起來。",
+    aboutStoryTitle: "從緣起到現在",
+    aboutStoryBody:
+      "最早只有基礎變化練習，後來慢慢長出句中填空、句型判斷、JLPT 綜合題庫、模擬考、漢字讀音、間隔複習與學習儀表板——一步一步，越做越完整。",
+    aboutAuthorTitle: "作者",
+    aboutAuthorName: "花雪（HanaYukii）",
+    aboutAuthorBody:
+      "程式競賽出身、在 Google 待過三年的工程師，現在於 AI 新創擔任 Tech Lead。也是十年的日系偶像粉絲（私立恵比寿中学、=LOVE、ukka…），日語就這樣跟著偶像、邊追邊自學了好多年。Jabiko 最初是做給自己練動詞變化的小工具，做著做著就分享給同樣在學日語的人了。",
+    aboutAuthorLink: "更多關於作者 →",
     homeHeroTitle: "今天想練什麼？",
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",
     homeGuideLink: "使用說明書",

--- a/src/styles.css
+++ b/src/styles.css
@@ -9,4 +9,5 @@
 @import "./styles/home.css";
 @import "./styles/rules.css";
 @import "./styles/mock.css";
+@import "./styles/about.css";
 @import "./styles/responsive.css";

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -1,0 +1,75 @@
+/* 關於 page (#about). A quiet reading layout: a centred hero spot + a few
+   paper-card sections. Tokenised so dark mode comes free. */
+.about-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.about-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0 0.2rem;
+}
+
+.about-hero .panel-header-spot {
+  width: 64px;
+  height: 64px;
+}
+
+.about-hero h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  color: var(--ink);
+}
+
+.about-tagline {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+  font-style: italic;
+}
+
+.about-section {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: 0.85rem;
+  padding: 1.1rem 1.2rem;
+}
+
+.about-section h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.05rem;
+  color: var(--ink);
+}
+
+.about-section p {
+  margin: 0;
+  color: var(--ink);
+  line-height: 1.85;
+  font-size: 0.95rem;
+}
+
+.about-author-name {
+  font-weight: 600;
+  margin: 0 0 0.35rem !important;
+}
+
+.about-link {
+  display: inline-block;
+  margin-top: 0.8rem;
+  color: var(--teal);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.about-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
依使用者要求新增「關於」介面。第 7 個導覽分頁,安靜的閱讀版面(eager 純文字 panel,無學習狀態/無重資料)。

## 內容
- **名字由來**:Jabiko（ジャビ子）的由來——**JA**panese ＋ 動詞變化 ＋ **子**,頭頂動詞變化表的助理機器人。
- **從緣起到現在**:從單純的動詞變化練習,一步步長成現在的句中填空 / 句型 / 綜合題庫 / 模擬考 / 漢字讀音 / 間隔複習 / 儀表板。
- **作者**:花雪（HanaYukii）簡介(程式競賽出身、前 Google 工程師、十年日系偶像粉、日語跟著偶像自學多年)+ blog 連結。

## 改動
`AboutPanel.tsx` + barrel + `App.tsx`(AppView/nav/route)、文案全進 `i18n.ts`、token 化 `about.css`(深色模式免費)。

## 驗證
- ✅ `vitest` 376、`tsc`、`build`(Supabase / examBlocks chunk 不變;eager entry +2.4KB 純文字)
- ✅ 瀏覽器:7 tab 含「關於」、三區段 + blog 連結都正常、無 console error

文案之後想改隨時可調(都在 i18n)。