### PR TITLE
refactor(nav): 上方導覽改橫向細條

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -126,7 +126,22 @@
 
 .view-switch {
   margin: 0 auto 1rem;
-  max-width: 360px;
+}
+
+/* Top nav is a horizontal, wrapping bar -- the compound selector beats the
+   shared `.segmented` 2-col grid (challenge.css) without touching the
+   in-panel pickers that still use that grid. Buttons hug their labels and
+   wrap to a second row on narrow screens instead of stacking 4 rows tall. */
+.view-switch.segmented {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 760px;
+}
+
+.view-switch.segmented button {
+  flex: 0 1 auto;
+  padding-inline: 1.1rem;
 }
 
 .view-switch button {


### PR DESCRIPTION
依使用者觀察:導覽列 item 變多(7 個),原本沿用 `.segmented` 的 2 欄 grid → 疊成 4 列、又高,還和下面的入口卡片形成「重複的方塊感」。

## 改法
只覆寫 **`.view-switch.segmented`**(複合選擇器,specificity 高於共用的 `.segmented`,且 challenge.css 載入較晚也壓得過)→ top nav 變成**置中橫向 flex-wrap 細條**;**頁內**(挑戰/模擬考)的 segmented 選擇器**完全不動**,仍是 2 欄 grid。卡片保留(它們帶 nav 沒有的情境資訊:進度、待複習數、說明)。

純 CSS、零邏輯變動。

## 驗證
- ✅ 桌機:7 顆**一行**;手機 375px:折成 **2 列**(高度 ~145→95px)、無水平溢出
- ✅ 頁內 segmented(模擬考 level picker)仍 `display:grid`(未受影響)
- ✅ tsc / build 過、無 console error