### PR TITLE
feat(brand): 換新 Jabiko logo + 修首頁英文

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,7 @@ export default function App() {
         <div className="app-brand">
           <JabikoMark className="app-brand-mark" />
           <div>
-            <p className="eyebrow">Minna no Nihongo practice</p>
+            <p className="eyebrow">Your JLPT self-study room.</p>
             <h1>{t.appTitle}</h1>
           </div>
         </div>

--- a/src/components/JabikoMark.tsx
+++ b/src/components/JabikoMark.tsx
@@ -1,10 +1,14 @@
-// Jabiko mascot — 合格ちゃん, a matcha-green daruma (the Japanese
-// pass-your-exam talisman). Used as the brand mark in the app heading and the
-// practice side-panel lockup. Inline SVG so it stays crisp at any size; the
-// brand palette is hardcoded because the mark must read identically in light
-// and dark mode (it is not a theme-tinted UI element). Refined from the
-// generated concept: friendly raised brows (not a frown), unified dark-matcha
-// features for contrast, and no tiny details that vanish at ~28px.
+// Jabiko mascot — ジャビ子, a friendly helper-robot wearing an open
+// conjugation-table book as a hat. Used as the brand mark in the app heading
+// and the practice side-panel lockup. Inline SVG so it stays crisp at any
+// size; the brand palette is hardcoded (navy / cream / coral) because the mark
+// must read identically in light and dark mode -- it is not a theme-tinted UI
+// element. The mascot sits on a cream rounded badge so its navy outline keeps
+// contrast on dark backgrounds too. Kept to bold shapes that survive at ~28px.
+const NAVY = "#28385a";
+const CREAM = "#fbf4e7";
+const CORAL = "#f0a49c";
+
 export function JabikoMark({ className, title = "Jabiko" }: { className?: string; title?: string }) {
   return (
     <svg
@@ -14,23 +18,55 @@ export function JabikoMark({ className, title = "Jabiko" }: { className?: string
       role="img"
       aria-label={title}
     >
-      <path
-        d="M32 7c12 0 19 11 19 26 0 13-7 23-19 23S13 46 13 33C13 18 20 7 32 7Z"
-        fill="#647c5c"
-        stroke="#4f6549"
-        strokeWidth="3"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M32 48c8 0 13.5-4.2 13.5-4.2C45 51 39 56 32 56s-13-5-13.5-12.2C18.5 43.8 24 48 32 48Z"
-        fill="#4f6549"
-      />
-      <ellipse cx="32" cy="31" rx="14.5" ry="13" fill="#fdfdf7" stroke="#4f6549" strokeWidth="2.5" />
-      <path d="M22 24q4-2.5 8 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
-      <path d="M34 24q4-2.5 8 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
-      <circle cx="26" cy="31" r="3.1" fill="#4f6549" />
-      <circle cx="38" cy="31" r="3.1" fill="#4f6549" />
-      <path d="M27 38q5 4 10 0" fill="none" stroke="#4f6549" strokeWidth="2.6" strokeLinecap="round" />
+      {/* cream badge so the navy-outlined mascot reads on any background */}
+      <rect x="2" y="2" width="60" height="60" rx="15" fill={CREAM} stroke={NAVY} strokeWidth="2.5" />
+      <g transform="translate(6.4 5) scale(0.8)">
+        {/* shoulders / body */}
+        <path
+          d="M16 52c4-5 9-7 16-7s12 2 16 7v8H16Z"
+          fill={CORAL}
+          stroke={NAVY}
+          strokeWidth="3"
+          strokeLinejoin="round"
+        />
+        {/* ears */}
+        <rect x="8" y="30" width="9" height="15" rx="4.5" fill={CORAL} stroke={NAVY} strokeWidth="3" />
+        <rect x="47" y="30" width="9" height="15" rx="4.5" fill={CORAL} stroke={NAVY} strokeWidth="3" />
+        {/* head */}
+        <rect x="15" y="24" width="34" height="28" rx="12" fill={CREAM} stroke={NAVY} strokeWidth="3" />
+        {/* book hat: two pages meeting at a centre spine */}
+        <path
+          d="M32 11C27 8.5 22 8.5 18 10v13c4-1.5 9-1.5 14 1Z"
+          fill={CREAM}
+          stroke={NAVY}
+          strokeWidth="2.6"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M32 11c5-2.5 10-2.5 14-1v13c-4-1.5-9-1.5-14 1Z"
+          fill={CREAM}
+          stroke={NAVY}
+          strokeWidth="2.6"
+          strokeLinejoin="round"
+        />
+        {/* left page: conjugation grid */}
+        <rect x="21.5" y="13.5" width="6.5" height="6" rx="1" fill="none" stroke={CORAL} strokeWidth="1.6" />
+        <path d="M24.75 13.5v6M21.5 16.5h6.5" stroke={CORAL} strokeWidth="1.4" />
+        {/* right page: lines */}
+        <path
+          d="M35.5 15h7M35.5 17.6h7M35.5 20.2h5"
+          stroke={CORAL}
+          strokeWidth="1.6"
+          strokeLinecap="round"
+        />
+        {/* cheeks */}
+        <circle cx="22.5" cy="41" r="3" fill={CORAL} />
+        <circle cx="41.5" cy="41" r="3" fill={CORAL} />
+        {/* eyes + smile */}
+        <circle cx="26" cy="37" r="2.8" fill={NAVY} />
+        <circle cx="38" cy="37" r="2.8" fill={NAVY} />
+        <path d="M28 42.5q4 3.5 8 0" fill="none" stroke={NAVY} strokeWidth="2.6" strokeLinecap="round" />
+      </g>
     </svg>
   );
 }


### PR DESCRIPTION
依使用者要求換首頁左上 logo + 修怪英文。

## 改動
- **JabikoMark**:抹茶達摩 → **ジャビ子**(頂著動詞變化表書本的助理機器人,深藍/奶油/珊瑚)。維持 inline SVG(任意尺寸清晰、零資產);**加一層奶油圓角底座**,讓深藍外框在**深色背景**也讀得出(深色模式安全)。component props 不變,既有 `JabikoMark.test` 仍過;header + ModePicker 共用。
- **首頁英文**:`Minna no Nihongo practice`(怪) → **`Your JLPT self-study room.`**(app 已是完整 JLPT 自習室,不再只是 Minna 練習)。

> logo 是依你貼的 mascot 圖做的 **SVG 重建**;之後想要像素級一致,把 PNG 丟進 `public/` 我再換成讀檔。

## 驗證
- ✅ `vitest` 376、`tsc`、`build`(Supabase / examBlocks chunk 不變)
- ✅ 已用內嵌 widget 在淺/深色背景確認 logo 對比(底座解決深色外框變淡問題)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app header tagline to a more welcoming JLPT self-study message.
  * Replaced the brand mark with a new friendly mascot illustration and refreshed color palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->