### PR TITLE
chore(about): 作者連結改 /about + 更新偶像清單

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,8 +1,8 @@
 import { copy, type Language } from "../i18n";
 import { BooksSpot } from "../illustrations";
 
-// The author's blog (same destination as the home hero's guide link).
-const BLOG_URL = "https://hanayukii.dev/blog/jabiko-jlpt-app";
+// The author's personal "about" page.
+const ABOUT_URL = "https://hanayukii.dev/about";
 
 // 關於 view: a quiet reading page -- where the name came from, how the app
 // grew, and a short note about who made it. Static text only (no learner
@@ -33,7 +33,8 @@ export function AboutPanel({ language }: { language: Language }) {
         <h2>{t.aboutAuthorTitle}</h2>
         <p className="about-author-name">{t.aboutAuthorName}</p>
         <p>{t.aboutAuthorBody}</p>
-        <a className="about-link" href={BLOG_URL} target="_blank" rel="noopener noreferrer">
+        <p className="about-author-idols">{t.aboutAuthorIdols}</p>
+        <a className="about-link" href={ABOUT_URL} target="_blank" rel="noopener noreferrer">
           {t.aboutAuthorLink}
         </a>
       </article>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -91,6 +91,7 @@ export type Copy = {
   aboutAuthorTitle: string;
   aboutAuthorName: string;
   aboutAuthorBody: string;
+  aboutAuthorIdols: string;
   aboutAuthorLink: string;
   mockExamLevelLabel: string;
   mockSectionTitle: string;
@@ -282,7 +283,9 @@ export const copy: Record<Language, Copy> = {
     aboutAuthorTitle: "作者",
     aboutAuthorName: "花雪（HanaYukii）",
     aboutAuthorBody:
-      "程式競賽出身、在 Google 待了三年的工程師，2025 年離開後，現在於 AI 新創當 Tech Lead。日語是十年前考過 N2 就擱著的老本，直到 2024 年重新追起日系偶像（私立恵比寿中学、=LOVE、ukka…）才又撿了回來。離開 Google 成了一個契機：與其把日文當成一張考過就收進抽屜的證書，不如當成一條慢慢精進的線走下去——Jabiko 就是這條線上的工具，最初做給自己，後來也分享給同樣在學的人。",
+      "程式競賽出身、在 Google 待了三年的工程師，2025 年離開後，現在於 AI 新創當 Tech Lead。日語是十年前考過 N2 就擱著的老本，直到 2024 年重新追起日系偶像才又撿了回來。離開 Google 成了一個契機：與其把日文當成一張考過就收進抽屜的證書，不如當成一條慢慢精進的線走下去——Jabiko 就是這條線上的工具，最初做給自己，後來也分享給同樣在學的人。",
+    aboutAuthorIdols:
+      "目前在追：私立恵比寿中学・TEAM SHACHI・超ときめき♡宣伝部・高嶺のなでしこ・ももいろクローバーZ・ukka・=LOVE・TrySail・Aqours",
     aboutAuthorLink: "更多關於作者 →",
     homeHeroTitle: "今天想練什麼？",
     homeHeroIntro: "從基礎變化到 N1 題感。文法、漢字、單字、整卷模擬，一處解決。",

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -61,6 +61,13 @@
   margin: 0 0 0.35rem !important;
 }
 
+.about-author-idols {
+  margin: 0.7rem 0 0 !important;
+  font-size: 0.84rem !important;
+  color: var(--muted) !important;
+  line-height: 1.7;
+}
+
 .about-link {
   display: inline-block;
   margin-top: 0.8rem;


### PR DESCRIPTION
- 「更多關於作者」連結 → https://hanayukii.dev/about(作者個人 about 頁),不再連到 Jabiko blog 文章。
- 偶像清單從 bio 句子移到獨立一行(muted 小字),並更新為:私立恵比寿中学・TEAM SHACHI・超ときめき♡宣伝部・高嶺のなでしこ・ももいろクローバーZ・ukka・=LOVE・TrySail・Aqours。

純文案/標記。tsc/build 過;瀏覽器確認偶像行 + 連結 href 正確。