### PR TITLE
chore(about): 作者簡介改口語、留發展空間

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -283,7 +283,7 @@ export const copy: Record<Language, Copy> = {
     aboutAuthorTitle: "作者",
     aboutAuthorName: "花雪（HanaYukii）",
     aboutAuthorBody:
-      "程式競賽出身、在 Google 待了三年的工程師，2025 年離開後，現在於 AI 新創當 Tech Lead。日語是十年前考過 N2 就擱著的老本，直到 2024 年重新追起日系偶像才又撿了回來。離開 Google 成了一個契機：與其把日文當成一張考過就收進抽屜的證書，不如當成一條慢慢精進的線走下去——Jabiko 就是這條線上的工具，最初做給自己，後來也分享給同樣在學的人。",
+      "程式競賽出身、在 Google 待了三年的工程師，2025 年離開後，現在於 AI 新創當 Tech Lead。日語是十年前考過 N2 就擱著的老本，直到 2024 年重新追起日系偶像才又撿了回來。那之後多了點時間，就開始認真把它練起來——Jabiko 就是這時候做出來的：一開始給自己用，現在也開放給其他在學的人，之後有機會再慢慢做下去。",
     aboutAuthorIdols:
       "這些年陸續在追（也有幾團已經解散）：私立恵比寿中学・TEAM SHACHI・超ときめき♡宣伝部・高嶺のなでしこ・ももいろクローバーZ・ukka・=LOVE・TrySail・Aqours",
     aboutAuthorLink: "更多關於作者 →",


### PR DESCRIPTION
把作者簡介後半段改得更口語、不那麼高大上,也拿掉『免費分享』的定調(日後可能營利)。原『與其…不如…一條精進的線…工具』改成『那之後多了點時間就開始認真練——Jabiko 一開始給自己用,現在也開放給其他在學的人,之後有機會再慢慢做下去。』純 i18n 文案。