### PR TITLE
chore(about): 關於頁放大的 Jabiko logo

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,5 +1,5 @@
 import { copy, type Language } from "../i18n";
-import { BooksSpot } from "../illustrations";
+import { JabikoMark } from "./JabikoMark";
 
 // The author's personal "about" page.
 const ABOUT_URL = "https://hanayukii.dev/about";
@@ -13,7 +13,7 @@ export function AboutPanel({ language }: { language: Language }) {
   return (
     <section className="about-panel" aria-label={t.about}>
       <header className="about-hero">
-        <BooksSpot className="panel-header-spot" />
+        <JabikoMark className="about-hero-mark" />
         <p className="eyebrow">{t.about}</p>
         <h1>{t.aboutTitle}</h1>
         <p className="about-tagline">{t.aboutTagline}</p>

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -18,9 +18,9 @@
   padding: 0.5rem 0 0.2rem;
 }
 
-.about-hero .panel-header-spot {
-  width: 64px;
-  height: 64px;
+.about-hero-mark {
+  width: 116px;
+  height: 116px;
 }
 
 .about-hero h1 {


### PR DESCRIPTION
把「關於」頁 hero 的小書本 icon 換成 JabikoMark 吉祥物、放大到 116px,讓這頁以實際品牌 logo 開場。純元件/CSS。tsc/build 過;瀏覽器確認 116×116、aria-label=Jabiko。