### PR TITLE
feat(routing): 每頁獨立網址(上一頁/分享/重整都對)

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+# Cloudflare Pages SPA fallback: client-side routes (/about, /mock, /learn …)
+# have no built file, so serve the app shell and let the in-app router resolve
+# the view. Real static assets (/assets/*, /icon.svg, …) are matched first and
+# served directly, so this only catches unknown paths.
+/*  /index.html  200

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -50,6 +50,9 @@ describe("App", () => {
     await user.click(screen.getByRole("button", { name: "漢字" }));
     await screen.findByRole("heading", { name: /漢字音読み/ }, { timeout: 30000 });
     unmount();
+    // Priming navigated the URL (the app now routes view -> path); reset so the
+    // first test starts at "/" (afterEach only runs after each test, not here).
+    window.history.replaceState({}, "", "/");
   }, 60000);
 
   afterEach(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { Languages, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
@@ -39,8 +39,48 @@ const KanjiOnyomiPanel = lazy(() =>
 type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about";
 type DrillPreset = LearningBlockDrillPreset;
 
+// Lightweight URL routing: each top-level view maps to a path so the browser
+// back/forward buttons, refresh, and shareable/bookmarkable links all work
+// (no router dependency). The challenge view's internal mode/filter stays as
+// ephemeral state -- deep-linking a specific drill is out of scope here.
+// Needs a SPA fallback on the host (public/_redirects) so a direct hit on a
+// sub-path serves index.html.
+const VIEW_PATHS: Record<AppView, string> = {
+  home: "/",
+  learn: "/learn",
+  rules: "/rules",
+  kanji: "/kanji",
+  challenge: "/challenge",
+  mock: "/mock",
+  about: "/about"
+};
+
+function viewFromPath(pathname: string): AppView {
+  const match = (Object.entries(VIEW_PATHS) as [AppView, string][]).find(
+    ([, path]) => path === pathname
+  );
+  return match ? match[0] : "home";
+}
+
 export default function App() {
-  const [appView, setAppView] = useState<AppView>("home");
+  const [appView, setAppView] = useState<AppView>(() => viewFromPath(window.location.pathname));
+
+  // Keep the URL in sync when the view changes (push a history entry only
+  // when the path actually differs, so popstate-driven changes don't loop).
+  useEffect(() => {
+    const target = VIEW_PATHS[appView];
+    if (window.location.pathname !== target) {
+      window.history.pushState({ view: appView }, "", target);
+    }
+  }, [appView]);
+
+  // Back/forward: read the view back off the URL.
+  useEffect(() => {
+    const onPopState = () => setAppView(viewFromPath(window.location.pathname));
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
   // Single-language app (zh-Hant). The `language` seam is kept so the
   // copy[language] call sites and component props don't have to change;
   // re-adding a locale later is just restoring entries in i18n.ts.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,10 @@ export default defineConfig({
         ]
       },
       workbox: {
+        // Client-side routes (/about, /mock, …) have no precached file; serve
+        // the app shell for navigations so deep links / refresh work offline
+        // too (the host's public/_redirects covers the online first-load).
+        navigateFallback: "index.html",
         // Code/markup only here; static images (icons / hero / og) are
         // precached via includeAssets above. Keeping them out of
         // globPatterns avoids duplicate precache entries for the same URL.


### PR DESCRIPTION
依使用者建議:讓 7 個主頁各有網址,瀏覽器上一頁/前進、分享、收藏、重新整理都能對。

## 做法(輕量、零依賴)
- `VIEW_PATHS` 把每個 view 對到路徑:`/`・`/learn`・`/rules`・`/kanji`・`/challenge`・`/mock`・`/about`。
- 初始 `appView` 從 `location.pathname` 推導;view 變更時 `pushState`(只在路徑不同才推,避免 popstate 迴圈);`popstate` 監聽器在上一頁/前進時把 view 讀回來。
- `public/_redirects`:Cloudflare Pages SPA fallback(`/* /index.html 200`),直接打子路徑也能載入 app shell。
- `vite.config` workbox `navigateFallback: index.html`:離線時 service worker 也走 SPA fallback。

挑戰頁內部的 mode/filter 仍是暫時狀態(深連特定 drill 不在這批範圍)。`App.test` 的 beforeAll 預熱後重置網址。

## 驗證
- ✅ `vitest` 376、`tsc`、`build`(dist 有 `_redirects`、`sw.js` 有 NavigationRoute→index.html)
- ✅ 瀏覽器:切 tab 網址會變;上一頁/前進切換 view;重整 `/about` 仍停在關於頁