### PR TITLE
refactor: 統一 exam preset 來源 + 4 個 quick wins

### DIFF
--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -88,30 +88,18 @@ export function DrillPanel({
   // Completion-screen copy: daily / review have their own wording; every
   // other (capped, #154) finite session uses the generic "這組完成" set.
   const wrongCount = attempts.length - correctCount;
-  const doneTitle =
+  // One copy set per finish flavour (daily / review / generic capped #154);
+  // pick once so a new variant is a single map entry, not four-in-lockstep.
+  const doneCopy =
     practiceMode === "daily"
-      ? t.dailyDoneTitle
+      ? { title: t.dailyDoneTitle, body: t.dailyDoneBody, again: t.dailyDoneAgain, exit: t.dailyDoneExit }
       : practiceMode === "review"
-        ? t.reviewDoneTitle
-        : t.sessionDoneTitle;
-  const doneBody =
-    practiceMode === "daily"
-      ? t.dailyDoneBody(correctCount, wrongCount)
-      : practiceMode === "review"
-        ? t.reviewDoneBody(correctCount, wrongCount)
-        : t.sessionDoneBody(correctCount, wrongCount);
-  const doneAgain =
-    practiceMode === "daily"
-      ? t.dailyDoneAgain
-      : practiceMode === "review"
-        ? t.reviewDoneAgain
-        : t.sessionDoneAgain;
-  const doneExit =
-    practiceMode === "daily"
-      ? t.dailyDoneExit
-      : practiceMode === "review"
-        ? t.reviewDoneExit
-        : t.sessionDoneExit;
+        ? { title: t.reviewDoneTitle, body: t.reviewDoneBody, again: t.reviewDoneAgain, exit: t.reviewDoneExit }
+        : { title: t.sessionDoneTitle, body: t.sessionDoneBody, again: t.sessionDoneAgain, exit: t.sessionDoneExit };
+  const doneTitle = doneCopy.title;
+  const doneBody = doneCopy.body(correctCount, wrongCount);
+  const doneAgain = doneCopy.again;
+  const doneExit = doneCopy.exit;
 
   // Container-level answer state for embedded AI / browser automation:
   // collapse feedback into one result string so .drill-panel exposes the

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -3,7 +3,13 @@ import { copy, type Language } from "../../i18n";
 import { JabikoMark } from "../JabikoMark";
 import type { PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
 import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../../domain/levelRange";
-import { type PracticeMode, type PracticeSession } from "../../hooks/usePracticeSession";
+import {
+  EXAM_PRESET_BY_RANGE,
+  type ExamPresetId,
+  type ModeCopyKey,
+  type PracticeMode
+} from "../../domain/practiceMode";
+import { type PracticeSession } from "../../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
 
@@ -30,22 +36,22 @@ const formOptions: TargetForm[] = [
   "plainPastNegative"
 ];
 
-// Mode picker entries. The exam pool is surfaced as three side-by-side
-// presets -- 綜合考題庫 (all levels) plus N1 備考 (N1+N2) and N2 備考
-// (N2+N3) -- so the備考 ranges are first-class picks rather than a filter
-// hidden inside the exam mode. `id` doubles as the i18n / count key.
-type ModePresetId = PracticeMode | "examN1" | "examN2" | "examN3" | "examN4";
-type ModePreset = { id: ModePresetId; mode: PracticeMode; levelRange?: LevelRange };
+// Mode picker entries. The exam pool is surfaced as several side-by-side
+// presets -- 綜合考題庫 (all levels) plus the 備考 bands -- so the ranges are
+// first-class picks rather than a filter hidden inside the exam mode. `id`
+// doubles as the i18n / count key (ModeCopyKey). The 備考 rows are generated
+// from the single EXAM_PRESET_BY_RANGE table, so adding a band is one edit there.
+type ModePreset = { id: ModeCopyKey; mode: PracticeMode; levelRange?: LevelRange };
+const examPresetRows: ModePreset[] = (
+  Object.entries(EXAM_PRESET_BY_RANGE) as [LevelRange, ExamPresetId][]
+).map(([levelRange, id]) => ({ id, mode: "exam", levelRange }));
 const modePresetOrder: ModePreset[] = [
   { id: "daily", mode: "daily" },
   { id: "basic", mode: "basic" },
   { id: "cloze", mode: "cloze" },
   { id: "pattern", mode: "pattern" },
   { id: "exam", mode: "exam", levelRange: "all" },
-  { id: "examN1", mode: "exam", levelRange: "n1n2" },
-  { id: "examN2", mode: "exam", levelRange: "n2n3" },
-  { id: "examN3", mode: "exam", levelRange: "n3n4" },
-  { id: "examN4", mode: "exam", levelRange: "n4n5" },
+  ...examPresetRows,
   { id: "vocab", mode: "vocab" },
   { id: "review", mode: "review" }
 ];

--- a/src/domain/analytics/questionType.ts
+++ b/src/domain/analytics/questionType.ts
@@ -28,6 +28,8 @@ export type ExamQuestionType = (typeof EXAM_QUESTION_TYPES)[number];
 /** All buckets: the 9 exam types, then the non-exam practice modes. */
 export type QuestionType = ExamQuestionType | "cloze" | "pattern" | "basic";
 
+// Ordered list of every bucket. Exported (its test pins order + uniqueness);
+// also reserved for the planned 2-D level×type weakness heatmap (#243/#242).
 export const QUESTION_TYPES: readonly QuestionType[] = [
   ...EXAM_QUESTION_TYPES,
   "cloze",

--- a/src/domain/examBlocks.ts
+++ b/src/domain/examBlocks.ts
@@ -22,6 +22,10 @@ export const examStyleQuestions: PracticeQuestion[] = [
   ...n5Items
 ];
 
+// Warm-up cap: how many N3 items leak into the default "all" pool so they
+// don't dilute the N1/N2 focus. Declared before its consumer below.
+const MAX_N3_IN_DEFAULT_POOL = 6;
+
 export function buildExamQuestionPool(
   level: JlptLevel | JlptLevel[] | "all" = "all"
 ): PracticeQuestion[] {
@@ -48,5 +52,3 @@ export function buildExamQuestionPool(
     .slice(0, MAX_N3_IN_DEFAULT_POOL);
   return [...n1AndN2, ...n3WarmUp];
 }
-
-const MAX_N3_IN_DEFAULT_POOL = 6;

--- a/src/domain/practiceMode.ts
+++ b/src/domain/practiceMode.ts
@@ -1,0 +1,30 @@
+import type { LevelRange } from "./levelRange";
+
+// The practice modes (challenge entry points). Lives in the domain layer so
+// the hook, the picker, and i18n can all share one definition without a
+// cross-layer cycle (usePracticeSession re-exports it for back-compat).
+export type PracticeMode = "basic" | "cloze" | "daily" | "pattern" | "exam" | "review" | "vocab";
+
+// The 備考 exam presets: exam mode pinned to a specific level band, surfaced
+// as first-class picker rows. They are i18n / mode-count keys, not modes.
+export type ExamPresetId = "examN1" | "examN2" | "examN3" | "examN4";
+
+// The key used for mode copy (i18n modeOptions) and mode counts: a base mode,
+// or one of the exam presets.
+export type ModeCopyKey = PracticeMode | ExamPresetId;
+
+// THE one source linking a level range to its 備考 preset id. The picker rows,
+// the active-copy-key logic, and the i18n modeOptions keys all derive from
+// this — adding a band (e.g. a 5th 備考) is a single edit here.
+export const EXAM_PRESET_BY_RANGE: Partial<Record<LevelRange, ExamPresetId>> = {
+  n1n2: "examN1",
+  n2n3: "examN2",
+  n3n4: "examN3",
+  n4n5: "examN4"
+};
+
+// The copy / count key for exam mode at a given range. "all" (and any range
+// with no preset) falls back to the generic 綜合考題庫 "exam" key.
+export function examPresetForRange(range: LevelRange): ModeCopyKey {
+  return EXAM_PRESET_BY_RANGE[range] ?? "exam";
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -4,24 +4,17 @@ import { getSupabase, isSupabaseConfigured } from "../lib/supabase";
 
 export function useAuth() {
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isSupabaseConfigured) {
-      setLoading(false);
-      return;
-    }
+    if (!isSupabaseConfigured) return;
 
     let active = true;
     let unsubscribe: (() => void) | undefined;
 
     getSupabase()
       .then((client) => {
-        if (!client || !active) {
-          setLoading(false);
-          return;
-        }
+        if (!client || !active) return;
 
         client.auth
           .getSession()
@@ -31,11 +24,9 @@ export function useAuth() {
               setError("無法取得登入狀態");
             }
             setUser(session?.user ?? null);
-            setLoading(false);
           })
           .catch((e: unknown) => {
             console.error("Supabase getSession exception:", e);
-            setLoading(false);
           });
 
         const {
@@ -48,7 +39,6 @@ export function useAuth() {
       })
       .catch((e: unknown) => {
         console.error("Supabase load error:", e);
-        setLoading(false);
       });
 
     return () => {
@@ -81,5 +71,5 @@ export function useAuth() {
     }
   }, []);
 
-  return { user, loading, error, signInWithGoogle, signOut };
+  return { user, error, signInWithGoogle, signOut };
 }

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { ADJECTIVE_FORMS, VERB_FORMS } from "../domain/conjugation";
 import { VOCAB_LEVEL_RANGE_OPTIONS, type LevelRange } from "../domain/levelRange";
+import { examPresetForRange, type ModeCopyKey, type PracticeMode } from "../domain/practiceMode";
 import type { MockExamLevel } from "../domain/mockExam";
 import { type SentencePatternId } from "../domain/sentencePatterns";
 import {
@@ -39,7 +40,9 @@ function readSessionLength(): number | null {
 }
 
 export type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbial" | "obligationPast";
-export type PracticeMode = "basic" | "cloze" | "daily" | "pattern" | "exam" | "review" | "vocab";
+// Re-exported (the canonical type now lives in domain/practiceMode) so the
+// many `import { PracticeMode } from "../hooks/usePracticeSession"` sites keep working.
+export type { PracticeMode };
 export type PracticeFilter = {
   patternIds?: SentencePatternId[];
   // Narrows exam mode to one JLPT section (by level + promptLabel), set
@@ -212,22 +215,12 @@ export function usePracticeSession({
     [practiceFocus, isCuratedFocus, selectedForm]
   );
   const activeFocusForms = targetForms.filter((form) => compatibleForms.includes(form));
-  // Exam mode is one PracticeMode but three picker presets (綜合 / N1 備考
-  // / N2 備考). Map the active mode+range to the matching copy key so the
-  // summary + mode description reflect the chosen 備考 preset, not the
-  // generic 綜合考題庫 text.
-  const activeModeCopyKey: PracticeMode | "examN1" | "examN2" | "examN3" | "examN4" =
-    practiceMode === "exam"
-      ? levelRange === "n1n2"
-        ? "examN1"
-        : levelRange === "n2n3"
-          ? "examN2"
-          : levelRange === "n3n4"
-            ? "examN3"
-            : levelRange === "n4n5"
-              ? "examN4"
-              : "exam"
-      : practiceMode;
+  // Exam mode is one PracticeMode but several picker presets (綜合 / 備考
+  // bands). Map the active mode+range to the matching copy key (via the
+  // single EXAM_PRESET_BY_RANGE table) so the summary + mode description
+  // reflect the chosen 備考 preset, not the generic 綜合考題庫 text.
+  const activeModeCopyKey: ModeCopyKey =
+    practiceMode === "exam" ? examPresetForRange(levelRange) : practiceMode;
   const focusSummary = isCuratedFocus
     ? t.modeOptions[activeModeCopyKey].subtitle
     : practiceFocus === "single"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,5 +1,6 @@
 import type { PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
 import type { QuestionType } from "./domain/analytics/questionType";
+import type { ModeCopyKey } from "./domain/practiceMode";
 
 export type Language = "zh-Hant";
 
@@ -209,7 +210,7 @@ export type Copy = {
   grammarNoteConfusions: string;
   keyboardHint: string;
   focusSummaryEmpty: string;
-  modeOptions: Record<"basic" | "cloze" | "daily" | "exam" | "examN1" | "examN2" | "examN3" | "examN4" | "pattern" | "review" | "vocab", { title: string; subtitle: string }>;
+  modeOptions: Record<ModeCopyKey, { title: string; subtitle: string }>;
   modeQuestionCount: (count: number) => string;
   homeCardVocabTitle: string;
   homeCardVocabSub: string;


### PR DESCRIPTION
依 codebase refactor review 的 **#1**(最高效益)+ 4 個 quick wins。行為不變。

## #1 統一 exam preset 身分(去重 + 型別安全)
exam preset 的 id↔level-range 對照原本散在 4 處(hook 5 層三元、ModePicker union+列、i18n Record key),只有 i18n 那處編譯期擋得到——在還在長大的備考功能上是真的漂移雷。

新 `src/domain/practiceMode.ts` 集中 `PracticeMode` / `ExamPresetId` / `ModeCopyKey` 型別 + **單一 `EXAM_PRESET_BY_RANGE` 表** + `examPresetForRange()`:
- `usePracticeSession` re-export `PracticeMode`(相容),`activeModeCopyKey` 收成一行 `examPresetForRange()`。
- `ModePicker` 的備考列改由 `EXAM_PRESET_BY_RANGE` 生成,id 型別 `ModeCopyKey`。
- `i18n.modeOptions` 改 `Record<ModeCopyKey, …>`——**加一個備考 band 現在只要改一處、且全程編譯期覆蓋**。

## Quick wins
- `useAuth`:移除沒人讀的 `loading` state(死碼)。
- `examBlocks`:`MAX_N3_IN_DEFAULT_POOL` 移到使用前。
- `analytics/questionType`:`QUESTION_TYPES` 加註(test pin + 保留給 #243/#242)。
- `DrillPanel`:完成畫面 4 條平行三元 → 一次 pick。

## 驗證
- ✅ `vitest` 376、`tsc`、`build`(eager / examBlocks chunk 不變)
- ✅ 瀏覽器:挑戰頁 11 張 mode 卡題數正確、N2 備考點選後顯示自己的描述(走統一後的路徑)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified practice-mode metadata for cleaner mode labels and exam preset handling.
  * Improved completion-screen messaging selection without changing the visible end result.

* **Bug Fixes**
  * Fixed auth state handling so sign-in errors are reported more reliably.
  * Kept exam mode labels consistent across practice sessions and the mode picker.

* **Refactor**
  * Consolidated shared mode and exam preset logic into a single source of truth.
  * Simplified internal selection logic for completion copy and exam pool setup.

* **Documentation**
  * Updated comments for question-type ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->