### PR TITLE
chore: add Google Search Console site-verification file

### DIFF
--- a/public/google329373477516a739.html
+++ b/public/google329373477516a739.html
@@ -1,0 +1,1 @@
+google-site-verification: google329373477516a739.html


### PR DESCRIPTION
Adds `public/google329373477516a739.html` so Google Search Console can verify ownership of https://jabiko.pages.dev/ via the HTML-file method. Vite copies `public/` to the site root; Cloudflare Pages serves the real file before the SPA `_redirects` fallback (same as robots.txt / icon.svg). No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added site verification support for Google, helping confirm ownership of the site and enable related search console features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->