### PR TITLE
feat(seo): per-view title/description/canonical + JSON-LD

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,14 +11,18 @@
     <meta name="theme-color" content="#647c5c" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
+    <link rel="canonical" href="https://jabiko.pages.dev/" />
+
     <!-- Open Graph (Facebook, LINE, Discord, Slack link previews) -->
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Jabiko · JLPT 自習室" />
+    <meta property="og:url" content="https://jabiko.pages.dev/" />
     <meta property="og:title" content="Jabiko · JLPT 自習室" />
     <meta
       property="og:description"
       content="JLPT N1 / N2 文法、漢字、單字、模擬考一處練到熟。間隔重複弱點複習，整卷模擬。"
     />
-    <meta property="og:image" content="/og-image.png" />
+    <meta property="og:image" content="https://jabiko.pages.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="zh_TW" />
@@ -30,7 +34,24 @@
       name="twitter:description"
       content="JLPT N1 / N2 文法、漢字、單字、模擬考一處練到熟。間隔重複弱點複習，整卷模擬。"
     />
-    <meta name="twitter:image" content="/og-image.png" />
+    <meta name="twitter:image" content="https://jabiko.pages.dev/og-image.png" />
+
+    <!-- Structured data: free educational web app (rich-result eligibility) -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        "name": "Jabiko",
+        "alternateName": "Jabiko · JLPT 自習室",
+        "url": "https://jabiko.pages.dev/",
+        "applicationCategory": "EducationalApplication",
+        "operatingSystem": "Web",
+        "inLanguage": "zh-Hant",
+        "isAccessibleForFree": true,
+        "description": "免費的 JLPT 自習網站：N5〜N1 文法、漢字、單字與整卷模擬考，間隔重複自動盯錯題複習。",
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { JabikoMark } from "./components/JabikoMark";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
 import { useFurigana } from "./hooks/useFurigana";
+import { useSeoMeta } from "./hooks/useSeoMeta";
 import { isSupabaseConfigured } from "./lib/supabase";
 import { useAuth } from "./hooks/useAuth";
 import { useProgressAttempts } from "./hooks/useProgressAttempts";
@@ -80,6 +81,10 @@ export default function App() {
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
+
+  // Per-view <title>/description/canonical/og so each route surfaces its own
+  // metadata to crawlers (SPA otherwise shares one static shell). See seo.ts.
+  useSeoMeta(appView);
 
   // Single-language app (zh-Hant). The `language` seam is kept so the
   // copy[language] call sites and component props don't have to change;

--- a/src/domain/seo.test.ts
+++ b/src/domain/seo.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { SITE_ORIGIN, VIEW_SEO, seoForView, type SeoView } from "./seo";
+
+const VIEWS: SeoView[] = ["home", "learn", "rules", "kanji", "challenge", "mock", "about"];
+
+describe("seo", () => {
+  it("has an entry for every view", () => {
+    for (const view of VIEWS) {
+      expect(VIEW_SEO[view], view).toBeDefined();
+    }
+    expect(Object.keys(VIEW_SEO).sort()).toEqual([...VIEWS].sort());
+  });
+
+  it("keeps the brand in the home title and a meaningful description", () => {
+    const home = seoForView("home");
+    expect(home.title).toMatch(/Jabiko/);
+    expect(home.description.length).toBeGreaterThan(20);
+  });
+
+  it("gives every view a distinct title and description (no shared SPA meta)", () => {
+    const titles = new Set(VIEWS.map((v) => seoForView(v).title));
+    const descriptions = new Set(VIEWS.map((v) => seoForView(v).description));
+    expect(titles.size).toBe(VIEWS.length);
+    expect(descriptions.size).toBe(VIEWS.length);
+  });
+
+  it("builds an absolute canonical URL rooted at the production origin", () => {
+    expect(SITE_ORIGIN).toBe("https://jabiko.pages.dev");
+    expect(seoForView("home").canonical).toBe("https://jabiko.pages.dev/");
+    expect(seoForView("mock").canonical).toBe("https://jabiko.pages.dev/mock");
+    expect(seoForView("kanji").canonical).toBe("https://jabiko.pages.dev/kanji");
+  });
+
+  it("keeps descriptions within a sane SEO length (<=160 chars)", () => {
+    for (const view of VIEWS) {
+      expect(seoForView(view).description.length, view).toBeLessThanOrEqual(160);
+    }
+  });
+});

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -1,0 +1,83 @@
+// Per-view SEO metadata for the SPA.
+//
+// Jabiko is a client-rendered single-page app: index.html ships ONE static
+// <title>/<meta description>, so every in-app route (/mock, /learn, …) would
+// otherwise look identical to a crawler. Google renders JS and reads the final
+// DOM, so updating these tags per view (via useSeoMeta) lets each route surface
+// its own title/description/canonical in search results.
+//
+// Pure data + a small resolver -> trivially testable, no DOM here.
+
+/** Top-level views that have their own URL (mirrors App's AppView / VIEW_PATHS). */
+export type SeoView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about";
+
+/** Production origin; canonical URLs are absolute so crawlers dedupe cleanly. */
+export const SITE_ORIGIN = "https://jabiko.pages.dev";
+
+interface PageSeo {
+  title: string;
+  description: string;
+  /** Path at SITE_ORIGIN. Keep in sync with App's VIEW_PATHS. */
+  path: string;
+}
+
+export const VIEW_SEO: Record<SeoView, PageSeo> = {
+  home: {
+    title: "Jabiko · JLPT 自習室",
+    description:
+      "免費的 JLPT 自習網站：N5〜N1 文法、漢字、單字與整卷模擬考，間隔重複自動盯錯題、章節式教學，打開就能練。",
+    path: "/"
+  },
+  learn: {
+    title: "分章學習 · Jabiko JLPT 自習室",
+    description:
+      "從動詞、形容詞變化一路到常用句型，一章一章看規則、例句與最容易踩的陷阱，看完直接進對應練習。",
+    path: "/learn"
+  },
+  rules: {
+    title: "日語變化規則速查表 · Jabiko",
+    description: "動詞變化、ます／て形、各種接續整理成一頁可查的表，需要時掃一眼就好。",
+    path: "/rules"
+  },
+  kanji: {
+    title: "漢字音讀速查 · Jabiko 自習室",
+    description:
+      "依音讀（同音家族）查漢字、確認讀音與例詞，把濁音、長短音一次搞清楚，涵蓋 N5〜N1 漢字。",
+    path: "/kanji"
+  },
+  challenge: {
+    title: "練習題庫 · Jabiko JLPT 自習室",
+    description:
+      "基礎變化、句中填空、句型練習，加上 N1〜N4 備考綜合題庫——自由選等級與題型，想練哪一塊就練哪一塊。",
+    path: "/challenge"
+  },
+  mock: {
+    title: "JLPT 模擬考 · Jabiko 自習室",
+    description:
+      "依 JLPT N1／N2／N3 官方題型分區練習：漢字読み、文法、語順組合、讀解，照真實考卷結構逐區攻略。",
+    path: "/mock"
+  },
+  about: {
+    title: "關於 Jabiko · JLPT 自習室",
+    description:
+      "Jabiko 的名字由來與作者介紹——一個免費、開源、和朋友一起做的 JLPT 自習網站。",
+    path: "/about"
+  }
+};
+
+export interface ResolvedSeo {
+  title: string;
+  description: string;
+  /** Absolute canonical URL for the view. */
+  canonical: string;
+}
+
+/** Resolve a view's title/description and its absolute canonical URL. */
+export function seoForView(view: SeoView): ResolvedSeo {
+  const entry = VIEW_SEO[view];
+  return {
+    title: entry.title,
+    description: entry.description,
+    canonical: SITE_ORIGIN + entry.path
+  };
+}

--- a/src/hooks/useSeoMeta.test.tsx
+++ b/src/hooks/useSeoMeta.test.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSeoMeta } from "./useSeoMeta";
+import { seoForView, type SeoView } from "../domain/seo";
+
+const desc = () =>
+  document.head.querySelector('meta[name="description"]')?.getAttribute("content");
+const canonical = () =>
+  document.head.querySelector('link[rel="canonical"]')?.getAttribute("href");
+const prop = (key: string) =>
+  document.head.querySelector(`meta[property="${key}"]`)?.getAttribute("content");
+
+describe("useSeoMeta", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.title = "";
+  });
+
+  it("sets the document title and description for the active view", () => {
+    renderHook(() => useSeoMeta("mock"));
+    const s = seoForView("mock");
+    expect(document.title).toBe(s.title);
+    expect(desc()).toBe(s.description);
+  });
+
+  it("writes an absolute canonical and og:url", () => {
+    renderHook(() => useSeoMeta("learn"));
+    const s = seoForView("learn");
+    expect(canonical()).toBe(s.canonical);
+    expect(prop("og:url")).toBe(s.canonical);
+    expect(prop("og:title")).toBe(s.title);
+    expect(prop("og:description")).toBe(s.description);
+  });
+
+  it("updates existing tags in place when the view changes (no duplicates)", () => {
+    const { rerender } = renderHook(({ v }) => useSeoMeta(v), {
+      initialProps: { v: "home" as SeoView }
+    });
+    rerender({ v: "kanji" });
+
+    expect(document.head.querySelectorAll('meta[name="description"]').length).toBe(1);
+    expect(document.head.querySelectorAll('link[rel="canonical"]').length).toBe(1);
+    expect(document.title).toBe(seoForView("kanji").title);
+    expect(canonical()).toBe(seoForView("kanji").canonical);
+  });
+
+  it("reuses a description tag that already exists in the static HTML", () => {
+    const existing = document.createElement("meta");
+    existing.setAttribute("name", "description");
+    existing.setAttribute("content", "stale");
+    document.head.appendChild(existing);
+
+    renderHook(() => useSeoMeta("rules"));
+    expect(document.head.querySelectorAll('meta[name="description"]').length).toBe(1);
+    expect(desc()).toBe(seoForView("rules").description);
+  });
+});

--- a/src/hooks/useSeoMeta.ts
+++ b/src/hooks/useSeoMeta.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { seoForView, type SeoView } from "../domain/seo";
+
+// Find-or-create a <meta> tag (keyed by name= or property=) and set its content.
+function upsertMeta(attr: "name" | "property", key: string, content: string) {
+  let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+  if (!el) {
+    el = document.createElement("meta");
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute("content", content);
+}
+
+function upsertCanonical(href: string) {
+  let el = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!el) {
+    el = document.createElement("link");
+    el.setAttribute("rel", "canonical");
+    document.head.appendChild(el);
+  }
+  el.setAttribute("href", href);
+}
+
+// Sync the document head to the active view's SEO metadata. Reuses the tags
+// already present in index.html (description / og:* / twitter:*) and adds the
+// per-view canonical + og:url. Runs on every view change so a crawler that
+// renders the JS sees route-specific title/description rather than the shared
+// static shell. Idempotent: re-applies in place, never duplicates a tag.
+export function useSeoMeta(view: SeoView) {
+  useEffect(() => {
+    const { title, description, canonical } = seoForView(view);
+    document.title = title;
+    upsertMeta("name", "description", description);
+    upsertMeta("property", "og:title", title);
+    upsertMeta("property", "og:description", description);
+    upsertMeta("property", "og:url", canonical);
+    upsertMeta("name", "twitter:title", title);
+    upsertMeta("name", "twitter:description", description);
+    upsertCanonical(canonical);
+  }, [view]);
+}


### PR DESCRIPTION
## What
SPA shipped a single static `<title>`/`description` for every route, so `/mock`, `/learn`, … looked identical to crawlers. This adds per-view SEO metadata.

- `src/domain/seo.ts` — per-view title/description + absolute canonical (pure, tested).
- `src/hooks/useSeoMeta.ts` — applies it to the document head on view change; idempotent (reuses existing tags, no dupes). Wired in `App`.
- `index.html` — WebApplication JSON-LD, canonical link, og:url, absolute og:image.

## Why
Google renders JS and reads the final DOM, so per-route title/description/canonical lets each view rank for its own intent (e.g. 「JLPT 模擬考」 → /mock). Pairs with the sitemap (#272) shipped earlier.

## Verify
- 385 tests pass (incl. new seo + useSeoMeta suites). Build green; `examBlocks`/`ChallengePanel` still lazy, eager index +~2 kB.
- Dev-server check: loading `/mock` sets title 「JLPT 模擬考 · Jabiko 自習室」 + canonical `https://jabiko.pages.dev/mock`.