### PR TITLE
feat(seo): sharpen home title + sync static meta (日檢, N5–N1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jabiko · JLPT 自習室</title>
+    <title>Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考</title>
     <meta
       name="description"
-      content="JLPT N1 / N2 文法、漢字、單字、模擬考一處練到熟。間隔重複弱點複習、整卷模擬、章節式教學，免費、開源。"
+      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta name="theme-color" content="#647c5c" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
@@ -15,12 +15,12 @@
 
     <!-- Open Graph (Facebook, LINE, Discord, Slack link previews) -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Jabiko · JLPT 自習室" />
+    <meta property="og:site_name" content="Jabiko" />
     <meta property="og:url" content="https://jabiko.pages.dev/" />
-    <meta property="og:title" content="Jabiko · JLPT 自習室" />
+    <meta property="og:title" content="Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       property="og:description"
-      content="JLPT N1 / N2 文法、漢字、單字、模擬考一處練到熟。間隔重複弱點複習，整卷模擬。"
+      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta property="og:image" content="https://jabiko.pages.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -29,10 +29,10 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Jabiko · JLPT 自習室" />
+    <meta name="twitter:title" content="Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       name="twitter:description"
-      content="JLPT N1 / N2 文法、漢字、單字、模擬考一處練到熟。間隔重複弱點複習，整卷模擬。"
+      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta name="twitter:image" content="https://jabiko.pages.dev/og-image.png" />
 
@@ -48,7 +48,7 @@
         "operatingSystem": "Web",
         "inLanguage": "zh-Hant",
         "isAccessibleForFree": true,
-        "description": "免費的 JLPT 自習網站：N5〜N1 文法、漢字、單字與整卷模擬考，間隔重複自動盯錯題複習。",
+        "description": "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" }
       }
     </script>

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -23,9 +23,9 @@ interface PageSeo {
 
 export const VIEW_SEO: Record<SeoView, PageSeo> = {
   home: {
-    title: "Jabiko · JLPT 自習室",
+    title: "Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考",
     description:
-      "免費的 JLPT 自習網站：N5〜N1 文法、漢字、單字與整卷模擬考，間隔重複自動盯錯題、章節式教學，打開就能練。",
+      "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
     path: "/"
   },
   learn: {


### PR DESCRIPTION
Adds 日檢 (the dominant zh-TW search term — was JLPT-only) + 免費 + full N5–N1 range to the home title/description.

Also fixes a real issue: static `index.html` still said 'N1 / N2' and the old brand title — what non-JS crawlers and LINE/FB/Discord/X preview cards read — underselling the product. Now `index.html` <title>/description/og/twitter/JSON-LD all agree with `seo.ts`.

New home title: `Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考`. Tests + build green; bundle unchanged.