### PR TITLE
chore(seo): drop 免費 from titles + structured-data free flags

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考</title>
+    <title>Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考</title>
     <meta
       name="description"
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
@@ -17,7 +17,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Jabiko" />
     <meta property="og:url" content="https://jabiko.pages.dev/" />
-    <meta property="og:title" content="Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
+    <meta property="og:title" content="Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       property="og:description"
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
@@ -29,7 +29,7 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
+    <meta name="twitter:title" content="Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       name="twitter:description"
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
@@ -47,9 +47,7 @@
         "applicationCategory": "EducationalApplication",
         "operatingSystem": "Web",
         "inLanguage": "zh-Hant",
-        "isAccessibleForFree": true,
-        "description": "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
-        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "TWD" }
+        "description": "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
       }
     </script>
   </head>

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -23,7 +23,7 @@ interface PageSeo {
 
 export const VIEW_SEO: Record<SeoView, PageSeo> = {
   home: {
-    title: "Jabiko · 免費 JLPT 日檢自習室｜N5–N1 文法單字模擬考",
+    title: "Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考",
     description:
       "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
     path: "/"


### PR DESCRIPTION
Keeps future monetization open: removes 免費 from the home <title>/og:title/twitter:title and the JSON-LD isAccessibleForFree/offers(price 0) machine claims. Descriptions keep 免費 (high-intent zh-TW search keyword, softer non-binding mention). Per user decision: 標題拿、描述留、結構化拿. Tests + build green.