### PR TITLE
feat(share): 分享成績 buttons on the score report

### DIFF
--- a/src/components/challenge/ScoreReport.tsx
+++ b/src/components/challenge/ScoreReport.tsx
@@ -1,5 +1,6 @@
 import { copy, type Language } from "../../i18n";
 import type { PracticeSession } from "../../hooks/usePracticeSession";
+import { ShareButtons } from "./ShareButtons";
 
 // The 今日戰報 stats block: answered / correct / review counts, the
 // accuracy value, and the accuracy progress bar. Sits atop the right-hand
@@ -50,6 +51,9 @@ export function ScoreReport({
       >
         <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
       </div>
+      {attempts.length > 0 ? (
+        <ShareButtons language={language} attempts={attempts.length} accuracy={accuracy} />
+      ) : null}
     </div>
   );
 }

--- a/src/components/challenge/ShareButtons.tsx
+++ b/src/components/challenge/ShareButtons.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { AtSign, Facebook, MessageCircle, Share2 } from "lucide-react";
+import { copy, type Language } from "../../i18n";
+import {
+  SHARE_URL,
+  composeMessage,
+  facebookShareUrl,
+  lineShareUrl,
+  threadsShareUrl
+} from "../../domain/share";
+
+// 「分享成績」 panel under the 戰報 (ScoreReport): one-tap share of the session
+// result to Facebook / Threads / LINE / the native share sheet. Drives
+// word-of-mouth reach. Lives in the lazy challenge chunk (imported only via
+// ScoreReport), so the share helpers never touch the eager home bundle.
+export function ShareButtons({
+  language,
+  attempts,
+  accuracy
+}: {
+  language: Language;
+  attempts: number;
+  accuracy: number;
+}) {
+  const t = copy[language];
+  const [copied, setCopied] = useState(false);
+  const message = composeMessage(t.shareText(attempts, accuracy));
+
+  const flagCopied = () => {
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2500);
+  };
+  const openWin = (url: string) => window.open(url, "_blank", "noopener,noreferrer");
+  const copyText = async () => {
+    try {
+      await navigator.clipboard?.writeText(message);
+      flagCopied();
+    } catch {
+      // clipboard blocked (insecure context / permissions) — open share anyway
+    }
+  };
+
+  const onFacebook = async () => {
+    // FB sharer can't prefill post text, so copy it for the user to paste.
+    await copyText();
+    openWin(facebookShareUrl());
+  };
+  const onThreads = () => openWin(threadsShareUrl(message));
+  const onLine = () => openWin(lineShareUrl(message));
+  const onOther = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ text: t.shareText(attempts, accuracy), url: SHARE_URL });
+        return;
+      } catch {
+        // user cancelled or share failed — fall through to clipboard
+      }
+    }
+    await copyText();
+  };
+
+  return (
+    <div className="share-panel" aria-label={t.shareTitle}>
+      <p className="share-title">{t.shareTitle}</p>
+
+      <button type="button" className="share-btn share-fb" onClick={onFacebook}>
+        <Facebook aria-hidden="true" />
+        Facebook
+      </button>
+      <p className="share-fb-hint">{copied ? t.shareCopied : t.shareFbHint}</p>
+
+      <button type="button" className="share-btn share-threads" onClick={onThreads}>
+        <AtSign aria-hidden="true" />
+        Threads
+      </button>
+      <button type="button" className="share-btn share-line" onClick={onLine}>
+        <MessageCircle aria-hidden="true" />
+        LINE
+      </button>
+      <button type="button" className="share-btn share-other" onClick={onOther}>
+        <Share2 aria-hidden="true" />
+        {t.shareOther}
+      </button>
+    </div>
+  );
+}

--- a/src/domain/share.test.ts
+++ b/src/domain/share.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import {
+  SHARE_URL,
+  composeMessage,
+  threadsShareUrl,
+  lineShareUrl,
+  facebookShareUrl
+} from "./share";
+
+describe("share", () => {
+  it("appends the site URL to the message on its own line", () => {
+    expect(composeMessage("やった！")).toBe(`やった！\n${SHARE_URL}`);
+  });
+
+  it("lets the URL be overridden", () => {
+    expect(composeMessage("hi", "https://x.test/")).toBe("hi\nhttps://x.test/");
+  });
+
+  it("builds a Threads intent URL with the message URL-encoded", () => {
+    const msg = composeMessage("正答率 80%");
+    const u = threadsShareUrl(msg);
+    expect(u.startsWith("https://www.threads.net/intent/post?text=")).toBe(true);
+    expect(u).toContain(encodeURIComponent(msg));
+    expect(u).not.toMatch(/\s/); // no raw whitespace
+  });
+
+  it("builds a LINE share deep link carrying the message", () => {
+    const msg = composeMessage("テスト");
+    const u = lineShareUrl(msg);
+    expect(u.startsWith("https://line.me/R/msg/text/?")).toBe(true);
+    expect(u).toContain(encodeURIComponent(msg));
+  });
+
+  it("builds a Facebook sharer URL pointing at the site (text is copied separately)", () => {
+    const u = facebookShareUrl();
+    expect(u.startsWith("https://www.facebook.com/sharer/sharer.php?u=")).toBe(true);
+    expect(u).toContain(encodeURIComponent(SHARE_URL));
+  });
+
+  it("Facebook sharer accepts a custom url", () => {
+    expect(facebookShareUrl("https://x.test/")).toContain(encodeURIComponent("https://x.test/"));
+  });
+});

--- a/src/domain/share.ts
+++ b/src/domain/share.ts
@@ -1,0 +1,33 @@
+// Social-share URL builders for the score report's 「分享成績」 panel.
+//
+// Pure string helpers (no DOM) so they're unit-testable; the ShareButtons
+// component handles the side effects (clipboard, window.open, navigator.share).
+//
+// Platform notes:
+//   - Facebook: sharer.php no longer prefills post text (the `quote` param was
+//     dropped), so we open it with just the URL (OG card) and copy the result
+//     text to the clipboard for the user to paste.
+//   - Threads: the intent endpoint DOES prefill text.
+//   - LINE: the msg/text deep link prefills a message (text incl. the URL).
+
+export const SHARE_URL = "https://jabiko.pages.dev/";
+
+/** Result message + the site URL on its own line (used for clipboard / text intents). */
+export function composeMessage(text: string, url: string = SHARE_URL): string {
+  return `${text}\n${url}`;
+}
+
+/** Threads intent post with the message prefilled. */
+export function threadsShareUrl(message: string): string {
+  return `https://www.threads.net/intent/post?text=${encodeURIComponent(message)}`;
+}
+
+/** LINE message deep link carrying the message (text includes the URL). */
+export function lineShareUrl(message: string): string {
+  return `https://line.me/R/msg/text/?${encodeURIComponent(message)}`;
+}
+
+/** Facebook share dialog for the URL (post text is copied to the clipboard separately). */
+export function facebookShareUrl(url: string = SHARE_URL): string {
+  return `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -183,6 +183,11 @@ export type Copy = {
   correctShort: string;
   reviewShort: string;
   accuracyLabel: string;
+  shareTitle: string;
+  shareText: (attempts: number, accuracy: number) => string;
+  shareFbHint: string;
+  shareOther: string;
+  shareCopied: string;
   resetSession: string;
   currentQuestion: string;
   questionNumber: (value: number) => string;
@@ -466,6 +471,12 @@ export const copy: Record<Language, Copy> = {
     correctShort: "正解",
     reviewShort: "複習",
     accuracyLabel: "目前正解率",
+    shareTitle: "分享成績",
+    shareText: (attempts, accuracy) =>
+      `我在 Jabiko 練日檢，今天練了 ${attempts} 題、正答率 ${accuracy}%！一起來練日文👇`,
+    shareFbHint: "按 FB 後，貼文文字自動複製 → 打開臉書新增貼文 → 貼上即可",
+    shareOther: "分享到其他平台",
+    shareCopied: "已複製貼文文字！",
     resetSession: "重設本次",
     currentQuestion: "目前題目",
     questionNumber: (value) => `第 ${value} 題`,

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -64,6 +64,77 @@
   transition: width 0.3s ease;
 }
 
+/* 「分享成績」 buttons under the score report. Brand colours are fixed (not
+   theme tokens) to match each platform's identity; 其他平台 uses theme tokens. */
+.share-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1.1rem;
+}
+
+.share-title {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.share-btn {
+  align-items: center;
+  border: none;
+  border-radius: 0.6rem;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  font-family: var(--font-japanese-ui);
+  font-size: 0.95rem;
+  font-weight: 700;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.7rem 1rem;
+  transition:
+    filter 0.15s ease,
+    transform 0.05s ease;
+}
+
+.share-btn:hover {
+  filter: brightness(1.07);
+}
+
+.share-btn:active {
+  transform: translateY(1px);
+}
+
+.share-btn svg {
+  height: 1.1em;
+  width: 1.1em;
+}
+
+.share-fb {
+  background: #1877f2;
+}
+
+.share-threads {
+  background: #101010;
+}
+
+.share-line {
+  background: #06c755;
+}
+
+.share-other {
+  background: color-mix(in srgb, var(--muted) 22%, transparent);
+  color: var(--ink);
+}
+
+.share-fb-hint {
+  color: var(--muted);
+  font-size: 0.74rem;
+  line-height: 1.4;
+  margin: 0 0 0.2rem;
+}
+
 /* In the right-hand review column the score report sits above the
    mistake-review heading; give it breathing room from that heading. */
 .review-panel .score-report {


### PR DESCRIPTION
Adds a Facebook / Threads / LINE / 分享到其他平台 panel under the 戰報 (score report) — one-tap share of the session result (題數 + 正答率) + site URL, to drive word-of-mouth reach.

- `domain/share.ts`: pure, unit-tested URL builders (FB sharer, Threads intent, LINE deep link). FB can't prefill post text → copy to clipboard + open share dialog (with the on-screen hint from the reference design).
- `ShareButtons` lives in the lazy challenge chunk → zero eager-bundle impact.
- 其他平台 uses the Web Share API with a clipboard fallback.

Verified in-browser: panel renders after answering, 4 buttons w/ correct labels + brand colours (FB #1877f2 / Threads #101010 / LINE #06c755). share.test 6/6; build green.