### PR TITLE
feat(share): 分享 Jabiko (site share) on home footer

### DIFF
--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -13,6 +13,7 @@ import { LevelBars } from "./dashboard/LevelBars";
 import { ActivityTrend } from "./dashboard/ActivityTrend";
 import { TypeBars } from "./dashboard/TypeBars";
 import { FeedbackForm } from "./FeedbackForm";
+import { ShareButtons } from "./challenge/ShareButtons";
 import type { FeedbackCategory } from "../domain/feedbackRemote";
 
 // External walkthrough / 使用說明書: the author's blog post about Jabiko.
@@ -370,6 +371,9 @@ export function HomePanel({
             onClose={() => setFeedbackKind(null)}
           />
         ) : null}
+        <div className="home-footer-share">
+          <ShareButtons language={language} text={t.shareSiteText} title={t.shareSiteTitle} />
+        </div>
       </footer>
     </section>
   );

--- a/src/components/challenge/ScoreReport.tsx
+++ b/src/components/challenge/ScoreReport.tsx
@@ -52,7 +52,7 @@ export function ScoreReport({
         <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
       </div>
       {attempts.length > 0 ? (
-        <ShareButtons language={language} attempts={attempts.length} accuracy={accuracy} />
+        <ShareButtons language={language} text={t.shareText(attempts.length, accuracy)} />
       ) : null}
     </div>
   );

--- a/src/components/challenge/ShareButtons.tsx
+++ b/src/components/challenge/ShareButtons.tsx
@@ -9,22 +9,25 @@ import {
   threadsShareUrl
 } from "../../domain/share";
 
-// 「分享成績」 panel under the 戰報 (ScoreReport): one-tap share of the session
-// result to Facebook / Threads / LINE / the native share sheet. Drives
-// word-of-mouth reach. Lives in the lazy challenge chunk (imported only via
-// ScoreReport), so the share helpers never touch the eager home bundle.
+// One-tap share panel (Facebook / Threads / LINE / native sheet) to drive
+// word-of-mouth reach. Reused in two places: the 戰報 (share the session
+// result) and the home footer (share the site). The caller passes the body
+// `text`; this component appends the site URL and wires the platform actions.
 export function ShareButtons({
   language,
-  attempts,
-  accuracy
+  text,
+  title
 }: {
   language: Language;
-  attempts: number;
-  accuracy: number;
+  /** The share body (without the URL); the URL is appended here. */
+  text: string;
+  /** Panel heading; defaults to 分享成績. */
+  title?: string;
 }) {
   const t = copy[language];
   const [copied, setCopied] = useState(false);
-  const message = composeMessage(t.shareText(attempts, accuracy));
+  const heading = title ?? t.shareTitle;
+  const message = composeMessage(text);
 
   const flagCopied = () => {
     setCopied(true);
@@ -50,7 +53,7 @@ export function ShareButtons({
   const onOther = async () => {
     if (navigator.share) {
       try {
-        await navigator.share({ text: t.shareText(attempts, accuracy), url: SHARE_URL });
+        await navigator.share({ text, url: SHARE_URL });
         return;
       } catch {
         // user cancelled or share failed — fall through to clipboard
@@ -60,8 +63,8 @@ export function ShareButtons({
   };
 
   return (
-    <div className="share-panel" aria-label={t.shareTitle}>
-      <p className="share-title">{t.shareTitle}</p>
+    <div className="share-panel" aria-label={heading}>
+      <p className="share-title">{heading}</p>
 
       <button type="button" className="share-btn share-fb" onClick={onFacebook}>
         <Facebook aria-hidden="true" />

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -188,6 +188,8 @@ export type Copy = {
   shareFbHint: string;
   shareOther: string;
   shareCopied: string;
+  shareSiteTitle: string;
+  shareSiteText: string;
   resetSession: string;
   currentQuestion: string;
   questionNumber: (value: number) => string;
@@ -477,6 +479,9 @@ export const copy: Record<Language, Copy> = {
     shareFbHint: "按 FB 後，貼文文字自動複製 → 打開臉書新增貼文 → 貼上即可",
     shareOther: "分享到其他平台",
     shareCopied: "已複製貼文文字！",
+    shareSiteTitle: "分享 Jabiko",
+    shareSiteText:
+      "我在用 Jabiko 練日檢：N5〜N1 文法、漢字、單字、模擬考一站練到熟，分享給也在備考的你👇",
     resetSession: "重設本次",
     currentQuestion: "目前題目",
     questionNumber: (value) => `第 ${value} 題`,

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -135,6 +135,19 @@
   margin: 0 0 0.2rem;
 }
 
+/* Home-footer 「分享 Jabiko」: centre the share panel and cap its width so it
+   doesn't stretch across the full footer. */
+.home-footer-share {
+  margin: 0.75rem auto 0;
+  max-width: 320px;
+  text-align: left;
+  width: 100%;
+}
+
+.home-footer-share .share-title {
+  text-align: center;
+}
+
 /* In the right-hand review column the score report sits above the
    mistake-review heading; give it breathing room from that heading. */
 .review-panel .score-report {


### PR DESCRIPTION
Generalizes ShareButtons (now takes `text` + `title`) so the same panel serves the 戰報 (share result) and a new **分享 Jabiko** panel in the home footer (share the site, with a 日檢/N5–N1 pitch; no 免費 to keep monetization open).

Verified in-browser: home footer renders 分享 Jabiko + 4 buttons; 戰報 still shows 分享成績. Eager bundle +~3 kB; examBlocks/vocabulary stay lazy; tsc + share.test green.