### PR TITLE
feat(learn): count sentence-pattern chapters toward progress (11→18)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -329,22 +329,25 @@ describe("App", () => {
     }
   });
 
-  it("renders reference chapters with '參考' badge and a drill-note", async () => {
-    // Reference chapters (verb-types + the 4 sentence-pattern chapters)
-    // have no requiredForms and should never get marked "完成". Their
-    // status badge says "參考"; sentence-pattern chapters carry an
-    // explicit drillNote saying the linked drill is a prerequisite-form
-    // practice, not the chapter's own pattern.
+  it("marks the verb-types explainer '參考', and keeps the drill-note on pattern chapters", async () => {
+    // verb-types is reading-only (no drill of its own) → status badge '參考'.
+    // Sentence-pattern chapters now have a counted pattern drill, so they no
+    // longer show '參考', but they keep a drillNote explaining their secondary
+    // (prerequisite-form) drill.
     const user = userEvent.setup();
     render(<App />);
 
     await gotoLearn(user);
-    const referenceChapter = screen.getByRole("button", {
-      name: "查看：てください / てもいい / てはいけない"
-    });
+
+    const referenceChapter = screen.getByRole("button", { name: "查看：動詞三類怎麼分" });
     expect(referenceChapter.textContent).toContain("參考");
 
-    await user.click(referenceChapter);
+    const patternChapter = screen.getByRole("button", {
+      name: "查看：てください / てもいい / てはいけない"
+    });
+    expect(patternChapter.textContent).not.toContain("參考");
+
+    await user.click(patternChapter);
     expect(
       screen.getByText(/上方按鈕直接練本章句型判斷.*前置「て形」音便/)
     ).toBeInTheDocument();

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { learningBlocks, isLearningBlockComplete } from "./learningBlocks";
+
+const byId = (id: string) => {
+  const block = learningBlocks.find((b) => b.id === id);
+  if (!block) throw new Error(`no learning block ${id}`);
+  return block;
+};
+
+describe("isLearningBlockComplete", () => {
+  it("a conjugation chapter completes once all its required forms are answered correctly", () => {
+    const masu = byId("masu");
+    expect(isLearningBlockComplete([], masu)).toBe(false);
+    const attempts = (masu.requiredForms ?? []).map((targetForm) => ({ isCorrect: true, targetForm }));
+    expect(isLearningBlockComplete(attempts, masu)).toBe(true);
+  });
+
+  it("the verb-types reference chapter is always complete (reading material)", () => {
+    expect(isLearningBlockComplete([], byId("verb-types"))).toBe(true);
+  });
+
+  it("a sentence-pattern chapter completes via a correct pattern-drill attempt", () => {
+    const tek = byId("te-kudasai");
+    expect(isLearningBlockComplete([], tek)).toBe(false);
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "te", questionId: "pattern-te-kudasai-001" }],
+        tek
+      )
+    ).toBe(true);
+    // a wrong attempt (or one for another pattern) does not complete it
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: false, targetForm: "te", questionId: "pattern-te-kudasai-002" }],
+        tek
+      )
+    ).toBe(false);
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "te", questionId: "pattern-to-omou-001" }],
+        tek
+      )
+    ).toBe(false);
+  });
+
+  it("the seven sentence-pattern chapters now count as trackable (drillable) chapters", () => {
+    const trackable = learningBlocks.filter(
+      (b) => b.group === "basic" && b.completionMode !== "reference"
+    );
+    // 11 conjugation + 7 sentence-pattern; only verb-types stays reference.
+    expect(trackable.length).toBe(18);
+    expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
+    expect(byId("verb-types").completionMode).toBe("reference");
+  });
+});

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -540,7 +540,6 @@ export const learningBlocks: LearningBlock[] = [
       "「ないでください」(請不要做) 比「てはいけません」(禁止) 軟，請對方時用前者較自然",
       "「もいい」常省略「ですか」變陳述，要看語境分清是徵求許可還是給予許可"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternTeKudasai",
@@ -581,7 +580,6 @@ export const learningBlocks: LearningBlock[] = [
       "名詞用「でなくてもいい」（不是「ではないでもいい」）",
       "口語常省略「いい」後面的「です」，正式書面要加上"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternNakuteMoII",
@@ -622,7 +620,6 @@ export const learningBlocks: LearningBlock[] = [
       "對上位／長輩用「ていただく」(=てもらう 謙讓) 或「てくださる」(=てくれる 尊敬)",
       "助詞配對：てもらう／てあげる 用「に」標記做事者；てくれる 用「が」"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternTeMorau",
@@ -663,7 +660,6 @@ export const learningBlocks: LearningBlock[] = [
       "な形容詞和名詞要加「だ」（×「静かと思う」→ ○「静かだと思う」）",
       "口語可把「と」說成「って」：「行くって言った」"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternToOmou",
@@ -704,7 +700,6 @@ export const learningBlocks: LearningBlock[] = [
       "あとで 前面用た形（× 食べるあとで → ○ 食べたあとで）",
       "てから 與 たあとで 都表「之後」，但 てから 更強調『做完前項緊接著做後項』"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternMaeAto",
@@ -745,7 +740,6 @@ export const learningBlocks: LearningBlock[] = [
       "たり 要成對使用（〜たり〜たりする），通常是『舉例』而非全部",
       "し 可以接形容詞（安いし）；ながら / て 不能直接接い形容詞"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternNagaraTari",
@@ -786,7 +780,6 @@ export const learningBlocks: LearningBlock[] = [
       "ておく 口語縮成「〜とく」（買っとく）",
       "ている 可表進行，也可表結果狀態（結婚している＝已婚的狀態，不是正在結婚）"
     ],
-    completionMode: "reference",
     patternDrills: [
       {
         labelKey: "drillPatternTeAux",
@@ -809,7 +802,7 @@ export const learningBlocks: LearningBlock[] = [
   }
 ];
 
-type CompletionAttempt = { isCorrect: boolean; targetForm: string };
+type CompletionAttempt = { isCorrect: boolean; targetForm: string; questionId?: string };
 
 export function isLearningBlockComplete(attempts: CompletionAttempt[], block: LearningBlock): boolean {
   // Reference chapters are reading material -- treat them as
@@ -817,6 +810,17 @@ export function isLearningBlockComplete(attempts: CompletionAttempt[], block: Le
   // park on them, and the UI shows "參考" rather than misleadingly
   // marking them perpetually incomplete.
   if (block.completionMode === "reference") return true;
+  // Sentence-pattern chapters are completed via their pattern drill -- a
+  // correct attempt on any of the chapter's patterns (id "pattern-<id>-…") --
+  // not via a conjugation form, so they count toward progress like the rest.
+  if (block.patternDrills && block.patternDrills.length > 0) {
+    const patternIds = block.patternDrills.flatMap((drill) => drill.patternIds);
+    return attempts.some(
+      (attempt) =>
+        attempt.isCorrect &&
+        patternIds.some((pid) => attempt.questionId?.startsWith(`pattern-${pid}-`))
+    );
+  }
   if (!block.requiredForms || block.requiredForms.length === 0) return false;
   return block.requiredForms.every((targetForm) =>
     attempts.some((attempt) => attempt.isCorrect && attempt.targetForm === targetForm)


### PR DESCRIPTION
The 7 sentence-pattern chapters (てください / なくてもいい / てもらう / と思う / まえに・あとで / ながら・たり / てみる・ておく) had real pattern drills but were `completionMode: "reference"`, so they never counted toward 完成章節 — home showed e.g. **2/11** even though there are 18 drillable chapters.

- Drop the reference flag on those 7; complete them via a correct pattern-drill attempt (`pattern-<id>-…`). Only the verb-types explainer stays 參考.
- `isLearningBlockComplete` gains a pattern-completion branch; `CompletionAttempt` carries `questionId`.
- Home learn count is now **/18**.

Tests: new learningBlocks.test (4) + updated App.test (verb-types '參考', pattern chapter keeps drill-note). Full suite + build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chapter completion now works correctly for pattern-based lessons, so progress is tracked when the right exercise is answered.
  * Several sentence-pattern chapters are no longer treated as always complete, making completion badges more accurate.
  * The “verb types” reference chapter still shows as completed in reading mode, while sentence-pattern chapters continue to require practice.
  * Added coverage for these completion rules to help keep lesson progress behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->