### PR TITLE
chore(supabase): RLS perf + tighten rls_auto_enable (#294 Phase 1)

### DIFF
--- a/supabase/migrations/0003_rls_perf.sql
+++ b/supabase/migrations/0003_rls_perf.sql
@@ -1,0 +1,44 @@
+-- Supabase advisor follow-ups (#294 Phase 1): RLS performance + SECURITY DEFINER
+-- exposure. NO schema/data change — only re-defines the `attempts` RLS policies
+-- and tightens execute on a leftover helper function.
+--
+-- HOW TO RUN (manual — an agent has no Supabase project login):
+--   • Supabase Dashboard → SQL Editor → paste this whole file → Run, OR
+--   • supabase db push  (if the Supabase CLI is linked to the project).
+-- Idempotent: safe to re-run.
+--
+-- 1) PERFORMANCE — wrap auth.uid() in a scalar subselect.
+--    `auth.uid() = user_id` re-evaluates the auth helper once PER ROW; the
+--    advisor-recommended `(select auth.uid()) = user_id` evaluates it ONCE per
+--    statement (Postgres treats the uncorrelated subselect as an initplan).
+--    Semantics are identical; only the per-row cost goes away. Fixes the
+--    "auth_rls_initplan" warnings on attempts_{select,insert,delete}_own.
+
+drop policy if exists "attempts_select_own" on public.attempts;
+create policy "attempts_select_own" on public.attempts
+  for select using ((select auth.uid()) = user_id);
+
+drop policy if exists "attempts_insert_own" on public.attempts;
+create policy "attempts_insert_own" on public.attempts
+  for insert with check ((select auth.uid()) = user_id);
+
+drop policy if exists "attempts_delete_own" on public.attempts;
+create policy "attempts_delete_own" on public.attempts
+  for delete using ((select auth.uid()) = user_id);
+
+-- 2) SECURITY — `public.rls_auto_enable()` is a SECURITY DEFINER function that
+--    lives only in the live DB (it is NOT defined by any repo migration — part
+--    of the schema drift noted in #294). It is an internal helper, never called
+--    as a client RPC, so anon/authenticated have no reason to EXECUTE it.
+--    Guarded so a fresh DB / `supabase db reset` (where the function is absent)
+--    is unaffected.
+do $$
+begin
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'rls_auto_enable'
+  ) then
+    revoke execute on function public.rls_auto_enable() from anon, authenticated, public;
+  end if;
+end $$;


### PR DESCRIPTION
針對 #294 **Phase 1** 中「能安全地由 repo migration 處理」的兩條 advisor follow-up。**不動 schema、不動資料、merge 本身也不會碰 live DB**（沿用 0001/0002 的手動 SQL Editor 流程）。

## 內容（`supabase/migrations/0003_rls_perf.sql`）
1. **效能**：`attempts_{select,insert,delete}_own` 政策改 `(select auth.uid()) = user_id`，讓 auth helper 每個 statement 只算一次（而非每列），消掉 `auth_rls_initplan` 警告。語意完全相同。
2. **安全**：對殘留的 `SECURITY DEFINER` helper `public.rls_auto_enable()` `revoke execute`（anon/authenticated/public）。用 guarded DO block 包住——**只有該函式存在時才執行**，所以 fresh DB／`db reset` 不受影響。

## ⚠️ 需要你（owner）確認 / 在 Supabase dashboard 操作的部分
- `rls_auto_enable()` 我是依 #294 的描述判斷它是內部 helper、非 client RPC。**merge/執行前請確認它沒被當 RPC 呼叫**（理論上沒有）。
- 這支 SQL 要由你在 **SQL Editor 貼上執行**才會生效到 live DB。
- #294 Phase 1 其餘項目仍屬 dashboard 工作、本 PR 未涵蓋：
  - migration history 漂移對齊（repo `0001/0002/0003` ↔ Supabase history 的 `20260623181723…` ↔ live schema）
  - 重新跑 Supabase security / performance advisors 確認 warning 清掉
  - `0002_create_feedback` 的 history drift

## 不做
Phase 2–5（`practice_attempts`／dual-write／`user_vocabulary_stats`／feedback 升級）刻意不在此 PR；建議等 SRS/analytics 功能真的要做時再一起設計（詳見我在討論串的建議）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance for your own record access, making list and row checks faster and more consistent.
  * Strengthened access controls by tightening permission handling for a database helper when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->