### PR TITLE
feat(challenge): 每題「回報問題」鈕 (#299)

### DIFF
--- a/src/components/FeedbackForm.test.tsx
+++ b/src/components/FeedbackForm.test.tsx
@@ -48,6 +48,27 @@ describe("FeedbackForm", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("shows the question context and folds it into the submitted message", async () => {
+    const submit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <FeedbackForm
+        language="zh-Hant"
+        category="bug"
+        context="題目 n3-order-tabini｜語順組合"
+        onClose={() => {}}
+        submit={submit}
+      />
+    );
+    expect(screen.getByText(/n3-order-tabini/)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/想許什麼願/), { target: { value: "  選項重複  " } });
+    fireEvent.click(screen.getByRole("button", { name: /送出/ }));
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    const arg = submit.mock.calls[0][0];
+    expect(arg.category).toBe("bug");
+    expect(arg.message).toContain("選項重複");
+    expect(arg.message).toContain("n3-order-tabini");
+  });
+
   it("shows a GitHub fallback link when submit fails", async () => {
     const submit = vi.fn().mockRejectedValue(new Error("boom"));
     render(<FeedbackForm language="zh-Hant" category="bug" onClose={() => {}} submit={submit} />);

--- a/src/components/FeedbackForm.tsx
+++ b/src/components/FeedbackForm.tsx
@@ -35,11 +35,15 @@ const KINDS: FeedbackCategory[] = ["wish", "bug", "other"];
 export function FeedbackForm({
   language,
   category,
+  context,
   onClose,
   submit = defaultSubmit
 }: {
   language: Language;
   category: FeedbackCategory;
+  /** Optional report context (e.g. the question id) — shown to the learner and
+   *  folded into the submitted message so the owner can identify the item. */
+  context?: string;
   onClose: () => void;
   submit?: (input: FeedbackInput) => Promise<void>;
 }) {
@@ -73,8 +77,9 @@ export function FeedbackForm({
     event.preventDefault();
     if (!trimmed || status === "sending") return;
     setStatus("sending");
+    const fullMessage = context ? `${trimmed}\n\n— ${context}` : trimmed;
     try {
-      await submit({ category: kind, message: trimmed, contact: contact.trim() || undefined });
+      await submit({ category: kind, message: fullMessage, contact: contact.trim() || undefined });
       setStatus("done");
     } catch {
       setStatus("error");
@@ -130,6 +135,13 @@ export function FeedbackForm({
           </button>
         ))}
       </div>
+
+      {context ? (
+        <p className="feedback-context">
+          {t.feedbackContextLabel}
+          <span>{context}</span>
+        </p>
+      ) : null}
 
       <textarea
         className="feedback-message"

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -1,9 +1,11 @@
-import { ArrowRight, Eye, GraduationCap, RotateCcw } from "lucide-react";
+import { useState } from "react";
+import { ArrowRight, Eye, Flag, GraduationCap, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech } from "../../domain/types";
 import { DarumaSpot, PaperNoteSpot, TeaCupSpot } from "../../illustrations";
 import { isReadingPrompt } from "../../domain/furigana";
 import { ExamPrompt } from "../ExamPrompt";
+import { FeedbackForm } from "../FeedbackForm";
 import { FeedbackPanel } from "../FeedbackPanel";
 import { Ruby } from "../Ruby";
 import { SpeakButton } from "../SpeakButton";
@@ -84,6 +86,9 @@ export function DrillPanel({
   | "handleDrillKeyDown"
 > & { language: Language; onExit: () => void }) {
   const t = copy[language];
+  // Per-question "report a problem" (#299): opens the feedback box prefilled as a
+  // bug, with the question id as context so the owner can locate the item.
+  const [reportOpen, setReportOpen] = useState(false);
 
   // Completion-screen copy: daily / review have their own wording; every
   // other (capped, #154) finite session uses the generic "這組完成" set.
@@ -214,6 +219,22 @@ export function DrillPanel({
 
           {feedback ? (
             <FeedbackPanel feedback={feedback} language={language} options={choiceOptions} />
+          ) : null}
+
+          {currentQuestion ? (
+            <button type="button" className="report-link" onClick={() => setReportOpen(true)}>
+              <Flag aria-hidden="true" />
+              {t.reportThisQuestion}
+            </button>
+          ) : null}
+
+          {reportOpen && currentQuestion ? (
+            <FeedbackForm
+              language={language}
+              category="bug"
+              context={`題目 ${currentQuestion.id}`}
+              onClose={() => setReportOpen(false)}
+            />
           ) : null}
         </>
       ) : sessionExhausted ? (

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -39,6 +39,8 @@ export type Copy = {
   feedbackClose: string;
   feedbackError: string;
   feedbackFallback: string;
+  feedbackContextLabel: string;
+  reportThisQuestion: string;
   homeContentStats: (total: number, examItems: number, vocab: number, kanjiReadings: number, patternChecks: number, chapters: number) => string;
   homeCardStageLearn: string;
   homeCardStageChallenge: string;
@@ -313,6 +315,8 @@ export const copy: Record<Language, Copy> = {
     feedbackClose: "關閉",
     feedbackError: "送出失敗，請稍後再試，或",
     feedbackFallback: "改用 GitHub 回報",
+    feedbackContextLabel: "回報的題目：",
+    reportThisQuestion: "這題有問題？回報",
     homeContentStats: (total, examItems, vocab, kanjiReadings, patternChecks, chapters) =>
       `全站 ${total.toLocaleString()} 題 · 檢定題 ${examItems} · 單字 ${vocab} · 漢字讀音 ${kanjiReadings} · 句型 ${patternChecks} · ${chapters} 學習章節`,
     homeCardStageLearn: "學",

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -517,3 +517,44 @@
   min-height: 18rem;
   color: var(--muted);
 }
+
+/* Per-question report (#299): context line inside the feedback box + the
+   low-key "report this question" link under the drill. */
+.feedback-context {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.feedback-context span {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.report-link {
+  align-self: center;
+  margin-top: 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.55rem;
+  border: none;
+  border-radius: 0.45rem;
+  background: none;
+  color: var(--muted);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.report-link:hover {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--paper) 85%, var(--rule));
+}
+
+.report-link svg {
+  width: 0.95em;
+  height: 0.95em;
+}


### PR DESCRIPTION
每題答題畫面下方加一顆低調的「這題有問題？回報」鈕，點了開啟既有意見箱（預設「回報問題」），並把**題目 id 自動帶入 context**，方便定位是哪一題。流量變大後就是內容品質的回饋雷達。

## 內容
- **FeedbackForm**：新增可選 `context` prop——顯示「回報的題目：…」一行，並把 context 併入送出的 message。無 context 時行為不變（既有測試全綠）。
- **DrillPanel**：報告鈕 + modal，context = 當前題目 id。
- i18n：`feedbackContextLabel` / `reportThisQuestion`。
- styles：`.feedback-context` / `.report-link`。

## 不改 DB
questionId 先塞進 message 文字；之後要乾淨的欄位查詢再走 #294 Phase 5 給 feedback 表加 `question_id`。

## 驗證
- TDD：新增 FeedbackForm context 測試（先 RED 後 GREEN）。
- 全部 **397 測試通過**、build 綠（index 不膨脹、examBlocks 仍 lazy）。
- preview 實機驗證：drill 出現回報鈕 → 點擊開 modal → 類別預設「回報問題」、context 自動帶入實際題目 id。

Closes #299（i18n 多語系部分另案處理）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-question “report this question” option in the drill view.
  * Feedback submissions can now include extra context alongside the user’s message.

* **Bug Fixes**
  * Submitted feedback now preserves the typed message while attaching the related question context.
  * The feedback form now clearly displays the context being reported.

* **Documentation**
  * Added Traditional Chinese text for the new feedback and reporting labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->