### PR TITLE
feat(i18n): clearer language switcher + ?lang= URL override (#326)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -729,18 +729,37 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "隱藏註音" })).toHaveAttribute("aria-pressed", "true");
   });
 
-  it("renders the language switcher with the shipped locales (#299)", () => {
+  it("opens the language picker from the header switcher button (#326)", async () => {
     // Default locale is zh-TW (test setup) -> zh-Hant.
+    const user = userEvent.setup();
+    render(<App />); // beforeEach seeds jabiko.lang = zh-Hant
+
+    // The switcher is now an obvious button labelled with the current language,
+    // not a low-key <select> sharing the furigana icon.
+    const switchButton = screen.getByRole("button", { name: "切換語言" });
+    expect(switchButton).toHaveTextContent("繁體中文");
+
+    await user.click(switchButton);
+
+    const picker = screen.getByRole("dialog", { name: /選擇語言/ });
+    for (const name of ["繁體中文", "日本語", "English", "ไทย", "Bahasa Indonesia", "한국어", "Tiếng Việt", "မြန်မာ"]) {
+      expect(within(picker).getByRole("button", { name })).toBeInTheDocument();
+    }
+
+    // Picking a language closes the picker.
+    await user.click(within(picker).getByRole("button", { name: "日本語" }));
+    expect(screen.queryByRole("dialog", { name: /選擇語言/ })).not.toBeInTheDocument();
+  });
+
+  it("respects ?lang= on load and skips the first-visit picker (#326)", () => {
+    localStorage.removeItem("jabiko.lang"); // a never-visited device...
+    window.history.replaceState({}, "", "/?lang=ja"); // ...arriving via a ja deep link
     render(<App />);
 
-    expect(screen.getByRole("button", { name: "首頁" })).toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("ja");
+    expect(screen.queryByRole("dialog", { name: /選擇語言/ })).not.toBeInTheDocument();
 
-    expect(screen.getByRole("combobox", { name: "切換語言" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "繁中" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "日本語" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "English" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "ไทย" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Bahasa Indonesia" })).toBeInTheDocument();
+    window.history.replaceState({}, "", "/");
   });
 
   it("lists 綜合考題庫 / N1 備考 / N2 備考 as side-by-side mode presets", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { Languages, Moon, Sun } from "lucide-react";
+import { Globe, Languages, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
@@ -98,6 +98,9 @@ export default function App() {
   // the whole tree on change, so the prop-drilled `language` stays a seam.
   const { language, setLanguage, needsLanguageChoice } = useLanguage();
   const t = copy[language];
+  // On-demand language picker, opened from the header switcher (#326). Separate
+  // from needsLanguageChoice, which is the one-time first-visit prompt.
+  const [langPickerOpen, setLangPickerOpen] = useState(false);
 
   const { theme, toggleTheme } = useTheme();
   // Global furigana (ruby) preference, default OFF (#134). The hook owns the
@@ -166,6 +169,18 @@ export default function App() {
       {needsLanguageChoice && (
         <LanguagePicker current={language} options={LANGUAGE_OPTIONS} onChoose={setLanguage} />
       )}
+      {langPickerOpen && (
+        <LanguagePicker
+          current={language}
+          options={LANGUAGE_OPTIONS}
+          onChoose={(code) => {
+            setLanguage(code);
+            setLangPickerOpen(false);
+          }}
+          onClose={() => setLangPickerOpen(false)}
+          closeLabel={t.feedbackClose}
+        />
+      )}
       <div className="app-heading" aria-label={t.appIntroLabel}>
         <div className="app-brand">
           <JabikoMark className="app-brand-mark" />
@@ -209,21 +224,16 @@ export default function App() {
           )}
           <div className="utility-actions">
             {LANGUAGE_OPTIONS.length > 1 && (
-              <div className="lang-switch">
-                <Languages aria-hidden="true" className="lang-switch-icon" />
-                <select
-                  className="lang-switch-select"
-                  aria-label={t.languageSwitchLabel}
-                  value={language}
-                  onChange={(event) => setLanguage(event.target.value as Language)}
-                >
-                  {LANGUAGE_OPTIONS.map((code) => (
-                    <option key={code} value={code}>
-                      {copy[code].languageName}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <button
+                type="button"
+                className="theme-toggle lang-switch-button"
+                aria-label={t.languageSwitchLabel}
+                aria-haspopup="dialog"
+                onClick={() => setLangPickerOpen(true)}
+              >
+                <Globe aria-hidden="true" />
+                <span className="lang-switch-name">{copy[language].languageName}</span>
+              </button>
             )}
             <button
               className={`theme-toggle furigana-toggle${furiganaEnabled ? " active" : ""}`}

--- a/src/components/LanguagePicker.test.tsx
+++ b/src/components/LanguagePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { LanguagePicker } from "./LanguagePicker";
@@ -50,5 +50,55 @@ describe("LanguagePicker", () => {
     render(<LanguagePicker current="vi" options={OPTIONS} onChoose={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: copy.vi.languageName })).toHaveFocus();
+  });
+
+  // Dismissible mode (#326): when opened on demand from the header switcher an
+  // onClose is passed, so the user can back out without changing language. The
+  // first-visit picker passes no onClose and stays mandatory.
+  describe("dismissible mode (onClose)", () => {
+    it("shows a close button that calls onClose", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <LanguagePicker
+          current="ja"
+          options={OPTIONS}
+          onChoose={vi.fn()}
+          onClose={onClose}
+          closeLabel="關閉"
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "關閉" }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes on Escape", () => {
+      const onClose = vi.fn();
+      render(<LanguagePicker current="ja" options={OPTIONS} onChoose={vi.fn()} onClose={onClose} />);
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes when the backdrop is clicked but not when the dialog is", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+      const { container } = render(
+        <LanguagePicker current="ja" options={OPTIONS} onChoose={vi.fn()} onClose={onClose} />
+      );
+
+      await user.click(screen.getByRole("dialog"));
+      expect(onClose).not.toHaveBeenCalled();
+
+      await user.click(container.querySelector(".lang-picker-overlay")!);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("has no close button when onClose is omitted (mandatory first-visit)", () => {
+      render(<LanguagePicker current="ja" options={OPTIONS} onChoose={vi.fn()} />);
+
+      expect(screen.queryByRole("button", { name: /關閉|close/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,24 +1,32 @@
 import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
 import { copy, type Language } from "../i18n";
 
-// First-visit language picker (#313 follow-up). Shown once, when no language
-// preference is stored yet (useLanguage.needsLanguageChoice), instead of
-// silently committing the auto-detected suggestion. The heading is deliberately
-// multilingual -- the visitor hasn't chosen a language yet, so a single-locale
-// title would beg the question. Each option is labelled in its own script via
-// copy[code].languageName, with lang={code} so the browser can pick the right
-// font (matters for Korean / Burmese). The suggested option (the detected /
-// ja-fallback guess) is pre-highlighted and focused so Enter commits it.
-// Choosing any option commits + dismisses for good; there is intentionally no
-// close affordance -- making a choice IS the action.
+// Language picker (#313 first-visit + #326 on-demand). The heading is
+// deliberately multilingual -- on a first visit the user hasn't chosen a
+// language yet, so a single-locale title would beg the question. Each option is
+// labelled in its own script via copy[code].languageName, with lang={code} so
+// the browser can pick the right font (matters for Korean / Burmese). The
+// suggested option (detected / ja-fallback guess, or the current language when
+// reopened) is pre-highlighted and focused so Enter commits it.
+//
+// Two modes:
+//  - First visit (no onClose): mandatory -- no close affordance, choosing IS the
+//    action.
+//  - On demand from the header switcher (onClose given): dismissible via a close
+//    button, Escape, or a backdrop click, so the user can back out unchanged.
 export function LanguagePicker({
   current,
   options,
-  onChoose
+  onChoose,
+  onClose,
+  closeLabel = "Close"
 }: {
   current: Language;
   options: readonly Language[];
   onChoose: (language: Language) => void;
+  onClose?: () => void;
+  closeLabel?: string;
 }) {
   const suggestedRef = useRef<HTMLButtonElement>(null);
 
@@ -31,14 +39,39 @@ export function LanguagePicker({
     };
   }, []);
 
+  // Escape closes only in dismissible mode.
+  useEffect(() => {
+    if (!onClose) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
-    <div className="lang-picker-overlay" role="presentation">
+    <div
+      className="lang-picker-overlay"
+      role="presentation"
+      onClick={onClose ? () => onClose() : undefined}
+    >
       <div
         className="lang-picker"
         role="dialog"
         aria-modal="true"
         aria-label="Choose your language / 選擇語言 / 言語を選択"
+        onClick={(event) => event.stopPropagation()}
       >
+        {onClose && (
+          <button
+            type="button"
+            className="lang-picker-close"
+            aria-label={closeLabel}
+            onClick={onClose}
+          >
+            <X aria-hidden="true" />
+          </button>
+        )}
         <div className="lang-picker-head">
           <span className="lang-picker-brand" lang="ja">
             ジャビ子

--- a/src/hooks/useLanguage.test.ts
+++ b/src/hooks/useLanguage.test.ts
@@ -150,6 +150,60 @@ describe("useLanguage", () => {
     expect(document.documentElement.lang).toBe("zh-Hant");
   });
 
+  // URL ?lang= override (#326): a deep link / marketing URL can force a
+  // language regardless of stored preference or browser. Priority is
+  // URL param > stored > navigator > default(ja).
+  describe("?lang= URL override", () => {
+    afterEach(() => {
+      window.history.replaceState({}, "", "/");
+    });
+
+    it("uses ?lang=ja over the navigator default", () => {
+      setNavigatorLanguage("zh-TW");
+      setNavigatorLanguages(["zh-TW"]);
+      window.history.replaceState({}, "", "/?lang=ja");
+
+      const { result } = renderHook(() => useLanguage());
+
+      expect(result.current.language).toBe("ja");
+    });
+
+    it("uses ?lang= over a stored preference (URL wins)", () => {
+      localStorage.setItem(KEY, "zh-Hant");
+      window.history.replaceState({}, "", "/?lang=ko");
+
+      const { result } = renderHook(() => useLanguage());
+
+      expect(result.current.language).toBe("ko");
+    });
+
+    it("accepts a BCP-47 tag and maps it by prefix (?lang=vi-VN -> vi)", () => {
+      window.history.replaceState({}, "", "/?lang=vi-VN");
+
+      const { result } = renderHook(() => useLanguage());
+
+      expect(result.current.language).toBe("vi");
+    });
+
+    it("ignores an unsupported ?lang= and falls through", () => {
+      localStorage.setItem(KEY, "th");
+      window.history.replaceState({}, "", "/?lang=fr");
+
+      const { result } = renderHook(() => useLanguage());
+
+      expect(result.current.language).toBe("th");
+    });
+
+    it("skips the first-visit picker and persists the choice", () => {
+      window.history.replaceState({}, "", "/?lang=my");
+
+      const { result } = renderHook(() => useLanguage());
+
+      expect(result.current.needsLanguageChoice).toBe(false);
+      expect(localStorage.getItem(KEY)).toBe("my");
+    });
+  });
+
   // First-visit language choice: with no stored preference the app shows a
   // language picker; once a choice is stored it never asks again.
   describe("needsLanguageChoice (first-visit picker)", () => {

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -54,11 +54,34 @@ export function hasStoredLanguage(): boolean {
   return isSupportedLanguage(readStored(LANGUAGE_STORAGE_KEY));
 }
 
-// The language to start with: a valid stored preference wins; otherwise the
-// best navigator match; otherwise Japanese (this is a Japanese-learning app, so
-// ja is the sensible default suggestion). On a first visit this value is only a
-// *suggestion* — it pre-selects the picker until the user makes a real choice.
+// Parse ?lang=<code> from a location search string (#326). Accepts an exact
+// supported locale ("ja", "zh-Hant") or a BCP-47 tag whose prefix maps to one
+// ("vi-VN" -> vi). Returns null when the param is absent or unrecognised. Lets
+// a deep link / marketing URL force a language regardless of stored preference
+// or browser detection.
+export function languageFromSearch(search: string): Language | null {
+  const raw = new URLSearchParams(search).get("lang");
+  if (!raw) return null;
+  if (isSupportedLanguage(raw)) return raw;
+  return languageForTag(raw);
+}
+
+function urlLanguage(): Language | null {
+  if (typeof window === "undefined") return null;
+  return languageFromSearch(window.location.search);
+}
+
+// The language to start with. Priority (#326): URL ?lang= override > a valid
+// stored preference > the best navigator match > Japanese (this is a
+// Japanese-learning app, so ja is the sensible default). On a first visit with
+// no URL override this value is only a *suggestion* — it pre-selects the picker
+// until the user makes a real choice.
 export function getInitialLanguage(): Language {
+  const fromUrl = urlLanguage();
+  if (fromUrl) {
+    return fromUrl;
+  }
+
   const stored = readStored(LANGUAGE_STORAGE_KEY);
   if (isSupportedLanguage(stored)) {
     return stored;
@@ -79,11 +102,24 @@ function storeLanguage(language: Language) {
 // the consumer shows the first-visit picker; setLanguage clears it for good.
 export function useLanguage() {
   const [language, setLanguageState] = useState<Language>(() => getInitialLanguage());
-  const [needsLanguageChoice, setNeedsLanguageChoice] = useState<boolean>(() => !hasStoredLanguage());
+  // A ?lang= override counts as an explicit choice: skip the first-visit picker.
+  const [needsLanguageChoice, setNeedsLanguageChoice] = useState<boolean>(
+    () => urlLanguage() === null && !hasStoredLanguage()
+  );
 
   useEffect(() => {
     document.documentElement.lang = language;
   }, [language]);
+
+  // Persist a ?lang= deep-link choice so it sticks on the next visit (and so the
+  // picker stays dismissed). Runs once on mount; the param itself stays in the
+  // URL untouched.
+  useEffect(() => {
+    const fromUrl = urlLanguage();
+    if (fromUrl) {
+      storeLanguage(fromUrl);
+    }
+  }, []);
 
   const setLanguage = (next: Language) => {
     setLanguageState(next);

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -1,7 +1,7 @@
 import type { Copy } from "../i18n";
 
 export const zhHant: Copy = {
-  languageName: "繁中",
+  languageName: "繁體中文",
   languageSwitchLabel: "切換語言",
   appIntroLabel: "Jabiko 介紹",
   appTitle: "Jabiko · JLPT 自習室",

--- a/src/styles/language-picker.css
+++ b/src/styles/language-picker.css
@@ -13,6 +13,7 @@
 }
 
 .lang-picker {
+  position: relative;
   width: 100%;
   max-width: 30rem;
   max-height: 90vh;
@@ -26,6 +27,37 @@
   background: var(--paper);
   box-shadow: 0 16px 48px rgba(23, 33, 38, 0.32);
   text-align: center;
+}
+
+/* Close button, only present when the picker is opened on demand (#326). */
+.lang-picker-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.lang-picker-close:hover {
+  color: var(--ink);
+  border-color: var(--matcha);
+}
+
+.lang-picker-close svg {
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .lang-picker-head {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -89,44 +89,22 @@
   color: var(--selected-text);
 }
 
-/* Language switcher (#299): a compact pill matching the theme/furigana
-   toggles, with the Languages icon as a leading adornment and a native
-   <select> for the five locales. Kept unobtrusive in the header row. */
-.lang-switch {
+/* Language switcher (#326): an explicit pill button (Globe icon + the current
+   language's native name) that opens the language picker. A Globe icon -- not
+   the Languages icon the furigana toggle uses -- so the two read as distinct.
+   The name is capped + ellipsised so a long endonym (e.g. "Bahasa Indonesia")
+   can't stretch the header row. */
+.lang-switch-button {
   align-items: center;
-  background: color-mix(in srgb, var(--paper) 86%, transparent);
-  border: 1px solid var(--button-border);
-  border-radius: 999px;
-  color: var(--button-text);
   display: inline-flex;
-  flex: 0 0 auto;
-  gap: 0.35rem;
-  height: 2.75rem;
-  min-width: 9.5rem;
-  padding: 0.3rem 0.6rem;
+  gap: 0.4rem;
 }
 
-.lang-switch-icon {
-  flex: 0 0 auto;
-}
-
-.lang-switch-select {
-  appearance: none;
-  background: transparent;
-  border: none;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  font-weight: 800;
-  line-height: 1;
-  min-width: 0;
-  padding: 0;
+.lang-switch-name {
+  max-width: 9ch;
+  overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.lang-switch-select:focus-visible {
-  outline: 2px solid var(--vermilion);
-  outline-offset: 2px;
+  white-space: nowrap;
 }
 
 .auth-button {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -131,13 +131,6 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .lang-switch {
-    grid-column: 1 / -1;
-    justify-content: center;
-    min-width: 0;
-    width: 100%;
-  }
-
   .theme-toggle {
     justify-self: stretch;
     padding-inline: 0.72rem;


### PR DESCRIPTION
Implements all four items in #326.

## Changes

**1. Switcher is now obvious + distinct from furigana**
Replaced the low-key `<select>` (which shared the `Languages` icon with the furigana toggle) with an explicit pill **button**: a **Globe** icon + the current language's native name. Clicking it opens the language picker. The Globe vs the furigana icon makes the two read as clearly different controls.

**2. `languageName` reads as a language**
`zh-Hant` "繁中" → **"繁體中文"** (propagates to both the header button and the picker).

**3. Default language is Japanese**
Already landed in #313 (navigator-miss fallback → `ja`); this PR completes the item and the priority chain below makes it explicit.

**4. `?lang=<code>` URL override**
Priority: **URL param > stored > navigator > default(ja)**. Accepts an exact locale (`?lang=ja`, `?lang=zh-Hant`) or a BCP-47 tag by prefix (`?lang=vi-VN` → `vi`). A valid param **skips the first-visit picker** and **persists** so it sticks on the next visit. An unsupported value is ignored (falls through).

## Implementation notes
- Reused the #313 `LanguagePicker` as the on-demand picker by adding an optional `onClose` (close button + Escape + backdrop click). The first-visit picker passes no `onClose` and stays mandatory — one component, two modes.
- New `useLanguage` helper `languageFromSearch()` is unit-tested; the deep-link choice is persisted in a mount effect.

## Tests (TDD)
- `useLanguage.test.ts`: `?lang=` priority over navigator + stored, BCP-47 prefix, invalid ignored, skips picker + persists.
- `LanguagePicker.test.tsx`: dismissible mode (close button / Escape / backdrop; backdrop-not-dialog; no close button when mandatory).
- `App.test.tsx`: header button shows the current language + opens the picker with all 8 options + closes on pick; `?lang=ja` applies and skips the first-visit picker.
- **Full suite 470 green**; `tsc` clean; build unaffected (locales still eager, examBlocks/ChallengePanel still lazy).

## Verified in-browser
Header now shows three distinct controls (🌐 繁體中文 / 顯示註音 / 深色模式); the on-demand picker has a close affordance; `?lang=ja` loads the app in Japanese with no first-visit prompt.

Closes #326.
