### PR TITLE
feat(grammar): per-grammar-point study pages at /grammar/<surface> (#281)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -751,6 +751,18 @@ describe("App", () => {
     expect(screen.queryByRole("dialog", { name: /選擇語言/ })).not.toBeInTheDocument();
   });
 
+  it("opens a per-grammar-point study page from /grammar/<surface> (#281)", async () => {
+    const { allGrammarSurfaces } = await import("./domain/grammarPoints");
+    const surface = allGrammarSurfaces()[0];
+    window.history.replaceState({}, "", `/grammar/${encodeURIComponent(surface)}`);
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { level: 1, name: surface })).toBeInTheDocument();
+
+    window.history.replaceState({}, "", "/");
+  });
+
   it("respects ?lang= on load and skips the first-visit picker (#326)", () => {
     localStorage.removeItem("jabiko.lang"); // a never-visited device...
     window.history.replaceState({}, "", "/?lang=ja"); // ...arriving via a ja deep link

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,8 +38,14 @@ const MockExamPanel = lazy(() =>
 const KanjiOnyomiPanel = lazy(() =>
   import("./components/KanjiOnyomiPanel").then((module) => ({ default: module.KanjiOnyomiPanel }))
 );
+// Per-grammar-point study page (#281). Pulls the exam bank + grammar notes via
+// buildGrammarPoint, so it's lazy + imported directly (never via the barrel) to
+// keep that data out of the initial bundle.
+const GrammarPointPage = lazy(() =>
+  import("./components/GrammarPointPage").then((module) => ({ default: module.GrammarPointPage }))
+);
 
-type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about";
+type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about" | "grammar";
 type DrillPreset = LearningBlockDrillPreset;
 
 // The UI locales, in menu order, for the header language <select>. Each
@@ -59,7 +65,10 @@ const VIEW_PATHS: Record<AppView, string> = {
   kanji: "/kanji",
   challenge: "/challenge",
   mock: "/mock",
-  about: "/about"
+  about: "/about",
+  // Base path; the live grammar route carries a surface segment (see parseRoute
+  // / pathForView). Bare /grammar with no surface falls back to home.
+  grammar: "/grammar"
 };
 
 function viewFromPath(pathname: string): AppView {
@@ -69,28 +78,60 @@ function viewFromPath(pathname: string): AppView {
   return match ? match[0] : "home";
 }
 
+// Per-grammar-point study pages (#281) live at /grammar/<encoded-surface>, the
+// one dynamic route. parseRoute pulls both the view and (for grammar) the
+// decoded surface off the path; pathForView is its inverse for URL sync.
+function parseRoute(pathname: string): { view: AppView; grammarSurface: string | null } {
+  const grammar = pathname.match(/^\/grammar\/(.+)$/);
+  if (grammar) {
+    let surface = grammar[1];
+    try {
+      surface = decodeURIComponent(surface);
+    } catch {
+      // Malformed escape -- keep the raw segment rather than throwing.
+    }
+    return { view: "grammar", grammarSurface: surface };
+  }
+  return { view: viewFromPath(pathname), grammarSurface: null };
+}
+
+function pathForView(view: AppView, grammarSurface: string | null): string {
+  if (view === "grammar" && grammarSurface) {
+    return `/grammar/${encodeURIComponent(grammarSurface)}`;
+  }
+  return VIEW_PATHS[view];
+}
+
 export default function App() {
-  const [appView, setAppView] = useState<AppView>(() => viewFromPath(window.location.pathname));
+  const [appView, setAppView] = useState<AppView>(() => parseRoute(window.location.pathname).view);
+  // The grammar-point surface for the active /grammar/<surface> route (#281).
+  const [grammarSurface, setGrammarSurface] = useState<string | null>(
+    () => parseRoute(window.location.pathname).grammarSurface
+  );
 
   // Keep the URL in sync when the view changes (push a history entry only
   // when the path actually differs, so popstate-driven changes don't loop).
   useEffect(() => {
-    const target = VIEW_PATHS[appView];
+    const target = pathForView(appView, grammarSurface);
     if (window.location.pathname !== target) {
       window.history.pushState({ view: appView }, "", target);
     }
-  }, [appView]);
+  }, [appView, grammarSurface]);
 
-  // Back/forward: read the view back off the URL.
+  // Back/forward: read the view (and grammar surface) back off the URL.
   useEffect(() => {
-    const onPopState = () => setAppView(viewFromPath(window.location.pathname));
+    const onPopState = () => {
+      const route = parseRoute(window.location.pathname);
+      setAppView(route.view);
+      setGrammarSurface(route.grammarSurface);
+    };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
 
   // Per-view <title>/description/canonical/og so each route surfaces its own
   // metadata to crawlers (SPA otherwise shares one static shell). See seo.ts.
-  useSeoMeta(appView);
+  useSeoMeta(appView, grammarSurface);
 
   // UI language: stored preference > navigator detection > zh-Hant default
   // (#299). The hook owns the <html lang> side-effect and persistence; the
@@ -345,6 +386,15 @@ export default function App() {
             onStartSection={(level, promptLabel) =>
               openChallenge({ mode: "exam", filter: { examSection: { level, promptLabel } } })
             }
+          />
+        </Suspense>
+      ) : appView === "grammar" ? (
+        <Suspense fallback={<PanelFallback label={t.loading} />}>
+          <GrammarPointPage
+            surface={grammarSurface ?? ""}
+            language={language}
+            onPractice={() => openChallenge()}
+            onBack={() => setAppView("home")}
           />
         </Suspense>
       ) : (

--- a/src/components/GrammarPointPage.test.tsx
+++ b/src/components/GrammarPointPage.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { GrammarPointPage } from "./GrammarPointPage";
+import { allGrammarSurfaces, buildGrammarPoint } from "../domain/grammarPoints";
+import { grammarNotes } from "../domain/grammarNotes";
+import { copy } from "../i18n";
+
+// A surface that exists in the exam bank AND has a curated note, so the page
+// renders its richest layout (GrammarNoteCard + examples + practice entry).
+const notedSurface = allGrammarSurfaces().find((s) => grammarNotes[s])!;
+const t = copy["zh-Hant"];
+
+describe("GrammarPointPage", () => {
+  it("shows the grammar point as an <h1> with its meaning and a worked example", () => {
+    const point = buildGrammarPoint(notedSurface)!;
+    render(
+      <GrammarPointPage surface={notedSurface} language="zh-Hant" onPractice={vi.fn()} onBack={vi.fn()} />
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: notedSurface })).toBeInTheDocument();
+    expect(screen.getByText(point.meaningZh)).toBeInTheDocument();
+    // The curated example's translation sits in its own element -> unique match.
+    expect(screen.getByText(point.note!.examples[0].zh)).toBeInTheDocument();
+  });
+
+  it("triggers practice from the practice entry", async () => {
+    const onPractice = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <GrammarPointPage surface={notedSurface} language="zh-Hant" onPractice={onPractice} onBack={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole("button", { name: t.startChallenge }));
+    expect(onPractice).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back gracefully for an unknown surface and supports going back", async () => {
+    const onBack = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <GrammarPointPage surface="存在しない文法zzz" language="zh-Hant" onPractice={vi.fn()} onBack={onBack} />
+    );
+
+    expect(screen.getByRole("heading", { level: 1, name: "存在しない文法zzz" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: t.reviewDoneExit }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/GrammarPointPage.tsx
+++ b/src/components/GrammarPointPage.tsx
@@ -1,0 +1,98 @@
+import { ArrowLeft, GraduationCap } from "lucide-react";
+import { copy, type Language } from "../i18n";
+import { buildGrammarPoint } from "../domain/grammarPoints";
+import { GrammarNoteCard } from "./GrammarNoteCard";
+
+// Standalone study page for a single 文法点 (issue #281). Deep-linkable at
+// /grammar/<surface>; content is aggregated from the exam bank and enriched
+// with the curated grammarNotes entry when one exists. Reaches the lazy
+// exam/notes data through buildGrammarPoint, so it is itself lazily loaded
+// (see App's React.lazy import) and never enters the initial bundle.
+export function GrammarPointPage({
+  surface,
+  language,
+  onPractice,
+  onBack
+}: {
+  surface: string;
+  language: Language;
+  onPractice: () => void;
+  onBack: () => void;
+}) {
+  const t = copy[language];
+  const point = buildGrammarPoint(surface);
+
+  const backButton = (
+    <button type="button" className="ghost-button grammar-point-back" onClick={onBack}>
+      <ArrowLeft aria-hidden="true" />
+      {t.reviewDoneExit}
+    </button>
+  );
+
+  // Unknown surface (e.g. a stale/typo link): show a minimal, non-crashing
+  // shell so the route still resolves and the user can step back.
+  if (!point) {
+    return (
+      <section className="grammar-point grammar-point-missing">
+        {backButton}
+        <h1 lang="ja">{surface}</h1>
+      </section>
+    );
+  }
+
+  // Curated examples are shown inside GrammarNoteCard; list only the additional
+  // exam-derived sentences here so nothing repeats.
+  const curatedJa = new Set((point.note?.examples ?? []).map((example) => example.ja));
+  const extraExamples = point.examples.filter((example) => !curatedJa.has(example.ja));
+
+  return (
+    <section className="grammar-point" aria-label={surface}>
+      {backButton}
+
+      <header className="grammar-point-head">
+        <h1 lang="ja">{surface}</h1>
+        {point.level ? (
+          <span className="grammar-point-level" aria-label={`JLPT ${point.level}`}>
+            {point.level}
+          </span>
+        ) : null}
+      </header>
+
+      {point.note ? (
+        <GrammarNoteCard note={point.note} language={language} />
+      ) : (
+        <div className="grammar-point-summary">
+          <p className="grammar-point-meaning">{point.meaningZh}</p>
+          {point.explanations.length > 0 ? (
+            <div className="grammar-point-rule">
+              {point.explanations.map((explanation) => (
+                <p key={explanation}>{explanation}</p>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      {extraExamples.length > 0 ? (
+        <div className="grammar-point-examples">
+          <p className="grammar-point-label">{t.grammarNoteExamples}</p>
+          <ul>
+            {extraExamples.map((example) => (
+              <li key={example.ja}>
+                <span className="grammar-point-ex-ja" lang="ja">
+                  {example.ja}
+                </span>
+                {example.zh ? <span className="grammar-point-ex-zh">{example.zh}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <button type="button" className="next-button grammar-point-practice" onClick={onPractice}>
+        <GraduationCap aria-hidden="true" />
+        {t.startChallenge}
+      </button>
+    </section>
+  );
+}

--- a/src/domain/grammarPoints.test.ts
+++ b/src/domain/grammarPoints.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { allGrammarSurfaces, buildGrammarPoint } from "./grammarPoints";
+import { examStyleQuestions } from "./examBlocks";
+import { grammarNotes } from "./grammarNotes";
+
+const grammarItems = examStyleQuestions.filter((q) => (q.promptLabel ?? "").includes("文法"));
+
+describe("grammarPoints", () => {
+  it("lists every distinct grammar surface, sorted and real", () => {
+    const surfaces = allGrammarSurfaces();
+    expect(surfaces.length).toBeGreaterThan(0);
+    expect(surfaces).toEqual([...surfaces].sort());
+
+    const real = new Set(grammarItems.map((q) => q.vocabulary.surface));
+    for (const surface of surfaces) {
+      expect(real.has(surface)).toBe(true);
+    }
+  });
+
+  it("returns null for a surface no grammar item uses", () => {
+    expect(buildGrammarPoint("この文法点は存在しないzzz")).toBeNull();
+  });
+
+  it("aggregates a real surface: meaning, complete examples, and a count", () => {
+    const surface = allGrammarSurfaces()[0];
+    const point = buildGrammarPoint(surface);
+
+    expect(point).not.toBeNull();
+    expect(point!.surface).toBe(surface);
+    expect(point!.meaningZh.length).toBeGreaterThan(0);
+    expect(point!.questionCount).toBeGreaterThanOrEqual(1);
+    expect(point!.explanations.length).toBeGreaterThanOrEqual(1);
+    expect(point!.examples.length).toBeGreaterThanOrEqual(1);
+    // The cloze blank is filled -- examples read as complete sentences.
+    for (const example of point!.examples) {
+      expect(example.ja).not.toContain("___");
+    }
+  });
+
+  it("attaches the curated grammarNotes entry when the surface has one", () => {
+    const noted = allGrammarSurfaces().find((s) => grammarNotes[s]);
+    // grammarNotes is keyed by exam surfaces, so an overlap must exist.
+    expect(noted).toBeDefined();
+
+    const point = buildGrammarPoint(noted!);
+    expect(point!.note).not.toBeNull();
+    expect(point!.note!.surface).toBe(noted);
+    // Curated examples are folded into the example list.
+    expect(point!.examples.length).toBeGreaterThanOrEqual(point!.note!.examples.length);
+  });
+});

--- a/src/domain/grammarPoints.ts
+++ b/src/domain/grammarPoints.ts
@@ -1,0 +1,101 @@
+// Per-grammar-point aggregation (issue #281). Builds a standalone study view
+// for a single 文法点 by gathering every 文法形式選擇 exam item that drills the
+// same `surface` (e.g. 「に伴って」「ないことには」) and enriching it with the
+// curated grammarNotes entry when one exists.
+//
+// MVP content source: the existing exam bank (aggregate) + curated notes. No
+// new authored content. This module reaches into examBlocks + grammarNotes, so
+// it carries the lazy exam-bank weight -- it MUST only be imported by the lazy
+// GrammarPointPage, never from an eager path (see bundle-codesplit discipline).
+import type { JlptLevel, PracticeQuestion } from "./types";
+import { examStyleQuestions } from "./examBlocks";
+import { grammarNotes, type GrammarNote } from "./grammarNotes";
+
+export type GrammarPointExample = { ja: string; zh: string };
+
+export type GrammarPoint = {
+  /** The grammar-point surface; also the route id (`/grammar/<surface>`). */
+  surface: string;
+  level: JlptLevel | null;
+  meaningZh: string;
+  /** Curated reference note (rule / usage / confusions), when one exists. */
+  note: GrammarNote | null;
+  /** Worked example sentences: curated first, then exam-item-derived. */
+  examples: GrammarPointExample[];
+  /** Distinct exam explanations -- the "rule" content for un-noted points. */
+  explanations: string[];
+  /** How many exam questions drill this point (a "練習這個文法" entry hint). */
+  questionCount: number;
+};
+
+const BLANK = "___";
+
+// A "grammar point" comes from 文法形式選擇 items, whose `surface` IS a single
+// pattern. 語順組合 (word-order) items have no clean single-point surface, so
+// they're excluded -- their promptLabel doesn't contain 文法.
+function isGrammarQuestion(question: PracticeQuestion): boolean {
+  return (question.promptLabel ?? "").includes("文法");
+}
+
+// Turn a cloze question into a complete example sentence by filling its blank
+// with the correct answer; pair it with the post-answer full translation.
+function exampleFromQuestion(question: PracticeQuestion): GrammarPointExample | null {
+  if (!question.promptText) return null;
+  const answer = question.expectedAnswers[0] ?? "";
+  const ja = question.promptText.includes(BLANK)
+    ? question.promptText.replace(BLANK, answer)
+    : question.promptText;
+  return { ja, zh: question.promptContextZh ?? "" };
+}
+
+// Curated note lookup, tolerant of a leading 〜/～ on the surface.
+function lookupNote(surface: string): GrammarNote | null {
+  return grammarNotes[surface] ?? grammarNotes[surface.replace(/^[〜～]/, "")] ?? null;
+}
+
+// Every distinct grammar-point surface present in the exam bank, sorted for a
+// stable order (an index page / build-time prerender can rely on it).
+export function allGrammarSurfaces(): string[] {
+  const surfaces = new Set<string>();
+  for (const question of examStyleQuestions) {
+    if (isGrammarQuestion(question)) surfaces.add(question.vocabulary.surface);
+  }
+  return [...surfaces].sort();
+}
+
+// Aggregate everything known about one grammar point. Returns null when no
+// grammar exam item uses this surface (so the route can 404 cleanly).
+export function buildGrammarPoint(surface: string): GrammarPoint | null {
+  const items = examStyleQuestions.filter(
+    (question) => isGrammarQuestion(question) && question.vocabulary.surface === surface
+  );
+  if (items.length === 0) return null;
+
+  const note = lookupNote(surface);
+
+  // Curated examples first (hand-written, cleaner), then exam-derived; dedupe
+  // by the Japanese sentence so a curated example isn't repeated by an item.
+  const seen = new Set<string>();
+  const examples: GrammarPointExample[] = [];
+  const candidates: GrammarPointExample[] = [
+    ...(note?.examples ?? []),
+    ...items.map(exampleFromQuestion).filter((ex): ex is GrammarPointExample => ex !== null)
+  ];
+  for (const example of candidates) {
+    if (!example.ja || seen.has(example.ja)) continue;
+    seen.add(example.ja);
+    examples.push(example);
+  }
+
+  const explanations = [...new Set(items.map((item) => item.explanation).filter(Boolean))];
+
+  return {
+    surface,
+    level: items[0].vocabulary.level ?? note?.jlptLevel ?? null,
+    meaningZh: note?.meaningZh ?? items[0].vocabulary.meaningZh,
+    note,
+    examples,
+    explanations,
+    questionCount: items.length
+  };
+}

--- a/src/domain/seo.test.ts
+++ b/src/domain/seo.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { SITE_ORIGIN, VIEW_SEO, seoForView, type SeoView } from "./seo";
 
-const VIEWS: SeoView[] = ["home", "learn", "rules", "kanji", "challenge", "mock", "about"];
+// The static-route views (every SeoView except the dynamic "grammar" route).
+const VIEWS: Exclude<SeoView, "grammar">[] = [
+  "home",
+  "learn",
+  "rules",
+  "kanji",
+  "challenge",
+  "mock",
+  "about"
+];
 
 describe("seo", () => {
   it("has an entry for every view", () => {
@@ -35,5 +44,19 @@ describe("seo", () => {
     for (const view of VIEWS) {
       expect(seoForView(view).description.length, view).toBeLessThanOrEqual(160);
     }
+  });
+
+  // The /grammar/<surface> route is dynamic (#281): its title/description/
+  // canonical are built from the surface rather than a VIEW_SEO entry.
+  it("builds per-surface metadata for a grammar-point route", () => {
+    const resolved = seoForView("grammar", "ばかりに");
+    expect(resolved.title).toContain("ばかりに");
+    expect(resolved.title).toMatch(/Jabiko/);
+    expect(resolved.description).toContain("ばかりに");
+    expect(resolved.canonical).toBe(`${SITE_ORIGIN}/grammar/${encodeURIComponent("ばかりに")}`);
+  });
+
+  it("falls back to home metadata if a grammar view arrives with no surface", () => {
+    expect(seoForView("grammar").canonical).toBe(seoForView("home").canonical);
   });
 });

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -9,7 +9,7 @@
 // Pure data + a small resolver -> trivially testable, no DOM here.
 
 /** Top-level views that have their own URL (mirrors App's AppView / VIEW_PATHS). */
-export type SeoView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about";
+export type SeoView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about" | "grammar";
 
 /** Production origin; canonical URLs are absolute so crawlers dedupe cleanly. */
 export const SITE_ORIGIN = "https://jabiko.pages.dev";
@@ -21,7 +21,7 @@ interface PageSeo {
   path: string;
 }
 
-export const VIEW_SEO: Record<SeoView, PageSeo> = {
+export const VIEW_SEO: Record<Exclude<SeoView, "grammar">, PageSeo> = {
   home: {
     title: "Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考",
     description:
@@ -73,9 +73,23 @@ export interface ResolvedSeo {
   canonical: string;
 }
 
-/** Resolve a view's title/description and its absolute canonical URL. */
-export function seoForView(view: SeoView): ResolvedSeo {
-  const entry = VIEW_SEO[view];
+/**
+ * Resolve a view's title/description and its absolute canonical URL. The
+ * `/grammar/<surface>` route is dynamic (#281): its metadata is built from the
+ * surface so each grammar-point page surfaces its own title/canonical to
+ * crawlers. Falls back to the home entry if a grammar view arrives with no
+ * surface (shouldn't happen in practice).
+ */
+export function seoForView(view: SeoView, grammarSurface?: string | null): ResolvedSeo {
+  if (view === "grammar" && grammarSurface) {
+    return {
+      title: `${grammarSurface} 的意思與用法 · JLPT／日檢文法 · Jabiko`,
+      description: `日檢文法「${grammarSurface}」的意思、接續、用法與例句，看完直接練——JLPT 文法逐點攻略。`,
+      canonical: `${SITE_ORIGIN}/grammar/${encodeURIComponent(grammarSurface)}`
+    };
+  }
+
+  const entry = VIEW_SEO[view === "grammar" ? "home" : view];
   return {
     title: entry.title,
     description: entry.description,

--- a/src/hooks/useSeoMeta.ts
+++ b/src/hooks/useSeoMeta.ts
@@ -27,9 +27,9 @@ function upsertCanonical(href: string) {
 // per-view canonical + og:url. Runs on every view change so a crawler that
 // renders the JS sees route-specific title/description rather than the shared
 // static shell. Idempotent: re-applies in place, never duplicates a tag.
-export function useSeoMeta(view: SeoView) {
+export function useSeoMeta(view: SeoView, grammarSurface?: string | null) {
   useEffect(() => {
-    const { title, description, canonical } = seoForView(view);
+    const { title, description, canonical } = seoForView(view, grammarSurface);
     document.title = title;
     upsertMeta("name", "description", description);
     upsertMeta("property", "og:title", title);
@@ -38,5 +38,5 @@ export function useSeoMeta(view: SeoView) {
     upsertMeta("name", "twitter:title", title);
     upsertMeta("name", "twitter:description", description);
     upsertCanonical(canonical);
-  }, [view]);
+  }, [view, grammarSurface]);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,7 @@
 @import "./styles/base.css";
 @import "./styles/layout.css";
 @import "./styles/learning.css";
+@import "./styles/grammar.css";
 @import "./styles/challenge.css";
 @import "./styles/feedback.css";
 @import "./styles/language-picker.css";

--- a/src/styles/grammar.css
+++ b/src/styles/grammar.css
@@ -1,0 +1,104 @@
+/* Standalone per-grammar-point study page (#281). Reuses the .grammar-note
+   card (feedback.css) for the curated reference; these rules cover the page
+   shell, header, exam-derived examples, and the practice entry. */
+.grammar-point {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 46rem;
+  margin: 0 auto;
+}
+
+.grammar-point-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.grammar-point-back svg,
+.grammar-point-practice svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.grammar-point-head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.grammar-point-head h1 {
+  margin: 0;
+  font-family: var(--font-japanese-display);
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.2;
+  color: var(--surface-ink);
+}
+
+.grammar-point-level {
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  color: var(--muted);
+}
+
+.grammar-point-meaning {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--ink);
+}
+
+.grammar-point-rule p {
+  margin: 0.3rem 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.grammar-point-examples {
+  margin-top: 0.2rem;
+}
+
+.grammar-point-label {
+  margin: 0 0 0.3rem;
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.grammar-point-examples ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.grammar-point-examples li {
+  border-left: 3px solid var(--matcha);
+  padding-left: 0.75rem;
+}
+
+.grammar-point-ex-ja {
+  display: block;
+  font-family: var(--font-japanese);
+  color: var(--surface-ink);
+  line-height: 1.6;
+}
+
+.grammar-point-ex-zh {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.grammar-point-practice {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}


### PR DESCRIPTION
Per-grammar-point study pages — the foundation of the SEO/study-page flywheel (#281, pre-approved). Deep-linkable, lazy, MVP-sourced from the existing exam bank.

## What

A new route **`/grammar/<surface>`** renders a standalone study page for one 文法点:
- **Heading** (the surface) + JLPT level badge
- **Rule**: the curated `grammarNotes` card (meaning / 接續 / 用法 / 易混點) when the point has one; otherwise meaning + the exam explanations
- **≥ example sentences**: real cloze questions with the blank filled by the answer, plus curated examples
- **Practice entry** + back link

Reached by direct URL / back-forward for now; **#282** will add an in-app link from the post-answer feedback (this PR is its prerequisite).

## How

- `src/domain/grammarPoints.ts` — `buildGrammarPoint(surface)` aggregates every `文法形式選擇` exam item sharing a surface and enriches it with the curated note; `allGrammarSurfaces()` lists them (for a future index / build-time prerender). Reaches the lazy exam bank + notes, so it's imported **only** by the lazy page.
- `src/components/GrammarPointPage.tsx` — lazy; reuses `GrammarNoteCard`. **No new copy keys** (reuses `startChallenge` / `reviewDoneExit`), so the 8-locale completeness guard is untouched.
- Routing — one dynamic route via `parseRoute` / `pathForView` in `App.tsx`; `encodeURIComponent(surface)` is the id.
- SEO — `seoForView("grammar", surface)` builds per-surface title/description/canonical.

## Bundle discipline
`GrammarPointPage` is its own **2.6 kB** lazy chunk; `examBlocks` stays in its own 1.9 MB lazy chunk (hash unchanged); the initial `index` chunk grows only by the small routing/SEO wiring. examBlocks/ChallengePanel remain lazy.

## Tests (TDD)
- `grammarPoints.test.ts`: aggregation, null for unknown surface, blanks filled, curated-note enrichment.
- `GrammarPointPage.test.tsx`: render (heading/meaning/example), practice entry, unknown-surface fallback + back.
- `seo.test.ts`: dynamic per-surface metadata + no-surface fallback.
- `App.test.tsx`: `/grammar/<surface>` renders the page.
- **Full suite 480 green**; `tsc` clean.

## Verified in-browser
`/grammar/ばかりに` (curated → GrammarNoteCard, 4 examples) and `/grammar/に伴って` (un-curated → meaning + 2 explanations + 2 filled examples) both render cleanly with the per-surface `<title>`.

Closes #281.
