### PR TITLE
feat(grammar): link from grammar feedback to its study page (#282)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,6 +109,13 @@ export default function App() {
     () => parseRoute(window.location.pathname).grammarSurface
   );
 
+  // Open a grammar point's study page (#282): from the post-answer feedback's
+  // "深入學習這個文法 →" link, and deep-linkable directly via the URL.
+  const openGrammar = (surface: string) => {
+    setGrammarSurface(surface);
+    setAppView("grammar");
+  };
+
   // Keep the URL in sync when the view changes (push a history entry only
   // when the path actually differs, so popstate-driven changes don't loop).
   useEffect(() => {
@@ -401,6 +408,7 @@ export default function App() {
             language={language}
             targetLevel={targetLevel}
             onExit={() => setAppView("home")}
+            onOpenGrammar={openGrammar}
           />
         </Suspense>
       )}

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -26,7 +26,8 @@ export function ChallengePanel({
   recordAttempt,
   language,
   targetLevel = null,
-  onExit
+  onExit,
+  onOpenGrammar
 }: {
   init?: SessionInit;
   progressAttempts: Attempt[];
@@ -36,6 +37,8 @@ export function ChallengePanel({
   // session hook to seed the daily / 綜合 / 単字 level range.
   targetLevel?: LevelRange | null;
   onExit: () => void;
+  // Navigate to a grammar point's study page from the post-answer feedback (#282).
+  onOpenGrammar?: (surface: string) => void;
 }) {
   const t = copy[language];
   const session = usePracticeSession({ language, init, progressAttempts, recordAttempt, targetLevel });
@@ -44,7 +47,7 @@ export function ChallengePanel({
     <section className="practice-layout" aria-label="Jabiko practice">
       <ModePicker language={language} {...session} />
 
-      <DrillPanel language={language} onExit={onExit} {...session} />
+      <DrillPanel language={language} onExit={onExit} onOpenGrammar={onOpenGrammar} {...session} />
 
       <aside className="review-panel" aria-label={t.mistakesLabel}>
         {session.showSessionLength ? (

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -9,6 +9,7 @@ import { buildSentencePatternPool } from "../domain/sentencePatterns";
 import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
 import { grammarNotes } from "../domain/grammarNotes";
+import { copy } from "../i18n";
 
 // Capture the props QuestionReportForm is opened with, so we can assert the
 // graded answer FeedbackPanel hands it comes from feedback.submittedAnswer
@@ -256,6 +257,64 @@ describe("FeedbackPanel grammar note (#137)", () => {
       />
     );
     expect(container.querySelector(".grammar-note-block")).toBeNull();
+  });
+});
+
+describe("FeedbackPanel grammar study link (#282)", () => {
+  const grammarBase = examStyleQuestions.find((q) => q.promptLabel === "文法形式選擇")!;
+  const linkName = copy["zh-Hant"].grammarStudyLink;
+
+  it("links a grammar item to its study page, calling onOpenGrammar with the surface", () => {
+    const onOpenGrammar = vi.fn();
+    render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: grammarBase, submittedAnswer: null }}
+        language="zh-Hant"
+        options={grammarBase.options ?? []}
+        onOpenGrammar={onOpenGrammar}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: linkName }));
+    expect(onOpenGrammar).toHaveBeenCalledWith(grammarBase.vocabulary.surface);
+  });
+
+  it("hides the link when no onOpenGrammar navigator is wired in", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: grammarBase, submittedAnswer: null }}
+        language="zh-Hant"
+        options={grammarBase.options ?? []}
+      />
+    );
+    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
+  });
+
+  it("hides the link for a non-grammar (reading) item", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: readingPool[0], submittedAnswer: null }}
+        language="zh-Hant"
+        options={[]}
+        onOpenGrammar={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
+  });
+
+  it("hides the link for a grammar surface that has no study page", () => {
+    const question = {
+      ...grammarBase,
+      vocabulary: { ...grammarBase.vocabulary, surface: "そんな文法点はないzzz" }
+    };
+    render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question, submittedAnswer: null }}
+        language="zh-Hant"
+        options={[]}
+        onOpenGrammar={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
   });
 });
 

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { BookOpen, CheckCircle2, Flag, XCircle } from "lucide-react";
+import { ArrowRight, BookOpen, CheckCircle2, Flag, XCircle } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
 import { lookupGrammarNote } from "../domain/grammarNotes";
+import { hasGrammarPoint } from "../domain/grammarPoints";
 import { GrammarNoteCard } from "./GrammarNoteCard";
 import { QuestionReportForm } from "./QuestionReportForm";
 import { Ruby } from "./Ruby";
@@ -16,11 +17,14 @@ import type { Feedback } from "./types";
 export function FeedbackPanel({
   feedback,
   language,
-  options
+  options,
+  onOpenGrammar
 }: {
   feedback: NonNullable<Feedback>;
   language: Language;
   options: string[];
+  /** Navigate to this grammar point's study page (#282). Omitted = no link. */
+  onOpenGrammar?: (surface: string) => void;
 }) {
   const t = copy[language];
   const [showGrammarNote, setShowGrammarNote] = useState(false);
@@ -53,9 +57,11 @@ export function FeedbackPanel({
   // a point with no note yet just hides the entry point (never an error).
   const isGrammarItem =
     promptLabel === "文法形式選擇" || promptLabel === "語順組合" || promptLabel === "文章脈絡";
-  const grammarNote = isGrammarItem
-    ? lookupGrammarNote(feedback.question.vocabulary.surface)
-    : null;
+  const grammarSurface = feedback.question.vocabulary.surface;
+  const grammarNote = isGrammarItem ? lookupGrammarNote(grammarSurface) : null;
+  // "Study this grammar point →" deep link (#282): only for grammar items whose
+  // point actually has a study page, and only when a navigator is wired in.
+  const showStudyLink = isGrammarItem && Boolean(onOpenGrammar) && hasGrammarPoint(grammarSurface);
 
   // One gloss string PER distractor, rendered one-per-line, so a long
   // option list stays readable on mobile instead of wrapping mid-item.
@@ -118,6 +124,16 @@ export function FeedbackPanel({
           </button>
           {showGrammarNote ? <GrammarNoteCard note={grammarNote} language={language} /> : null}
         </div>
+      ) : null}
+      {showStudyLink ? (
+        <button
+          type="button"
+          className="grammar-study-link"
+          onClick={() => onOpenGrammar?.(grammarSurface)}
+        >
+          {t.grammarStudyLink}
+          <ArrowRight aria-hidden="true" />
+        </button>
       ) : null}
       <div className="report-question-block">
         <button

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -60,7 +60,8 @@ export function DrillPanel({
   resetSession,
   revealAnswer,
   handleDrillKeyDown,
-  onExit
+  onExit,
+  onOpenGrammar
 }: Pick<
   PracticeSession,
   | "questionIndex"
@@ -82,7 +83,7 @@ export function DrillPanel({
   | "resetSession"
   | "revealAnswer"
   | "handleDrillKeyDown"
-> & { language: Language; onExit: () => void }) {
+> & { language: Language; onExit: () => void; onOpenGrammar?: (surface: string) => void }) {
   const t = copy[language];
 
   // Completion-screen copy: daily / review have their own wording; every
@@ -217,6 +218,7 @@ export function DrillPanel({
               feedback={feedback}
               language={language}
               options={choiceOptions}
+              onOpenGrammar={onOpenGrammar}
             />
           ) : null}
         </>

--- a/src/domain/grammarPoints.test.ts
+++ b/src/domain/grammarPoints.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { allGrammarSurfaces, buildGrammarPoint } from "./grammarPoints";
+import { allGrammarSurfaces, buildGrammarPoint, hasGrammarPoint } from "./grammarPoints";
 import { examStyleQuestions } from "./examBlocks";
 import { grammarNotes } from "./grammarNotes";
 
@@ -18,6 +18,15 @@ describe("grammarPoints", () => {
   });
 
   it("returns null for a surface no grammar item uses", () => {
+    expect(buildGrammarPoint("この文法点は存在しないzzz")).toBeNull();
+  });
+
+  it("hasGrammarPoint matches buildGrammarPoint's existence (#282)", () => {
+    const real = allGrammarSurfaces()[0];
+    expect(hasGrammarPoint(real)).toBe(true);
+    expect(buildGrammarPoint(real)).not.toBeNull();
+
+    expect(hasGrammarPoint("この文法点は存在しないzzz")).toBe(false);
     expect(buildGrammarPoint("この文法点は存在しないzzz")).toBeNull();
   });
 

--- a/src/domain/grammarPoints.ts
+++ b/src/domain/grammarPoints.ts
@@ -53,6 +53,15 @@ function lookupNote(surface: string): GrammarNote | null {
   return grammarNotes[surface] ?? grammarNotes[surface.replace(/^[〜～]/, "")] ?? null;
 }
 
+// Cheap existence check (#282): does a /grammar/<surface> page have content?
+// Used by the post-answer feedback to decide whether to show the study link,
+// without building the whole point.
+export function hasGrammarPoint(surface: string): boolean {
+  return examStyleQuestions.some(
+    (question) => isGrammarQuestion(question) && question.vocabulary.surface === surface
+  );
+}
+
 // Every distinct grammar-point surface present in the exam bank, sorted for a
 // stable order (an index page / build-time prerender can rely on it).
 export function allGrammarSurfaces(): string[] {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -243,6 +243,7 @@ export type Copy = {
   grammarNoteUsage: string;
   grammarNoteExamples: string;
   grammarNoteConfusions: string;
+  grammarStudyLink: string;
   keyboardHint: string;
   focusSummaryEmpty: string;
   modeOptions: Record<ModeCopyKey, { title: string; subtitle: string }>;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -274,6 +274,7 @@ export const en: Copy = {
   grammarNoteUsage: "Usage",
   grammarNoteExamples: "Examples",
   grammarNoteConfusions: "Easy to confuse",
+  grammarStudyLink: "Study this grammar point",
   keyboardHint: "Desktop shortcuts: press 1–4 to answer, Enter for the next question",
   focusSummaryEmpty: "No forms available for this focus",
   modeOptions: {

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -274,6 +274,7 @@ export const id: Copy = {
   grammarNoteUsage: "Penggunaan",
   grammarNoteExamples: "Contoh kalimat",
   grammarNoteConfusions: "Titik rawan tertukar",
+  grammarStudyLink: "Pelajari tata bahasa ini lebih dalam",
   keyboardHint: "Pintasan desktop: tekan 1–4 untuk memilih jawaban, Enter untuk soal berikutnya",
   focusSummaryEmpty: "Fokus saat ini tidak punya bentuk yang tersedia",
   modeOptions: {

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -282,6 +282,7 @@ export const ja: Copy = {
   grammarNoteUsage: "用法",
   grammarNoteExamples: "例文",
   grammarNoteConfusions: "間違えやすい点",
+  grammarStudyLink: "この文法をくわしく学ぶ",
   keyboardHint: "デスクトップのショートカット：1〜4 で回答、Enter で次の問題へ",
   focusSummaryEmpty: "現在の重点に使える形がありません",
   modeOptions: {

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -274,6 +274,7 @@ export const ko: Copy = {
   grammarNoteUsage: "용법",
   grammarNoteExamples: "예문",
   grammarNoteConfusions: "헷갈리기 쉬운 점",
+  grammarStudyLink: "이 문법 자세히 배우기",
   keyboardHint: "데스크톱 단축키: 1–4로 답하고, Enter로 다음 문제",
   focusSummaryEmpty: "이 초점에 사용할 수 있는 활용형이 없어요",
   modeOptions: {

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -274,6 +274,7 @@ export const my: Copy = {
   grammarNoteUsage: "အသုံးပြုပုံ",
   grammarNoteExamples: "နမူနာများ",
   grammarNoteConfusions: "ရှုပ်ထွေးလွယ်",
+  grammarStudyLink: "ဤသဒ္ဒါကို အသေးစိတ် လေ့လာရန်",
   keyboardHint: "ဒက်စ်တော့ဖြတ်လမ်း — ဖြေဆိုရန် 1–4 ကိုနှိပ်ပါ၊ နောက်မေးခွန်းအတွက် Enter",
   focusSummaryEmpty: "ဤအာရုံစိုက်ရာအတွက် ရရှိနိုင်သော ပုံစံ မရှိပါ",
   modeOptions: {

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -275,6 +275,7 @@ export const th: Copy = {
   grammarNoteUsage: "การใช้งาน",
   grammarNoteExamples: "ประโยคตัวอย่าง",
   grammarNoteConfusions: "จุดที่มักสับสน",
+  grammarStudyLink: "เรียนรู้ไวยากรณ์นี้เพิ่มเติม",
   keyboardHint: "ทางลัดบนเดสก์ท็อป: กด 1–4 เลือกคำตอบ, Enter ไปข้อถัดไป",
   focusSummaryEmpty: "จุดเน้นปัจจุบันไม่มีรูปที่ใช้ได้",
   modeOptions: {

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -274,6 +274,7 @@ export const vi: Copy = {
   grammarNoteUsage: "Cách dùng",
   grammarNoteExamples: "Ví dụ",
   grammarNoteConfusions: "Dễ nhầm lẫn",
+  grammarStudyLink: "Học sâu hơn ngữ pháp này",
   keyboardHint: "Phím tắt máy tính: bấm 1–4 để trả lời, Enter để sang câu tiếp theo",
   focusSummaryEmpty: "Không có thể nào cho trọng tâm này",
   modeOptions: {

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -274,6 +274,7 @@ export const zhHant: Copy = {
   grammarNoteUsage: "用法",
   grammarNoteExamples: "例句",
   grammarNoteConfusions: "易混點",
+  grammarStudyLink: "深入學習這個文法",
   keyboardHint: "桌面快捷：按 1–4 選答、Enter 進下一題",
   focusSummaryEmpty: "目前重點沒有可用形",
   modeOptions: {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -204,6 +204,38 @@
   height: 0.9rem;
 }
 
+/* "深入學習這個文法 →" deep link to the grammar study page (#282). A clear,
+   matcha-tinted call to action under the feedback -- distinct from the subtle
+   report link -- shown only for grammar items whose study page has content. */
+.grammar-study-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.8rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--matcha) 55%, var(--panel-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--matcha) 12%, transparent);
+  color: var(--matcha-dark);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.grammar-study-link:hover {
+  background: color-mix(in srgb, var(--matcha) 20%, transparent);
+  border-color: var(--matcha);
+}
+
+.grammar-study-link svg {
+  width: 1rem;
+  height: 1rem;
+}
+
 .report-reason-label {
   margin: 0;
   color: var(--ink);


### PR DESCRIPTION
After answering a 文法 question, the post-answer panel shows a 「深入學習這個文法 →」 link to that point's `/grammar/<surface>` study page (#281) — closing the wrong→learn loop at the moment curiosity peaks.

## How
- Shows **only** for grammar items whose point has a page (`hasGrammarPoint(surface)`) and only when a navigator is wired in — never dead-ends.
- Plumbed `onOpenGrammar` App → ChallengePanel → DrillPanel → FeedbackPanel; click pushes `/grammar/<surface>`.
- New copy key `grammarStudyLink` in all 8 locales (i18n completeness guard green); new `hasGrammarPoint()` domain helper.

## Tests (TDD)
- grammarPoints: `hasGrammarPoint` matches build existence.
- FeedbackPanel: link shows + correct surface payload; hidden without a navigator / for non-grammar items / for a surface with no page.
- **Full suite green**; build keeps examBlocks/ChallengePanel lazy, initial bundle unchanged (the link logic rides the existing lazy challenge chunk).

Depends on #281 (merged). Closes #282.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “study this grammar point” link after certain grammar answers.
  * Users can now open a related grammar study page directly from feedback.
  * Added translations for the new link text across supported languages.

* **Bug Fixes**
  * The study link now appears only when a matching grammar topic is available, avoiding irrelevant links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->