### PR TITLE
feat(routing): deep-link a challenge drill via ?mode= / ?level= (#264)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -708,6 +708,18 @@ describe("App", () => {
     expect(screen.getByText("繁體中文")).toBeInTheDocument();
   });
 
+  it("restores a drill from a /challenge?mode= deep link (#264)", async () => {
+    window.history.replaceState({}, "", "/challenge?mode=vocab");
+    render(<App />);
+
+    // The challenge mounts with 単字讀音 (vocab) preselected from the URL,
+    // not the default 今日練習 landing — proving the deep link was applied.
+    const vocabCard = await screen.findByRole("button", { name: /単字讀音/ });
+    expect(vocabCard).toHaveAttribute("aria-pressed", "true");
+
+    window.history.replaceState({}, "", "/");
+  });
+
   it("lists 綜合考題庫 / N1 備考 / N2 備考 as side-by-side mode presets", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { isSupabaseConfigured } from "./lib/supabase";
 import { useAuth } from "./hooks/useAuth";
 import { useProgressAttempts } from "./hooks/useProgressAttempts";
 import type { SessionInit } from "./hooks/usePracticeSession";
+import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
 import type { LevelRange } from "./domain/levelRange";
 import "./styles.css";
@@ -131,6 +132,10 @@ export default function App() {
       const route = parseRoute(window.location.pathname);
       setAppView(route.view);
       setGrammarSurface(route.grammarSurface);
+      // Restore the drill from a /challenge?mode=&level= deep link on back/forward.
+      if (route.view === "challenge") {
+        setLaunch(challengeInitFromQuery(window.location.search));
+      }
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
@@ -166,7 +171,14 @@ export default function App() {
   // the "start X" actions just before navigating; undefined = the default
   // basic drill. Read once when ChallengePanel mounts (it owns the
   // session), so changing it while already in the challenge is a no-op.
-  const [launch, setLaunch] = useState<SessionInit | undefined>(undefined);
+  // Seed from a /challenge?mode=&level= deep link on a direct hit / refresh
+  // (#264), so a shared or bookmarked drill restores; a bare /challenge or any
+  // other route stays undefined (default landing).
+  const [launch, setLaunch] = useState<SessionInit | undefined>(() =>
+    parseRoute(window.location.pathname).view === "challenge"
+      ? challengeInitFromQuery(window.location.search)
+      : undefined
+  );
   // Global target-level preference (#199), read once at startup. Seeds the
   // fresh-pool level range (今日練習 / 綜合 / 単字) and drives the first-run
   // onboarding card; the home card persists it.

--- a/src/domain/challengeDeepLink.test.ts
+++ b/src/domain/challengeDeepLink.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { challengeInitFromQuery, challengeQueryFromInit } from "./challengeDeepLink";
+
+describe("challengeDeepLink", () => {
+  it("parses a mode-only deep link", () => {
+    expect(challengeInitFromQuery("?mode=daily")).toEqual({ mode: "daily" });
+    expect(challengeInitFromQuery("?mode=review")).toEqual({ mode: "review" });
+  });
+
+  it("parses mode + level range", () => {
+    expect(challengeInitFromQuery("?mode=exam&level=n2n3")).toEqual({
+      mode: "exam",
+      levelRange: "n2n3"
+    });
+  });
+
+  it("parses a level-only deep link", () => {
+    expect(challengeInitFromQuery("?level=n1n2")).toEqual({ levelRange: "n1n2" });
+  });
+
+  it("ignores unknown mode / level values", () => {
+    expect(challengeInitFromQuery("?mode=bogus&level=zzz")).toBeUndefined();
+    expect(challengeInitFromQuery("?mode=exam&level=zzz")).toEqual({ mode: "exam" });
+  });
+
+  it("returns undefined when there is nothing usable", () => {
+    expect(challengeInitFromQuery("")).toBeUndefined();
+    expect(challengeInitFromQuery("?foo=bar")).toBeUndefined();
+  });
+
+  it("round-trips through the query serializer", () => {
+    for (const init of [
+      { mode: "daily" as const },
+      { mode: "exam" as const, levelRange: "n2n3" as const },
+      { levelRange: "all" as const }
+    ]) {
+      expect(challengeInitFromQuery(challengeQueryFromInit(init))).toEqual(init);
+    }
+    expect(challengeQueryFromInit(undefined)).toBe("");
+  });
+});

--- a/src/domain/challengeDeepLink.ts
+++ b/src/domain/challengeDeepLink.ts
@@ -1,0 +1,48 @@
+// Challenge deep-linking (issue #264): express a challenge drill's mode + level
+// range as URL query params so a specific drill can be shared / bookmarked /
+// survive a refresh, e.g. `/challenge?mode=daily` or `/challenge?mode=exam&level=n2n3`.
+//
+// Scope (MVP): the unambiguous mode + level-range subset. Mock-section deep
+// links (examSection {level, promptLabel}) are a follow-up. The result is
+// structurally a subset of SessionInit, so App can hand it straight to
+// openChallenge -- this module stays UI-free and only depends on domain types.
+import type { PracticeMode } from "./practiceMode";
+import type { LevelRange } from "./levelRange";
+
+export type ChallengeDeepLink = { mode?: PracticeMode; levelRange?: LevelRange };
+
+const MODES: readonly PracticeMode[] = ["basic", "cloze", "daily", "pattern", "exam", "review", "vocab"];
+const RANGES: readonly LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5"];
+
+function asMode(value: string | null): PracticeMode | undefined {
+  return value !== null && (MODES as readonly string[]).includes(value) ? (value as PracticeMode) : undefined;
+}
+
+function asRange(value: string | null): LevelRange | undefined {
+  return value !== null && (RANGES as readonly string[]).includes(value) ? (value as LevelRange) : undefined;
+}
+
+// Parse `?mode=&level=` into a launch seed. Unknown/absent params are ignored;
+// returns undefined when nothing usable is present (caller keeps the default
+// landing) so a bare `/challenge` is unchanged.
+export function challengeInitFromQuery(search: string): ChallengeDeepLink | undefined {
+  const params = new URLSearchParams(search);
+  const mode = asMode(params.get("mode"));
+  const levelRange = asRange(params.get("level"));
+  if (!mode && !levelRange) return undefined;
+  const init: ChallengeDeepLink = {};
+  if (mode) init.mode = mode;
+  if (levelRange) init.levelRange = levelRange;
+  return init;
+}
+
+// Inverse: build the shareable query string for a drill. Kept here (with a
+// tested round-trip) for link-building / a future live URL sync.
+export function challengeQueryFromInit(init: ChallengeDeepLink | undefined): string {
+  if (!init) return "";
+  const params = new URLSearchParams();
+  if (init.mode) params.set("mode", init.mode);
+  if (init.levelRange) params.set("level", init.levelRange);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}


### PR DESCRIPTION
A direct hit or refresh on `/challenge?mode=daily` or `/challenge?mode=exam&level=n2n3` now **restores that drill** instead of dropping to the default landing — so a specific drill is shareable / bookmarkable / survives a refresh.

## Scope (MVP)
The unambiguous **mode + level-range** subset:
- New pure module `challengeDeepLink.ts` parses `?mode=&level=` → a launch seed (and serializes the inverse, with a tested round-trip).
- `App` seeds `launch` from the query on initial mount and on back/forward popstate. The pathname-keyed URL-sync effect leaves the query untouched, so it survives.

## Out of scope (follow-up — flagged)
- **Live URL-out sync** as the learner changes mode mid-session — needs lifting `usePracticeSession` state up to App; deferred to keep blast radius small.
- **Mock-section** (`examSection {level, promptLabel}`) deep links — the encoding is ambiguous vs the pool `level` range; left for a follow-up.

A bare `/challenge` is unchanged — purely additive.

## Tests (TDD)
- `challengeDeepLink`: parse mode / level / both, ignore unknown values, undefined when empty, round-trip via the serializer.
- `App`: `/challenge?mode=vocab` mounts with 単字讀音 preselected (not the default 今日練習) — proving the deep link applied.
- **Full suite 474 green**; build keeps examBlocks/ChallengePanel lazy, initial bundle unchanged.

Closes #264.
