### PR TITLE
fix(pwa): prompt to update instead of stranding users on the old build (#327)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@supabase/supabase-js": "^2.108.2",
     "lucide-react": "^0.561.0",
     "react": "^19.2.1",
-    "react-dom": "^19.2.1"
+    "react-dom": "^19.2.1",
+    "workbox-window": "^7.4.1"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
+      workbox-window:
+        specifier: ^7.4.1
+        version: 7.4.1
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -3371,7 +3374,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/runtime@7.29.2': {}
@@ -3668,7 +3671,7 @@ snapshots:
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.4)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@rollup/pluginutils': 5.4.0(rollup@4.60.4)
     optionalDependencies:
       '@types/babel__core': 7.20.5
@@ -3820,7 +3823,7 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import { countDueReviews } from "./domain/srs";
 import { copy, type Language } from "./i18n";
 import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
+import { UpdateToast } from "./components/UpdateToast";
+import { usePwaUpdate } from "./hooks/usePwaUpdate";
 import { JabikoMark } from "./components/JabikoMark";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
@@ -152,6 +154,8 @@ export default function App() {
   const t = copy[language];
   // Language picker, opened from the header Globe button (#326).
   const [langPickerOpen, setLangPickerOpen] = useState(false);
+  // Service-worker update prompt (#327): toast when a new build is ready.
+  const { needRefresh, updateApp } = usePwaUpdate();
 
   const { theme, toggleTheme } = useTheme();
   // Global furigana (ruby) preference, default OFF (#134). The hook owns the
@@ -224,6 +228,7 @@ export default function App() {
 
   return (
     <main className="app-shell">
+      {needRefresh && <UpdateToast label={t.updateAvailable} onUpdate={updateApp} />}
       {langPickerOpen && (
         <LanguagePicker
           current={language}

--- a/src/components/UpdateToast.test.tsx
+++ b/src/components/UpdateToast.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { UpdateToast } from "./UpdateToast";
+
+describe("UpdateToast", () => {
+  it("renders a polite status with an update action", () => {
+    render(<UpdateToast label="有新版本，點此更新" onUpdate={vi.fn()} />);
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByRole("button", { name: "有新版本，點此更新" })).toBeInTheDocument();
+  });
+
+  it("calls onUpdate when clicked", async () => {
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+    render(<UpdateToast label="有新版本，點此更新" onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole("button", { name: "有新版本，點此更新" }));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/UpdateToast.tsx
+++ b/src/components/UpdateToast.tsx
@@ -1,0 +1,16 @@
+import { RefreshCw } from "lucide-react";
+
+// "A new version is available" toast (#327). Non-intrusive: a returning learner
+// with an installed service worker sees this instead of being silently reloaded
+// mid-drill. Clicking it applies the waiting SW and reloads. Pure presentation;
+// the SW lifecycle lives in usePwaUpdate.
+export function UpdateToast({ label, onUpdate }: { label: string; onUpdate: () => void }) {
+  return (
+    <div className="update-toast" role="status" aria-live="polite">
+      <button type="button" className="update-toast-button" onClick={onUpdate}>
+        <RefreshCw aria-hidden="true" />
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/usePwaUpdate.ts
+++ b/src/hooks/usePwaUpdate.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { registerSW } from "virtual:pwa-register";
+
+// Service-worker update lifecycle (#327). registerType is "prompt", so a new
+// build installs into the waiting SW without auto-reloading; this hook surfaces
+// `needRefresh` (drives the UpdateToast) and `updateApp` (applies the waiting SW
+// + reloads). Without this, the auto-injected bare registerSW.js only called
+// navigator.serviceWorker.register and never told the running page about a new
+// version, so users were stuck on the old build until an incognito visit.
+//
+// onRegisteredSW also polls for a new SW hourly, so a long-open tab still
+// notices a deploy instead of waiting for the browser's ~24h check.
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+export function usePwaUpdate() {
+  const [needRefresh, setNeedRefresh] = useState(false);
+  const updateRef = useRef<((reloadPage?: boolean) => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    updateRef.current = registerSW({
+      immediate: true,
+      onNeedRefresh() {
+        setNeedRefresh(true);
+      },
+      onRegisteredSW(_swUrl, registration) {
+        if (registration) {
+          setInterval(() => {
+            void registration.update();
+          }, UPDATE_CHECK_INTERVAL_MS);
+        }
+      }
+    });
+  }, []);
+
+  const updateApp = useCallback(() => {
+    void updateRef.current?.(true);
+  }, []);
+
+  return { needRefresh, updateApp };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,6 +16,7 @@ export type Copy = {
   furiganaHide: string;
   flowLabel: string;
   loading: string;
+  updateAvailable: string;
   home: string;
   learn: string;
   rules: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -12,6 +12,7 @@ export const en: Copy = {
   furiganaHide: "Hide furigana",
   flowLabel: "Study flow",
   loading: "Loading…",
+  updateAvailable: "A new version is available — tap to update",
   home: "Home",
   learn: "Learn",
   rules: "Rules",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -12,6 +12,7 @@ export const id: Copy = {
   furiganaHide: "Sembunyikan furigana",
   flowLabel: "Alur belajar",
   loading: "Memuat…",
+  updateAvailable: "Versi baru tersedia — ketuk untuk memperbarui",
   home: "Beranda",
   learn: "Belajar",
   rules: "Tabel aturan",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -12,6 +12,7 @@ export const ja: Copy = {
   furiganaHide: "ふりがなを隠す",
   flowLabel: "学習の流れ",
   loading: "読み込み中…",
+  updateAvailable: "新しいバージョンがあります。タップして更新",
   home: "ホーム",
   learn: "学習",
   rules: "活用表",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -12,6 +12,7 @@ export const ko: Copy = {
   furiganaHide: "후리가나 숨김",
   flowLabel: "학습 흐름",
   loading: "불러오는 중…",
+  updateAvailable: "새 버전이 있습니다 — 탭하여 업데이트",
   home: "홈",
   learn: "학습",
   rules: "규칙표",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -12,6 +12,7 @@ export const my: Copy = {
   furiganaHide: "ဖူရိဂါနာ ဖျောက်ရန်",
   flowLabel: "လေ့လာမှု အဆင့်ဆင့်",
   loading: "ဖွင့်နေသည်…",
+  updateAvailable: "ဗားရှင်းအသစ် ရရှိနိုင်ပါပြီ — အပ်ဒိတ်လုပ်ရန် တို့ပါ",
   home: "ပင်မ",
   learn: "လေ့လာရန်",
   rules: "စည်းမျဉ်းများ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -12,6 +12,7 @@ export const th: Copy = {
   furiganaHide: "ซ่อนคำอ่าน",
   flowLabel: "ขั้นตอนการเรียน",
   loading: "กำลังโหลด…",
+  updateAvailable: "มีเวอร์ชันใหม่ — แตะเพื่ออัปเดต",
   home: "หน้าแรก",
   learn: "เรียนรู้",
   rules: "ตารางกฎ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -12,6 +12,7 @@ export const vi: Copy = {
   furiganaHide: "Ẩn furigana",
   flowLabel: "Lộ trình học",
   loading: "Đang tải…",
+  updateAvailable: "Đã có phiên bản mới — chạm để cập nhật",
   home: "Trang chủ",
   learn: "Học",
   rules: "Bảng quy tắc",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -12,6 +12,7 @@ export const zhHant: Copy = {
   furiganaHide: "隱藏註音",
   flowLabel: "學習流程",
   loading: "載入中…",
+  updateAvailable: "有新版本，點此更新",
   home: "首頁",
   learn: "學習",
   rules: "規則表",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -109,6 +109,44 @@
   white-space: nowrap;
 }
 
+/* "New version available" toast (#327): a fixed pill at the bottom centre,
+   above everything. Non-intrusive -- the learner taps it to reload when ready,
+   instead of being yanked off the page mid-drill. */
+.update-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  transform: translateX(-50%);
+  z-index: 1200;
+  max-width: calc(100% - 2rem);
+}
+
+.update-toast-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  border: 1px solid var(--matcha);
+  border-radius: 999px;
+  background: var(--matcha-dark);
+  color: var(--selected-text, #fff);
+  font: inherit;
+  font-weight: 700;
+  font-size: 0.92rem;
+  cursor: pointer;
+  box-shadow: 0 8px 24px rgba(23, 33, 38, 0.28);
+  white-space: nowrap;
+}
+
+.update-toast-button:hover {
+  filter: brightness(1.06);
+}
+
+.update-toast-button svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
 .auth-button {
   background: color-mix(in srgb, var(--paper) 86%, transparent);
   border: 1px solid var(--button-border);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,14 @@ import "@testing-library/jest-dom/vitest";
 
 import { beforeEach, vi } from "vitest";
 
+// The PWA register module (#327) is a build-time virtual module with no test
+// implementation; stub it so anything importing usePwaUpdate (App) can load.
+// registerSW returns a no-op updateSW and never fires onNeedRefresh, so the
+// update toast stays hidden in tests.
+vi.mock("virtual:pwa-register", () => ({
+  registerSW: () => () => Promise.resolve()
+}));
+
 // Pin the test-environment UI locale to zh-Hant at module load. Since the
 // default is now ja (no navigator detection), we pre-store zh-Hant so the
 // Chinese-label assertions in App.test.tsx and elsewhere still work without

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,15 +5,17 @@ import { VitePWA } from "vite-plugin-pwa";
 export default defineConfig({
   plugins: [
     react(),
-    // PWA: installable + offline (issue #131). registerType "autoUpdate"
-    // keeps the service worker fresh without a manual update prompt; the
-    // registration script is auto-injected into index.html. Precaches the
-    // built chunks (incl. the lazy examBlocks ~1MB) so a returning learner
-    // can practise offline; the lazy split is unchanged -- precaching runs
-    // in the background after load, the initial render still pulls only the
-    // index chunk.
+    // PWA: installable + offline (issue #131). registerType "prompt" (#327):
+    // a returning learner with an installed SW gets a non-intrusive "new
+    // version" toast (usePwaUpdate + UpdateToast) instead of being silently
+    // reloaded mid-drill -- the old "auto-inject bare registerSW.js" never
+    // reloaded the running page at all, so users were stuck on the old build
+    // until they opened an incognito tab. Precaches the built chunks (incl. the
+    // lazy examBlocks ~1MB) so a returning learner can practise offline; the
+    // lazy split is unchanged -- precaching runs in the background after load,
+    // the initial render still pulls only the index chunk.
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
       includeAssets: ["icon.svg", "apple-touch-icon.png", "hero.webp", "og-image.png"],
       manifest: {
         name: "Jabiko · JLPT 自習室",


### PR DESCRIPTION
## The bug
Returning users with an installed SW were stuck on the old build until they opened incognito — even a normal reload kept serving the precached old shell. Root cause (per the issue): the auto-injected `registerSW.js` only called `navigator.serviceWorker.register` and **never told the running page about a new version**, so the page was never refreshed onto the new build.

## The fix — client-handled update prompt
- `registerType` **`autoUpdate` → `prompt`**: the new SW installs but waits.
- **`usePwaUpdate`** wires `virtual:pwa-register`: `onNeedRefresh` → `needRefresh`; `updateApp()` applies the waiting SW (`SKIP_WAITING`) and reloads. `onRegisteredSW` also polls hourly, so a long-open tab notices a deploy without waiting for the browser's ~24h check.
- **`UpdateToast`**: a non-intrusive bottom-centre "**有新版本，點此更新**" pill (new i18n key `updateAvailable`, all 8 locales). Deliberately a prompt, not a silent reload — a learner shouldn't be yanked off the page mid-drill; one tap loads the new build.
- Added **`workbox-window`** (vite-plugin-pwa peer dep, required once we import the register virtual module) + the `vite-plugin-pwa/client` types ref.

## Why not just `autoUpdate`?
`autoUpdate` was *already* set and still didn't work — because nothing on the client acted on the update. `autoUpdate`'s alternative (silent auto-reload) would interrupt practice; `prompt` + toast is the issue's recommended "better UX".

## Tests
- `UpdateToast`: status role, action button, `onUpdate` on click.
- The SW lifecycle can't run in jsdom; `virtual:pwa-register` is stubbed in test setup so App tests load. **Full suite green**; `tsc` clean.
- Build emits a **prompt-mode `sw.js`** (`SKIP_WAITING` handler, no unconditional `skipWaiting`) and **no longer injects the bare `registerSW.js`** (registration now rides the app bundle). examBlocks/ChallengePanel stay lazy.

## ⚠️ Verification note
End-to-end (deploy → toast appears → tap → new version) is only observable **across two real deploys** (dev mode doesn't run the production SW). Verified locally via the component test + the generated SW artifact. The real proof is the next deploy after this merges.

Closes #327.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-intrusive “new version available” prompt so users can update the app when an updated version is ready.
  * Expanded support for the update message across multiple languages.

* **Bug Fixes**
  * Improved update handling so the app checks for newer versions more reliably in the background.

* **Style**
  * Added styling for the update prompt to keep it fixed, compact, and easy to tap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->