### PR TITLE
fix(challenge): ambient challenge entries default to 今日練習 (#340)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -720,6 +720,24 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
   });
 
+  it("a grammar page's 開始挑戰 starts 今日練習, not 基礎變化 (#340)", async () => {
+    const { allGrammarSurfaces } = await import("./domain/grammarPoints");
+    const surface = allGrammarSurfaces()[0];
+    window.history.replaceState({}, "", `/grammar/${encodeURIComponent(surface)}`);
+    const user = userEvent.setup();
+    render(<App />);
+
+    // The page renders (route works) and its practice CTA drops into the
+    // guided 今日練習 session, not the raw 基礎變化 cascade.
+    await user.click(await screen.findByRole("button", { name: "開始挑戰" }));
+    expect(await screen.findByRole("button", { name: /今日練習/ })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+
+    window.history.replaceState({}, "", "/");
+  });
+
   it("lists 綜合考題庫 / N1 備考 / N2 備考 as side-by-side mode presets", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -370,7 +370,9 @@ export default function App() {
           language={language}
           progressAttempts={progressAttempts}
           reviewCount={reviewCount}
-          onNavigate={(target) => (target === "challenge" ? openChallenge() : setAppView(target))}
+          onNavigate={(target) =>
+            target === "challenge" ? openChallenge({ mode: "daily" }) : setAppView(target)
+          }
           onStartReview={() => openChallenge({ mode: "review" })}
           onStartVocab={() => openChallenge({ mode: "vocab" })}
           onStartDaily={() => openChallenge({ mode: "daily" })}
@@ -412,7 +414,7 @@ export default function App() {
           <GrammarPointPage
             surface={grammarSurface ?? ""}
             language={language}
-            onPractice={() => openChallenge()}
+            onPractice={() => openChallenge({ mode: "daily" })}
             onBack={() => setAppView("home")}
           />
         </Suspense>


### PR DESCRIPTION
文法學習頁的「開始挑戰」CTA 與首頁「挑戰」卡片，原本會落到 raw 基礎變化 cascade（跟剛學的內容無關）。改為導向 guided 今日練習（導覽列「挑戰」本來就是 daily）。

情境式入口刻意保留各自 mode：分章學習「開始挑戰」仍 basic（練剛學的變化）、mock section 保留 exam section、?mode= 深連結(#264)不變。故 usePracticeSession 預設維持 basic，只有兩個泛用入口帶 {mode:daily}。

TDD：App 測試——grammar 頁「開始挑戰」落在今日練習(aria-pressed)、非基礎變化。全測試綠。

Closes #340.