### PR TITLE
feat(grammar): redesign the single-grammar-point study page (#339)

### DIFF
--- a/src/components/GrammarPointPage.tsx
+++ b/src/components/GrammarPointPage.tsx
@@ -3,11 +3,19 @@ import { copy, type Language } from "../i18n";
 import { buildGrammarPoint } from "../domain/grammarPoints";
 import { GrammarNoteCard } from "./GrammarNoteCard";
 
-// Standalone study page for a single 文法点 (issue #281). Deep-linkable at
-// /grammar/<surface>; content is aggregated from the exam bank and enriched
-// with the curated grammarNotes entry when one exists. Reaches the lazy
-// exam/notes data through buildGrammarPoint, so it is itself lazily loaded
-// (see App's React.lazy import) and never enters the initial bundle.
+// Strip a leading "正解是「…」，" answer-explanation lead-in (#339): the exam
+// bank's explanations are written for a quiz ("the correct answer is X,
+// because…"), which reads wrong on a study page. Drop that prefix so what's
+// left reads as a usage note; non-matching strings pass through untouched.
+function cleanExplanation(text: string): string {
+  return text.replace(/^正解是「[^」]*」[，、。]?\s*/, "");
+}
+
+// Standalone study page for a single 文法点 (issue #281, redesigned in #339).
+// Card-based layout: a hero with the point + meaning, a reference card (curated
+// GrammarNoteCard when available, otherwise meaning + usage notes from the exam
+// bank), worked examples, and a practice CTA. Deep-linkable at /grammar/<surface>;
+// reaches the lazy exam/notes data so it is itself lazily loaded.
 export function GrammarPointPage({
   surface,
   language,
@@ -23,73 +31,82 @@ export function GrammarPointPage({
   const point = buildGrammarPoint(surface);
 
   const backButton = (
-    <button type="button" className="ghost-button grammar-point-back" onClick={onBack}>
+    <button type="button" className="ghost-button gp-back" onClick={onBack}>
       <ArrowLeft aria-hidden="true" />
       {t.reviewDoneExit}
     </button>
   );
 
-  // Unknown surface (e.g. a stale/typo link): show a minimal, non-crashing
-  // shell so the route still resolves and the user can step back.
+  // Unknown surface (stale/typo link): minimal, non-crashing shell.
   if (!point) {
     return (
       <section className="grammar-point grammar-point-missing">
         {backButton}
-        <h1 lang="ja">{surface}</h1>
+        <header className="gp-hero">
+          <h1 className="gp-surface" lang="ja">
+            {surface}
+          </h1>
+        </header>
       </section>
     );
   }
 
-  // Curated examples are shown inside GrammarNoteCard; list only the additional
-  // exam-derived sentences here so nothing repeats.
-  const curatedJa = new Set((point.note?.examples ?? []).map((example) => example.ja));
-  const extraExamples = point.examples.filter((example) => !curatedJa.has(example.ja));
+  // A curated point shows everything (meaning / rule / examples / confusions)
+  // inside GrammarNoteCard, so the page adds nothing more. An un-noted point
+  // gets a usage card + an examples card built from the exam bank.
+  const usageNotes = point.explanations.map(cleanExplanation).filter(Boolean).slice(0, 2);
+  const showExamples = !point.note && point.examples.length > 0;
 
   return (
     <section className="grammar-point" aria-label={surface}>
       {backButton}
 
-      <header className="grammar-point-head">
-        <h1 lang="ja">{surface}</h1>
-        {point.level ? (
-          <span className="grammar-point-level" aria-label={`JLPT ${point.level}`}>
-            {point.level}
-          </span>
-        ) : null}
+      <header className="gp-hero">
+        <div className="gp-hero-row">
+          <h1 className="gp-surface" lang="ja">
+            {surface}
+          </h1>
+          {point.level ? (
+            <span className="gp-level" aria-label={`JLPT ${point.level}`}>
+              {point.level}
+            </span>
+          ) : null}
+        </div>
+        {/* The curated card carries its own meaning; only lead with it here when
+            there's no note, to avoid showing the same line twice. */}
+        {point.note ? null : <p className="gp-meaning">{point.meaningZh}</p>}
       </header>
 
       {point.note ? (
         <GrammarNoteCard note={point.note} language={language} />
-      ) : (
-        <div className="grammar-point-summary">
-          <p className="grammar-point-meaning">{point.meaningZh}</p>
-          {point.explanations.length > 0 ? (
-            <div className="grammar-point-rule">
-              {point.explanations.map((explanation) => (
-                <p key={explanation}>{explanation}</p>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      )}
+      ) : usageNotes.length > 0 ? (
+        <section className="gp-card">
+          <h2 className="gp-card-title">{t.grammarNoteUsage}</h2>
+          {usageNotes.map((note) => (
+            <p key={note} className="gp-usage">
+              {note}
+            </p>
+          ))}
+        </section>
+      ) : null}
 
-      {extraExamples.length > 0 ? (
-        <div className="grammar-point-examples">
-          <p className="grammar-point-label">{t.grammarNoteExamples}</p>
-          <ul>
-            {extraExamples.map((example) => (
+      {showExamples ? (
+        <section className="gp-card">
+          <h2 className="gp-card-title">{t.grammarNoteExamples}</h2>
+          <ul className="gp-examples">
+            {point.examples.map((example) => (
               <li key={example.ja}>
-                <span className="grammar-point-ex-ja" lang="ja">
+                <span className="gp-ex-ja" lang="ja">
                   {example.ja}
                 </span>
-                {example.zh ? <span className="grammar-point-ex-zh">{example.zh}</span> : null}
+                {example.zh ? <span className="gp-ex-zh">{example.zh}</span> : null}
               </li>
             ))}
           </ul>
-        </div>
+        </section>
       ) : null}
 
-      <button type="button" className="next-button grammar-point-practice" onClick={onPractice}>
+      <button type="button" className="next-button gp-practice" onClick={onPractice}>
         <GraduationCap aria-hidden="true" />
         {t.startChallenge}
       </button>

--- a/src/styles/grammar.css
+++ b/src/styles/grammar.css
@@ -1,104 +1,137 @@
-/* Standalone per-grammar-point study page (#281). Reuses the .grammar-note
-   card (feedback.css) for the curated reference; these rules cover the page
-   shell, header, exam-derived examples, and the practice entry. */
+/* Per-grammar-point study page (#281, redesigned #339). Card-based layout: a
+   hero banner, reference cards (curated .grammar-note from feedback.css, or a
+   usage card), an examples card, and a practice CTA. */
 .grammar-point {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  max-width: 46rem;
+  gap: 1.1rem;
+  max-width: 44rem;
   margin: 0 auto;
 }
 
-.grammar-point-back {
+.gp-back {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
 }
 
-.grammar-point-back svg,
-.grammar-point-practice svg {
+.gp-back svg,
+.gp-practice svg {
   width: 1.05rem;
   height: 1.05rem;
 }
 
-.grammar-point-head {
+/* Hero banner: the grammar point + its meaning, on a tinted card so the page
+   opens with a clear focal point instead of bare text. */
+.gp-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1.5rem 1.5rem 1.6rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--matcha) 14%, var(--paper)), var(--paper));
+  box-shadow: var(--shadow);
+}
+
+.gp-hero-row {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-.grammar-point-head h1 {
+.gp-surface {
   margin: 0;
   font-family: var(--font-japanese-display);
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  line-height: 1.2;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.15;
   color: var(--surface-ink);
 }
 
-.grammar-point-level {
-  font-size: 0.8rem;
-  font-weight: 700;
-  padding: 0.15rem 0.55rem;
+.gp-level {
+  flex: 0 0 auto;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  padding: 0.22rem 0.6rem;
   border-radius: 999px;
-  border: 1px solid var(--panel-border);
-  color: var(--muted);
+  background: var(--matcha-dark);
+  color: var(--selected-text, #fff);
 }
 
-.grammar-point-meaning {
+.gp-meaning {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.2rem;
+  font-weight: 700;
   color: var(--ink);
 }
 
-.grammar-point-rule p {
-  margin: 0.3rem 0;
+/* Content cards (usage / examples). The curated reference uses .grammar-note. */
+.gp-card {
+  padding: 1.1rem 1.25rem 1.2rem;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.9rem;
+  background: var(--paper);
+}
+
+.gp-card-title {
+  margin: 0 0 0.7rem;
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: var(--matcha-dark);
+}
+
+.gp-usage {
+  margin: 0.4rem 0;
+  line-height: 1.75;
   color: var(--muted);
-  line-height: 1.7;
 }
 
-.grammar-point-examples {
-  margin-top: 0.2rem;
-}
-
-.grammar-point-label {
-  margin: 0 0 0.3rem;
-  font-weight: 700;
-  color: var(--muted);
-}
-
-.grammar-point-examples ul {
+.gp-examples {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.85rem;
 }
 
-.grammar-point-examples li {
-  border-left: 3px solid var(--matcha);
-  padding-left: 0.75rem;
+.gp-examples li {
+  padding-left: 0.85rem;
+  border-left: 3px solid color-mix(in srgb, var(--matcha) 60%, var(--panel-border));
 }
 
-.grammar-point-ex-ja {
+.gp-ex-ja {
   display: block;
   font-family: var(--font-japanese);
-  color: var(--surface-ink);
+  font-size: 1.05rem;
   line-height: 1.6;
+  color: var(--surface-ink);
 }
 
-.grammar-point-ex-zh {
+.gp-ex-zh {
   display: block;
-  margin-top: 0.15rem;
-  font-size: 0.9rem;
+  margin-top: 0.2rem;
+  font-size: 0.92rem;
   color: var(--muted);
 }
 
-.grammar-point-practice {
+/* Reuse the curated GrammarNoteCard look but let it sit flush as a page card. */
+.grammar-point .grammar-note {
+  border: 1px solid var(--panel-border);
+  border-radius: 0.9rem;
+  padding: 1.1rem 1.25rem 1.2rem;
+  background: var(--paper);
+}
+
+.gp-practice {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.45rem;
+  margin-top: 0.2rem;
 }


### PR DESCRIPTION
feat(grammar): redesign the single-grammar-point study page (#339)

The /grammar/<surface> page was a flat stack of paragraphs, and un-noted points
dumped the exam bank's answer-style explanations ("正解是「X」，…") as if they
were the rule -- reading like quiz solutions, not study material.

Redesign (card-based):
- Hero banner: the point + JLPT pill on a tinted card; the meaning leads.
- Reference: curated points keep GrammarNoteCard (now styled as a page card);
  un-noted points get a 用法 card whose notes have the "正解是「…」，" answer
  lead-in stripped (cleanExplanation) and are capped to two, so they read as
  usage notes rather than quiz answers.
- Examples card (un-noted points; curated points already list examples in their
  card, so no duplicate 例句 heading).
- Clear borders / spacing / hierarchy throughout; reuses existing copy keys
  (grammarNoteUsage / grammarNoteExamples) -- no new i18n.

TDD: GrammarPointPage tests still green (heading / meaning / example). Full
suite green; build keeps GrammarPointPage + examBlocks lazy, initial bundle
unchanged. Verified in-browser (noted ばかりに + un-noted なければならない).

Closes #339.
