### PR TITLE
fix(challenge): default to 今日練習 everywhere, never 基礎變化 (#340 follow-up)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -491,6 +491,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
 
     expect(screen.getByText("練習重點")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "否定整理" })).toBeInTheDocument();
@@ -505,6 +508,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "書いて" }));
 
     expect(screen.getByRole("heading", { name: "正解" })).toBeInTheDocument();
@@ -521,6 +527,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
 
     // Default first question in basic mode is 書く -> て形.
     expect(screen.getByText("書く")).toBeInTheDocument();
@@ -545,6 +554,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByText("再想一下")).toBeInTheDocument();
@@ -558,6 +570,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "書って" }));
 
     expect(screen.getByRole("heading", { name: "錯題複習" })).toBeInTheDocument();
@@ -570,6 +585,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "書いて" }));
     await user.keyboard("{Enter}");
 
@@ -583,6 +601,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
 
     // Options are shuffled, so find 書いて's slot and press its 1-based
     // position. The number key must select AND submit that option, even
@@ -603,6 +624,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
 
     // Only 4 options exist; pressing 9 must not submit anything.
     await user.keyboard("9");
@@ -617,6 +641,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "否定整理" }));
 
     expect(within(screen.getByRole("region", { name: "目前題目" })).getByText("ない形")).toBeInTheDocument();
@@ -632,6 +659,9 @@ describe("App", () => {
 
     await gotoLearn(user);
     await user.click(screen.getByRole("button", { name: "開始挑戰" }));
+    // Default landing is now 今日練習 (#340); switch to 基礎變化 for the
+    // conjugation-drill assertions below.
+    await user.click(screen.getByRole("button", { name: /基礎變化/ }));
     await user.click(screen.getByRole("button", { name: "名詞" }));
 
     expect(screen.getByText("学生")).toBeInTheDocument();

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -139,7 +139,11 @@ export function usePracticeSession({
   const [verbGroup, setVerbGroup] = useState<VerbGroup | "all">(init?.verbGroup ?? "godan");
   const [targetForm, setTargetForm] = useState<TargetForm>(init?.targetForm ?? "te");
   const [practiceFocus, setPracticeFocus] = useState<PracticeFocus>(init?.practiceFocus ?? "single");
-  const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "basic");
+  // Default landing is 今日練習 (#340): no challenge entry should drop the
+  // learner into the raw 基礎變化 cascade. Every no-mode entry (nav 挑戰, home
+  // card, grammar CTA, learn 開始挑戰) starts in the guided mixed session;
+  // explicit seeds (incl. {mode:"basic"} drills) and ?mode= deep links win.
+  const [practiceMode, setPracticeMode] = useState<PracticeMode>(init?.mode ?? "daily");
   const [practiceFilter, setPracticeFilter] = useState<PracticeFilter>(init?.filter ?? {});
   const [levelRange, setLevelRange] = useState<LevelRange>(() => initialLevelRange(init, targetLevel));
   const [sessionLength, setSessionLength] = useState<number | null>(() => readSessionLength());


### PR DESCRIPTION
fix(challenge): default to 今日練習 everywhere, never 基礎變化 (#340)

Follow-up to #341: the learn-path 開始挑戰 still dropped into the raw 基礎變化
cascade because usePracticeSession defaulted practiceMode to "basic" when no
mode was seeded. Flip the default to "daily" so EVERY no-mode entry (nav 挑戰,
home card, grammar CTA, learn 開始挑戰) lands in the guided 今日練習 session.
Explicit seeds — the 基礎變化 mode card, startDrill ({mode:"basic"}), exam
sections, ?mode= deep links — still win.

Tests: the 9 conjugation-drill App tests entered via 開始挑戰 and assumed basic
was the default; they now click the 基礎變化 mode card first to reach the basic
drills they assert on. Full suite green.

Closes #340 (for real this time).
