### PR TITLE
fix(ui): #358 quick-wins - dedup desc, level chip row, compact mobile toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -299,14 +299,15 @@ export default function App() {
               className={`theme-toggle furigana-toggle${furiganaEnabled ? " active" : ""}`}
               type="button"
               aria-pressed={furiganaEnabled}
+              aria-label={furiganaToggleLabel}
               onClick={toggleFurigana}
             >
               <Languages aria-hidden="true" />
-              {furiganaToggleLabel}
+              <span className="toggle-text">{furiganaToggleLabel}</span>
             </button>
-            <button className="theme-toggle" type="button" onClick={toggleTheme}>
+            <button className="theme-toggle" type="button" aria-label={themeToggleLabel} onClick={toggleTheme}>
               <ThemeIcon aria-hidden="true" />
-              {themeToggleLabel}
+              <span className="toggle-text">{themeToggleLabel}</span>
             </button>
           </div>
         </div>

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -87,7 +87,7 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
             </button>
           ))}
         </div>
-        <div className="segmented" role="group" aria-label={t.kanjiLevelFilter}>
+        <div className="segmented level-segmented" role="group" aria-label={t.kanjiLevelFilter}>
           {LEVELS.map((option) => (
             <button
               key={option}

--- a/src/components/MockExamPanel.tsx
+++ b/src/components/MockExamPanel.tsx
@@ -42,7 +42,7 @@ export function MockExamPanel({
 
       <fieldset className="mock-level-picker">
         <legend>{t.mockExamLevelLabel}</legend>
-        <div className="segmented">
+        <div className="segmented level-segmented">
           {(["N3", "N2", "N1"] as MockExamLevel[]).map((option) => (
             <button
               key={option}

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -77,7 +77,6 @@ export function ModePicker({
   isVerbCapable,
   availableFocusOptions,
   focusSummary,
-  activeModeCopyKey,
   reviewQueue,
   modeCounts,
   handlePartOfSpeechChange,
@@ -100,7 +99,6 @@ export function ModePicker({
   | "isVerbCapable"
   | "availableFocusOptions"
   | "focusSummary"
-  | "activeModeCopyKey"
   | "reviewQueue"
   | "modeCounts"
   | "handlePartOfSpeechChange"
@@ -252,12 +250,11 @@ export function ModePicker({
             </label>
           ) : null}
         </>
-      ) : (
-        <div className="mode-description">
-          <p>{t.modeOptions[activeModeCopyKey].subtitle}</p>
-        </div>
-      )}
+      ) : null}
 
+      {/* Non-basic modes: the focus-summary line below already shows the active
+          mode's subtitle (focusSummary falls back to it), so a separate
+          mode-description block would duplicate it (#358). */}
       <p className="focus-summary">{focusSummary}</p>
 
       <button className="ghost-button" type="button" onClick={resetSession}>

--- a/src/styles/challenge.css
+++ b/src/styles/challenge.css
@@ -100,6 +100,13 @@ legend,
   grid-template-columns: 1fr;
 }
 
+/* Level chip rows (漢字 N5–N1 filter, 題型練習 N3/N2/N1). Short chips flow as
+   one equal-width row instead of the default 2-col grid that orphaned an odd
+   last chip (#358). Wraps cleanly on narrow screens. */
+.level-segmented {
+  grid-template-columns: repeat(auto-fit, minmax(2.8rem, 1fr));
+}
+
 /* 自訂題數: manual count entry below the session-length presets. */
 .session-length-custom {
   display: flex;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -125,30 +125,25 @@
     justify-content: center;
   }
 
+  /* Language / furigana / theme controls collapse to a compact icon-only row
+     on small screens instead of stacking full-width and dominating the first
+     screen (#358). aria-label on each button keeps the accessible name; the
+     visible text (.toggle-text / .lang-switch-name) is hidden here only. */
   .utility-actions {
-    display: grid;
-    gap: 0.65rem;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: flex-end;
   }
 
-  .theme-toggle {
-    justify-self: stretch;
-    padding-inline: 0.72rem;
+  .utility-actions .theme-toggle {
+    gap: 0;
+    padding-inline: 0.62rem;
   }
 
-  @media (max-width: 380px) {
-    .utility-actions {
-      grid-template-columns: 1fr;
-    }
-
-    .utility-actions > * {
-      grid-column: 1 / -1;
-    }
-
-    .theme-toggle {
-      min-width: 0;
-      white-space: normal;
-    }
+  .utility-actions .toggle-text,
+  .utility-actions .lang-switch-name {
+    display: none;
   }
 
   .controls-panel,


### PR DESCRIPTION
Fixes #358（UI/UX polish review 的 P0 quick-wins）。三個獨立小修，行為不變。

### 1. 挑戰頁 mode 描述橫幅重複兩次
`ModePicker` 在非 basic 模式下同時渲染 `mode-description` 區塊**和** `focus-summary`，而 `focusSummary` 對這些模式正好 fallback 成同一句 subtitle → 兩個框同字。移除多餘的 `mode-description`（`focus-summary` 已涵蓋、basic/非 basic 都顯示，較一致），並清掉因此不再使用的 `activeModeCopyKey` prop。

### 2. 等級選擇器「3 塞 2 欄 → 孤行」
共用 `.segmented` 是固定 `repeat(2, 1fr)`，3 項的等級選擇器（題型練習 N3/N2/N1）會孤行。新增 `.level-segmented`（`repeat(auto-fit, minmax(2.8rem, 1fr))`）套到 **漢字 N5–N1 篩選器** 與 **題型練習 N3/N2/N1**，短 chip 變成一行等寬流動、窄screen 自然換行。不動全域 `.segmented`（避免影響整個 controls panel）。

### 3. 手機版三個 toggle 各佔整列全寬
手機把 `.utility-actions` 從「2 欄 grid／≤380px 單欄全寬」改成 **compact icon 列**（flex 一行）；toggle 文字（`.toggle-text` / `.lang-switch-name`）只在手機隱藏，並替 furigana / theme 鈕補 `aria-label`，icon-only 時無障礙名稱仍在。

### 驗證（preview 程式化檢查）
- `.mode-description` 已不存在、`focus-summary` 只顯示一次。
- 題型練習等級 `N3 / N2 / N1` → **1 列**（3 等寬欄）。
- 手機 `.utility-actions` = flex、3 個 toggle **同一列**（各 ~37px、文字隱藏）、aria-label 完整。
- full suite **477 pass**、`tsc + vite build` 綠；CSS 全進單一 `index.css`、無 bundle 變動。

> 文案尾巴（tagline/hero/分享/SEO 裡殘留的「模擬考／整卷模擬」字樣）另開 PR 處理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the header controls for clearer labels and better accessibility, including on-screen text handling for toggle buttons.
  - Updated level selection controls to display more consistently across the app.

- **Bug Fixes**
  - Removed duplicated mode description text in challenge screens so the active mode information is shown only once.

- **Style**
  - Refined small-screen layout for utility controls, making them more compact and icon-focused on narrow displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->