### PR TITLE
refactor(css): #359 consolidate radius, shadow, overlay into tokens

### DIFF
--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -39,7 +39,7 @@
 .about-section {
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
   padding: 1.1rem 1.2rem;
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -37,7 +37,22 @@
   --indigo: #647c5c; /* repurposed -> matcha; see palette note above */
   --gold: #b7791f;
   --green: #4f7a3f;
+  /* Radius ladder (#359): consolidates ~20 ad-hoc radii into 5 steps so corner
+     rounding stays consistent. Values snap to the nearest existing radius
+     (max shift ~2px), theme-independent. */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-pill: 999px;
   --shadow: 0 6px 18px rgba(120, 95, 55, 0.09);
+  /* Elevation tokens (#359): the heavier overlay/modal shadows that were
+     hardcoded per component. Same values as before (no visual change). */
+  --shadow-md: 0 8px 24px rgba(23, 33, 38, 0.28);
+  --shadow-lg: 0 16px 48px rgba(23, 33, 38, 0.32);
+  /* Overlay tokens (#359): modal scrim + subtle row tint, previously inline. */
+  --overlay-bg: rgba(23, 33, 38, 0.55);
+  --overlay-subtle: rgba(0, 0, 0, 0.04);
   --body-grid-row: transparent;
   --body-grid-column: transparent;
   --bg-glow-primary: transparent;
@@ -184,7 +199,7 @@ select {
 button {
   align-items: center;
   border: 1px solid var(--button-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--button-text);
   cursor: pointer;
   display: inline-flex;

--- a/src/styles/challenge.css
+++ b/src/styles/challenge.css
@@ -15,7 +15,7 @@
   animation: panel-rise 240ms ease both;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
   padding: 1.15rem;
 }
@@ -121,7 +121,7 @@ legend,
   width: 5rem;
   padding: 0.32rem 0.5rem;
   border: 1px solid var(--field-border);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
   background: var(--field-bg);
   color: var(--button-text);
   font: inherit;
@@ -136,7 +136,7 @@ legend,
 select {
   background: linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 95%, var(--indigo) 5%), var(--field-bg));
   border: 1px solid var(--field-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--ink);
   min-height: 2.9rem;
   padding: 0.64rem 0.75rem;
@@ -158,7 +158,7 @@ select:disabled {
 .focus-summary {
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--summary-text);
   font-size: 0.84rem;
   font-weight: 800;
@@ -181,7 +181,7 @@ select:disabled {
   gap: 0.18rem;
   padding: 0.7rem 0.8rem;
   border: 1px solid var(--rule);
-  border-radius: 9px;
+  border-radius: var(--radius-md);
   background: var(--paper);
   color: var(--ink);
   text-align: left;
@@ -236,7 +236,7 @@ select:disabled {
   padding: 0.7rem 0.8rem;
   margin: 0.4rem 0 0;
   border: 1px dashed var(--rule);
-  border-radius: 9px;
+  border-radius: var(--radius-md);
   background: var(--paper-deep);
   color: var(--muted);
   font-size: 0.85rem;

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -51,14 +51,14 @@
 
 .score-bar {
   background: var(--rule);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   height: 0.5rem;
   overflow: hidden;
 }
 
 .score-bar-fill {
   background: var(--matcha);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   display: block;
   height: 100%;
   transition: width 0.3s ease;
@@ -91,7 +91,7 @@
   align-items: center;
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--teal) 38%, var(--panel-border));
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--teal-dark);
   cursor: pointer;
   display: inline-flex;
@@ -157,7 +157,7 @@
 .prompt-header span,
 .prompt-header strong {
   border: 1px solid var(--prompt-chip-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--prompt-chip-text);
   font-size: 0.88rem;
   line-height: 1;
@@ -202,7 +202,7 @@
   align-items: center;
   background: var(--word-kind-bg);
   border: 1px solid var(--word-kind-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--indigo);
   display: inline-flex;
   font-size: 0.82rem;
@@ -255,7 +255,7 @@
 .hint-toggle {
   align-self: flex-start;
   padding: 0.25rem 0.7rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--panel-border);
   background: transparent;
   color: var(--muted);
@@ -363,7 +363,7 @@
   background: var(--field-bg);
   border: 1px solid;
   border-left-width: 5px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   margin-top: 1rem;
   padding: 1rem;
 }
@@ -405,7 +405,7 @@
   font-weight: 700;
   letter-spacing: 0.02em;
   padding: 0.1rem 0.5rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--panel-border);
   color: var(--muted);
 }
@@ -477,7 +477,7 @@
 .review-heading span {
   background: var(--review-pill-bg);
   border: 1px solid var(--review-pill-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--indigo);
   font-size: 0.82rem;
   font-weight: 800;

--- a/src/styles/grammar.css
+++ b/src/styles/grammar.css
@@ -30,7 +30,7 @@
   gap: 0.6rem;
   padding: 1.5rem 1.5rem 1.6rem;
   border: 1px solid var(--panel-border);
-  border-radius: 1rem;
+  border-radius: var(--radius-xl);
   background:
     linear-gradient(135deg, color-mix(in srgb, var(--matcha) 14%, var(--paper)), var(--paper));
   box-shadow: var(--shadow);
@@ -57,7 +57,7 @@
   font-weight: 800;
   letter-spacing: 0.03em;
   padding: 0.22rem 0.6rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--matcha-dark);
   color: var(--selected-text, #fff);
 }
@@ -73,7 +73,7 @@
 .gp-card {
   padding: 1.1rem 1.25rem 1.2rem;
   border: 1px solid var(--panel-border);
-  border-radius: 0.9rem;
+  border-radius: var(--radius-xl);
   background: var(--paper);
 }
 
@@ -123,7 +123,7 @@
 /* Reuse the curated GrammarNoteCard look but let it sit flush as a page card. */
 .grammar-point .grammar-note {
   border: 1px solid var(--panel-border);
-  border-radius: 0.9rem;
+  border-radius: var(--radius-xl);
   padding: 1.1rem 1.25rem 1.2rem;
   background: var(--paper);
 }

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -47,7 +47,7 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.4rem 0.85rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--panel-border);
   background: var(--paper);
   color: var(--teal-dark);
@@ -78,7 +78,7 @@
   align-items: center;
   justify-content: center;
   padding: 1rem;
-  background: rgba(23, 33, 38, 0.5);
+  background: var(--overlay-bg);
 }
 
 .feedback-form {
@@ -91,9 +91,9 @@
   gap: 0.6rem;
   padding: 1rem 1.1rem 1.1rem;
   border: 1px solid var(--panel-border);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
   background: var(--paper);
-  box-shadow: 0 12px 40px rgba(23, 33, 38, 0.28);
+  box-shadow: var(--shadow-lg);
   text-align: left;
 }
 
@@ -127,7 +127,7 @@
   width: 100%;
   padding: 0.55rem 0.7rem;
   border: 1px solid var(--field-border);
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
   background: var(--field-bg);
   color: var(--button-text);
   font: inherit;
@@ -188,7 +188,7 @@
   font: inherit;
   font-size: 0.8rem;
   cursor: pointer;
-  border-radius: 0.35rem;
+  border-radius: var(--radius-sm);
   flex-wrap: wrap;
   max-width: 100%;
   white-space: normal;
@@ -214,7 +214,7 @@
   margin-top: 0.8rem;
   padding: 0.45rem 0.8rem;
   border: 1px solid color-mix(in srgb, var(--matcha) 55%, var(--panel-border));
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: color-mix(in srgb, var(--matcha) 12%, transparent);
   color: var(--matcha-dark);
   font: inherit;
@@ -261,7 +261,7 @@
      center crop would clip the books and emphasise the empty wood
      foreground. */
   object-position: center 38%;
-  border-radius: 0.95rem;
+  border-radius: var(--radius-xl);
   border: 1px solid var(--panel-border);
   background: var(--paper);
   display: block;
@@ -305,7 +305,7 @@
   gap: 0.45rem;
   margin-top: 0.5rem;
   padding: 0.5rem 1.05rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, var(--teal) 55%, var(--panel-border));
   background: color-mix(in srgb, var(--teal) 18%, var(--paper));
   color: var(--teal-dark);
@@ -339,7 +339,7 @@
   align-items: center;
   gap: 0.8rem;
   padding: 1rem 1.15rem;
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--panel-border);
   cursor: pointer;
   text-align: left;
@@ -410,7 +410,7 @@
   padding: 0.9rem 1.1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 .home-stats-cell {
@@ -466,7 +466,7 @@
   padding: 1rem 1.1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 /* Accuracy ring */
@@ -561,7 +561,7 @@
   display: block;
   height: 0.5rem;
   background: var(--rule);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   overflow: hidden;
 }
 
@@ -569,7 +569,7 @@
   display: block;
   height: 100%;
   background: var(--matcha);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition: width 0.3s ease;
 }
 
@@ -595,7 +595,7 @@
   padding: 0.9rem 1.1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 .activity-trend-head {
@@ -654,7 +654,7 @@
   padding: 0.9rem 1.1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 .type-bars-head {
@@ -693,7 +693,7 @@
   content: "";
   width: 0.55rem;
   height: 0.55rem;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--rule);
 }
 
@@ -737,7 +737,7 @@
   display: block;
   height: 0.5rem;
   background: var(--rule);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   overflow: hidden;
 }
 
@@ -745,7 +745,7 @@
   display: block;
   height: 100%;
   background: var(--matcha);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   transition: width 0.3s ease;
 }
 
@@ -796,7 +796,7 @@
   padding: 1.05rem 1.1rem 1.2rem;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 0.95rem;
+  border-radius: var(--radius-xl);
   text-align: left;
   cursor: pointer;
   transition: box-shadow 0.16s ease, transform 0.16s ease;
@@ -825,7 +825,7 @@
   color: var(--matcha-dark);
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--matcha) 42%, var(--rule));
-  border-radius: 0.4rem;
+  border-radius: var(--radius-sm);
   line-height: 1;
 }
 
@@ -892,7 +892,7 @@
   gap: 0.75rem;
   padding: 1rem 1.1rem;
   border: 1px solid var(--panel-border);
-  border-radius: 0.95rem;
+  border-radius: var(--radius-xl);
   background: var(--paper);
 }
 

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -24,7 +24,7 @@
 .kanji-search {
   flex: 1 1 12rem;
   padding: 0.5rem 0.75rem;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--panel-border);
   background: var(--paper);
   color: var(--ink);
@@ -33,7 +33,7 @@
 .kanji-card {
   border: 1px solid color-mix(in srgb, var(--matcha) 45%, var(--panel-border));
   background: color-mix(in srgb, var(--matcha) 10%, var(--paper));
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
   padding: 1rem;
 }
 
@@ -164,7 +164,7 @@
   align-items: flex-start;
   gap: 0.15rem;
   padding: 0.6rem;
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--panel-border);
   background: var(--paper);
   cursor: pointer;

--- a/src/styles/language-picker.css
+++ b/src/styles/language-picker.css
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: center;
   padding: 1rem;
-  background: rgba(23, 33, 38, 0.55);
+  background: var(--overlay-bg);
   backdrop-filter: blur(2px);
 }
 
@@ -23,9 +23,9 @@
   gap: 1.1rem;
   padding: 1.6rem 1.4rem;
   border: 1px solid var(--panel-border);
-  border-radius: 1rem;
+  border-radius: var(--radius-xl);
   background: var(--paper);
-  box-shadow: 0 16px 48px rgba(23, 33, 38, 0.32);
+  box-shadow: var(--shadow-lg);
   text-align: center;
 }
 
@@ -41,7 +41,7 @@
   height: 2rem;
   padding: 0;
   border: 1px solid var(--panel-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--muted);
   cursor: pointer;
@@ -96,7 +96,7 @@
 .lang-picker-option {
   padding: 0.85rem 0.8rem;
   border: 1px solid var(--field-border);
-  border-radius: 0.7rem;
+  border-radius: var(--radius-lg);
   background: var(--field-bg);
   color: var(--ink);
   font-size: 1.05rem;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -127,14 +127,14 @@
   gap: 0.5rem;
   padding: 0.6rem 1.1rem;
   border: 1px solid var(--matcha);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--matcha-dark);
   color: var(--selected-text, #fff);
   font: inherit;
   font-weight: 700;
   font-size: 0.92rem;
   cursor: pointer;
-  box-shadow: 0 8px 24px rgba(23, 33, 38, 0.28);
+  box-shadow: var(--shadow-md);
   white-space: nowrap;
 }
 
@@ -232,7 +232,7 @@
   animation: panel-rise 240ms ease both;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
   margin: 0 auto;
   max-width: 1220px;

--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -219,7 +219,7 @@
     linear-gradient(135deg, color-mix(in srgb, var(--vermilion) 16%, transparent), transparent 72%),
     var(--field-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--summary-text);
   display: flex;
   flex-wrap: wrap;
@@ -249,7 +249,7 @@
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 92%, transparent), color-mix(in srgb, var(--paper-deep) 74%, transparent));
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   min-width: 0;
   padding: 0.95rem;
 }
@@ -344,7 +344,7 @@
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 96%, var(--indigo) 4%), var(--field-bg));
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   display: grid;
   gap: 0.62rem;
   min-width: 0;
@@ -386,7 +386,7 @@
 .quick-start-card code {
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--summary-text);
   font-family: var(--font-japanese-ui);
   font-weight: 700;
@@ -463,7 +463,7 @@
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 96%, var(--teal) 4%), var(--field-bg));
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   display: grid;
   gap: 0.65rem;
   min-width: 0;
@@ -490,7 +490,7 @@
 .sound-table {
   background: var(--field-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: hidden;
 }
 
@@ -552,7 +552,7 @@
 .pipeline-card code {
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow-wrap: anywhere;
   padding: 0.55rem 0.62rem;
 }
@@ -565,7 +565,7 @@
 .block-pitfalls {
   background: color-mix(in srgb, var(--vermilion) 10%, var(--paper));
   border: 1px solid color-mix(in srgb, var(--vermilion) 36%, var(--rule));
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   padding: 0.7rem 0.9rem;
 }
 
@@ -596,7 +596,7 @@
 .block-drill-note {
   background: var(--summary-bg);
   border: 1px dashed var(--summary-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   color: var(--summary-text);
   font-size: 0.84rem;
   line-height: 1.55;
@@ -631,7 +631,7 @@
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--field-bg) 96%, var(--indigo) 4%), var(--field-bg));
   border: 1px solid var(--panel-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   display: grid;
   gap: 0.7rem;
   min-height: 17rem;
@@ -664,7 +664,7 @@
 .formula-row code {
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--summary-text);
   font-family: var(--font-japanese-ui);
   font-weight: 700;

--- a/src/styles/mock.css
+++ b/src/styles/mock.css
@@ -17,7 +17,7 @@
   gap: 1.4rem;
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
-  border-radius: 1.1rem;
+  border-radius: var(--radius-xl);
   padding: 1.6rem 1.8rem;
   box-shadow: var(--shadow);
 }
@@ -95,7 +95,7 @@
   padding: 0.65rem 0.9rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.7rem;
+  border-radius: var(--radius-lg);
 }
 
 .mock-section-row.empty {
@@ -117,9 +117,9 @@
   font-size: 0.78rem;
   font-weight: 600;
   color: var(--prompt-chip-text);
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--overlay-subtle);
   border: 1px solid var(--prompt-chip-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .mock-section-meta {
@@ -192,7 +192,7 @@
   padding: 0.85rem 1rem;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 0.8rem;
+  border-radius: var(--radius-lg);
   cursor: pointer;
   min-height: 0;
 }
@@ -257,7 +257,7 @@
   padding: 0.4rem 0.7rem;
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   font-variant-numeric: tabular-nums;
   color: var(--summary-text);
 }
@@ -273,7 +273,7 @@
   padding: 1rem 1.1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.9rem;
+  border-radius: var(--radius-xl);
 }
 
 .mock-question .prompt-header {
@@ -287,9 +287,9 @@
 .mock-question .prompt-header span {
   display: inline-flex;
   padding: 0.15rem 0.6rem;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--overlay-subtle);
   border: 1px solid var(--prompt-chip-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
 }
 
 .mock-nav {
@@ -334,7 +334,7 @@
   padding: 0.55rem 0.8rem;
   background: var(--feedback-revealed-bg);
   border: 1px solid var(--feedback-revealed-border);
-  border-radius: 0.6rem;
+  border-radius: var(--radius-md);
   color: var(--feedback-revealed-title);
   font-size: 0.92rem;
 }
@@ -352,7 +352,7 @@
   padding: 0.85rem 1rem;
   background: var(--paper);
   border: 1px solid var(--rule);
-  border-radius: 0.7rem;
+  border-radius: var(--radius-lg);
   display: flex;
   flex-direction: column;
   gap: 0.45rem;

--- a/src/styles/rules.css
+++ b/src/styles/rules.css
@@ -8,7 +8,7 @@
   margin-bottom: 1rem;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 .dashboard-card .eyebrow {
@@ -28,7 +28,7 @@
   padding: 0.7rem 0.85rem;
   background: var(--feedback-revealed-bg);
   border: 1px solid var(--feedback-revealed-border);
-  border-radius: 0.7rem;
+  border-radius: var(--radius-lg);
   color: var(--feedback-revealed-title);
   font-weight: 600;
   cursor: pointer;
@@ -47,7 +47,7 @@
   padding: 0.18rem 0.55rem;
   background: var(--vermilion);
   color: var(--selected-text);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.02em;
@@ -61,7 +61,7 @@
   padding: 0.55rem 0.7rem;
   background: var(--summary-bg);
   border: 1px solid var(--summary-border);
-  border-radius: 0.65rem;
+  border-radius: var(--radius-lg);
   color: var(--summary-text);
   font-size: 0.9rem;
 }
@@ -91,7 +91,7 @@
   height: 1.6rem;
   background: transparent;
   border: 1px solid var(--prompt-chip-border);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   color: var(--teal-dark);
   cursor: pointer;
   vertical-align: middle;
@@ -155,7 +155,7 @@
   padding: 1.1rem 1.2rem 1.2rem;
   background: var(--paper);
   border: 1px solid var(--panel-border);
-  border-radius: 0.85rem;
+  border-radius: var(--radius-lg);
 }
 
 .rules-table-head {


### PR DESCRIPTION
部分完成 #359（樣式系統收斂的「快速贏」階段）。把散落的硬編碼值收進 `:root` 的 token 階梯，**視覺幾乎不變**（radius 就近 snap、最多差 ~2px；shadow/overlay 沿用原值）。符合「大方向不大改」。

## 改動
| 類別 | 之前 | 之後 |
|---|---|---|
| border-radius | **20 種** 散落（px/rem 混用） | **5 token** `--radius-sm/md/lg/xl/pill`，64 處改用 var |
| box-shadow | 3 個硬編碼 overlay/modal 陰影 | `--shadow-md` / `--shadow-lg` |
| overlay 顏色 | 散落 rgba（scrim / 列底色） | `--overlay-bg` / `--overlay-subtle` |

- 2 個方向性圓角（`3px 3px 0 0`、`0 .4rem .4rem 0`）刻意保留字面值。
- token 皆 theme-independent；shadow/overlay 沿用原本兩主題共用的值，**零視覺變化**。

## 刻意未做（避免大改、留後續可選）
- **spacing scale（~136 種組合 → 5–8 token）**：snapping 會動到大量 padding/gap → 版面位移，與「不大改」衝突，先擱。
- **panel/card/button 基類（43 → ~15）**：牽動大量 markup，工程大，最後做。

## 驗證
- 盤點：border-radius 非 token 殘留 = 0（除 2 個方向性）、box-shadow 硬編碼 = 0、overlay rgba 已 token 化。
- runtime 驗證（preview）：token 正確解析（button 8px、card 16px、無 undefined 掉直角）。
- full suite **477 pass**、`tsc + vite build` 綠；CSS 64.08→65.25kB（token 定義，可忽略）。
