### PR TITLE
feat(i18n): prominent language switcher with SVG flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.108.2",
+    "flag-icons": "^7.5.0",
     "lucide-react": "^0.561.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.108.2
         version: 2.108.2
+      flag-icons:
+        specifier: ^7.5.0
+        version: 7.5.0
       lucide-react:
         specifier: ^0.561.0
         version: 0.561.0(react@19.2.6)
@@ -1691,6 +1694,9 @@ packages:
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+
+  flag-icons@7.5.0:
+    resolution: {integrity: sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -4332,6 +4338,8 @@ snapshots:
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
+
+  flag-icons@7.5.0: {}
 
   for-each@0.3.5:
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { Globe, Languages, Moon, Sun } from "lucide-react";
+import { ChevronDown, Languages, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
 import { copy, type Language } from "./i18n";
 import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
+import { LanguageFlag } from "./components/LanguageFlag";
 import { UpdateToast } from "./components/UpdateToast";
 import { usePwaUpdate } from "./hooks/usePwaUpdate";
 import { JabikoMark } from "./components/JabikoMark";
@@ -291,8 +292,9 @@ export default function App() {
                 aria-haspopup="dialog"
                 onClick={() => setLangPickerOpen(true)}
               >
-                <Globe aria-hidden="true" className="lang-switch-icon" />
+                <LanguageFlag language={language} className="lang-switch-flag" />
                 <span className="lang-switch-name">{copy[language].languageName}</span>
+                <ChevronDown aria-hidden="true" className="lang-switch-caret" />
               </button>
             )}
             <button

--- a/src/components/LanguageFlag.tsx
+++ b/src/components/LanguageFlag.tsx
@@ -1,0 +1,35 @@
+import type { Language } from "../i18n";
+import twFlag from "flag-icons/flags/4x3/tw.svg";
+import jpFlag from "flag-icons/flags/4x3/jp.svg";
+import gbFlag from "flag-icons/flags/4x3/gb.svg";
+import thFlag from "flag-icons/flags/4x3/th.svg";
+import idFlag from "flag-icons/flags/4x3/id.svg";
+import krFlag from "flag-icons/flags/4x3/kr.svg";
+import vnFlag from "flag-icons/flags/4x3/vn.svg";
+import mmFlag from "flag-icons/flags/4x3/mm.svg";
+
+// Per-language flag (SVG, cross-platform — emoji flags don't render on Windows).
+// zh-Hant -> Taiwan, en -> United Kingdom; the rest map to their language's
+// home country. Decorative: alt="" + aria-hidden, the language name carries the
+// accessible label.
+const FLAG_SRC: Record<Language, string> = {
+  "zh-Hant": twFlag,
+  ja: jpFlag,
+  en: gbFlag,
+  th: thFlag,
+  id: idFlag,
+  ko: krFlag,
+  vi: vnFlag,
+  my: mmFlag,
+};
+
+export function LanguageFlag({ language, className }: { language: Language; className?: string }) {
+  return (
+    <img
+      src={FLAG_SRC[language]}
+      alt=""
+      aria-hidden="true"
+      className={className ? `lang-flag ${className}` : "lang-flag"}
+    />
+  );
+}

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { X } from "lucide-react";
 import { copy, type Language } from "../i18n";
+import { LanguageFlag } from "./LanguageFlag";
 
 // Language picker (#313 first-visit + #326 on-demand). The heading is
 // deliberately multilingual -- on a first visit the user hasn't chosen a
@@ -92,6 +93,7 @@ export function LanguagePicker({
                 lang={code}
                 onClick={() => onChoose(code)}
               >
+                <LanguageFlag language={code} className="lang-picker-flag" />
                 {copy[code].languageName}
               </button>
             );

--- a/src/styles/language-picker.css
+++ b/src/styles/language-picker.css
@@ -94,6 +94,9 @@
 }
 
 .lang-picker-option {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
   padding: 0.85rem 0.8rem;
   border: 1px solid var(--field-border);
   border-radius: var(--radius-lg);
@@ -106,6 +109,10 @@
     border-color 0.15s ease,
     background 0.15s ease,
     transform 0.05s ease;
+}
+
+.lang-picker-flag {
+  width: 1.6rem;
 }
 
 .lang-picker-option:hover {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -89,17 +89,32 @@
   color: var(--selected-text);
 }
 
-/* Language switcher (#326): pill button (Globe icon in vermilion + the current
-   language's native name) that opens the LanguagePicker. The icon colour makes
-   this the first thing the eye lands on in the header row. */
+/* Language switcher (#326, #360): a prominent pill showing the current
+   language's flag + native name + a caret, so it reads clearly as a language
+   menu. Flags are SVGs (emoji flags don't render on Windows). A teal-tinted
+   border makes it the first thing the eye lands on in the header row. */
 .lang-switch-button {
   align-items: center;
+  border-color: color-mix(in srgb, var(--teal) 42%, var(--button-border));
   display: inline-flex;
   gap: 0.4rem;
 }
 
-.lang-switch-icon {
-  color: var(--vermilion);
+.lang-flag {
+  aspect-ratio: 4 / 3;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+  display: block;
+  flex: 0 0 auto;
+  height: auto;
+  object-fit: cover;
+  width: 1.3rem;
+}
+
+.lang-switch-caret {
+  color: var(--muted);
+  height: 0.9rem;
+  width: 0.9rem;
 }
 
 .lang-switch-name {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -142,7 +142,8 @@
   }
 
   .utility-actions .toggle-text,
-  .utility-actions .lang-switch-name {
+  .utility-actions .lang-switch-name,
+  .utility-actions .lang-switch-caret {
     display: none;
   }
 


### PR DESCRIPTION
讓「切換語言」更明顯、更一眼看懂（花雪要求）。第一次進站維持乾淨的日文預設（不彈語言選單——interstitial 對 SEO 不好）。

## 改動
- **Header 語言鈕**：原本是安靜的 globe pill → 改成 **國旗＋語言名＋下拉箭頭**，並加 teal 色調邊框讓它在 header 一排裡跳出來。
- **LanguagePicker**：每個語言選項前面也加上國旗。
- **新 `LanguageFlag` 元件**：把每個語言對應到 SVG 國旗（`flag-icons`）：zh-Hant→🇹🇼台灣、ja→🇯🇵、en→🇬🇧、th/id/ko/vi/my。
- **為何 SVG 不用 emoji**：國旗 emoji 在 **Windows 會顯示成「TW」「JP」字母**、不是旗子，所以用 SVG（跨平台正常；旗子很小、以 inline data-URI 進 bundle）。
- **手機**：保留國旗（清楚的語言入口），隱藏語言名＋箭頭以維持 compact（延續 #358）。

## 驗證
- runtime（preview）：header 鈕旗子載入、name、caret、accent 邊框都在；picker **8 個選項旗子全部載入**（含 ko/vi/my 複雜旗）。
- full suite **477 pass**、`tsc + vite build` 綠。flag-icons 僅 header eager bundle、不碰 challenge lazy chunk。

相關 UI review umbrella #361。
