### PR TITLE
feat(ui): #360 home - emphasize daily primary CTA, secondary cards

### DIFF
--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -362,12 +362,24 @@
   color: var(--summary-text);
 }
 
-/* Primary daily-practice entry: matcha accent so it reads as the
-   headline action, distinct from the vermilion review banner. */
+/* Primary daily-practice entry: matcha accent + a heavier frame, larger
+   padding and bigger title so it reads as the single headline action above
+   the secondary banners and entry cards (#360 "主 CTA 化"). */
 .home-banner-daily {
-  background: color-mix(in srgb, var(--matcha) 12%, var(--paper));
-  border-color: color-mix(in srgb, var(--matcha) 45%, var(--panel-border));
+  background: color-mix(in srgb, var(--matcha) 16%, var(--paper));
+  border-color: color-mix(in srgb, var(--matcha) 58%, var(--panel-border));
+  border-width: 2px;
   color: var(--matcha-dark);
+  padding: 1.3rem 1.35rem;
+}
+
+.home-banner-daily .home-banner-text strong {
+  font-size: 1.2rem;
+}
+
+.home-banner-daily > svg:first-child {
+  height: 1.45rem;
+  width: 1.45rem;
 }
 
 .home-banner-text {
@@ -834,15 +846,17 @@
 .home-card-spot {
   grid-area: icon;
   align-self: start;
-  width: 2.7rem;
-  height: 2.7rem;
+  /* Slightly smaller than before so the entry cards read as secondary to the
+     primary 今日練習 CTA above (#360). */
+  width: 2.4rem;
+  height: 2.4rem;
   margin-top: 0.05rem;
 }
 
 .home-card h2 {
   grid-area: title;
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   color: var(--ink);
 }
 


### PR DESCRIPTION
#360 的 Decision 1（首頁「主 CTA 化」，option B）——**保守版、純 CSS、不刪不動 markup**（守你「首頁慢慢調、別主動刪」）。

只調層級：讓頂部「今日練習」一鍵 CTA 成為唯一主視覺動作，重複入口卡片（學習/挑戰/題型練習 nav 也有）退為次級。

- `.home-banner-daily`：matcha 填色加深、2px 框、放大 padding 與標題、前導 icon 變大 → 明確主 CTA。
- `.home-card`：spot 插圖 2.7→2.4rem、標題 1.1→1.05rem → 卡片讀起來是次級。

驗證：build 綠；preview computed-style 確認（主 CTA padding/border/標題變大、卡片 spot 縮小）。

> #360 的 Decision 2（挑戰頁答題收起設定）牽動版面結構，另一個 PR 謹慎處理。相關 umbrella #361。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the daily-practice banner so it stands out more with stronger coloring, a thicker border, and added spacing.
  * Improved the banner’s title/icon presentation by enlarging the icon and emphasizing the main text.
  * Adjusted card visuals by slightly reducing the size of the spot illustration and making card titles a bit smaller for better balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->