### PR TITLE
feat(i18n): per-locale content overlay for exam explanation - #378 pilot

### DIFF
--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -376,6 +376,48 @@ describe("FeedbackPanel report-this-question entry (#299)", () => {
   });
 });
 
+describe("FeedbackPanel localized explanation (#378)", () => {
+  const base = {
+    ...readingPool[0],
+    explanation: "這題在問動詞的て形。",
+    explanationI18n: { en: "This asks about the verb te-form." }
+  };
+
+  it("shows the zh-Hant explanation by default (source locale)", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question: base, submittedAnswer: null }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    expect(screen.getByText("這題在問動詞的て形。")).toBeInTheDocument();
+  });
+
+  it("shows the localized explanation when the language has an overlay entry", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question: base, submittedAnswer: null }}
+        language="en"
+        options={[]}
+      />
+    );
+    expect(screen.getByText("This asks about the verb te-form.")).toBeInTheDocument();
+    expect(screen.queryByText("這題在問動詞的て形。")).toBeNull();
+  });
+
+  it("falls back to the zh source when the language has no overlay entry", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question: base, submittedAnswer: null }}
+        language="ja"
+        options={[]}
+      />
+    );
+    expect(screen.getByText("這題在問動詞的て形。")).toBeInTheDocument();
+  });
+});
+
 describe("FeedbackPanel furigana (#134)", () => {
   // Override the example with a pre-baked sentence (学校 -> がっこう) so the
   // ruby path has data. The feedback example is POST-answer, so it shows

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -5,6 +5,7 @@ import { lookupWordsByReading } from "../domain/readingLookup";
 import { lookupPatternMeaning } from "../domain/patternMeaning";
 import { lookupGrammarNote } from "../domain/grammarNotes";
 import { hasGrammarPoint } from "../domain/grammarPoints";
+import { pickLocalized } from "../domain/localizedContent";
 import { GrammarNoteCard } from "./GrammarNoteCard";
 import { QuestionReportForm } from "./QuestionReportForm";
 import { Ruby } from "./Ruby";
@@ -94,7 +95,7 @@ export function FeedbackPanel({
         ) : null}
       </div>
       <p className="answer-key">{t.answerKey}：{feedback.question.expectedAnswers.join(" / ")}</p>
-      <p>{feedback.question.explanation}</p>
+      <p>{pickLocalized(feedback.question.explanation, feedback.question.explanationI18n, language)}</p>
       {distractorGlosses.length > 0 ? (
         <div className="distractor-gloss">
           <p className="distractor-gloss-label">{t.feedbackOtherOptions}：</p>

--- a/src/domain/exam/helpers.ts
+++ b/src/domain/exam/helpers.ts
@@ -24,6 +24,7 @@ export function examQuestion(input: ExamQuestionInput): PracticeQuestion {
     targetForm: input.targetForm ?? "reading",
     expectedAnswers: [input.expectedAnswer],
     explanation: input.explanation,
+    explanationI18n: input.explanationI18n,
     promptLabel: input.promptLabel,
     promptText: input.promptText,
     promptContextZh: input.promptContextZh,

--- a/src/domain/exam/types.ts
+++ b/src/domain/exam/types.ts
@@ -1,4 +1,4 @@
-import type { JlptLevel, TargetForm } from "../types";
+import type { JlptLevel, LocalizedText, TargetForm } from "../types";
 
 export type ExamQuestionInput = {
   id: string;
@@ -21,6 +21,11 @@ export type ExamQuestionInput = {
   expectedAnswer: string;
   options: string[];
   explanation: string;
+  /**
+   * Per-locale translations of `explanation` (#378). AI-assisted translation
+   * writes only this overlay; absent locales fall back to the Chinese source.
+   */
+  explanationI18n?: LocalizedText;
   /**
    * Override the auto-generated example sentence. Needed for question types
    * (e.g. 用法 / 言い換え類義) where the prompt is an instruction or the

--- a/src/domain/localizedContent.test.ts
+++ b/src/domain/localizedContent.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { pickLocalized } from "./localizedContent";
+
+describe("pickLocalized", () => {
+  const zh = "這題在問動詞的て形。";
+
+  it("falls back to the zh-Hant source when there is no overlay", () => {
+    expect(pickLocalized(zh, undefined, "en")).toBe(zh);
+  });
+
+  it("falls back to the source when the overlay has no entry for the language", () => {
+    expect(pickLocalized(zh, { ja: "これはて形の問題です。" }, "en")).toBe(zh);
+  });
+
+  it("returns the localized variant when present for the language", () => {
+    expect(pickLocalized(zh, { en: "This asks about the te-form." }, "en")).toBe(
+      "This asks about the te-form."
+    );
+  });
+
+  it("treats an empty/whitespace overlay value as missing and falls back", () => {
+    expect(pickLocalized(zh, { en: "" }, "en")).toBe(zh);
+    expect(pickLocalized(zh, { en: "   " }, "en")).toBe(zh);
+  });
+
+  it("uses the source for the source locale itself", () => {
+    expect(pickLocalized(zh, { en: "x" }, "zh-Hant")).toBe(zh);
+  });
+});

--- a/src/domain/localizedContent.ts
+++ b/src/domain/localizedContent.ts
@@ -1,0 +1,16 @@
+import type { LocaleCode, LocalizedText } from "./types";
+
+/**
+ * Pick the localized variant of a Chinese-source content field for `lang`,
+ * falling back to the zh-Hant source when there is no (non-empty) overlay
+ * entry. This is the single read path for #378 content overlays so missing
+ * translations degrade to Chinese rather than silently rendering blank.
+ */
+export function pickLocalized(
+  source: string,
+  overlay: LocalizedText | undefined,
+  lang: LocaleCode
+): string {
+  const value = overlay?.[lang];
+  return typeof value === "string" && value.trim() !== "" ? value : source;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -4,6 +4,21 @@ export type VerbGroup = "godan" | "ichidan" | "irregular";
 
 export type JlptLevel = "N5" | "N4" | "N3" | "N2" | "N1";
 
+/**
+ * Supported UI locale codes. Single source of truth in the domain layer so
+ * content overlays (e.g. `explanationI18n`) and the i18n `Language` type can
+ * both reference it without the UI layer owning a domain concept. `i18n.ts`
+ * derives `Language` from this.
+ */
+export type LocaleCode = "zh-Hant" | "ja" | "en" | "th" | "id" | "ko" | "vi" | "my";
+
+/**
+ * Per-locale translation overlay for a Chinese-source content field. Absent
+ * locales fall back to the zh-Hant source (see `pickLocalized`). AI-assisted
+ * translation (#378) only ever writes these overlays, never the source.
+ */
+export type LocalizedText = Partial<Record<LocaleCode, string>>;
+
 export type TargetForm =
   | "dictionary"
   | "masu"
@@ -56,6 +71,8 @@ export interface PracticeQuestion {
   targetForm: TargetForm;
   expectedAnswers: string[];
   explanation: string;
+  /** Per-locale translations of `explanation`; falls back to the zh source (#378). */
+  explanationI18n?: LocalizedText;
   promptLabel?: string;
   promptText?: string;
   /**

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,8 +1,11 @@
-import type { PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
+import type { LocaleCode, PartOfSpeech, TargetForm, VerbGroup } from "./domain/types";
 import type { QuestionType } from "./domain/analytics/questionType";
 import type { ModeCopyKey } from "./domain/practiceMode";
 
-export type Language = "zh-Hant" | "ja" | "en" | "th" | "id" | "ko" | "vi" | "my";
+// Single source of truth for the locale code union lives in the domain layer
+// (src/domain/types.ts) so content overlays can reference it too; `Language`
+// is the same set, kept as the UI-facing name.
+export type Language = LocaleCode;
 
 export type Copy = {
   languageName: string;


### PR DESCRIPTION
#378 N5 試水的 **app 端讀取路徑**（PR-A）。純 additive、向後相容：**沒有翻譯時行為完全不變**（fallback 中文）。

## 變更
- `domain/types.ts`：新增 `LocaleCode`（locale 碼單一來源）＋ `LocalizedText`；`PracticeQuestion.explanationI18n?`
- `i18n.ts`：`Language` 改為從 `LocaleCode` 派生（移除重複 union、避免層級循環）
- `domain/localizedContent.ts`：`pickLocalized(source, overlay, lang)` → 有當前語言翻譯就用、否則退中文（空字串視為缺）
- `exam/types.ts` ＋ `helpers.ts`：`explanationI18n` 經 `examQuestion()` 流進 runtime question
- `FeedbackPanel`：答後解析改用當前語言的 `explanationI18n`，缺則中文

## 測試
- `pickLocalized` 5 例（fallback／override／空值／源語系）
- `FeedbackPanel` 3 例（預設中文／en overlay 顯示英文／無 overlay 退中文）
- 全測試 **485 pass**、typecheck＋build 綠

## Scope
只先做 `explanation` 一個欄位，作為 #378 N5/單語系試水的讀取端。**填這個 overlay 的 Gemini translate 腳本＋GitHub Actions workflow 另一個 PR 上**（需 `GEMINI_API_KEY` repo secret、在 CI 跑、PR-only 人工審）。其餘欄位（meaning/hint/promptContext…）之後照同 pattern 擴。
