### PR TITLE
fix(seo): browser-tab favicon = Jabiko logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta name="theme-color" content="#647c5c" />
+    <!-- Browser-tab favicon (Jabiko mascot). SVG scales crisply in modern
+         browsers; the PNG is a fallback for ones without SVG-favicon support. -->
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
+    <link rel="icon" type="image/png" sizes="192x192" href="/pwa-192x192.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
     <link rel="canonical" href="https://jabiko.pages.dev/" />


### PR DESCRIPTION
分頁 favicon 之前是預設地球（index.html 只有 apple-touch-icon、缺 <link rel=icon>）。指向既有的 public/icon.svg（Jabiko 吉祥物）：SVG 為主、pwa-192 PNG 後備。build 確認 link 進 dist、icon.svg 已複製。