### PR TITLE
feat(practice): unattempted (新題) exam items first - #385

### DIFF
--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -315,6 +315,41 @@ describe("composeDailySet", () => {
   });
 });
 
+describe("buildPracticeQuestions unattempted-first exam ordering (#385)", () => {
+  it("surfaces unattempted exam items before attempted ones (綜合)", () => {
+    const pool = buildExamQuestionPool("all");
+    const attemptedIds = new Set(pool.slice(0, 8).map((q) => q.id));
+    const out = buildPracticeQuestions(
+      poolParams({ isExamFocus: true, levelRange: "all", attemptedIds })
+    );
+    // membership unchanged...
+    expect(new Set(out.map((q) => q.id))).toEqual(new Set(pool.map((q) => q.id)));
+    // ...and every attempted item comes after every unattempted item.
+    const flags = out.map((q) => attemptedIds.has(q.id));
+    const firstAttempted = flags.indexOf(true);
+    const lastFresh = flags.lastIndexOf(false);
+    expect(firstAttempted).toBeGreaterThan(lastFresh);
+  });
+
+  it("a capped session pulls unattempted items first (#385 + #154)", () => {
+    const pool = buildExamQuestionPool("all");
+    const attemptedIds = new Set(pool.slice(0, 10).map((q) => q.id));
+    const capped = buildPracticeQuestions(
+      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: 20, attemptedIds })
+    );
+    expect(capped.length).toBe(20);
+    // The bank has far more than 20 unattempted, so a capped set is all fresh.
+    expect(capped.every((q) => !attemptedIds.has(q.id))).toBe(true);
+  });
+
+  it("no attemptedIds: membership unchanged (fresh learner sees the plain pool)", () => {
+    const out = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "all" }));
+    expect(new Set(out.map((q) => q.id))).toEqual(
+      new Set(buildExamQuestionPool("all").map((q) => q.id))
+    );
+  });
+});
+
 describe("buildQuestionPool part-of-speech handling (#60)", () => {
   it("does not generate conjugation drills for adverbs", () => {
     const adverb = jlptVocabulary.find((item) => item.partOfSpeech === "adverb");

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -24,6 +24,7 @@ import {
   shuffleQuestions
 } from "./practice";
 import type { PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./types";
+import { prioritizeUnattempted } from "./unattempted";
 import { vocabulary } from "./vocabulary";
 import { jlptVocabulary } from "./vocabulary-jlpt";
 
@@ -167,6 +168,10 @@ export type PracticePoolParams = {
   // <=0 means no cap (the old endless behaviour). review (clears the whole
   // due queue) and 今日練習 (already a fixed ~20 set) are NEVER capped.
   sessionLength?: number | null;
+  // Ids the learner has already attempted. When provided, the 綜合 / 備考 exam
+  // pool surfaces unattempted (新題) items first (#385). Empty / omitted = no
+  // reordering (logged-out or fresh learner sees the plain shuffle).
+  attemptedIds?: Set<string>;
 };
 
 // Derives the active question pool for the current mode. This is the body
@@ -189,8 +194,11 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     targetForms,
     levelRange,
     reviewQueue,
-    sessionLength
+    sessionLength,
+    attemptedIds
   } = params;
+  const fresh = (pool: PracticeQuestion[]): PracticeQuestion[] =>
+    attemptedIds ? prioritizeUnattempted(pool, attemptedIds) : pool;
 
   // Cap the endless drill modes to the chosen session length (#154). A
   // null / non-positive length leaves the pool whole (old behaviour).
@@ -213,8 +221,11 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
         )
       );
     }
-    // 綜合考題庫: optionally narrowed to a level range (N1+N2 / N2+N3).
-    return cap(shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all")));
+    // 綜合考題庫 + 備考 presets: optionally narrowed to a level range, then
+    // unattempted (新題) items first so a capped session pulls new content
+    // before anything already done (#385). The section-filtered mock path
+    // above keeps its pure shuffle (a mock test shouldn't reorder by history).
+    return cap(fresh(shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"))));
   }
 
   if (isClozeFocus) {

--- a/src/domain/unattempted.test.ts
+++ b/src/domain/unattempted.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { collectAttemptedIds, prioritizeUnattempted } from "./unattempted";
+import type { Attempt, PracticeQuestion } from "./types";
+
+const q = (id: string) => ({ id } as PracticeQuestion);
+const ids = (pool: PracticeQuestion[]) => pool.map((p) => p.id);
+
+describe("collectAttemptedIds", () => {
+  it("collects both questionId and vocabularyId, de-duplicated", () => {
+    const attempts = [
+      { questionId: "exam-1", vocabularyId: "exam-1" },
+      { vocabularyId: "kaku" },
+      { questionId: "exam-2", vocabularyId: "exam-2" },
+      { questionId: "exam-1", vocabularyId: "exam-1" } // dup
+    ] as Attempt[];
+    const set = collectAttemptedIds(attempts);
+    expect(set.has("exam-1")).toBe(true);
+    expect(set.has("exam-2")).toBe(true);
+    expect(set.has("kaku")).toBe(true);
+    expect(set.size).toBe(3);
+  });
+
+  it("returns an empty set for no attempts", () => {
+    expect(collectAttemptedIds([]).size).toBe(0);
+  });
+});
+
+describe("prioritizeUnattempted", () => {
+  const pool = [q("a"), q("b"), q("c"), q("d")];
+
+  it("moves unattempted items to the front, preserving order within each group", () => {
+    const attempted = new Set(["a", "c"]); // b, d are fresh
+    expect(ids(prioritizeUnattempted(pool, attempted))).toEqual(["b", "d", "a", "c"]);
+  });
+
+  it("is a no-op when nothing has been attempted", () => {
+    expect(ids(prioritizeUnattempted(pool, new Set()))).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("keeps the pool order when everything has been attempted", () => {
+    expect(ids(prioritizeUnattempted(pool, new Set(["a", "b", "c", "d"])))).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("does not mutate the input pool", () => {
+    const input = [q("a"), q("b")];
+    prioritizeUnattempted(input, new Set(["a"]));
+    expect(ids(input)).toEqual(["a", "b"]);
+  });
+});

--- a/src/domain/unattempted.ts
+++ b/src/domain/unattempted.ts
@@ -1,0 +1,38 @@
+import type { Attempt, PracticeQuestion } from "./types";
+
+// "Unattempted-first" ordering for the exam practice pool (新題優先): items the
+// learner has never answered (0 attempts) surface before ones they've already
+// done, so new / newly-added content comes up first. The wrong-answer review
+// (錯題複習) and 今日練習 modes keep their own ordering -- this only reorders
+// the endless exam pool.
+
+/** Set of every question id the learner has ever attempted (any result). */
+export function collectAttemptedIds(attempts: Attempt[]): Set<string> {
+  const ids = new Set<string>();
+  for (const attempt of attempts) {
+    // Exam items use the same value for question id and vocabulary id; older
+    // attempts may carry only vocabularyId. Add both so a match is robust.
+    if (attempt.questionId) ids.add(attempt.questionId);
+    if (attempt.vocabularyId) ids.add(attempt.vocabularyId);
+  }
+  return ids;
+}
+
+/**
+ * Stable partition: unattempted questions first (in their existing order),
+ * then attempted ones (in theirs). A no-op when nothing has been attempted,
+ * so a logged-out / fresh learner sees the pool unchanged. Never mutates the
+ * input.
+ */
+export function prioritizeUnattempted(
+  questions: PracticeQuestion[],
+  attemptedIds: Set<string>
+): PracticeQuestion[] {
+  if (attemptedIds.size === 0) return questions;
+  const fresh: PracticeQuestion[] = [];
+  const done: PracticeQuestion[] = [];
+  for (const question of questions) {
+    (attemptedIds.has(question.id) ? done : fresh).push(question);
+  }
+  return [...fresh, ...done];
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -17,6 +17,7 @@ import {
   buildPracticeQuestions,
   uniqueForms
 } from "../domain/sessionPools";
+import { collectAttemptedIds } from "../domain/unattempted";
 import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
 import { readStored, writeStored } from "../domain/safeStorage";
 import { copy, type Language } from "../i18n";
@@ -197,6 +198,12 @@ export function usePracticeSession({
     [progressAttempts, allKnownQuestions]
   );
 
+  // Snapshot of every question the learner has attempted, so the exam pool
+  // surfaces 新題 (unattempted) first (#385). Like reviewQueue it's fed into
+  // the pool builder but kept OUT of the `questions` memo deps below -- a fresh
+  // snapshot is captured on mode change / reset, never reshuffled mid-session.
+  const attemptedIds = useMemo(() => collectAttemptedIds(progressAttempts), [progressAttempts]);
+
   // Pool size per practice mode, shown on the mode cards so the learner
   // can see how big each bank is before picking. Static pools are
   // computed once; "basic" is intentionally omitted (its size depends on
@@ -248,7 +255,8 @@ export function usePracticeSession({
         targetForms,
         levelRange,
         reviewQueue,
-        sessionLength
+        sessionLength,
+        attemptedIds
       });
     },
     // INTENTIONALLY excluding `reviewQueue` from deps. The live queue


### PR DESCRIPTION
讓綜合＋備考 exam 模式**未做過(答0次)的題優先出現**（新題自動涵蓋），預設開、無新 UI；難度沿用現有 mode/備考 preset。prioritizeUnattempted 穩定分區、插在 shuffle 後 cap 前（capped session 先抽新題）；mock section 維持純隨機；review/今日練習不動。attemptedIds 由 progressAttempts(含同步)算、session 內快照不中途重排。無紀錄/登出＝現狀。508 測試過、build 綠。Closes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice sessions now prioritize unattempted questions first, helping learners see new items before repeats.
  * Session selection now considers past attempts when building practice question sets.

* **Bug Fixes**
  * Fixed capped practice sessions so they continue to favor unattempted questions.
  * Preserved the expected question pool when no attempt history is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->