### PR TITLE
docs: rewrite README as a product intro - #309

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,78 @@
-# Jabiko
+# Jabiko · ジャビ子
 
-Jabiko 是給《大家的日本語》學習者使用的日文變化練習網站。第一版聚焦在動詞一二三類、普通形、辭書形、否定形、過去、て形、た形、否定て形 `ないで`、否定接續 `なくて`，以及い形容詞、な形容詞、名詞型的基本變化。
+**A free, open, no-signup JLPT self-study web app.** Practice grammar, kanji
+readings, vocabulary, and mock-exam-style questions from **N5 to N1** — wrong
+answers flow into spaced-repetition review, so you keep drilling your weak
+points. Open it and practise; nothing to install, no account needed.
 
-## 開發
+> 免費、免註冊、開源的 **JLPT 日檢自習室**：N5〜N1 文法、漢字讀音、單字與依官方題型的練習，答錯自動排進間隔重複複習，跨裝置同步，打開就能練。
+
+**▶ Live: [jabiko.pages.dev](https://jabiko.pages.dev/)**
+
+![Jabiko](public/og-image.png)
+
+---
+
+## Features
+
+- **Today's practice (今日練習)** — a guided ~20-question mixed set: due reviews first, then fresh grammar / vocab, balanced for you.
+- **Exam question bank (綜合考題庫)** — ~2,000 original exam-style items across N5–N1: grammar-form choice, sentence-flow (文章脈絡), word order, kanji readings, vocabulary cloze, synonyms and usage. Level bands (N1/N2/N3/N4 備考 presets) let you dial the difficulty, and **unseen questions surface first** so new content comes up before things you've already done.
+- **Conjugation drills (基礎變化)** — verb groups, ます/て・た, negatives, adjective and noun forms, potential / volitional / passive / causative, and more.
+- **Kanji readings (漢字読み)** — an on'yomi/kun'yomi reference table (N5–N1) plus reading drills.
+- **Weak-point review (弱點複習)** — a Leitner spaced-repetition system: miss a question and it comes back on a schedule until it sticks.
+- **Grammar study pages** — jump from any grammar item to a focused note (formation, usage, examples, common confusions).
+- **Cross-device sync** — your progress follows you across devices (optional sign-in; everything works logged-out too, stored locally first).
+- **8-language UI** — Traditional Chinese, Japanese, English, Thai, Indonesian, Korean, Vietnamese, Burmese. Furigana toggle, dark / light theme.
+- **Installable PWA** — add to home screen and practise offline.
+
+## Who it's for
+
+- JLPT candidates preparing for **N5 through N1**
+- Self-learners and anyone working through **《大家的日本語》/ Minna no Nihongo**
+- Learners who want short, focused drills with automatic weak-point review
+
+## Tech stack
+
+- **React 19 + TypeScript** (strict) + **Vite 7**, tested with **Vitest 4** / jsdom
+- **Domain-driven** layout: business logic in `src/domain/`, UI in `src/components/`, hooks in `src/hooks/`
+- **PWA** via `vite-plugin-pwa` (installable + offline)
+- **Supabase** for optional cross-device sync
+- **pnpm**; deployed on **Cloudflare Pages**
+
+## Development
 
 ```bash
-rtk pnpm install
-rtk pnpm dev
-rtk pnpm test
-rtk pnpm build
+pnpm install
+pnpm dev        # local dev server
+pnpm test       # unit tests (Vitest)
+pnpm build      # typecheck + production build
+pnpm check:exam # fast content-guard check for question-bank edits
 ```
 
-## 第一版範圍
+The question bank is generated from typed data in `src/domain/exam/items/` via
+`scripts/import-exam-items.mjs`; content correctness is enforced by
+`src/domain/contentGuard.test.ts`.
 
-- Vite + React + TypeScript 前端。
-- 動詞與形容詞變化邏輯放在可測試的 TypeScript 模組。
-- 預設先進入教學環節，再切換到挑戰練習。
-- 支援單一形、て/た比較、否定整理、普通形整理等練習重點。
-- 預設使用選擇題答題，也可切換成輸入答案。
-- 介面支援繁體中文、英文、韓文切換，並記住本機偏好。
-- 預設使用深色主題，支援淺色 / 深色切換，並記住本機偏好。
-- 練習紀錄使用瀏覽器 LocalStorage。
-- 不包含登入、後端、雲端同步或 AI 解釋生成。
+## Contributing
+
+- **TDD** is the house rule: write the failing test first, then the code.
+- New question-bank content follows a batch pipeline (author → adversarial
+  double-answer / leak review → import → three content gates → PR). See
+  `CLAUDE.md` and `docs/item-quality-rubric.md`.
+- Every change lands via a PR; CI (`Test and build`) must be green before merge.
+
+## Roadmap
+
+Tracked in [GitHub Issues](https://github.com/nurockplayer/Jabiko/issues). In
+flight / planned: AI-assisted content localisation (per-locale explanations),
+a personal favourites list, more grammar study chapters (N3/N2), achievement
+badges + daily goals, and data-driven difficulty once there's enough signal.
+
+## License & credits
+
+Built by **花雪 (HanaYukii)**. The mascot ジャビ子 is Jabiko's own.
+
+> **License:** the source is public but a formal open-source license file has
+> not been added yet — see [issue tracker] before reusing the code.
+
+[issue tracker]: https://github.com/nurockplayer/Jabiko/issues


### PR DESCRIPTION
把 README 從第一版開發備忘改寫成產品介紹：一句話定位＋hero banner＋功能列表＋適合誰＋live demo＋tech stack＋開發/貢獻＋roadmap＋license/credits（並標註目前無 LICENSE 檔）。英文為主(利於 OSS 社群搜尋)＋一句繁中。純 docs、無程式影響。Closes #309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the README to present Jabiko as a free, open JLPT self-study web app.
  * Added a live app link, preview image, feature highlights, audience, tech stack, development commands, contribution guidance, roadmap, and credits.
  * Documented major user-facing capabilities like guided practice, question banks, drills, spaced repetition, multilingual UI, and offline installable use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->