### PR TITLE
fix(i18n): make the language switcher discoverable on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { ChevronDown, Languages, Moon, Sun } from "lucide-react";
+import { ChevronDown, Globe, Languages, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
@@ -292,6 +292,7 @@ export default function App() {
                 aria-haspopup="dialog"
                 onClick={() => setLangPickerOpen(true)}
               >
+                <Globe aria-hidden="true" className="lang-switch-globe" />
                 <LanguageFlag language={language} className="lang-switch-flag" />
                 <span className="lang-switch-name">{copy[language].languageName}</span>
                 <ChevronDown aria-hidden="true" className="lang-switch-caret" />

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -124,6 +124,15 @@
   white-space: nowrap;
 }
 
+/* Globe affordance for the language switcher: hidden on desktop (the flag +
+   native name already read as a language menu), shown on mobile in place of
+   the flag so the icon-only control still reads as "change language" rather
+   than a decorative national flag (#326 discoverability). */
+.lang-switch-globe {
+  display: none;
+  color: var(--teal-dark);
+}
+
 /* "New version available" toast (#327): a fixed pill at the bottom centre,
    above everything. Non-intrusive -- the learner taps it to reload when ready,
    instead of being yanked off the page mid-drill. */

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -157,8 +157,16 @@
 
   .utility-actions .toggle-text,
   .utility-actions .lang-switch-name,
-  .utility-actions .lang-switch-caret {
+  .utility-actions .lang-switch-caret,
+  .utility-actions .lang-switch-flag {
     display: none;
+  }
+
+  /* Swap the flag for a globe on mobile so the icon-only language control
+     reads as "change language" (not a decorative flag) -- first-time
+     visitors default to Japanese and need an obvious way out. */
+  .utility-actions .lang-switch-globe {
+    display: inline-flex;
   }
 
   .controls-panel,


### PR DESCRIPTION
## What

First-time visitors default to **Japanese** (`getInitialLanguage`: `?lang=` > stored > `ja`, no navigator detection). On mobile the language switcher collapsed to only the current language's national flag (#358) — a national flag reads as decoration, so a non-Japanese reader has no obvious way to switch.

## Change
Add a globe icon to the switcher:
- **Desktop:** globe hidden — the flag + native name + caret already read as a language menu (unchanged).
- **Mobile (<=560px):** globe shown in place of the flag, so the icon-only control clearly means "change language" and matches the other icon toggles.

`aria-label` and the default language are unchanged — this is discoverability only (lever 1), not a default-language change.

## Verification
- `pnpm build` OK, vitest OK 515/515
- Preview (mobile 375px, default ja): `.lang-switch-globe` display `flex`, 16px, teal; `.lang-switch-flag` display `none`. Desktop: globe `none`, flag shown. Screenshot confirms the first toggle icon is now a globe, not a national flag.
