### PR TITLE
feat(i18n): detect browser language for first-time visitors (ja fallback)

### DIFF
--- a/src/hooks/useLanguage.test.ts
+++ b/src/hooks/useLanguage.test.ts
@@ -12,15 +12,33 @@ function setLocationSearch(search: string) {
   window.location.search = search;
 }
 
-// Priority: URL ?lang= > stored > ja default (no navigator detection).
+// Override navigator.languages / navigator.language (getters on the prototype)
+// with own shadowing properties, so browser-language detection can be exercised
+// deterministically. Cleaned up in afterEach.
+function setBrowserLanguages(languages: string[]) {
+  Object.defineProperty(window.navigator, "languages", { configurable: true, get: () => languages });
+  Object.defineProperty(window.navigator, "language", { configurable: true, get: () => languages[0] });
+}
+
+function resetBrowserLanguages() {
+  Reflect.deleteProperty(window.navigator, "languages");
+  Reflect.deleteProperty(window.navigator, "language");
+}
+
+// Priority: URL ?lang= > stored > browser language (navigator) > ja fallback.
 describe("useLanguage", () => {
   beforeEach(() => {
     localStorage.clear();
+    // Default to an unsupported browser language so, unless a test opts in,
+    // detection falls through to the ja fallback.
+    setBrowserLanguages(["fr-FR"]);
   });
 
   afterEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("lang");
+    resetBrowserLanguages();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -32,7 +50,7 @@ describe("useLanguage", () => {
     expect(result.current.language).toBe("zh-Hant");
   });
 
-  it("ignores an invalid stored value and defaults to ja", () => {
+  it("ignores an invalid stored value and falls back to ja (browser unsupported)", () => {
     localStorage.setItem(KEY, "fr");
 
     const { result } = renderHook(() => useLanguage());
@@ -40,10 +58,18 @@ describe("useLanguage", () => {
     expect(result.current.language).toBe("ja");
   });
 
-  it("defaults to ja when nothing is stored", () => {
+  it("falls back to ja when nothing is stored and the browser language is unsupported", () => {
     const { result } = renderHook(() => useLanguage());
 
     expect(result.current.language).toBe("ja");
+  });
+
+  it("detects the browser language when nothing is stored (zh-TW -> zh-Hant)", () => {
+    setBrowserLanguages(["zh-TW"]);
+
+    const { result } = renderHook(() => useLanguage());
+
+    expect(result.current.language).toBe("zh-Hant");
   });
 
   it("sets document.documentElement.lang to the active language", () => {
@@ -65,14 +91,17 @@ describe("useLanguage", () => {
   });
 });
 
-describe("getInitialLanguage with URL param", () => {
+describe("getInitialLanguage priority", () => {
   beforeEach(() => {
     localStorage.clear();
+    setBrowserLanguages(["fr-FR"]); // unsupported by default
   });
 
   afterEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("lang");
+    resetBrowserLanguages();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -83,8 +112,9 @@ describe("getInitialLanguage with URL param", () => {
     expect(getInitialLanguage()).toBe("en");
   });
 
-  it("URL param wins over everything", () => {
+  it("URL param wins over stored and browser language", () => {
     localStorage.setItem(KEY, "zh-Hant");
+    setBrowserLanguages(["ja"]);
     setLocationSearch("?lang=id");
 
     expect(getInitialLanguage()).toBe("id");
@@ -109,7 +139,7 @@ describe("getInitialLanguage with URL param", () => {
     expect(getInitialLanguage()).toBe("ja");
   });
 
-  it("no stored + no ?lang= -> ja default", () => {
+  it("no stored + no ?lang= + unsupported browser -> ja fallback", () => {
     setLocationSearch("");
 
     expect(getInitialLanguage()).toBe("ja");
@@ -118,6 +148,44 @@ describe("getInitialLanguage with URL param", () => {
   it("?lang= with no value falls through to stored", () => {
     localStorage.setItem(KEY, "ja");
     setLocationSearch("?lang=");
+
+    expect(getInitialLanguage()).toBe("ja");
+  });
+
+  // ---- Browser-language detection (navigator layer) ----
+
+  it("detects a supported browser language when nothing is stored (ko-KR -> ko)", () => {
+    setLocationSearch("");
+    setBrowserLanguages(["ko-KR"]);
+
+    expect(getInitialLanguage()).toBe("ko");
+  });
+
+  it("picks the first supported entry from navigator.languages", () => {
+    setLocationSearch("");
+    setBrowserLanguages(["fr-FR", "de", "ko", "en"]);
+
+    expect(getInitialLanguage()).toBe("ko");
+  });
+
+  it("maps zh variants to zh-Hant (zh-CN -> zh-Hant)", () => {
+    setLocationSearch("");
+    setBrowserLanguages(["zh-CN"]);
+
+    expect(getInitialLanguage()).toBe("zh-Hant");
+  });
+
+  it("stored preference wins over the browser language", () => {
+    localStorage.setItem(KEY, "th");
+    setLocationSearch("");
+    setBrowserLanguages(["ja"]);
+
+    expect(getInitialLanguage()).toBe("th");
+  });
+
+  it("falls back to ja when the browser language is unsupported (fr -> ja)", () => {
+    setLocationSearch("");
+    setBrowserLanguages(["fr-FR"]);
 
     expect(getInitialLanguage()).toBe("ja");
   });

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -36,13 +36,36 @@ function urlLanguage(): Language | null {
   return languageFromSearch(window.location.search);
 }
 
-// Priority: URL ?lang= > stored > ja (no navigator detection).
+// Best supported match from the browser's preferred languages (navigator),
+// in the browser's own priority order. Returns null when none of the
+// browser's languages map to one we ship -- callers then fall back to ja.
+function navigatorLanguage(): Language | null {
+  if (typeof navigator === "undefined") return null;
+  const tags =
+    navigator.languages && navigator.languages.length > 0
+      ? navigator.languages
+      : navigator.language
+        ? [navigator.language]
+        : [];
+  for (const tag of tags) {
+    const mapped = languageForTag(tag);
+    if (mapped) return mapped;
+  }
+  return null;
+}
+
+// Priority: URL ?lang= > stored preference > browser language > ja fallback.
+// ja is the deliberate fallback (Japanese-language-school audience) for
+// visitors whose browser language we don't ship.
 export function getInitialLanguage(): Language {
   const fromUrl = urlLanguage();
   if (fromUrl) return fromUrl;
 
   const stored = readStored(LANGUAGE_STORAGE_KEY);
   if (isSupportedLanguage(stored)) return stored;
+
+  const fromNavigator = navigatorLanguage();
+  if (fromNavigator) return fromNavigator;
 
   return "ja";
 }


### PR DESCRIPTION
## What

First-time visitors previously always landed in **Japanese** — `getInitialLanguage` resolved `?lang=` > stored > hardcoded `ja`, with no browser detection. Now it detects the browser language, keeping Japanese as the fallback.

New priority: **`?lang=` > stored preference > browser language > `ja`**.

`navigatorLanguage()` reads `navigator.languages` (or `navigator.language`) and maps each tag through the existing `languageForTag()` prefix matcher, taking the first supported match. `ja` stays the deliberate fallback for browser languages we don't ship (Japanese-language-school audience). The detected language is **not persisted** — only explicit URL / user choices are stored.

## Why
Default-Japanese was intentional for the JP-language-school market, but a beginner whose browser isn't Japanese landed in a wall of Japanese with the switcher hard to find. Detection serves the right language automatically; unsupported languages still fall back to Japanese, so the market intent is preserved. This is silent detection, **not** the removed #329 blocking first-visit picker.

## Verification
- `pnpm build` OK, vitest OK **521/521** (useLanguage.test.ts: 18, incl. new navigator-layer cases — zh-TW -> zh-Hant, ko-KR -> ko, first-supported-of-many, stored-wins, unsupported -> ja).
- Live preview: a `zh-TW` browser with no stored pref now renders `zh-Hant` (`document.documentElement.lang === "zh-Hant"`, `jabiko.lang` unset) — previously forced `ja`.
- Adversarial review (2 lenses: correctness/edge-cases + regression/product-intent) returned no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language selection now considers your browser’s preferred language when no URL language or saved preference is available.
  * Supported browser languages can now be detected from browser settings, including the first matching language in a preferred-language list.

* **Bug Fixes**
  * Improved language fallback behavior so unsupported or invalid saved settings no longer override a valid default.
  * `zh-*` browser language variants now map more reliably to Traditional Chinese language support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->