### PR TITLE
a11y(nav): mark the active top-nav tab with aria-current

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -76,6 +76,25 @@ describe("App", () => {
     expect(screen.queryByRole("heading", { name: "一章一章解鎖" })).not.toBeInTheDocument();
   });
 
+  it("marks the active nav tab with aria-current=page and moves it on navigation", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const nav = screen.getByRole("navigation", { name: "學習流程" });
+    // Default view is home -> 首頁 is the current page, and the only one.
+    expect(screen.getByRole("button", { name: "首頁" })).toHaveAttribute("aria-current", "page");
+    expect(
+      within(nav)
+        .getAllByRole("button")
+        .filter((button) => button.getAttribute("aria-current") === "page")
+    ).toHaveLength(1);
+
+    // Navigating moves aria-current to the new tab and clears the old one.
+    await user.click(screen.getByRole("button", { name: "規則表" }));
+    expect(screen.getByRole("button", { name: "規則表" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "首頁" })).not.toHaveAttribute("aria-current");
+  });
+
   it("opens the rules reference page after clicking the 規則表 tab", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -320,6 +320,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "home" ? "selected" : ""}
+          aria-current={appView === "home" ? "page" : undefined}
           onClick={() => setAppView("home")}
         >
           {t.home}
@@ -327,6 +328,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "learn" ? "selected" : ""}
+          aria-current={appView === "learn" ? "page" : undefined}
           onClick={() => setAppView("learn")}
         >
           {t.learn}
@@ -334,6 +336,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "rules" ? "selected" : ""}
+          aria-current={appView === "rules" ? "page" : undefined}
           onClick={() => setAppView("rules")}
         >
           {t.rules}
@@ -341,6 +344,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "kanji" ? "selected" : ""}
+          aria-current={appView === "kanji" ? "page" : undefined}
           onClick={() => setAppView("kanji")}
         >
           {t.kanji}
@@ -348,6 +352,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "challenge" ? "selected" : ""}
+          aria-current={appView === "challenge" ? "page" : undefined}
           onClick={() => openChallenge({ mode: "daily" })}
         >
           {t.challenge}
@@ -355,6 +360,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "mock" ? "selected" : ""}
+          aria-current={appView === "mock" ? "page" : undefined}
           onClick={() => setAppView("mock")}
         >
           {t.mockExam}
@@ -362,6 +368,7 @@ export default function App() {
         <button
           type="button"
           className={appView === "about" ? "selected" : ""}
+          aria-current={appView === "about" ? "page" : undefined}
           onClick={() => setAppView("about")}
         >
           {t.about}


### PR DESCRIPTION
## What

Add `aria-current="page"` to the active top-nav tab. The active state previously read as "you are here" only via the matcha background (`.segmented button.selected`) — a colour-only cue that screen readers don't announce (and a WCAG 1.4.1 smell).

- `aria-current="page"` on the active button, `undefined` (attribute absent) when inactive.
- Styling stays on `.selected` — this is purely an additive accessibility attribute, **no visual change**.

This is item (a) of the nav-polish set. Items (b) de-emphasise "reference" tabs and (c) mobile horizontal-scroll were assessed and **deliberately skipped** (the practice/reference split miscategorises 漢字 — a real feature — and interleaves in DOM order; horizontal scroll hides tabs). Routed to the #361 UI umbrella as discussion, not shipped.

## Verification
- `pnpm build` OK, vitest OK **522/522**.
- New App test: asserts exactly one nav tab has `aria-current="page"`, and that it moves to the new tab (and clears the old) on navigation.
- No observable visual change, so no browser screenshot needed.
