### PR TITLE
a11y(headings): one h1 per view (keep grammar surface as its page h1)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -95,6 +95,33 @@ describe("App", () => {
     expect(screen.getByRole("button", { name: "首頁" })).not.toHaveAttribute("aria-current");
   });
 
+  it("home has a single h1 (the persistent app title); the hero is demoted to h2", () => {
+    render(<App />);
+
+    const h1s = screen.getAllByRole("heading", { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent("Jabiko");
+    // The hero heading stays visible but is now a level-2 heading.
+    expect(screen.getByRole("heading", { name: "今天想練什麼？", level: 2 })).toBeInTheDocument();
+  });
+
+  it("grammar route: the single h1 is the grammar surface, and the app title yields to h2", async () => {
+    const { allGrammarSurfaces } = await import("./domain/grammarPoints");
+    const surface = allGrammarSurfaces()[0];
+    window.history.replaceState({}, "", `/grammar/${encodeURIComponent(surface)}`);
+    render(<App />);
+
+    await screen.findByRole("heading", { name: surface, level: 1 });
+    // Exactly one h1 on the SEO landing page, and it's the page-specific surface.
+    const h1s = screen.getAllByRole("heading", { level: 1 });
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0]).toHaveTextContent(surface);
+    // The persistent app title is still present, but demoted to h2 on this route.
+    expect(screen.getByRole("heading", { name: /Jabiko/, level: 2 })).toBeInTheDocument();
+
+    window.history.replaceState({}, "", "/");
+  });
+
   it("opens the rules reference page after clicking the 規則表 tab", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -247,7 +247,16 @@ export default function App() {
           <JabikoMark className="app-brand-mark" />
           <div>
             <p className="eyebrow">Your JLPT self-study room.</p>
-            <h1>{t.appTitle}</h1>
+            {/* The persistent brand title is the site's single h1 -- except on
+                the /grammar/<surface> SEO landing route, where the grammar
+                surface is the page-specific h1, so the brand title yields to h2
+                to keep exactly one h1 per view. Styling rides the .app-title
+                class, not the tag, so the level change is purely semantic. */}
+            {appView === "grammar" ? (
+              <h2 className="app-title">{t.appTitle}</h2>
+            ) : (
+              <h1 className="app-title">{t.appTitle}</h1>
+            )}
           </div>
         </div>
         <div className="heading-actions">

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -15,7 +15,7 @@ export function AboutPanel({ language }: { language: Language }) {
       <header className="about-hero">
         <JabikoMark className="about-hero-mark" />
         <p className="eyebrow">{t.about}</p>
-        <h1>{t.aboutTitle}</h1>
+        <h2>{t.aboutTitle}</h2>
         <p className="about-tagline">{t.aboutTagline}</p>
       </header>
 

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -233,7 +233,7 @@ export function HomePanel({
         />
         <div className="home-hero-text">
           <p className="home-hero-kicker">{t.homeHeroKicker}</p>
-          <h1>{t.homeHeroTitle}</h1>
+          <h2>{t.homeHeroTitle}</h2>
           <p>{t.homeHeroIntro}</p>
           <a
             className="home-hero-guide"

--- a/src/components/RulesPanel.tsx
+++ b/src/components/RulesPanel.tsx
@@ -13,7 +13,7 @@ export function RulesPanel({ language }: { language: Language }) {
       <header className="rules-header">
         <BrushSpot className="panel-header-spot" />
         <p className="eyebrow">{t.rulesEyebrow}</p>
-        <h1>{t.rulesPanelTitle}</h1>
+        <h2>{t.rulesPanelTitle}</h2>
         <p>{t.rulesPanelIntro}</p>
       </header>
       {CONJUGATION_TABLES.map((table) => (

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -23,7 +23,7 @@
   height: 116px;
 }
 
-.about-hero h1 {
+.about-hero h2 {
   margin: 0;
   font-size: 1.6rem;
   color: var(--ink);

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -281,7 +281,7 @@
   text-transform: uppercase;
 }
 
-.home-hero-text h1 {
+.home-hero-text h2 {
   margin: 0;
   font-size: clamp(1.6rem, 3vw, 2.1rem);
   color: var(--ink);

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -12,7 +12,7 @@
   max-width: 1220px;
 }
 
-.app-heading h1,
+.app-heading .app-title,
 .app-heading p,
 .brand-lockup p,
 .brand-lockup h2,
@@ -34,7 +34,7 @@
   width: 3rem;
 }
 
-.app-heading h1 {
+.app-heading .app-title {
   color: var(--ink);
   font-family: var(--font-title);
   font-size: 2rem;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -93,7 +93,7 @@
     padding: 0.75rem;
   }
 
-  .app-heading h1 {
+  .app-heading .app-title {
     font-size: 1.65rem;
   }
 

--- a/src/styles/rules.css
+++ b/src/styles/rules.css
@@ -134,7 +134,7 @@
   font-size: 0.78rem;
 }
 
-.rules-header h1 {
+.rules-header h2 {
   margin: 0;
   font-family: var(--font-japanese-display);
   font-size: clamp(1.7rem, 3vw, 2.2rem);


### PR DESCRIPTION
## What

Fix the heading outline so every view has exactly one `<h1>` (semantic only — **zero visual change**).

home / about / rules each rendered a second `<h1>` (the panel hero) on top of the persistent app-title `<h1>`, so those views had two competing top-level headings — a document-outline / screen-reader smell. Now:

- **home / 關於 / rules** panel headings demoted `<h1>` → `<h2>`; the persistent app-title stays the single site `<h1>`.
- **/grammar/&lt;surface&gt;** (SEO landing route): the grammar surface stays the page-specific `<h1>` and the app-title yields to `<h2>`, so that route has exactly one h1 and it describes the page (SEO flywheel #281). The existing `GrammarPointPage` "surface is an h1" test stays green.
- Styling unchanged: the app-title now rides an `.app-title` class (CSS targets the class, not the tag), and the three panel-heading selectors switch `h1`→`h2` — every heading keeps its exact size/weight/colour.

Decided via a 3-lens review (a11y / SEO / minimal-impl) → hybrid (app-title as sole h1 except the grammar route). Item #3 of the polish set.

## Verification
- `pnpm build` OK, vitest OK **526/526** (2 new App tests: home has one h1 = app title, hero is h2; grammar route has one h1 = surface, app title is h2).
- Preview inspect: `.app-title` renders 2rem desktop / 1.65rem mobile (unchanged); home hero `<h2>` renders at the same clamp size/colour (unchanged). Purely semantic — no visual diff.
