### PR TITLE
a11y(toggles): full 44px tap target for the mobile header toggles

### DIFF
--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -151,7 +151,13 @@
   }
 
   .utility-actions .theme-toggle {
+    /* Icon-only on mobile, so pin the hit area to a full 44px WCAG 2.5.5
+       target (the global button min-height already gives 44px tall; this
+       closes the width axis, 38px -> 44px). box-sizing:border-box keeps the
+       0.62rem padding inside the 44px, so the icon just centers -- no visual
+       bloat, desktop (labelled, wider) never hits this breakpoint. */
     gap: 0;
+    min-width: 44px;
     padding-inline: 0.62rem;
   }
 


### PR DESCRIPTION
## What

Give the mobile header toggles (language / furigana / theme) a full **44×44** tap target.

On mobile they collapse to icon-only and measured **38px wide × 44px tall**. The global `button` `min-height` already provides the 44px height (WCAG 2.5.8 AA passes at 24px); only the width missed WCAG 2.5.5 AAA (44×44). Added `min-width: 44px` to the mobile `.utility-actions .theme-toggle` rule so all three (incl. the globe language button) become a true 44×44 target.

`box-sizing: border-box` keeps the existing `0.62rem` padding inside the 44px, so the 16px icon just centers — no visual bloat — and the rule is scoped to the `≤560px` breakpoint, so desktop (labelled, wider) is untouched.

**The paired `title` tooltip idea was deliberately dropped** (two independent reviews agreed): it duplicates the existing `aria-label`s (double-announcement smell in NVDA/JAWS) and never renders on the only surface lacking a visible label — mobile touch has no hover.

## Verification
- `pnpm build` OK, vitest OK **526/526** (CSS-only; jsdom has no layout engine so tap-size isn't unit-testable — verified live instead).
- Preview (mobile 375px): all three toggles render **44×44**; the row still fits one line (right edge 363px ≤ 375px, no wrap). Desktop unaffected (media-scoped).

Item #4/#5 of the polish set — completes the set (#1 aria-current, #2 grid label, #3 single-h1, #4/#5 tap target).
