### PR TITLE
fix: move GEMINI_API_KEY from URL param to header, pin action SHA

### DIFF
--- a/.github/workflows/ai-i18n-translation.yml
+++ b/.github/workflows/ai-i18n-translation.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ inputs.dryRun == false }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: ai/i18n-${{ inputs.locale }}-${{ inputs.level }}-${{ github.run_id }}
           title: "i18n: ${{ inputs.locale }} ${{ inputs.level }} explanation translations (Gemini)"

--- a/scripts/ai-translate-content.mjs
+++ b/scripts/ai-translate-content.mjs
@@ -237,10 +237,10 @@ export function parseGeminiJson(raw) {
 }
 
 async function callGemini({ apiKey, model, prompt }) {
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "x-goog-api-key": apiKey, "content-type": "application/json" },
     body: JSON.stringify({
       contents: [{ parts: [{ text: prompt }] }],
       generationConfig: { temperature: 0, responseMimeType: "application/json" }


### PR DESCRIPTION
## Summary

Two minimal security fixes on top of the existing #378 pipeline (already on `main`):

1. **scripts/ai-translate-content.mjs** — Replace `?key=GEMINI_API_KEY` URL query param with `x-goog-api-key` HTTP header. Query params leak into proxy/server logs; headers don't.

2. **.github/workflows/ai-i18n-translation.yml** — Pin `peter-evans/create-pull-request@v7` to its commit SHA for supply-chain integrity.

## Test plan
- [x] `pnpm typecheck` ✅
- [x] `pnpm test` (52 files, 522 tests) ✅
- [x] `pnpm build` ✅

## Notes
- Codex post-diff review requested but timed out — 2-line change, low risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and security of automated translation-related updates by using a more stable integration setup.
  * Updated API authentication handling so requests are sent in a safer, more standard way.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->