### PR TITLE
feat(i18n): read exam prompt fields through per-locale overlays (#400 read-path)

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { ExamPrompt } from "./ExamPrompt";
+import type { PracticeQuestion } from "../domain/types";
 import { FuriganaContext } from "./furiganaContext";
 import { examStyleQuestions } from "../domain/examBlocks";
 import { buildClozeQuestionPool } from "../domain/cloze";
@@ -146,5 +147,73 @@ describe("ExamPrompt furigana (#134)", () => {
     const { container } = renderOn(grammarReading);
     const readings = Array.from(container.querySelectorAll(".exam-prompt rt")).map((n) => n.textContent);
     expect(readings).toContain("がっこう");
+  });
+});
+
+describe("ExamPrompt content localization (#400)", () => {
+  // A cloze-style item whose vocab row IS shown (surface not in answers, no
+  // exam_style / sentence_pattern tag) so the instruction / hint / meaning all
+  // render, letting us assert the per-locale overlays with a Chinese fallback.
+  const makeQuestion = (overrides: Partial<PracticeQuestion> = {}): PracticeQuestion => ({
+    id: "loc-1",
+    vocabulary: {
+      id: "loc-1",
+      surface: "待つ",
+      reading: "まつ",
+      meaningZh: "等待",
+      meaningI18n: { en: "to wait" },
+      partOfSpeech: "verb",
+      group: null,
+      lesson: null,
+      tags: [],
+      examples: []
+    },
+    targetForm: "reading",
+    expectedAnswers: ["待って"],
+    explanation: "解說",
+    promptLabel: "句中填空",
+    promptText: "ちょっと ___ ください。",
+    promptContextZh: "情境中文",
+    promptContextI18n: { en: "English context" },
+    hintZh: "提示中文",
+    hintI18n: { en: "English hint" },
+    instructionZh: "說明中文",
+    instructionI18n: { en: "English instruction" },
+    options: ["待って", "待つ", "待ち", "待った"],
+    ...overrides
+  });
+
+  it("renders the instruction in the target locale when an overlay exists", () => {
+    render(<ExamPrompt question={makeQuestion()} language="en" />);
+    expect(screen.getByText("English instruction")).toBeInTheDocument();
+    expect(screen.queryByText("說明中文")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the Chinese instruction when the locale has no overlay", () => {
+    render(<ExamPrompt question={makeQuestion({ instructionI18n: { ja: "x" } })} language="en" />);
+    expect(screen.getByText("說明中文")).toBeInTheDocument();
+  });
+
+  it("localizes the pre-answer hint once revealed", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<ExamPrompt question={makeQuestion()} language="en" />);
+    await user.click(container.querySelector(".hint-toggle") as HTMLElement);
+    expect(screen.getByText("English hint")).toBeInTheDocument();
+    expect(screen.queryByText("提示中文")).not.toBeInTheDocument();
+  });
+
+  it("localizes the vocab-row meaning, falling back to Chinese when the overlay is absent", () => {
+    // The vocab row is a single <p> "surface・reading・meaning", so assert on
+    // its combined text content rather than an exact-text element match.
+    const { container, unmount } = render(<ExamPrompt question={makeQuestion()} language="en" />);
+    const row = container.querySelector("p.reading");
+    expect(row?.textContent).toContain("to wait");
+    expect(row?.textContent).not.toContain("等待");
+    unmount();
+
+    const noOverlay = makeQuestion();
+    noOverlay.vocabulary = { ...noOverlay.vocabulary, meaningI18n: undefined };
+    const { container: c2 } = render(<ExamPrompt question={noOverlay} language="en" />);
+    expect(c2.querySelector("p.reading")?.textContent).toContain("等待");
   });
 });

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { GraduationCap } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
+import { pickLocalized } from "../domain/localizedContent";
 import { shuffleOrderFragments } from "../domain/wordOrder";
 import { isReadingPrompt } from "../domain/furigana";
 import { Ruby } from "./Ruby";
@@ -45,7 +46,23 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
   // to the full translation for items that haven't been audited yet
   // (legacy exam items). The full translation still appears in the
   // FeedbackPanel post-answer via vocabulary.examples[0].meaningZh.
-  const preAnswerHint = question.hintZh ?? question.promptContextZh;
+  // Each Chinese field is read through its per-locale overlay (#400) so a
+  // non-Chinese learner sees the target language, falling back to zh source.
+  const localizedHint = question.hintZh
+    ? pickLocalized(question.hintZh, question.hintI18n, language)
+    : undefined;
+  const localizedContext = question.promptContextZh
+    ? pickLocalized(question.promptContextZh, question.promptContextI18n, language)
+    : undefined;
+  const preAnswerHint = localizedHint ?? localizedContext;
+  const instruction = question.instructionZh
+    ? pickLocalized(question.instructionZh, question.instructionI18n, language)
+    : question.instructionZh;
+  const meaning = pickLocalized(
+    question.vocabulary.meaningZh,
+    question.vocabulary.meaningI18n,
+    language
+  );
   // 語順組合 prompts list their fragments in answer order (［a / b / c / d］),
   // which spells out the answer. Shuffle them at render time (seeded by id so
   // it's stable and never reshuffles mid-question). Other labels render as-is.
@@ -57,7 +74,7 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
     <>
       <p className="word-kind">
         <GraduationCap aria-hidden="true" />
-        {question.instructionZh}
+        {instruction}
       </p>
       <p className="exam-prompt">
         {promptText ? (
@@ -82,7 +99,7 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
       ) : null}
       {showVocabRow ? (
         <p className="reading">
-          {question.vocabulary.surface}・{question.vocabulary.reading}・{question.vocabulary.meaningZh}
+          {question.vocabulary.surface}・{question.vocabulary.reading}・{meaning}
         </p>
       ) : null}
     </>

--- a/src/domain/exam/helpers.ts
+++ b/src/domain/exam/helpers.ts
@@ -9,6 +9,7 @@ export function examQuestion(input: ExamQuestionInput): PracticeQuestion {
       surface: input.surface,
       reading: input.reading,
       meaningZh: input.meaningZh,
+      meaningI18n: input.meaningI18n,
       partOfSpeech: "noun",
       group: null,
       lesson: null,
@@ -28,8 +29,11 @@ export function examQuestion(input: ExamQuestionInput): PracticeQuestion {
     promptLabel: input.promptLabel,
     promptText: input.promptText,
     promptContextZh: input.promptContextZh,
+    promptContextI18n: input.promptContextI18n,
     hintZh: input.hintZh,
+    hintI18n: input.hintI18n,
     instructionZh: input.instructionZh,
+    instructionI18n: input.instructionI18n,
     options: input.options
   };
 }

--- a/src/domain/exam/types.ts
+++ b/src/domain/exam/types.ts
@@ -6,11 +6,17 @@ export type ExamQuestionInput = {
   surface: string;
   reading: string;
   meaningZh: string;
+  /** Per-locale `meaningZh` overlay (#400); AI translation writes only this. */
+  meaningI18n?: LocalizedText;
   targetForm?: TargetForm;
   promptLabel: string;
   instructionZh: string;
+  /** Per-locale `instructionZh` overlay (#400). */
+  instructionI18n?: LocalizedText;
   promptText: string;
   promptContextZh: string;
+  /** Per-locale `promptContextZh` overlay (#400). */
+  promptContextI18n?: LocalizedText;
   /**
    * Pre-answer neutral situation hint. Optional during the staged
    * audit -- items without it fall back to promptContextZh (which
@@ -18,6 +24,8 @@ export type ExamQuestionInput = {
    * should never go back to nullable hintZh.
    */
   hintZh?: string;
+  /** Per-locale `hintZh` overlay (#400). */
+  hintI18n?: LocalizedText;
   expectedAnswer: string;
   options: string[];
   explanation: string;

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -51,6 +51,8 @@ export interface VocabularyItem {
   surface: string;
   reading: string;
   meaningZh: string;
+  /** Per-locale translations of `meaningZh`; falls back to the zh source (#378/#400). */
+  meaningI18n?: LocalizedText;
   partOfSpeech: PartOfSpeech;
   group: VerbGroup | null;
   lesson: number | null;
@@ -82,6 +84,8 @@ export interface PracticeQuestion {
    * which is why pre-answer display switched from this to `hintZh`.
    */
   promptContextZh?: string;
+  /** Per-locale translations of `promptContextZh`; falls back to the zh source (#400). */
+  promptContextI18n?: LocalizedText;
   /**
    * Pre-answer "neutral situation" hint shown above the prompt. Should
    * describe WHO/WHERE/WHAT the context is without naming the answer's
@@ -89,7 +93,11 @@ export interface PracticeQuestion {
    * compatibility shim for items that haven't been audited yet.
    */
   hintZh?: string;
+  /** Per-locale translations of `hintZh`; falls back to the zh source (#400). */
+  hintI18n?: LocalizedText;
   instructionZh?: string;
+  /** Per-locale translations of `instructionZh`; falls back to the zh source (#400). */
+  instructionI18n?: LocalizedText;
   options?: string[];
 }
 


### PR DESCRIPTION
## What

The display half of #400: read the exam **prompt** Chinese fields through per-locale overlays with a Chinese fallback, so non-Chinese learners stop seeing Chinese instruction / hint / context / word-meaning once translations exist.

- `types.ts`: `VocabularyItem.meaningI18n` + `PracticeQuestion.{promptContextI18n,hintI18n,instructionI18n}` (optional `LocalizedText`).
- `exam/types.ts`: matching overlay fields on `ExamQuestionInput`.
- `exam/helpers.ts`: thread the overlays through the `examQuestion` factory.
- `ExamPrompt.tsx`: render instruction, the pre-answer hint/context, and the vocab-row meaning via `pickLocalized(source, overlay, language)`.

**Purely additive + display-only.** No answer logic touched — `expectedAnswers`, conjugation `answers`, the contentGuard tokenization and `patternMeaning` keys all keep reading the Chinese source. No visible change until overlays are generated.

## Context (foreign-user feedback → #400)
Verified live in English: UI chrome is fully translated, but exam-content fields render in Chinese. This PR is the read-path; the Gemini generation that fills the overlays is a follow-up PR + a manual workflow run (owner-triggered, `ja`/`en` first).

## Deferred follow-ups
- The `ai-translate-content.mjs` multi-field + context-prompt extension (PR B).
- FeedbackPanel example-sentence gloss (`ExampleSentence.meaningZh`).
- The vocab-bank `meaningZh` display (the 単字讀音 case — Track 2).

## Verification
- `pnpm build` OK, vitest OK **530/530** (4 new ExamPrompt tests: localized instruction / hint / vocab-meaning + Chinese fallback; existing answer-leak-guard + furigana tests still green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized display support for exam prompts, hints, and vocabulary meanings across available languages.
  * When a translation is unavailable, the app now falls back to the Chinese content automatically.

* **Bug Fixes**
  * Improved consistency in exam content rendering so localized text appears in the right places, including after revealing hints.
  * Updated coverage to verify localization and fallback behavior for prompt instructions and vocabulary meanings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->