### PR TITLE
fix(i18n): nullish semantics on exam prompt overlay fallback (#401 follow-up)

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -216,4 +216,25 @@ describe("ExamPrompt content localization (#400)", () => {
     const { container: c2 } = render(<ExamPrompt question={noOverlay} language="en" />);
     expect(c2.querySelector("p.reading")?.textContent).toContain("等待");
   });
+
+  it("falls back to the localized promptContextZh hint when there is no hintZh", async () => {
+    const user = userEvent.setup();
+    const q = makeQuestion({ hintZh: undefined, hintI18n: undefined });
+    const { container } = render(<ExamPrompt question={q} language="en" />);
+    await user.click(container.querySelector(".hint-toggle") as HTMLElement);
+    expect(screen.getByText("English context")).toBeInTheDocument();
+    expect(screen.queryByText("情境中文")).not.toBeInTheDocument();
+  });
+
+  it("an empty-string hintZh suppresses the hint instead of leaking promptContextZh", () => {
+    // Regression guard (Codex must-fix): a nullish -- not truthy -- check means
+    // an authored empty hint is "no hint", NOT a fall-through to the
+    // answer-leaky promptContextZh.
+    const { container } = render(
+      <ExamPrompt question={makeQuestion({ hintZh: "", hintI18n: undefined })} language="en" />
+    );
+    expect(container.querySelector(".hint-toggle")).toBeNull();
+    expect(screen.queryByText("English context")).not.toBeInTheDocument();
+    expect(screen.queryByText("情境中文")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { GraduationCap } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
-import { pickLocalized } from "../domain/localizedContent";
+import { pickLocalized, pickLocalizedOptional } from "../domain/localizedContent";
 import { shuffleOrderFragments } from "../domain/wordOrder";
 import { isReadingPrompt } from "../domain/furigana";
 import { Ruby } from "./Ruby";
@@ -48,16 +48,17 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
   // FeedbackPanel post-answer via vocabulary.examples[0].meaningZh.
   // Each Chinese field is read through its per-locale overlay (#400) so a
   // non-Chinese learner sees the target language, falling back to zh source.
-  const localizedHint = question.hintZh
-    ? pickLocalized(question.hintZh, question.hintI18n, language)
-    : undefined;
-  const localizedContext = question.promptContextZh
-    ? pickLocalized(question.promptContextZh, question.promptContextI18n, language)
-    : undefined;
+  // pickLocalizedOptional keeps NULLISH (not truthy) semantics so an authored
+  // empty hint still suppresses via `hint ?? context` instead of falling
+  // through to the answer-leaky promptContextZh.
+  const localizedHint = pickLocalizedOptional(question.hintZh, question.hintI18n, language);
+  const localizedContext = pickLocalizedOptional(
+    question.promptContextZh,
+    question.promptContextI18n,
+    language
+  );
   const preAnswerHint = localizedHint ?? localizedContext;
-  const instruction = question.instructionZh
-    ? pickLocalized(question.instructionZh, question.instructionI18n, language)
-    : question.instructionZh;
+  const instruction = pickLocalizedOptional(question.instructionZh, question.instructionI18n, language);
   const meaning = pickLocalized(
     question.vocabulary.meaningZh,
     question.vocabulary.meaningI18n,

--- a/src/domain/localizedContent.test.ts
+++ b/src/domain/localizedContent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pickLocalized } from "./localizedContent";
+import { pickLocalized, pickLocalizedOptional } from "./localizedContent";
 
 describe("pickLocalized", () => {
   const zh = "這題在問動詞的て形。";
@@ -25,5 +25,23 @@ describe("pickLocalized", () => {
 
   it("uses the source for the source locale itself", () => {
     expect(pickLocalized(zh, { en: "x" }, "zh-Hant")).toBe(zh);
+  });
+});
+
+describe("pickLocalizedOptional", () => {
+  it("returns undefined when the source field is absent (nullish)", () => {
+    expect(pickLocalizedOptional(undefined, { en: "hint" }, "en")).toBeUndefined();
+  });
+
+  it("localizes a present source, falling back to the zh source", () => {
+    expect(pickLocalizedOptional("提示", { en: "hint" }, "en")).toBe("hint");
+    expect(pickLocalizedOptional("提示", undefined, "en")).toBe("提示");
+  });
+
+  it("keeps an empty-string source as present (nullish check, NOT truthy)", () => {
+    // "" is a real (empty) authored value, not an absent field, so it must
+    // NOT collapse to undefined -- otherwise an empty hint would wrongly fall
+    // through to the answer-leaky promptContextZh fallback.
+    expect(pickLocalizedOptional("", undefined, "en")).toBe("");
   });
 });

--- a/src/domain/localizedContent.ts
+++ b/src/domain/localizedContent.ts
@@ -14,3 +14,19 @@ export function pickLocalized(
   const value = overlay?.[lang];
   return typeof value === "string" && value.trim() !== "" ? value : source;
 }
+
+/**
+ * Same as {@link pickLocalized} but for OPTIONAL source fields (e.g. hintZh,
+ * instructionZh, promptContextZh). Returns `undefined` only when the source is
+ * genuinely absent (null/undefined) -- an empty string is a real value and is
+ * kept, so a nullish (not truthy) fallback chain like
+ * `hint ?? context` preserves its original semantics: an authored empty hint
+ * suppresses rather than falling through to the (answer-leaky) context.
+ */
+export function pickLocalizedOptional(
+  source: string | undefined,
+  overlay: LocalizedText | undefined,
+  lang: LocaleCode
+): string | undefined {
+  return source == null ? undefined : pickLocalized(source, overlay, lang);
+}


### PR DESCRIPTION
## What

Follow-up to #401, fixing a latent regression a **Codex review flagged as must-fix**.

The #400 read-path replaced `hintZh ?? promptContextZh` (nullish) with a **truthy** check (`hintZh ? … : undefined`). For an authored **empty-string** `hintZh`, the truthy version falls through to `promptContextZh` — a field documented as possibly leaking the answer. No item currently has `hintZh: ""`, so it never fires, but it's a latent **answer-leak** regression and a behaviour change from the original.

## Fix
Restore nullish semantics via a small extracted helper (also the extraction CodeRabbit suggested):

- `pickLocalizedOptional(source, overlay, lang)` — returns `undefined` **only** for a nullish source; an empty string is a real value and is kept, so `hint ?? context` behaves exactly like before.
- `ExamPrompt` reads hint / context / instruction through it.

## Tests (both reviewers flagged the coverage gap)
5 new tests: `pickLocalizedOptional` nullish/empty/present, the `promptContextZh` fallback path (previously untested), and an empty-hint **suppression regression guard**.

## Verification
- `pnpm build` OK, vitest OK **535/535**.
