### PR TITLE
feat(i18n): extend Gemini translate script to all exam content fields (#400)

### DIFF
--- a/.github/workflows/ai-i18n-translation.yml
+++ b/.github/workflows/ai-i18n-translation.yml
@@ -1,9 +1,10 @@
 name: AI i18n Translation
 
-# Manual, small-batch, PR-only AI-assisted translation of exam content (#378).
-# Generates a per-locale `explanationI18n` overlay with Gemini and opens a PR
-# for human review. It never auto-merges, never pushes to main, and never
-# touches protected fields (the script only adds/merges the overlay).
+# Manual, small-batch, PR-only AI-assisted translation of exam content (#378/#400).
+# Generates per-locale content overlays (meaning / instruction / context / hint /
+# explanation) with Gemini and opens a PR for human review. It never auto-merges,
+# never pushes to main, and never touches protected fields (the script only
+# adds/merges the `<field>I18n` overlays).
 #
 # Requires repository secret GEMINI_API_KEY, and (for the PR step) the repo
 # setting "Allow GitHub Actions to create and approve pull requests".
@@ -75,8 +76,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           branch: ai/i18n-${{ inputs.locale }}-${{ inputs.level }}-${{ github.run_id }}
-          title: "i18n: ${{ inputs.locale }} ${{ inputs.level }} explanation translations (Gemini)"
-          commit-message: "i18n: add ${{ inputs.locale }} ${{ inputs.level }} explanation overlay (Gemini)"
+          title: "i18n: ${{ inputs.locale }} ${{ inputs.level }} content translations (Gemini)"
+          commit-message: "i18n: add ${{ inputs.locale }} ${{ inputs.level }} content overlays (Gemini)"
           body-path: .tmp/i18n-summary.md
           add-paths: src/domain/exam/items/*.ts
           labels: i18n, ai-generated

--- a/scripts/ai-translate-content.mjs
+++ b/scripts/ai-translate-content.mjs
@@ -1,32 +1,32 @@
 #!/usr/bin/env node
 // =============================================================================
-// ai-translate-content.mjs -- Gemini-assisted exam-content translation (#378)
+// ai-translate-content.mjs -- Gemini-assisted exam-content translation (#378/#400)
 // =============================================================================
 //
-// Reads exam items, finds ones missing a per-locale `explanationI18n` overlay
-// for the target locale, asks Gemini for STRICT JSON translations, validates
-// them hard, and writes ONLY the `explanationI18n` overlay back into the item
-// file. It never touches protected fields (id / expectedAnswer / options /
+// Reads exam items and, for the target locale, finds the Chinese content fields
+// that are still missing a per-locale overlay, asks Gemini for STRICT JSON
+// translations (using the question's Japanese prompt / answer / options as
+// context so the result reads NATURALLY, not word-for-word), validates them
+// hard, and writes ONLY the `<field>I18n` overlays back into the item file.
+//
+// Translatable fields (source -> overlay):
+//   meaningZh       -> meaningI18n
+//   instructionZh   -> instructionI18n
+//   promptContextZh -> promptContextI18n
+//   hintZh          -> hintI18n
+//   explanation     -> explanationI18n
+//
+// It NEVER touches protected fields (id / expectedAnswer / options / surface /
 // reading / level / the Chinese source) -- the write transform only adds or
-// merges the `explanationI18n` field.
+// merges the `<field>I18n` overlays.
 //
 // The actual Gemini call runs in CI (GitHub Actions) with the GEMINI_API_KEY
 // repository secret. There is no API key in the repo or the frontend.
 //
 // Usage
 //   node scripts/ai-translate-content.mjs --locale en --level N5 --limit 10
-//   node scripts/ai-translate-content.mjs --locale ko --limit 10 --source-report .tmp/i18n-coverage.json
+//   node scripts/ai-translate-content.mjs --locale ja --limit 10 --dry-run
 //   (env GEMINI_API_KEY required for the live call; --dry-run skips the call)
-//
-// Args
-//   --locale <code>       target locale (ja|en|th|id|ko|vi|my). required.
-//   --level <N1..N5>      JLPT level file to translate. default N5.
-//   --limit <n>           max items this run. default 10.
-//   --source-report <p>   optional coverage report (accepted for workflow
-//                         compatibility; the script also detects gaps itself).
-//   --model <name>        Gemini model. default gemini-2.0-flash.
-//   --dry-run             find + print targets, skip the Gemini call + write.
-//   --summary <path>      write a short markdown run summary (for the PR body).
 // =============================================================================
 
 import fs from "node:fs";
@@ -37,11 +37,18 @@ import { fileURLToPath } from "node:url";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ITEMS_DIR = path.join(REPO_ROOT, "src", "domain", "exam", "items");
 const LOCALES = new Set(["ja", "en", "th", "id", "ko", "vi", "my"]); // zh-Hant is the source
-const SOURCE_FIELD = "explanation";
-const OVERLAY_FIELD = "explanationI18n";
+
+// Every translatable Chinese content field and its per-locale overlay sibling.
+export const FIELDS = [
+  { source: "meaningZh", overlay: "meaningI18n" },
+  { source: "instructionZh", overlay: "instructionI18n" },
+  { source: "promptContextZh", overlay: "promptContextI18n" },
+  { source: "hintZh", overlay: "hintI18n" },
+  { source: "explanation", overlay: "explanationI18n" }
+];
 
 // ---------------------------------------------------------------------------
-// string escaping for TS string literals (mirrors import-exam-items.mjs)
+// string escaping / unescaping for TS string literals
 // ---------------------------------------------------------------------------
 export const esc = (s) =>
   String(s)
@@ -51,14 +58,15 @@ export const esc = (s) =>
     .replace(/\r/g, "\\r")
     .replace(/\t/g, "\\t");
 
+const unescapeTs = (s) =>
+  s.replace(/\\([\\"ntr])/g, (_, c) => ({ "\\": "\\", '"': '"', n: "\n", t: "\t", r: "\r" })[c]);
+
 // ---------------------------------------------------------------------------
 // parse item file into blocks (one examQuestion({...}) each)
-// Format is the importer's: a line `  examQuestion({`, 4-space fields, then a
-// closing line `  })` / `  }),`.
 // ---------------------------------------------------------------------------
 export function splitItemBlocks(text) {
   const lines = text.split("\n");
-  const blocks = []; // { startLine, endLine, lines: [...] }
+  const blocks = [];
   let cur = null;
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -84,31 +92,59 @@ const idOf = (blockLines) => {
   return null;
 };
 
-const sourceTextOf = (blockLines) => {
+// Extract a 4-space-indented `name: "..."` string field, unescaped. The exact
+// `name:` anchor means `meaningZh` never matches `exampleMeaningZh`, etc.
+const stringFieldOf = (blockLines, name) => {
+  const re = new RegExp(`^ {4}${name}:\\s*"((?:[^"\\\\]|\\\\.)*)"`);
   for (const l of blockLines) {
-    const m = l.match(/^ {4}explanation:\s*"((?:[^"\\]|\\.)*)"/);
-    if (m) {
-      return m[1]
-        .replace(/\\n/g, "\n").replace(/\\t/g, "\t").replace(/\\"/g, '"').replace(/\\\\/g, "\\");
-    }
+    const m = l.match(re);
+    if (m) return unescapeTs(m[1]);
   }
   return null;
 };
 
-const hasOverlayLocale = (blockLines, locale) =>
-  blockLines.some((l) => l.includes(`${OVERLAY_FIELD}:`) && l.includes(`"${locale}"`));
+// Raw single-line value (e.g. the options array literal) for prompt context.
+const rawFieldOf = (blockLines, name) => {
+  const re = new RegExp(`^ {4}${name}:\\s*(.+?),?\\s*$`);
+  for (const l of blockLines) {
+    const m = l.match(re);
+    if (m) return m[1];
+  }
+  return null;
+};
+
+const hasOverlayLocale = (blockLines, overlayField, locale) =>
+  blockLines.some((l) => new RegExp(`^ {4}${overlayField}:`).test(l) && l.includes(`"${locale}"`));
+
+const hasOverlayField = (blockLines, overlayField) =>
+  blockLines.some((l) => new RegExp(`^ {4}${overlayField}:`).test(l));
 
 // ---------------------------------------------------------------------------
-// find items missing the overlay for `locale`
+// find items with >=1 field missing the overlay for `locale`
+// returns [{ id, context: {promptText, expectedAnswer, options}, fields: {source: zh} }]
 // ---------------------------------------------------------------------------
 export function findTargets(text, locale, limit) {
   const out = [];
   for (const b of splitItemBlocks(text)) {
     const id = idOf(b.lines);
-    const source = sourceTextOf(b.lines);
-    if (!id || !source) continue;
-    if (hasOverlayLocale(b.lines, locale)) continue;
-    out.push({ id, source });
+    if (!id) continue;
+    const fields = {};
+    for (const { source, overlay } of FIELDS) {
+      const val = stringFieldOf(b.lines, source);
+      if (val == null || val.trim() === "") continue; // nothing to translate
+      if (hasOverlayLocale(b.lines, overlay, locale)) continue; // already done
+      fields[source] = val;
+    }
+    if (Object.keys(fields).length === 0) continue;
+    out.push({
+      id,
+      context: {
+        promptText: stringFieldOf(b.lines, "promptText"),
+        expectedAnswer: stringFieldOf(b.lines, "expectedAnswer"),
+        options: rawFieldOf(b.lines, "options")
+      },
+      fields
+    });
     if (out.length >= limit) break;
   }
   return out;
@@ -116,87 +152,112 @@ export function findTargets(text, locale, limit) {
 
 // ---------------------------------------------------------------------------
 // validate Gemini's response against the request (HARD fail on any mismatch)
+// requested = [{ id, fieldKeys: [...] }]
 // ---------------------------------------------------------------------------
-export function validateTranslations(parsed, requestedIds) {
-  const want = new Set(requestedIds);
+export function validateTranslations(parsed, requested) {
+  const wantById = new Map(requested.map((r) => [r.id, new Set(r.fieldKeys)]));
   if (!Array.isArray(parsed)) return { ok: false, error: "response is not a JSON array" };
-  if (parsed.length !== requestedIds.length) {
-    return { ok: false, error: `count mismatch: got ${parsed.length}, requested ${requestedIds.length}` };
+  if (parsed.length !== requested.length) {
+    return { ok: false, error: `count mismatch: got ${parsed.length}, requested ${requested.length}` };
   }
   const seen = new Set();
+  const items = [];
   for (const entry of parsed) {
     if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
       return { ok: false, error: "entry is not an object" };
     }
     const keys = Object.keys(entry);
-    if (keys.length !== 2 || !keys.includes("id") || !keys.includes("translation")) {
-      return { ok: false, error: `entry must have exactly {id, translation}; got keys [${keys.join(", ")}]` };
+    if (keys.length !== 2 || !keys.includes("id") || !keys.includes("fields")) {
+      return { ok: false, error: `entry must have exactly {id, fields}; got [${keys.join(", ")}]` };
     }
-    if (typeof entry.id !== "string" || !want.has(entry.id)) {
+    if (typeof entry.id !== "string" || !wantById.has(entry.id)) {
       return { ok: false, error: `unexpected or non-string id: ${JSON.stringify(entry.id)}` };
     }
     if (seen.has(entry.id)) return { ok: false, error: `duplicate id: ${entry.id}` };
     seen.add(entry.id);
-    if (typeof entry.translation !== "string" || entry.translation.trim() === "") {
-      return { ok: false, error: `empty/non-string translation for ${entry.id}` };
+    const want = wantById.get(entry.id);
+    const f = entry.fields;
+    if (f === null || typeof f !== "object" || Array.isArray(f)) {
+      return { ok: false, error: `fields must be an object for ${entry.id}` };
     }
+    const fkeys = Object.keys(f);
+    if (fkeys.length !== want.size || !fkeys.every((k) => want.has(k))) {
+      return { ok: false, error: `field mismatch for ${entry.id}: got [${fkeys.join(", ")}], want [${[...want].join(", ")}]` };
+    }
+    for (const k of fkeys) {
+      if (typeof f[k] !== "string" || f[k].trim() === "") {
+        return { ok: false, error: `empty/non-string ${k} for ${entry.id}` };
+      }
+    }
+    items.push({ id: entry.id, fields: { ...f } });
   }
-  if (seen.size !== want.size) {
-    const missing = [...want].filter((id) => !seen.has(id));
+  if (seen.size !== wantById.size) {
+    const missing = [...wantById.keys()].filter((id) => !seen.has(id));
     return { ok: false, error: `missing translations for: ${missing.join(", ")}` };
   }
-  return { ok: true, items: parsed.map((e) => ({ id: e.id, translation: e.translation })) };
+  return { ok: true, items };
 }
 
 // ---------------------------------------------------------------------------
-// apply overlay -- the ONLY write. Adds/merges `explanationI18n[locale]` into
-// each target item block; never alters any other field.
+// apply overlays -- the ONLY write. For each target item, insert or merge each
+// translated field's `<overlay>[locale]` sibling. Never alters other fields.
+// items = [{ id, fields: {source: translation} }]
 // ---------------------------------------------------------------------------
-export function applyExplanationOverlay(text, translations, locale) {
-  const byId = new Map(translations.map((t) => [t.id, t.translation]));
-  // Pre-scan: which TARGET items already carry an explanationI18n field, so we
-  // merge into that line instead of inserting a duplicate after `explanation`.
-  const overlayRe = new RegExp(`^ {4}${OVERLAY_FIELD}:`);
-  const hasOverlayField = new Set();
+export function applyOverlays(text, items, locale) {
+  const transById = new Map(items.map((it) => [it.id, it.fields]));
+
+  // Pre-scan: which (id, overlayField) already exist -> merge vs insert.
+  const existing = new Set(); // key `${id}\0${overlay}`
   for (const b of splitItemBlocks(text)) {
     const id = idOf(b.lines);
-    if (id && byId.has(id) && b.lines.some((l) => overlayRe.test(l))) hasOverlayField.add(id);
+    if (!id || !transById.has(id)) continue;
+    for (const { overlay } of FIELDS) {
+      if (hasOverlayField(b.lines, overlay)) existing.add(`${id} ${overlay}`);
+    }
   }
 
   const lines = text.split("\n");
   const out = [];
   let curId = null;
-  let pending = null; // translation to apply for the current target block
 
   for (const line of lines) {
-    if (line === "  examQuestion({")  { curId = null; pending = null; }
+    if (line === "  examQuestion({") curId = null;
     const idM = line.match(/^ {4}id:\s*"((?:[^"\\]|\\.)*)"/);
-    if (idM) {
-      curId = idM[1];
-      pending = byId.has(curId) ? byId.get(curId) : null;
-    }
+    if (idM) curId = idM[1];
+    const trans = curId ? transById.get(curId) : null;
 
-    // Merge path: existing explanationI18n line (single-line object).
-    if (pending !== null && curId && hasOverlayField.has(curId) && new RegExp(`^ {4}${OVERLAY_FIELD}:\\s*\\{`).test(line)) {
-      const merged = line.includes(`"${locale}"`)
-        ? line
-        : line.replace(/\{\s*/, `{ "${locale}": "${esc(pending)}", `);
-      out.push(merged);
-      pending = null;
-      continue;
+    // Merge path: an existing overlay line for a field we translated.
+    if (trans) {
+      let merged = null;
+      for (const { source, overlay } of FIELDS) {
+        if (!(source in trans)) continue;
+        if (!existing.has(`${curId} ${overlay}`)) continue;
+        if (new RegExp(`^ {4}${overlay}:\\s*\\{`).test(line)) {
+          merged = line.includes(`"${locale}"`)
+            ? line
+            : line.replace(/\{\s*/, `{ "${locale}": "${esc(trans[source])}", `);
+          break;
+        }
+      }
+      if (merged !== null) {
+        out.push(merged);
+        continue;
+      }
     }
 
     out.push(line);
 
-    // Insert path: only for target items WITHOUT an existing overlay field.
-    if (pending !== null && curId && !hasOverlayField.has(curId)) {
-      const expM = line.match(/^( {4}explanation:\s*"(?:[^"\\]|\\.)*")(,?)\s*$/);
-      if (expM) {
-        // ensure the explanation line ends with a comma, then add the overlay
-        // (a trailing comma on the overlay is valid TS even if it ends up last).
-        if (expM[2] !== ",") out[out.length - 1] = expM[1] + ",";
-        out.push(`    ${OVERLAY_FIELD}: { "${locale}": "${esc(pending)}" },`);
-        pending = null;
+    // Insert path: after a source-field line whose overlay does not yet exist.
+    if (trans) {
+      for (const { source, overlay } of FIELDS) {
+        if (!(source in trans)) continue;
+        if (existing.has(`${curId} ${overlay}`)) continue;
+        const m = line.match(new RegExp(`^( {4}${source}:\\s*"(?:[^"\\\\]|\\\\.)*")(,?)\\s*$`));
+        if (m) {
+          if (m[2] !== ",") out[out.length - 1] = m[1] + ",";
+          out.push(`    ${overlay}: { "${locale}": "${esc(trans[source])}" },`);
+          break; // one source field per line
+        }
       }
     }
   }
@@ -211,26 +272,38 @@ const LOCALE_NAME = {
   ko: "Korean", vi: "Vietnamese", my: "Burmese"
 };
 
+const FIELD_NOTE = {
+  meaningZh: "the word/phrase meaning",
+  instructionZh: "the task instruction (e.g. 'choose the most natural word')",
+  promptContextZh: "situational context for the sentence",
+  hintZh: "a neutral pre-answer hint",
+  explanation: "why the correct answer is right and the distractors are wrong"
+};
+
 export function buildPrompt(items, locale) {
   const name = LOCALE_NAME[locale] ?? locale;
   return [
-    `You translate JLPT study explanations from Traditional Chinese into ${name}.`,
-    `These explain why a Japanese grammar/vocab answer is correct and why the distractors are wrong.`,
+    `You are a professional JLPT-study localizer. Translate the given Traditional Chinese exam-content fields into natural, native ${name}.`,
+    `Each item is a Japanese-language exam question. Use the provided CONTEXT (the Japanese prompt, the correct answer, and the options) so the translation is accurate and reads the way a ${name} teacher would write it -- NOT a word-for-word calque.`,
+    `Field meanings: ${Object.entries(FIELD_NOTE).map(([k, v]) => `${k} = ${v}`).join("; ")}.`,
     `Rules:`,
-    `- Keep all Japanese terms, kana, kanji and example fragments EXACTLY as written (do not translate the Japanese itself).`,
-    `- Translate only the Chinese explanatory prose into natural ${name}.`,
-    `- Keep each translation faithful and concise; do not add or drop information.`,
-    `- Return STRICT JSON only: an array of objects {"id": string, "translation": string}.`,
-    `- One object per input id, same ids, no extra keys, no markdown, no commentary.`,
+    `- Keep ALL Japanese (kana, kanji, example fragments) and JLPT level tags EXACTLY as written; translate ONLY the Chinese prose.`,
+    `- Natural, idiomatic, concise ${name}; faithful (never add or drop meaning).`,
+    `- For each item, translate ONLY the fields under "translate" and return the SAME field keys.`,
+    `- Return STRICT JSON only: an array of {"id": string, "fields": { <fieldKey>: <${name} translation>, ... }}.`,
+    `- Same ids as the input, no extra keys, no markdown, no commentary.`,
     ``,
     `Input (${items.length} items):`,
-    JSON.stringify(items.map((it) => ({ id: it.id, zh: it.source })), null, 2)
+    JSON.stringify(
+      items.map((it) => ({ id: it.id, context: it.context, translate: it.fields })),
+      null,
+      2
+    )
   ].join("\n");
 }
 
 export function parseGeminiJson(raw) {
   let s = String(raw).trim();
-  // defensive: strip ```json ... ``` fences if a model adds them
   const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
   if (fence) s = fence[1].trim();
   return JSON.parse(s);
@@ -272,6 +345,12 @@ function parseArgs(argv) {
   return o;
 }
 
+function fieldCounts(targets) {
+  const counts = {};
+  for (const t of targets) for (const k of Object.keys(t.fields)) counts[k] = (counts[k] ?? 0) + 1;
+  return counts;
+}
+
 async function main() {
   const o = parseArgs(process.argv.slice(2));
   if (!o.locale || !LOCALES.has(o.locale)) {
@@ -290,16 +369,17 @@ async function main() {
   const text = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
   const targets = findTargets(text, o.locale, o.limit);
 
-  console.log(`[ai-translate] level=${o.level} locale=${o.locale} limit=${o.limit} -> ${targets.length} target(s)`);
+  const fc = fieldCounts(targets);
+  console.log(`[ai-translate] level=${o.level} locale=${o.locale} limit=${o.limit} -> ${targets.length} item(s), fields ${JSON.stringify(fc)}`);
   if (o.sourceReport) console.log(`[ai-translate] (source-report ${o.sourceReport} noted; gaps detected directly)`);
   if (targets.length === 0) {
     console.log("[ai-translate] nothing to translate; exiting 0");
-    if (o.summary) fs.writeFileSync(o.summary, `No untranslated ${o.level} \`explanation\` items for \`${o.locale}\`.\n`);
+    if (o.summary) fs.writeFileSync(o.summary, `No untranslated ${o.level} content fields for \`${o.locale}\`.\n`);
     return;
   }
 
   if (o.dryRun) {
-    for (const t of targets) console.log(`  - ${t.id}`);
+    for (const t of targets) console.log(`  - ${t.id} [${Object.keys(t.fields).join(", ")}]`);
     console.log("[ai-translate] --dry-run: skipped Gemini call + write");
     return;
   }
@@ -319,14 +399,15 @@ async function main() {
     console.error(`Gemini did not return valid JSON: ${e.message}`);
     process.exit(1);
   }
-  const v = validateTranslations(parsed, targets.map((t) => t.id));
+  const requested = targets.map((t) => ({ id: t.id, fieldKeys: Object.keys(t.fields) }));
+  const v = validateTranslations(parsed, requested);
   if (!v.ok) {
     console.error(`translation validation failed: ${v.error}`);
     process.exit(1);
   }
 
   const before = splitItemBlocks(text).length;
-  const next = applyExplanationOverlay(text, v.items, o.locale);
+  const next = applyOverlays(text, v.items, o.locale);
   const after = splitItemBlocks(next).length;
   if (after !== before) {
     console.error(`internal error: item count changed ${before} -> ${after}; aborting write`);
@@ -337,24 +418,24 @@ async function main() {
     process.exit(1);
   }
   fs.writeFileSync(file, next);
-  console.log(`[ai-translate] wrote ${v.items.length} ${o.locale} overlay(s) -> ${path.relative(REPO_ROOT, file)}`);
+  const totalFields = v.items.reduce((n, it) => n + Object.keys(it.fields).length, 0);
+  console.log(`[ai-translate] wrote ${totalFields} ${o.locale} overlay field(s) across ${v.items.length} item(s) -> ${path.relative(REPO_ROOT, file)}`);
 
   if (o.summary) {
     const lines = [
       `AI-assisted i18n translation (Gemini ${o.model})`,
       ``,
-      `- locale: \`${o.locale}\` · level: \`${o.level}\` · items: ${v.items.length}`,
-      `- field: \`explanation\` -> \`explanationI18n.${o.locale}\` (overlay only; source untouched)`,
+      `- locale: \`${o.locale}\` · level: \`${o.level}\` · items: ${v.items.length} · fields: ${totalFields}`,
+      `- fields covered: ${Object.keys(fc).map((k) => `\`${k}\``).join(", ")} (overlay only; Chinese source untouched)`,
       ``,
       `Please review translation quality before merge.`,
       ``,
-      ...v.items.map((t) => `- \`${t.id}\``)
+      ...v.items.map((t) => `- \`${t.id}\` [${Object.keys(t.fields).join(", ")}]`)
     ];
     fs.writeFileSync(o.summary, lines.join("\n") + "\n");
   }
 }
 
-// run only when invoked directly (so tests can import the pure helpers)
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main().catch((e) => {
     console.error(e?.stack || String(e));

--- a/scripts/ai-translate-content.mjs
+++ b/scripts/ai-translate-content.mjs
@@ -113,8 +113,24 @@ const rawFieldOf = (blockLines, name) => {
   return null;
 };
 
-const hasOverlayLocale = (blockLines, overlayField, locale) =>
-  blockLines.some((l) => new RegExp(`^ {4}${overlayField}:`).test(l) && l.includes(`"${locale}"`));
+// Whether an item's `<overlayField>` object already has a value for `locale`.
+// Multi-line-aware (a hand-reflowed overlay may span several lines) and matches
+// the locale as an object KEY (`"en":`) so a value that merely CONTAINS the
+// text "en" never false-skips a real gap -- and, critically, a multi-line
+// overlay never fools the gap check into re-translating an existing locale
+// (which would write a duplicate object key and break the build).
+const overlayHasLocale = (blockLines, overlayField, locale) => {
+  const startRe = new RegExp(`^ {4}${overlayField}:`);
+  const keyRe = new RegExp(`"${locale}"\\s*:`);
+  const start = blockLines.findIndex((l) => startRe.test(l));
+  if (start < 0) return false;
+  if (keyRe.test(blockLines[start])) return true; // single-line object
+  for (let i = start + 1; i < blockLines.length; i++) {
+    if (keyRe.test(blockLines[i])) return true;
+    if (/^ {4}\S/.test(blockLines[i])) break; // back to field indent -> object closed
+  }
+  return false;
+};
 
 const hasOverlayField = (blockLines, overlayField) =>
   blockLines.some((l) => new RegExp(`^ {4}${overlayField}:`).test(l));
@@ -132,7 +148,7 @@ export function findTargets(text, locale, limit) {
     for (const { source, overlay } of FIELDS) {
       const val = stringFieldOf(b.lines, source);
       if (val == null || val.trim() === "") continue; // nothing to translate
-      if (hasOverlayLocale(b.lines, overlay, locale)) continue; // already done
+      if (overlayHasLocale(b.lines, overlay, locale)) continue; // already done
       fields[source] = val;
     }
     if (Object.keys(fields).length === 0) continue;
@@ -206,13 +222,18 @@ export function validateTranslations(parsed, requested) {
 export function applyOverlays(text, items, locale) {
   const transById = new Map(items.map((it) => [it.id, it.fields]));
 
-  // Pre-scan: which (id, overlayField) already exist -> merge vs insert.
-  const existing = new Set(); // key `${id}\0${overlay}`
+  // Pre-scan per (id, overlayField): does the field exist (merge vs insert),
+  // and does it already have this locale (never re-add -> guards against a
+  // duplicate object key when an overlay was hand-reflowed onto several lines).
+  const existing = new Set();
+  const alreadyLocale = new Set();
   for (const b of splitItemBlocks(text)) {
     const id = idOf(b.lines);
     if (!id || !transById.has(id)) continue;
     for (const { overlay } of FIELDS) {
-      if (hasOverlayField(b.lines, overlay)) existing.add(`${id} ${overlay}`);
+      const key = `${id} ${overlay}`;
+      if (hasOverlayField(b.lines, overlay)) existing.add(key);
+      if (overlayHasLocale(b.lines, overlay, locale)) alreadyLocale.add(key);
     }
   }
 
@@ -231,7 +252,8 @@ export function applyOverlays(text, items, locale) {
       let merged = null;
       for (const { source, overlay } of FIELDS) {
         if (!(source in trans)) continue;
-        if (!existing.has(`${curId} ${overlay}`)) continue;
+        const key = `${curId} ${overlay}`;
+        if (!existing.has(key) || alreadyLocale.has(key)) continue;
         if (new RegExp(`^ {4}${overlay}:\\s*\\{`).test(line)) {
           merged = line.includes(`"${locale}"`)
             ? line
@@ -251,7 +273,8 @@ export function applyOverlays(text, items, locale) {
     if (trans) {
       for (const { source, overlay } of FIELDS) {
         if (!(source in trans)) continue;
-        if (existing.has(`${curId} ${overlay}`)) continue;
+        const key = `${curId} ${overlay}`;
+        if (existing.has(key) || alreadyLocale.has(key)) continue;
         const m = line.match(new RegExp(`^( {4}${source}:\\s*"(?:[^"\\\\]|\\\\.)*")(,?)\\s*$`));
         if (m) {
           if (m[2] !== ",") out[out.length - 1] = m[1] + ",";

--- a/scripts/ai-translate-content.test.ts
+++ b/scripts/ai-translate-content.test.ts
@@ -172,3 +172,57 @@ describe("applyOverlays (multi-field)", () => {
     expect(x2.lines.some((l) => l.includes('"en"'))).toBe(false);
   });
 });
+
+// A hand-edited/reflowed overlay object that spans several lines must NOT fool
+// the gap check into re-translating an existing locale (which would write a
+// duplicate object key -> TS1117 build break / corrupt content file).
+describe("multi-line overlay safety", () => {
+  const MULTILINE = `import { examQuestion } from "../helpers";
+
+export const n5Items = [
+  examQuestion({
+    id: "m-1",
+    level: "N5",
+    surface: "行く",
+    reading: "いく",
+    meaningZh: "去",
+    meaningI18n: {
+      "ja": "行く",
+      "en": "to go"
+    },
+    promptLabel: "文法形式選擇",
+    instructionZh: "選最自然的詞語。",
+    promptText: "毎日 学校___行きます。",
+    promptContextZh: "描述每天上學。",
+    hintZh: "說明去某地。",
+    expectedAnswer: "に",
+    options: ["に", "を", "で", "が"],
+    explanation: "答案是に。"
+  })
+];
+`;
+
+  it("findTargets skips a field whose locale lives in a multi-line overlay", () => {
+    const en = findTargets(MULTILINE, "en", 1)[0];
+    expect(en).toBeDefined();
+    // meaningI18n already has "en" (on its own line) -> not a gap
+    expect(Object.keys(en.fields)).not.toContain("meaningZh");
+    // ...but the other fields with no overlay still are gaps
+    expect(Object.keys(en.fields)).toContain("instructionZh");
+  });
+
+  it("findTargets still finds a locale missing from a multi-line overlay", () => {
+    const th = findTargets(MULTILINE, "th", 1)[0];
+    expect(th.fields.meaningZh).toBe("去"); // no "th" key in the multi-line object
+  });
+
+  it("applyOverlays does NOT add a duplicate key for an existing multi-line locale", () => {
+    // Even if a caller wrongly asks to re-translate meaningZh for "en",
+    // the pre-scan must detect the existing multi-line "en" and skip it.
+    const out = applyOverlays(MULTILINE, [{ id: "m-1", fields: { meaningZh: "DUP" } }], "en");
+    const enKeys = out.split("\n").filter((l) => /^\s*"en"\s*:/.test(l));
+    expect(enKeys).toHaveLength(1); // exactly one "en" -> no duplicate object key
+    expect(out).not.toContain('"en": "DUP"');
+    expect(splitItemBlocks(out)).toHaveLength(1);
+  });
+});

--- a/scripts/ai-translate-content.test.ts
+++ b/scripts/ai-translate-content.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 // @ts-expect-error -- plain .mjs tooling module, no types
 import {
   validateTranslations,
-  applyExplanationOverlay,
+  applyOverlays,
   findTargets,
   splitItemBlocks
 } from "./ai-translate-content.mjs";
@@ -16,13 +16,14 @@ export const n5Items = [
     surface: "行く",
     reading: "いく",
     meaningZh: "去",
-    promptLabel: "漢字読み",
-    instructionZh: "讀音",
-    promptText: "「行く」",
-    promptContextZh: "去",
-    expectedAnswer: "いく",
-    options: ["いく", "ゆく", "こう", "ぎょう"],
-    explanation: "答案是いく。"
+    promptLabel: "文法形式選擇",
+    instructionZh: "選最自然的詞語。",
+    promptText: "毎日 学校___行きます。",
+    promptContextZh: "描述每天上學。",
+    hintZh: "說明去某地。",
+    expectedAnswer: "に",
+    options: ["に", "を", "で", "が"],
+    explanation: "答案是に。"
   }),
   examQuestion({
     id: "x-2",
@@ -42,80 +43,131 @@ export const n5Items = [
 ];
 `;
 
-describe("findTargets", () => {
-  it("finds items missing the locale overlay, respecting limit", () => {
+describe("findTargets (multi-field)", () => {
+  it("finds items with any missing overlay field, respecting limit", () => {
     expect(findTargets(FIXTURE, "en", 10).map((t) => t.id)).toEqual(["x-1", "x-2"]);
     expect(findTargets(FIXTURE, "en", 1).map((t) => t.id)).toEqual(["x-1"]);
   });
-  it("skips items that already have the locale overlay", () => {
-    expect(findTargets(FIXTURE, "ja", 10).map((t) => t.id)).toEqual(["x-1"]);
+
+  it("collects every translatable field for an item with no overlays", () => {
+    const x1 = findTargets(FIXTURE, "en", 1)[0];
+    expect(Object.keys(x1.fields).sort()).toEqual(
+      ["explanation", "hintZh", "instructionZh", "meaningZh", "promptContextZh"].sort()
+    );
+    expect(x1.fields.meaningZh).toBe("去");
+    expect(x1.fields.instructionZh).toBe("選最自然的詞語。");
   });
-  it("extracts the unescaped source explanation", () => {
-    expect(findTargets(FIXTURE, "en", 1)[0].source).toBe("答案是いく。");
+
+  it("skips a field that already has the overlay for the locale, keeps the rest", () => {
+    // x-2 has explanationI18n.ja, so for ja: explanation is skipped but the
+    // other Chinese fields (which have no ja overlay) are still gaps.
+    const x2 = findTargets(FIXTURE, "ja", 10).find((t) => t.id === "x-2");
+    expect(x2).toBeDefined();
+    expect(Object.keys(x2.fields)).not.toContain("explanation");
+    expect(Object.keys(x2.fields).sort()).toEqual(
+      ["instructionZh", "meaningZh", "promptContextZh"].sort()
+    );
+  });
+
+  it("attaches question context (prompt / answer / options) for the prompt", () => {
+    const x1 = findTargets(FIXTURE, "en", 1)[0];
+    expect(x1.context.expectedAnswer).toBe("に");
+    expect(x1.context.promptText).toBe("毎日 学校___行きます。");
+    expect(x1.context.options).toContain('"に"');
+  });
+
+  it("does NOT confuse meaningZh with exampleMeaningZh (anchored field match)", () => {
+    const withExample = FIXTURE.replace(
+      '    meaningZh: "去",',
+      '    meaningZh: "去",\n    exampleMeaningZh: "去學校的例句意思",'
+    );
+    const x1 = findTargets(withExample, "en", 1)[0];
+    expect(x1.fields.meaningZh).toBe("去");
+    // exampleMeaningZh is not a translatable field
+    expect(Object.keys(x1.fields)).not.toContain("exampleMeaningZh");
   });
 });
 
-describe("validateTranslations", () => {
-  const ids = ["x-1", "x-2"];
-  it("accepts a well-formed response", () => {
-    const r = validateTranslations([{ id: "x-1", translation: "a" }, { id: "x-2", translation: "b" }], ids);
+describe("validateTranslations (multi-field)", () => {
+  const requested = [
+    { id: "x-1", fieldKeys: ["meaningZh", "explanation"] },
+    { id: "x-2", fieldKeys: ["meaningZh"] }
+  ];
+  const good = [
+    { id: "x-1", fields: { meaningZh: "to go", explanation: "The answer is ni." } },
+    { id: "x-2", fields: { meaningZh: "to see" } }
+  ];
+
+  it("accepts a well-formed multi-field response", () => {
+    const r = validateTranslations(good, requested);
     expect(r.ok).toBe(true);
     expect(r.items).toHaveLength(2);
+    expect(r.items[0].fields.meaningZh).toBe("to go");
   });
+
   it("rejects a count mismatch", () => {
-    expect(validateTranslations([{ id: "x-1", translation: "a" }], ids).ok).toBe(false);
+    expect(validateTranslations([good[0]], requested).ok).toBe(false);
   });
-  it("rejects extra keys (protected-field guard)", () => {
-    const r = validateTranslations(
-      [{ id: "x-1", translation: "a", expectedAnswer: "hacked" }, { id: "x-2", translation: "b" }],
-      ids
-    );
-    expect(r.ok).toBe(false);
+
+  it("rejects an extra top-level key (protected-field guard)", () => {
+    const bad = [{ id: "x-1", fields: { meaningZh: "x", explanation: "y" }, expectedAnswer: "hacked" }, good[1]];
+    expect(validateTranslations(bad, requested).ok).toBe(false);
   });
-  it("rejects an unknown id", () => {
-    expect(validateTranslations([{ id: "x-1", translation: "a" }, { id: "zzz", translation: "b" }], ids).ok).toBe(false);
+
+  it("rejects a field-key mismatch (missing a requested field)", () => {
+    const bad = [{ id: "x-1", fields: { meaningZh: "x" } }, good[1]]; // explanation missing
+    expect(validateTranslations(bad, requested).ok).toBe(false);
   });
-  it("rejects a duplicate id", () => {
-    expect(validateTranslations([{ id: "x-1", translation: "a" }, { id: "x-1", translation: "b" }], ids).ok).toBe(false);
+
+  it("rejects an extra (unrequested) field key", () => {
+    const bad = [{ id: "x-1", fields: { meaningZh: "x", explanation: "y", hintZh: "z" } }, good[1]];
+    expect(validateTranslations(bad, requested).ok).toBe(false);
   });
-  it("rejects an empty translation", () => {
-    expect(validateTranslations([{ id: "x-1", translation: "  " }, { id: "x-2", translation: "b" }], ids).ok).toBe(false);
+
+  it("rejects an unknown id, a duplicate id, an empty value, and a non-array", () => {
+    expect(validateTranslations([{ id: "zzz", fields: { meaningZh: "x" } }, good[1]], requested).ok).toBe(false);
+    expect(validateTranslations([good[0], good[0]], requested).ok).toBe(false);
+    expect(validateTranslations([{ id: "x-1", fields: { meaningZh: "  ", explanation: "y" } }, good[1]], requested).ok).toBe(false);
+    expect(validateTranslations({ id: "x-1" }, requested).ok).toBe(false);
   });
-  it("rejects a non-array", () => {
-    expect(validateTranslations({ id: "x-1", translation: "a" }, ids).ok).toBe(false);
+
+  it("rejects a non-object fields value", () => {
+    expect(validateTranslations([{ id: "x-1", fields: "nope" }, good[1]], requested).ok).toBe(false);
   });
 });
 
-describe("applyExplanationOverlay", () => {
-  it("inserts a fresh overlay after the explanation field (adds the comma) and keeps item count", () => {
-    const out = applyExplanationOverlay(FIXTURE, [{ id: "x-1", translation: "The answer is iku." }], "en");
-    expect(out).toContain('explanationI18n: { "en": "The answer is iku." },');
-    // explanation line for x-1 now ends with a comma
-    expect(out).toContain('explanation: "答案是いく。",');
-    // protected fields untouched, block count stable
+describe("applyOverlays (multi-field)", () => {
+  it("inserts fresh overlays after each source field, adds commas, keeps item count", () => {
+    const out = applyOverlays(
+      FIXTURE,
+      [{ id: "x-1", fields: { meaningZh: "to go", instructionZh: "Choose the most natural word." } }],
+      "en"
+    );
+    expect(out).toContain('meaningI18n: { "en": "to go" },');
+    expect(out).toContain('instructionI18n: { "en": "Choose the most natural word." },');
+    expect(out).toContain('meaningZh: "去",');
+    expect(out).toContain('instructionZh: "選最自然的詞語。",');
     expect(splitItemBlocks(out)).toHaveLength(2);
-    expect(out).toContain('expectedAnswer: "いく"');
-    expect(out).toContain('options: ["いく", "ゆく", "こう", "ぎょう"]');
+    // protected fields untouched
+    expect(out).toContain('expectedAnswer: "に"');
+    expect(out).toContain('options: ["に", "を", "で", "が"]');
   });
 
-  it("merges into an existing overlay, preserving the other locale", () => {
-    const out = applyExplanationOverlay(FIXTURE, [{ id: "x-2", translation: "The answer is miru." }], "en");
+  it("merges into an existing overlay line, preserving the other locale", () => {
+    const out = applyOverlays(FIXTURE, [{ id: "x-2", fields: { explanation: "The answer is miru." } }], "en");
     expect(out).toContain('"en": "The answer is miru."');
-    expect(out).toContain('"ja": "答えはみる。"'); // existing locale preserved
-    // x-2 still one block, single explanationI18n line
+    expect(out).toContain('"ja": "答えはみる。"');
     const x2 = splitItemBlocks(out).find((b) => b.lines.some((l) => l.includes('id: "x-2"')));
-    const overlayLines = x2.lines.filter((l) => l.includes("explanationI18n:"));
-    expect(overlayLines).toHaveLength(1);
+    expect(x2.lines.filter((l) => l.includes("explanationI18n:"))).toHaveLength(1);
   });
 
-  it("escapes quotes and newlines in the translation", () => {
-    const out = applyExplanationOverlay(FIXTURE, [{ id: "x-1", translation: 'a "quote"\nnext' }], "en");
-    expect(out).toContain('"en": "a \\"quote\\"\\nnext"');
+  it("escapes quotes and newlines in a translation", () => {
+    const out = applyOverlays(FIXTURE, [{ id: "x-1", fields: { meaningZh: 'a "q"\nb' } }], "en");
+    expect(out).toContain('meaningI18n: { "en": "a \\"q\\"\\nb" },');
   });
 
-  it("does not touch items not in the translation set", () => {
-    const out = applyExplanationOverlay(FIXTURE, [{ id: "x-1", translation: "x" }], "en");
-    // x-2 line unchanged (still only ja overlay)
+  it("does not touch items outside the translation set", () => {
+    const out = applyOverlays(FIXTURE, [{ id: "x-1", fields: { meaningZh: "to go" } }], "en");
     const x2 = splitItemBlocks(out).find((b) => b.lines.some((l) => l.includes('id: "x-2"')));
     expect(x2.lines.some((l) => l.includes('"en"'))).toBe(false);
   });


### PR DESCRIPTION
## What

Extend the Gemini translate script (#400) from **explanation-only** to **all translatable exam content fields**, with question context in the prompt for natural (not literal) translations.

- Fields: `meaningZh` / `instructionZh` / `promptContextZh` / `hintZh` / `explanation` → their `<field>I18n` overlays.
- `buildPrompt` now passes the Japanese `promptText` / `expectedAnswer` / `options` as **context** and asks for natural, native target-language prose; per item it translates **only** the fields with a gap.
- `findTargets` → `{id, context, fields}`; `validateTranslations` enforces the `{id, fields}` shape with an **exact per-item field-key match** (protected-field guard); `applyOverlays` inserts/merges each `<field>I18n` sibling and touches nothing else.
- Workflow YAML title/commit-message/comment updated (content, not just explanation).

This is **PR B** — the generator side. The read-path (PR #401) + the nullish fix (#402) are already in `main`. Once merged, the workflow can be run per `(locale × level)` batch (ja / en first) to produce content-translation PRs.

## Safety
Protected fields (id / expectedAnswer / options / surface / reading / level / promptText / the Chinese source) are **never written**. Verified by an in-memory apply over the real N5 file: **183 items, count stable, every protected line byte-identical, 20 overlay lines added, no CRLF**. The workflow also runs typecheck / test / build on the generated overlay before opening any PR.

## Verification
- `pnpm build` OK, vitest OK **537/537** (16 script tests: multi-field find/validate/apply, merge, escape, `exampleMeaningZh` anchor guard, protected-field-guard rejections).
- Dry-run on real N5 (en + ja): finds items with all 5 fields, no crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded AI translation support to cover multiple content fields per locale, not just one text field.
  * Updated the translation workflow to generate broader content overlays and clearer progress reporting.

* **Bug Fixes**
  * Improved handling of existing translations so new locale content is added without duplicating entries.
  * Added stronger validation to reduce invalid or incomplete translation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->