### PR TITLE
fix(pwa): raise workbox precache cap for the growing examBlocks chunk (#400)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
     // reloaded mid-drill -- the old "auto-inject bare registerSW.js" never
     // reloaded the running page at all, so users were stuck on the old build
     // until they opened an incognito tab. Precaches the built chunks (incl. the
-    // lazy examBlocks ~1MB) so a returning learner can practise offline; the
+    // lazy examBlocks chunk, now several MB with i18n overlays) so a returning
+    // learner can practise offline; the
     // lazy split is unchanged -- precaching runs in the background after load,
     // the initial render still pulls only the index chunk.
     VitePWA({
@@ -48,9 +49,13 @@ export default defineConfig({
         // precached via includeAssets above. Keeping them out of
         // globPatterns avoids duplicate precache entries for the same URL.
         globPatterns: ["**/*.{js,css,html,woff2}"],
-        // The lazy examBlocks chunk is ~1MB; lift the precache size cap so
-        // it's available offline.
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024
+        // The lazy examBlocks chunk holds every exam item + its per-locale
+        // content overlays (#400), so it grows with each language we translate
+        // (~3.6MB at en, heading toward ~6MB once ja lands). Lift the precache
+        // size cap so it stays available offline. NOTE: once several more
+        // locales are translated this chunk gets large to precache for every
+        // user -- revisit per-locale code-splitting / runtime caching then.
+        maximumFileSizeToCacheInBytes: 8 * 1024 * 1024
       }
     })
   ],


### PR DESCRIPTION
fix(pwa): raise workbox precache cap for the growing examBlocks chunk (#400)

The lazy examBlocks chunk carries every exam item plus its per-locale content
overlays (#400), so it grows with each language translated. It has crossed the
old 3 MiB workbox `maximumFileSizeToCacheInBytes`, which made `vite build` hard-
fail in the PWA step (the chunk "won't be precached" turns into an error).

Raise the cap to 8 MiB so the exam data stays precached/offline through the
English + Japanese translation rollout. Added a NOTE: once several more locales
land this chunk gets large to precache for every user, so per-locale code-
splitting / runtime caching should be revisited then.

No runtime behaviour change; build green.
