### PR TITLE
i18n(study): English + Japanese for grammar-point reference notes (#400)

### DIFF
--- a/src/components/GrammarNoteCard.tsx
+++ b/src/components/GrammarNoteCard.tsx
@@ -1,5 +1,7 @@
 import { copy, type Language } from "../i18n";
 import type { GrammarNote } from "../domain/grammarNotes";
+import { localizeGrammarNote } from "../domain/grammarNoteText";
+import { grammarNoteI18n } from "../domain/grammarNotes.i18n";
 
 // Reusable presentation for one grammar-point reference note (issue #137):
 // meaning / formation / usage / examples / easily-confused points. Pure
@@ -8,28 +10,31 @@ import type { GrammarNote } from "../domain/grammarNotes";
 // tier. Carries no data lookup of its own.
 export function GrammarNoteCard({ note, language }: { note: GrammarNote; language: Language }) {
   const t = copy[language];
+  // Localize the Chinese prose to the current language (falls back to zh);
+  // the Japanese examples / surface / level are preserved.
+  const n = localizeGrammarNote(note, language, grammarNoteI18n);
   return (
     <div className="grammar-note">
       <div className="grammar-note-head">
-        <strong>{note.surface}</strong>
-        {note.jlptLevel ? (
-          <span className="grammar-note-level" aria-label={`JLPT ${note.jlptLevel}`}>
-            {note.jlptLevel}
+        <strong>{n.surface}</strong>
+        {n.jlptLevel ? (
+          <span className="grammar-note-level" aria-label={`JLPT ${n.jlptLevel}`}>
+            {n.jlptLevel}
           </span>
         ) : null}
       </div>
-      <p className="grammar-note-meaning">{note.meaningZh}</p>
+      <p className="grammar-note-meaning">{n.meaningZh}</p>
       <dl className="grammar-note-fields">
         <dt>{t.grammarNoteFormation}</dt>
-        <dd>{note.formation}</dd>
+        <dd>{n.formation}</dd>
         <dt>{t.grammarNoteUsage}</dt>
-        <dd>{note.usageZh}</dd>
+        <dd>{n.usageZh}</dd>
       </dl>
-      {note.examples.length > 0 ? (
+      {n.examples.length > 0 ? (
         <div className="grammar-note-examples">
           <p className="grammar-note-label">{t.grammarNoteExamples}</p>
           <ul>
-            {note.examples.map((example) => (
+            {n.examples.map((example) => (
               <li key={example.ja}>
                 {example.ja}
                 <span>{example.zh}</span>
@@ -38,11 +43,11 @@ export function GrammarNoteCard({ note, language }: { note: GrammarNote; languag
           </ul>
         </div>
       ) : null}
-      {note.confusions.length > 0 ? (
+      {n.confusions.length > 0 ? (
         <div className="grammar-note-confusions">
           <p className="grammar-note-label">{t.grammarNoteConfusions}</p>
           <ul>
-            {note.confusions.map((confusion) => (
+            {n.confusions.map((confusion) => (
               <li key={confusion}>{confusion}</li>
             ))}
           </ul>

--- a/src/domain/grammarNoteText.test.ts
+++ b/src/domain/grammarNoteText.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { localizeGrammarNote, type GrammarNoteOverlays } from "./grammarNoteText";
+import type { GrammarNote } from "./grammarNotes";
+
+const baseNote: GrammarNote = {
+  surface: "ばかりに",
+  jlptLevel: "N2",
+  meaningZh: "就因為…",
+  formation: "動詞普通形＋ばかりに",
+  usageZh: "強調負面原因。",
+  examples: [{ ja: "言ったばかりに、怒らせた。", zh: "就因為說了，惹火了。" }],
+  confusions: ["せいで：單純歸咎", "だけあって：正面評價"]
+};
+
+const overlay = (text: object, lang = "en"): GrammarNoteOverlays => ({
+  [baseNote.surface]: { [lang]: text }
+});
+
+describe("localizeGrammarNote", () => {
+  it("returns the source note when there is no overlay for the surface/locale", () => {
+    expect(localizeGrammarNote(baseNote, "en", {})).toBe(baseNote);
+    expect(localizeGrammarNote(baseNote, "en", overlay({ meaningZh: "x" }, "ja"))).toBe(baseNote);
+  });
+
+  it("applies overlay fields, falling back to source per field", () => {
+    const out = localizeGrammarNote(
+      baseNote,
+      "en",
+      overlay({ meaningZh: "just because …", usageZh: "Stresses a negative cause." })
+    );
+    expect(out.meaningZh).toBe("just because …");
+    expect(out.usageZh).toBe("Stresses a negative cause.");
+    expect(out.formation).toBe("動詞普通形＋ばかりに"); // omitted -> source
+  });
+
+  it("localizes example zh by index but keeps the Japanese example", () => {
+    const out = localizeGrammarNote(baseNote, "en", overlay({ examplesZh: ["because I said it, I angered him."] }));
+    expect(out.examples[0].zh).toBe("because I said it, I angered him.");
+    expect(out.examples[0].ja).toBe("言ったばかりに、怒らせた。");
+  });
+
+  it("localizes confusions by index with source fallback", () => {
+    const out = localizeGrammarNote(baseNote, "en", overlay({ confusions: ["せいで: just blames a cause"] }));
+    expect(out.confusions).toEqual(["せいで: just blames a cause", "だけあって：正面評價"]);
+  });
+
+  it("never touches surface / jlptLevel", () => {
+    const out = localizeGrammarNote(baseNote, "en", overlay({ meaningZh: "m" }));
+    expect(out.surface).toBe("ばかりに");
+    expect(out.jlptLevel).toBe("N2");
+  });
+});

--- a/src/domain/grammarNoteText.ts
+++ b/src/domain/grammarNoteText.ts
@@ -1,0 +1,51 @@
+import type { GrammarNote } from "./grammarNotes";
+import type { LocaleCode } from "./types";
+
+/**
+ * Read-path helper for the grammar-note reference overlays (#137 / #400). The
+ * per-locale text lives in `grammarNotes.i18n.ts`; this module is data-free so
+ * it can be imported cheaply. grammarNotes itself only loads inside the lazy
+ * challenge chunk, so both are out of the eager bundle.
+ *
+ * Only the Chinese prose is localized. The Japanese example sentences
+ * (`examples[].ja`), the point `surface`, and `jlptLevel` are never overlaid.
+ */
+export type GrammarNoteText = {
+  meaningZh?: string;
+  formation?: string;
+  usageZh?: string;
+  /** Aligned by index with the note's `examples[]`; localizes each `.zh`. */
+  examplesZh?: (string | null)[];
+  /** Aligned by index with the note's `confusions[]`. */
+  confusions?: string[];
+};
+
+export type GrammarNoteOverlays = Record<string, Partial<Record<LocaleCode, GrammarNoteText>>>;
+
+const pick = (value: string | null | undefined, source: string): string =>
+  typeof value === "string" && value.trim() !== "" ? value : source;
+
+/**
+ * Return a copy of `note` with its Chinese fields replaced by the `lang` overlay
+ * (keyed by surface), falling back to the source per field / per array index.
+ * Returns the source note untouched when there's no overlay for its surface/locale.
+ */
+export function localizeGrammarNote(
+  note: GrammarNote,
+  lang: LocaleCode,
+  overlays: GrammarNoteOverlays
+): GrammarNote {
+  const text = overlays[note.surface]?.[lang];
+  if (!text) return note;
+  return {
+    ...note,
+    meaningZh: pick(text.meaningZh, note.meaningZh),
+    formation: pick(text.formation, note.formation),
+    usageZh: pick(text.usageZh, note.usageZh),
+    examples: note.examples.map((example, i) => {
+      const zh = pick(text.examplesZh?.[i], example.zh);
+      return zh === example.zh ? example : { ...example, zh };
+    }),
+    confusions: note.confusions.map((confusion, i) => pick(text.confusions?.[i], confusion))
+  };
+}

--- a/src/domain/grammarNotes.i18n.ts
+++ b/src/domain/grammarNotes.i18n.ts
@@ -1,0 +1,141 @@
+import type { GrammarNoteOverlays } from "./grammarNoteText";
+
+/**
+ * Per-locale text overlays for the grammar-point reference notes, keyed by
+ * `surface`. Data-only and imported by the (lazy) GrammarNoteCard, so it rides
+ * in the lazy challenge chunk alongside grammarNotes itself — never the eager
+ * bundle. Only the Chinese prose is overlaid; Japanese examples and identifiers
+ * are never touched. Populated by the study-content translation pass (#400).
+ */
+export const grammarNoteI18n: GrammarNoteOverlays = {
+  "ばかりに": {
+    "en": {
+      "meaningZh": "just because… (which is exactly what led to a bad outcome)",
+      "formation": "plain form of a verb / い-adjective ＋ ばかりに; な-adjective ＋ な / noun ＋ である ＋ ばかりに",
+      "usageZh": "Emphasizes that it was precisely this one cause that brought about the (usually negative, regrettable) result that follows, carrying a tone of regret and frustration.",
+      "examplesZh": [
+        "Just because I said one word too many, I ended up making him angry."
+      ],
+      "confusions": [
+        "だけあって: a positive appraisal (living up to expectations), so the direction is the opposite.",
+        "せいで: simply pins the blame on a negative cause, without the 'precisely because of this' emphasis or the note of regret."
+      ]
+    },
+    "ja": {
+      "meaningZh": "ほかでもなく～が原因で(よくない結果を招いてしまう)",
+      "formation": "動詞・い形容詞の普通形＋ばかりに；な形容詞＋な／名詞＋である＋ばかりに",
+      "usageZh": "「まさにこの原因があったからこそ」後件の(多くは否定的で悔やまれる)結果を招いたことを強調し、後悔や無念の気持ちを込めた言い方。",
+      "examplesZh": [
+        "余計な一言を言ってしまったせいで、彼を怒らせてしまった。"
+      ],
+      "confusions": [
+        "だけあって：肯定的な評価(さすが～だ)を表し、方向が正反対である。",
+        "せいで：否定的な原因を単に責めるだけで、「まさにそのために」という強調や悔やむニュアンスはない。"
+      ]
+    }
+  },
+  "だけあって": {
+    "en": {
+      "meaningZh": "as one would expect of…; precisely because… (and so, naturally, excellent)",
+      "formation": "noun / plain form of a verb / い-adjective ＋ だけあって; な-adjective ＋ な ＋ だけあって",
+      "usageZh": "Expresses that 'precisely because of some status, background, or condition, the result naturally follows,' leading into an appraisal (usually positive and admiring) that lives up to that premise.",
+      "examplesZh": [
+        "As you'd expect of a first-class hotel, the service is impeccable."
+      ],
+      "confusions": [
+        "ばかりに: a negative consequence tinged with regret, so the direction is the opposite.",
+        "おかげで: simply credits some cause, without the nuance of 'living up to its reputation, as one would expect.'"
+      ]
+    },
+    "ja": {
+      "meaningZh": "さすが～だけのことはある；まさに～だからこそ(当然のように優れている)",
+      "formation": "名詞／動詞・い形容詞の普通形＋だけあって；な形容詞＋な＋だけあって",
+      "usageZh": "「ある身分・経歴・条件があるからこそ、結果も当然そうなる」ことを表し、その前提にふさわしい(多くは肯定的で感心させられる)評価が続く。",
+      "examplesZh": [
+        "さすが一流ホテルだけあって、サービスが行き届いている。"
+      ],
+      "confusions": [
+        "ばかりに：後悔を伴う否定的な結果を表し、方向が正反対である。",
+        "おかげで：ある原因のおかげだと単に述べるだけで、「名実相応で当然だ」というニュアンスはない。"
+      ]
+    }
+  },
+  "なり": {
+    "en": {
+      "meaningZh": "the moment… (immediately) …",
+      "formation": "dictionary form of a verb ＋ なり",
+      "usageZh": "Indicates that the second action follows (often unexpectedly) the instant the first one has just occurred; the subject is the same for both clauses, and the second is often a surprising act witnessed by the speaker.",
+      "examplesZh": [
+        "The moment he sat down, he began talking a mile a minute, as if a dam had burst."
+      ],
+      "confusions": [
+        "たとたん: 'the moment…,' but なり places more emphasis on the same person's very next action following immediately.",
+        "次第: 'as soon as…,' with a more formal, businesslike tone; the second clause is usually a volitional arrangement."
+      ]
+    },
+    "ja": {
+      "meaningZh": "～すると(すぐに)～する",
+      "formation": "動詞の辞書形＋なり",
+      "usageZh": "前の動作が起こった直後、(しばしば意外にも)すぐに後件を行うことを表す。前後は同一主語で、後件は話し手が目撃した意外な行動であることが多い。",
+      "examplesZh": [
+        "彼は席に着くなり、堰を切ったように話し始めた。"
+      ],
+      "confusions": [
+        "たとたん：「～するとすぐに」だが、「なり」は同一人物が直後に取る次の動作をより強調する。",
+        "次第：「～するとすぐに」だが、語感が改まって事務的で、後件は意志的な取り決めであることが多い。"
+      ]
+    }
+  },
+  "あげく": {
+    "en": {
+      "meaningZh": "in the end, after all… (only to end up with a — usually negative — result)",
+      "formation": "plain past form of a verb ＋ あげく; noun ＋ の ＋ あげく",
+      "usageZh": "Indicates that after a great deal of (prolonged or repeated) trouble and effort, one ends up with some (usually undesirable) result.",
+      "examplesZh": [
+        "After agonizing over it forever, I ended up going home without buying anything."
+      ],
+      "confusions": [
+        "すえに: 'after … one finally arrives at a result,' but the result can be either good or bad, with a more formal tone.",
+        "結果: a neutral statement of the outcome, without the nuance of the hardship of 'going through a lot of trouble.'"
+      ]
+    },
+    "ja": {
+      "meaningZh": "～した末に(結局、多くは否定的な結果になる)",
+      "formation": "動詞のた形＋あげく；名詞＋の＋あげく",
+      "usageZh": "(長時間または繰り返し)さんざん苦労した末に、最終的にある(たいていよくない)結果に至ることを表す。",
+      "examplesZh": [
+        "さんざん迷ったあげく、結局何も買わずに帰った。"
+      ],
+      "confusions": [
+        "すえに：「～した末に結果を得る」だが、結果は良い場合も悪い場合もあり、語感がより改まっている。",
+        "結果：中立的な事実の陳述で、「さんざん苦労した」という苦労のニュアンスはない。"
+      ]
+    }
+  },
+  "っぱなし": {
+    "en": {
+      "meaningZh": "leaving something … (left as it is, unattended — usually implying negligence / a negative sense)",
+      "formation": "ます-stem of a verb (drop ます) ＋ っぱなし",
+      "usageZh": "Indicates that after doing some action, one leaves it unattended when it ought to be wrapped up, so the state simply persists — often carrying the negative nuance of 'not doing the follow-up that should have been done.'",
+      "examplesZh": [
+        "I was brushing my teeth with the tap left running."
+      ],
+      "confusions": [
+        "たまま: merely keeps a state unchanged, with a neutral tone; っぱなし carries the reproachful sense of 'left undone when it should have been dealt with.'",
+        "ておく: deliberately keeping a state for some purpose — it is intentional, unlike simply leaving something neglected."
+      ]
+    },
+    "ja": {
+      "meaningZh": "～したまま(放っておく。多くは不注意・否定的な意味を含む)",
+      "formation": "動詞のます形(ますを取る)＋っぱなし",
+      "usageZh": "ある動作をした後、始末をつけるべきなのに放置し、その状態がずっと続くことを表す。しばしば「やるべき後始末をしていない」という否定的なニュアンスを伴う。",
+      "examplesZh": [
+        "水を出しっぱなしにして、歯を磨いていた。"
+      ],
+      "confusions": [
+        "たまま：ある状態をそのまま保つだけで語感は中立的。「っぱなし」は「始末すべきなのにしていない」という非難のニュアンスを帯びる。",
+        "ておく：ある目的のために「意図的に」状態を保つもので、意図があり、放置とは異なる。"
+      ]
+    }
+  }
+};


### PR DESCRIPTION
i18n(study): English + Japanese for grammar-point reference notes (#400)

The grammar-note reference cards (#137) — shown post-answer and on the
/grammar/<surface> study page — rendered meaning / formation / usage / example
glosses / confusions in Chinese for every locale. Add en + ja overlays.

- New data-free `grammarNoteText.ts` holds `localizeGrammarNote`, which swaps the
  Chinese prose for the `lang` overlay (keyed by surface), falling back to the zh
  source per field / per array index and never touching the Japanese examples,
  `surface`, or `jlptLevel`.
- New `grammarNotes.i18n.ts` is the data-only overlay record; both it and
  grammarNotes ride only in the lazy challenge chunk (via GrammarNoteCard /
  FeedbackPanel), never the eager bundle.
- GrammarNoteCard localizes its note internally, so GrammarPointPage's curated
  notes are covered too.

Data: all 5 curated notes translated to en + ja by a Claude subagent
(index-aligned examples/confusions, each confusion's leading Japanese pattern
kept). TDD: 5 helper tests. Build green, full suite 551 green, no CRLF.
