### PR TITLE
fix(i18n): localize the post-answer example line + distractor glosses (#400 review follow-up)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,8 @@ import "./styles.css";
 
 // Lazy routes. The challenge view owns the practice engine, which
 // statically imports the entire question bank (examBlocks alone is
-// ~288 KB); the mock-exam picker reads the exam pool too. Loading them
+// several MB and grows with each content locale, #420); the mock-exam
+// picker reads the exam pool too. Loading them
 // with React.lazy keeps that data out of the initial bundle -- it's
 // fetched only when the learner actually opens those views. They're
 // imported straight from their modules (not the components barrel) on

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -418,6 +418,60 @@ describe("FeedbackPanel localized explanation (#378)", () => {
   });
 });
 
+describe("FeedbackPanel localized example translation (#400 follow-up)", () => {
+  const base = readingPool[0];
+  const question = {
+    ...base,
+    vocabulary: {
+      ...base.vocabulary,
+      examples: [
+        {
+          japanese: "毎朝、パンを食べます。",
+          meaningZh: "每天早上吃麵包。",
+          meaningI18n: { en: "I eat bread every morning." }
+        }
+      ]
+    }
+  };
+
+  it("renders the post-answer example meaning in the active language via the overlay", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question, submittedAnswer: null }}
+        language="en"
+        options={[]}
+      />
+    );
+    expect(screen.getByText("I eat bread every morning.")).toBeInTheDocument();
+    expect(screen.queryByText("每天早上吃麵包。")).toBeNull();
+  });
+
+  it("falls back to the zh example meaning when the locale has no overlay", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question, submittedAnswer: null }}
+        language="th"
+        options={[]}
+      />
+    );
+    expect(screen.getByText("每天早上吃麵包。")).toBeInTheDocument();
+  });
+
+  it("threads promptContextI18n onto every exam item's baked example (factory)", () => {
+    // The factory bakes examples[0].meaningZh from promptContextZh when the item
+    // has no custom exampleMeaningZh; the localized variant must ride along, or
+    // en/ja users see Chinese on every post-answer example line.
+    const q = examStyleQuestions.find(
+      (x) =>
+        x.promptContextZh &&
+        x.vocabulary.examples[0]?.meaningZh === x.promptContextZh &&
+        x.promptContextI18n?.en
+    )!;
+    expect(q).toBeDefined();
+    expect(q.vocabulary.examples[0].meaningI18n?.en).toBe(q.promptContextI18n!.en);
+  });
+});
+
 describe("FeedbackPanel furigana (#134)", () => {
   // Override the example with a pre-baked sentence (学校 -> がっこう) so the
   // ruby path has data. The feedback example is POST-answer, so it shows

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -73,7 +73,10 @@ export function FeedbackPanel({
       return `${reading}（${words.length > 0 ? words.join("／") : t.feedbackNoWord}）`;
     });
   } else if (isGrammarGloss) {
-    const glossed = distractors.map((pattern) => ({ pattern, meaning: lookupPatternMeaning(pattern) }));
+    const glossed = distractors.map((pattern) => ({
+      pattern,
+      meaning: lookupPatternMeaning(pattern, language)
+    }));
     // Only show the block if the bank knew at least one pattern -- otherwise
     // it would just re-list the options with no added information.
     if (glossed.some((entry) => entry.meaning)) {
@@ -109,7 +112,13 @@ export function FeedbackPanel({
       {feedback.question.vocabulary.examples[0] ? (
         <p className="example">
           <Ruby text={feedback.question.vocabulary.examples[0].japanese} />
-          <span>{feedback.question.vocabulary.examples[0].meaningZh}</span>
+          <span>
+            {pickLocalized(
+              feedback.question.vocabulary.examples[0].meaningZh,
+              feedback.question.vocabulary.examples[0].meaningI18n,
+              language
+            )}
+          </span>
         </p>
       ) : null}
       {grammarNote ? (

--- a/src/domain/exam/helpers.ts
+++ b/src/domain/exam/helpers.ts
@@ -17,7 +17,12 @@ export function examQuestion(input: ExamQuestionInput): PracticeQuestion {
       examples: [
         {
           japanese: input.exampleJapanese ?? input.promptText.replace("___", input.expectedAnswer),
-          meaningZh: input.exampleMeaningZh ?? input.promptContextZh
+          meaningZh: input.exampleMeaningZh ?? input.promptContextZh,
+          // The localized variant must match whichever zh source was baked in:
+          // a custom example meaning gets its own overlay; the promptContext
+          // fallback reuses the (already translated) promptContextI18n.
+          meaningI18n:
+            input.exampleMeaningZh != null ? input.exampleMeaningI18n : input.promptContextI18n
         }
       ],
       level: input.level

--- a/src/domain/exam/types.ts
+++ b/src/domain/exam/types.ts
@@ -41,4 +41,6 @@ export type ExamQuestionInput = {
    */
   exampleJapanese?: string;
   exampleMeaningZh?: string;
+  /** Per-locale `exampleMeaningZh` overlay (#400). */
+  exampleMeaningI18n?: LocalizedText;
 };

--- a/src/domain/learningBlockText.test.ts
+++ b/src/domain/learningBlockText.test.ts
@@ -82,6 +82,15 @@ describe("localizeLearningBlock", () => {
     expect(out.pitfalls).toEqual(["pitfall one", "陷阱二"]);
   });
 
+  it("never invents kicker or drillNote the source block lacks", () => {
+    const bare: LearningBlock = { ...baseBlock, kicker: undefined, drillNote: undefined };
+    const out = localizeLearningBlock(bare, "en", {
+      [bare.id]: { en: { kicker: "Invented kicker", drillNote: "Invented note" } }
+    });
+    expect(out.kicker).toBeUndefined();
+    expect(out.drillNote).toBeUndefined();
+  });
+
   it("never touches Japanese/logic fields", () => {
     const out = localizeLearningBlock(
       baseBlock,

--- a/src/domain/learningBlockText.ts
+++ b/src/domain/learningBlockText.ts
@@ -29,10 +29,13 @@ export type LearningBlockOverlays = Record<string, Partial<Record<LocaleCode, Le
 const pick = (value: string | null | undefined, source: string): string =>
   typeof value === "string" && value.trim() !== "" ? value : source;
 
+// Never INVENTS a field the source lacks: an overlay can only replace existing
+// Chinese text, so a stray translated kicker/drillNote cannot conjure UI the
+// source author didn't write.
 const pickOptional = (
   value: string | null | undefined,
   source: string | undefined
-): string | undefined => (typeof value === "string" && value.trim() !== "" ? value : source);
+): string | undefined => (source == null ? undefined : pick(value, source));
 
 /**
  * Return a copy of `block` with its Chinese text fields replaced by the `lang`

--- a/src/domain/patternMeaning.test.ts
+++ b/src/domain/patternMeaning.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { lookupPatternMeaning } from "./patternMeaning";
+import { examStyleQuestions } from "./examBlocks";
+
+// Pick a real bank pattern whose vocabulary carries an en overlay, so the
+// localized lookup has something to return (all exam items have en/ja
+// overlays as of #400).
+const sample = examStyleQuestions.find(
+  (q) => q.vocabulary.surface && q.vocabulary.meaningZh && q.vocabulary.meaningI18n?.en
+)!;
+
+describe("lookupPatternMeaning", () => {
+  it("returns the Chinese gloss by default (backwards compatible)", () => {
+    expect(lookupPatternMeaning(sample.vocabulary.surface)).toBe(sample.vocabulary.meaningZh);
+  });
+
+  it("returns the localized gloss for a locale with an overlay", () => {
+    expect(lookupPatternMeaning(sample.vocabulary.surface, "en")).toBe(
+      sample.vocabulary.meaningI18n!.en
+    );
+  });
+
+  it("falls back to the Chinese gloss for a locale without an overlay", () => {
+    // th content overlays don't exist yet -- must degrade to zh, not blank.
+    expect(lookupPatternMeaning(sample.vocabulary.surface, "th")).toBe(
+      sample.vocabulary.meaningZh
+    );
+  });
+
+  it("still returns null for a pattern the bank does not know", () => {
+    expect(lookupPatternMeaning("ぜったいにそんざいしないぶんけい", "en")).toBeNull();
+  });
+});

--- a/src/domain/patternMeaning.ts
+++ b/src/domain/patternMeaning.ts
@@ -1,28 +1,39 @@
 import { examStyleQuestions } from "./examBlocks";
+import { pickLocalized } from "./localizedContent";
+import type { LocaleCode, LocalizedText } from "./types";
 
-// pattern (an option string a learner sees in a 文法 question) -> its
-// Chinese gloss, sourced from wherever that pattern is an exam item's
-// answer or surface in the bank. Used post-answer to annotate grammar
-// distractors (ものの -> 雖然…但是), turning a wrong pick into a quick
-// "what was that one?" note. Built once at module load; only ever loaded
-// inside the lazy challenge chunk (examBlocks already lives there).
-const patternToMeaning = new Map<string, string>();
+// pattern (an option string a learner sees in a 文法 question) -> its gloss,
+// sourced from wherever that pattern is an exam item's answer or surface in
+// the bank. Used post-answer to annotate grammar distractors (ものの ->
+// 雖然…但是), turning a wrong pick into a quick "what was that one?" note.
+// Carries the per-locale meaning overlays (#400) alongside the zh source so
+// the gloss follows the UI language. Built once at module load; only ever
+// loaded inside the lazy challenge chunk (examBlocks already lives there).
+const patternToMeaning = new Map<string, { meaningZh: string; meaningI18n?: LocalizedText }>();
 for (const question of examStyleQuestions) {
   const meaning = question.vocabulary.meaningZh;
   if (!meaning) continue;
   for (const key of [question.vocabulary.surface, ...question.expectedAnswers]) {
     if (key && !patternToMeaning.has(key)) {
-      patternToMeaning.set(key, meaning);
+      patternToMeaning.set(key, {
+        meaningZh: meaning,
+        meaningI18n: question.vocabulary.meaningI18n
+      });
     }
   }
 }
 
 /**
- * Chinese gloss for a grammar pattern if the bank knows it, else null.
- * Distractors not present in the bank stay un-annotated (they are still
- * real patterns -- unlike reading distractors, "not found" is not a
- * content defect here).
+ * Gloss for a grammar pattern if the bank knows it, else null. Localized to
+ * `lang` when the sourcing item carries an overlay, falling back to the
+ * Chinese source. Distractors not present in the bank stay un-annotated
+ * (they are still real patterns -- unlike reading distractors, "not found"
+ * is not a content defect here).
  */
-export function lookupPatternMeaning(pattern: string): string | null {
-  return patternToMeaning.get(pattern) ?? null;
+export function lookupPatternMeaning(
+  pattern: string,
+  lang: LocaleCode = "zh-Hant"
+): string | null {
+  const entry = patternToMeaning.get(pattern);
+  return entry ? pickLocalized(entry.meaningZh, entry.meaningI18n, lang) : null;
 }

--- a/src/domain/sentencePatterns.i18n.test.ts
+++ b/src/domain/sentencePatterns.i18n.test.ts
@@ -13,16 +13,22 @@ describe("sentence-pattern overlays", () => {
     }
   });
 
+  // Coverage of NEW items is a warn-level concern for the check:i18n report
+  // (#422), deliberately NOT a hard CI gate here -- content batches land
+  // zh-first by design. This test only proves the THREADING works, using a
+  // known item that has overlays.
   it("carries per-item hint / context / explanation overlays through to the question", () => {
-    const pool = buildSentencePatternPool();
-    const withEn = pool.filter(
-      (q) => q.hintI18n?.en && q.promptContextI18n?.en && q.explanationI18n?.en
-    );
-    const withJa = pool.filter(
-      (q) => q.hintI18n?.ja && q.promptContextI18n?.ja && q.explanationI18n?.ja
-    );
-    // Every pattern item should be fully overlaid once the translation pass lands.
-    expect(withEn.length).toBe(pool.length);
-    expect(withJa.length).toBe(pool.length);
+    const q = buildSentencePatternPool().find((x) => x.id === "pattern-te-kudasai-001")!;
+    expect(q).toBeDefined();
+    for (const lang of ["en", "ja"] as const) {
+      expect(q.hintI18n?.[lang]).toBeTruthy();
+      expect(q.promptContextI18n?.[lang]).toBeTruthy();
+      expect(q.explanationI18n?.[lang]).toBeTruthy();
+    }
+  });
+
+  it("threads the context overlay onto the baked example meaning (post-answer line)", () => {
+    const q = buildSentencePatternPool().find((x) => x.id === "pattern-te-kudasai-001")!;
+    expect(q.vocabulary.examples[0]?.meaningI18n?.en).toBe(q.promptContextI18n?.en);
   });
 });

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -726,7 +726,10 @@ function toPracticeQuestion(item: SentencePatternItem): PracticeQuestion {
     examples: [
       {
         japanese: item.promptText.replace("___", item.expectedAnswer),
-        meaningZh: item.promptContextZh
+        meaningZh: item.promptContextZh,
+        // Same source as promptContextZh, so it shares that overlay -- keeps
+        // the post-answer example line in the UI language (#400).
+        meaningI18n: sentencePatternI18n[item.id]?.promptContextI18n
       }
     ],
     level: "N5"

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -44,6 +44,8 @@ export type TargetForm =
 export interface ExampleSentence {
   japanese: string;
   meaningZh: string;
+  /** Per-locale translations of `meaningZh`; falls back to the zh source (#400). */
+  meaningI18n?: LocalizedText;
 }
 
 export interface VocabularyItem {


### PR DESCRIPTION
fix(i18n): localize the post-answer example line + distractor glosses (#400 review follow-up)

Findings from the 2026-07 whole-repo review: two post-answer surfaces still
rendered Chinese for en/ja users, plus two small hardening items.

1. Post-answer example line (the big one). FeedbackPanel rendered
   `examples[0].meaningZh` raw. The exam factory bakes that from
   `exampleMeaningZh ?? promptContextZh` -- and promptContextI18n was already
   fully translated, so ~72% of exam items get a localized example line purely
   by threading it through:
   - `ExampleSentence` gains optional `meaningI18n` (additive, contract-safe);
   - examQuestion() threads `exampleMeaningI18n ?? promptContextI18n` to match
     whichever zh source it baked;
   - sentence-pattern questions thread their promptContextI18n the same way;
   - FeedbackPanel reads the line via pickLocalized.
   Items with a CUSTOM exampleMeaningZh (550) still fall back to zh until that
   field is translated (tracked in #422 / pipeline FIELDS follow-up).

2. Grammar distractor glosses. lookupPatternMeaning() now takes a locale and
   resolves through the sourcing item's meaningI18n (zh fallback), so the
   "other options" block follows the UI language.

3. sentencePatterns.i18n.test: replaced the 100%-coverage hard gate (a CI
   landmine for future content batches, and it never named the missing id)
   with known-id threading tests; coverage visibility moves to the #422
   warn-level report.

4. learningBlockText.pickOptional can no longer INVENT a kicker/drillNote the
   source block lacks (overlays only replace existing text).

5. App.tsx stale comment (examBlocks "~288 KB" -> reality: several MB, #420).

TDD: 5 new RED tests first (example-line en render + th fallback + factory
threading, localized/default/fallback/unknown patternMeaning, invent guard).
Full suite 564 green, build green, no CRLF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Example meanings and pattern glosses now follow the active language when a translation is available.
  * Practice feedback now shows localized example text, with a fallback to the original Chinese meaning when needed.

* **Bug Fixes**
  * Improved fallback behavior so missing translations no longer appear blank or get filled in unexpectedly.
  * Learning block text now preserves empty fields unless they were already provided.

* **Tests**
  * Added coverage for localized examples, pattern meaning lookups, and translation fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->