### PR TITLE
i18n(exam): translate the 550 custom example meanings + pipeline field (#400)

### DIFF
--- a/scripts/ai-translate-content.mjs
+++ b/scripts/ai-translate-content.mjs
@@ -39,11 +39,15 @@ const ITEMS_DIR = path.join(REPO_ROOT, "src", "domain", "exam", "items");
 const LOCALES = new Set(["ja", "en", "th", "id", "ko", "vi", "my"]); // zh-Hant is the source
 
 // Every translatable Chinese content field and its per-locale overlay sibling.
+// exampleMeaningZh only exists on items with a CUSTOM example sentence; items
+// without it reuse promptContextZh (whose overlay the factory threads onto the
+// example line), so no per-item gap arises from its absence.
 export const FIELDS = [
   { source: "meaningZh", overlay: "meaningI18n" },
   { source: "instructionZh", overlay: "instructionI18n" },
   { source: "promptContextZh", overlay: "promptContextI18n" },
   { source: "hintZh", overlay: "hintI18n" },
+  { source: "exampleMeaningZh", overlay: "exampleMeaningI18n" },
   { source: "explanation", overlay: "explanationI18n" }
 ];
 

--- a/scripts/ai-translate-content.test.ts
+++ b/scripts/ai-translate-content.test.ts
@@ -76,15 +76,16 @@ describe("findTargets (multi-field)", () => {
     expect(x1.context.options).toContain('"に"');
   });
 
-  it("does NOT confuse meaningZh with exampleMeaningZh (anchored field match)", () => {
+  it("keeps meaningZh and exampleMeaningZh apart (anchored field match)", () => {
     const withExample = FIXTURE.replace(
       '    meaningZh: "去",',
       '    meaningZh: "去",\n    exampleMeaningZh: "去學校的例句意思",'
     );
     const x1 = findTargets(withExample, "en", 1)[0];
+    // Each field is matched at its own anchor -- no cross-contamination in
+    // either direction now that exampleMeaningZh is itself translatable.
     expect(x1.fields.meaningZh).toBe("去");
-    // exampleMeaningZh is not a translatable field
-    expect(Object.keys(x1.fields)).not.toContain("exampleMeaningZh");
+    expect(x1.fields.exampleMeaningZh).toBe("去學校的例句意思");
   });
 });
 

--- a/src/domain/exam/items/n1.ts
+++ b/src/domain/exam/items/n1.ts
@@ -696,6 +696,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "来月から、新しい 委員会が 発足する 予定だ。",
     exampleJapanese: "来月から、新しい 委員会が 発足する 予定だ。",
     exampleMeaningZh: "下個月起新委員會將正式成立。",
+    exampleMeaningI18n: { "ja": "来月から新しい委員会が正式にスタートする予定です。", "en": "A new committee is set to be launched next month." },
     options: [
       "来月から、新しい 委員会が 発足する 予定だ。",
       "桜の 季節が 今年は 早めに 発足した。",
@@ -723,6 +724,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "彼は これまでに 多くの 著名な 建築物を 手がけて きた。",
     exampleJapanese: "彼は これまでに 多くの 著名な 建築物を 手がけて きた。",
     exampleMeaningZh: "他至今操刀過許多著名建築。",
+    exampleMeaningI18n: { "ja": "彼はこれまで数多くの有名な建築物の設計・施工に携わってきました。", "en": "He has worked on many famous buildings so far." },
     options: [
       "彼は これまでに 多くの 著名な 建築物を 手がけて きた。",
       "弟は 階段で 転んで 手を 手がけて しまった。",
@@ -750,6 +752,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "校正で 細かい 誤字を いくつか 見落として しまった。",
     exampleJapanese: "校正で 細かい 誤字を いくつか 見落として しまった。",
     exampleMeaningZh: "校稿時把幾個小錯字看漏了。",
+    exampleMeaningI18n: { "ja": "校正のとき、小さな誤字をいくつか見逃してしまいました。", "en": "I overlooked a few small typos while proofreading." },
     options: [
       "校正で 細かい 誤字を いくつか 見落として しまった。",
       "山の 頂上から 街全体を 見落として 写真を 撮った。",
@@ -777,6 +780,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "来週の 会議の 議題に ついて、課長と 打ち合わせた。",
     exampleJapanese: "来週の 会議の 議題に ついて、課長と 打ち合わせた。",
     exampleMeaningZh: "我跟課長協商了下週會議的議題。",
+    exampleMeaningI18n: { "ja": "来週の会議の議題について、課長と事前に相談しました。", "en": "I discussed the agenda for next week's meeting with the section chief." },
     options: [
       "来週の 会議の 議題に ついて、課長と 打ち合わせた。",
       "二人は 目を 打ち合わせて、互いに 微笑んだ。",
@@ -1210,6 +1214,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "けんちょ",
     exampleJapanese: "近年、環境問題の影響は顕著に現れている。",
     exampleMeaningZh: "近年來環境問題的影響顯而易見。",
+    exampleMeaningI18n: { "ja": "近年、環境問題の影響がはっきりと現れています。", "en": "In recent years, the impact of environmental problems has become strikingly apparent." },
     options: ["けんちょ", "けんしょ", "げんちょ", "けんちょう"],
     explanation: "「顕」音讀「けん」，「著」音讀「ちょ」→ けんちょ。「けんしょ」是清濁混淆；「げんちょ」是首字濁音；「けんちょう」是多餘的長音（撞到「県庁」）。",
     explanationI18n: { "ja": "「顕」の音読みは「けん」、「著」の音読みは「ちょ」で、けんちょ となります。「けんしょ」は清濁の混同、「げんちょ」は最初の字を濁音にした誤り、「けんちょう」は余分な長音（「県庁」との混同）です。", "en": "「顕」is read 「けん」and 「著」is read 「ちょ」→ けんちょ. 「けんしょ」confuses voiced/voiceless kana; 「げんちょ」voices the first syllable; 「けんちょう」adds a superfluous long vowel (colliding with 「県庁」)." },
@@ -1230,6 +1235,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "すいこう",
     exampleJapanese: "与えられた任務を確実に遂行する。",
     exampleMeaningZh: "確實執行所受託付的任務。",
+    exampleMeaningI18n: { "ja": "与えられた任務を確実にやり遂げます。", "en": "Carry out the assigned task without fail." },
     options: ["すいこう", "ついこう", "ずいこう", "すいぎょう"],
     explanation: "「遂」音讀「すい」，「行」音讀「こう」→ すいこう。「ついこう」是首字子音錯誤；「ずいこう」是「随行」（濁音化）；「すいぎょう」是「行」誤讀為「ぎょう」（修行 しゅぎょう 的類推）。",
     explanationI18n: { "ja": "「遂」の音読みは「すい」、「行」の音読みは「こう」で、すいこう となります。「ついこう」は最初の子音の誤り、「ずいこう」は「随行」（濁音化）、「すいぎょう」は「行」を「ぎょう」と誤読したもの（「修行 しゅぎょう」からの類推）です。", "en": "「遂」is read 「すい」and 「行」is read 「こう」→ すいこう. 「ついこう」has the wrong initial consonant on the first syllable; 「ずいこう」is 「随行」(voiced); 「すいぎょう」misreads 「行」as 「ぎょう」(by analogy with 修行 しゅぎょう)." },
@@ -1250,6 +1256,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "だきょう",
     exampleJapanese: "この問題で安易な妥協はできない。",
     exampleMeaningZh: "在這個問題上不能輕易妥協。",
+    exampleMeaningI18n: { "ja": "この問題では安易に譲歩することはできません。", "en": "We cannot make an easy compromise on this issue." },
     options: ["だきょう", "たきょう", "だこう", "だぎょう"],
     explanation: "「妥」音讀「だ」，「協」音讀「きょう」→ だきょう。「たきょう」是清濁混淆；「だこう」是「蛇行」（次字錯讀）；「だぎょう」是次字濁音化。",
     explanationI18n: { "ja": "「妥」の音読みは「だ」、「協」の音読みは「きょう」で、だきょう となります。「たきょう」は清濁の混同、「だこう」は「蛇行」（二字目の誤読）、「だぎょう」は二字目の濁音化です。", "en": "「妥」is read 「だ」and 「協」is read 「きょう」→ だきょう. 「たきょう」confuses voiced/voiceless kana; 「だこう」is 「蛇行」(the second character misread); 「だぎょう」voices the second character." },
@@ -1270,6 +1277,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "あんもく",
     exampleJapanese: "チーム内には暗黙のルールがある。",
     exampleMeaningZh: "團隊內存在默契性的規則。",
+    exampleMeaningI18n: { "ja": "チームの中には、口に出さなくても皆が了解しているルールがあります。", "en": "There are unspoken rules within the team." },
     options: ["あんもく", "あんぼく", "あんしょう", "あんめい"],
     explanation: "「暗」音讀「あん」，「黙」音讀「もく」→ あんもく。「あんぼく」是次字濁音；「あんしょう」是「暗証／暗唱」（次字錯讀）；「あんめい」是「暗冥」類錯讀。",
     explanationI18n: { "ja": "「暗」の音読みは「あん」、「黙」の音読みは「もく」で、あんもく となります。「あんぼく」は二字目の濁音、「あんしょう」は「暗証／暗唱」（二字目の誤読）、「あんめい」は「暗冥」のような誤読です。", "en": "「暗」is read 「あん」and 「黙」is read 「もく」→ あんもく. 「あんぼく」voices the second character; 「あんしょう」is 「暗証／暗唱」(the second character misread); 「あんめい」is a misreading along the lines of 「暗冥」." },
@@ -1290,6 +1298,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "とどこおって",
     exampleJapanese: "作業の進行が予定より滞っている。",
     exampleMeaningZh: "工作進度比預定還要拖延。",
+    exampleMeaningI18n: { "ja": "作業の進み具合が予定より遅れています。", "en": "Progress on the work is falling behind schedule." },
     options: ["とどこおって", "とどまって", "とどろいて", "たくおって"],
     explanation: "「滞」訓讀「とどこお-る」→ とどこおって。「とどまって」是「留まる／止まる」（同字根 とど- 但不同字）；「とどろいて」是「轟いて」（同字根，意為轟鳴）；「たくおって」是無對應字的擬音陷阱。",
     explanationI18n: { "ja": "「滞」の訓読みは「とどこお-る」で、とどこおって となります。「とどまって」は「留まる／止まる」（同じ「とど-」で始まるが別の字）、「とどろいて」は「轟いて」（同じ語頭で「とどろく＝鳴り響く」の意）、「たくおって」は対応する字のない語呂合わせの罠です。", "en": "「滞」has the kun reading 「とどこお-る」→ とどこおって. 「とどまって」is 「留まる／止まる」(same 「とど-」root but a different character); 「とどろいて」is 「轟いて」(same root, meaning \"to roar\"); 「たくおって」is a sound-alike trap with no corresponding character." },
@@ -1310,6 +1319,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "つちかう",
     exampleJapanese: "豊かな感性を培う教育を目指している。",
     exampleMeaningZh: "致力於培養豐富感性的教育。",
+    exampleMeaningI18n: { "ja": "豊かな感性を育てる教育を目指しています。", "en": "We aim for an education that cultivates rich sensitivity." },
     options: ["つちかう", "ばいかう", "つちこう", "つくろう"],
     explanation: "「培」訓讀「つちか-う」→ つちかう。「ばいかう」是把訓讀換成音讀「ばい」的陷阱；「つちこう」是次音節母音錯誤；「つくろう」是「繕う」（修補，不同字）。",
     explanationI18n: { "ja": "「培」の訓読みは「つちか-う」で、つちかう となります。「ばいかう」は訓読みを音読みの「ばい」に置き換えた罠、「つちこう」は二つ目の音節の母音の誤り、「つくろう」は「繕う」（修繕する、別の字）です。", "en": "「培」has the kun reading 「つちか-う」→ つちかう. 「ばいかう」is a trap that swaps in the on reading 「ばい」; 「つちこう」has a wrong vowel in the second syllable; 「つくろう」is 「繕う」(to mend, a different character)." },
@@ -2530,6 +2540,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "うながす",
     exampleJapanese: "改善を促す声が市民の間で高まっている。",
     exampleMeaningZh: "市民之間要求改善的呼聲越來越高。",
+    exampleMeaningI18n: { "ja": "改善を求める声が市民の間でますます高まっています。", "en": "Calls urging improvement are growing among the citizens." },
     options: ["うながす","そくす","もよおす","せかす"],
     explanation: "「促」訓讀「うなが-す」→ うながす。「そくす」是直接套音讀「そく」（如「促進」）的錯讀；「もよおす」是「催す」（不同字，意思接近）；「せかす」是「急かす」（口語近義詞，不同字）。",
     explanationI18n: { "ja": "「促」の訓読みは「うなが-す」で、「うながす」となります。「そくす」は音読みの「そく」（例：促進）をそのまま当てた誤読、「もよおす」は「催す」（別字・意味は近い）、「せかす」は「急かす」（口語の類義語・別字）です。", "en": "「促」has the kun'yomi「うなが-す」→ うながす. 「そくす」wrongly applies the on'yomi「そく」directly (as in「促進」). 「もよおす」is「催す」(a different kanji, close in meaning). 「せかす」is「急かす」(a colloquial near-synonym written with a different kanji)." },
@@ -2550,6 +2561,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "こばんだ",
     exampleJapanese: "彼は最後まで提案を拒んだ。",
     exampleMeaningZh: "他直到最後都拒絕了那個提案。",
+    exampleMeaningI18n: { "ja": "彼は最後までその提案を受け入れませんでした。", "en": "He refused the proposal right up to the end." },
     options: ["こばんだ","ふせいだ","はばんだ","ことわった"],
     explanation: "「拒」訓讀「こば-む」→ こばんだ（た形）。「ふせいだ」是「防いだ」（防止，不同字）；「はばんだ」是「阻んだ」（阻擋，字形相近但訓讀不同）；「ことわった」是「断った」（拒絕，同義字但漢字不同）。",
     explanationI18n: { "ja": "「拒」の訓読みは「こば-む」で、た形は「こばんだ」です。「ふせいだ」は「防いだ」（別字）、「はばんだ」は「阻んだ」（字形は似ているが訓読みが異なる）、「ことわった」は「断った」（同義だが漢字が異なる）です。", "en": "「拒」has the kun'yomi「こば-む」→ こばんだ (past form). 「ふせいだ」is「防いだ」(to prevent — a different kanji). 「はばんだ」is「阻んだ」(to block — similar in shape but a different kun'yomi). 「ことわった」is「断った」(to refuse — a synonym written with a different kanji)." },
@@ -2570,6 +2582,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "はばむ",
     exampleJapanese: "高い壁が彼の野心を阻む。",
     exampleMeaningZh: "一道高牆阻擋著他的野心。",
+    exampleMeaningI18n: { "ja": "高い壁が彼の野心の前に立ちはだかっています。", "en": "A high wall blocks his ambition." },
     options: ["はばむ","こばむ","ふせぐ","そむ"],
     explanation: "「阻」訓讀「はば-む」→ はばむ。「こばむ」是「拒む」（字形相近，但拒む是「拒絕」，阻む是「阻擋」）；「ふせぐ」是「防ぐ」（不同字）；「そむ」是把音讀「そ」（如「阻止」）+ 訓尾的錯讀。",
     explanationI18n: { "ja": "「阻」の訓読みは「はば-む」で、「はばむ」となります。「こばむ」は「拒む」（字形は似ているが、拒むは「拒絶する」、阻むは「さまたげる」で意味が異なる）、「ふせぐ」は「防ぐ」（別字）、「そむ」は音読みの「そ」（例：阻止）に訓読みの語尾を付けた誤読です。", "en": "「阻」has the kun'yomi「はば-む」→ はばむ. 「こばむ」is「拒む」(similar in shape, but 拒む means \"to refuse\" while 阻む means \"to block\"). 「ふせぐ」is「防ぐ」(a different kanji). 「そむ」is a wrong reading combining the on'yomi「そ」(as in「阻止」) with a kun-style ending." },
@@ -2590,6 +2603,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "つのって",
     exampleJapanese: "不安が日に日に募ってきた。",
     exampleMeaningZh: "不安一天比一天強烈。",
+    exampleMeaningI18n: { "ja": "不安が日ごとに強くなってきました。", "en": "My anxiety grew stronger day by day." },
     options: ["つのって","ぼって","ぼしゅうって","あつまって"],
     explanation: "「募」訓讀「つの-る」→ つのって（て形）。「ぼって」是直接套音讀「ぼ」的錯讀；「ぼしゅうって」是把熟語「募集」拆出讀法的陷阱；「あつまって」是「集まって」（聚集，意義接近但不同字）。注意「募る」是自他兩用：自動詞義「（情感）增強」、他動詞義「徵集」。",
     explanationI18n: { "ja": "「募」の訓読みは「つの-る」で、て形は「つのって」です。「ぼって」は音読みの「ぼ」をそのまま当てた誤読、「ぼしゅうって」は熟語「募集」の読みを分けて当てたひっかけ、「あつまって」は「集まって」（意味は近いが別字）です。なお「募る」は自他両用で、自動詞では「（感情が）強まる」、他動詞では「集める」の意味になります。", "en": "「募」has the kun'yomi「つの-る」→ つのって (て-form). 「ぼって」wrongly applies the on'yomi「ぼ」directly. 「ぼしゅうって」is a trap pulling a reading out of the compound「募集」. 「あつまって」is「集まって」(to gather — close in meaning but a different kanji). Note that「募る」works both ways: intransitively it means \"(emotion) intensifies,\" and transitively it means \"to recruit/solicit.\"" },
@@ -2610,6 +2624,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "あやつる",
     exampleJapanese: "彼は四つの言語を自在に操る。",
     exampleMeaningZh: "他能自如地運用四種語言。",
+    exampleMeaningI18n: { "ja": "彼は四つの言語を自由自在に使いこなします。", "en": "He handles four languages with ease." },
     options: ["あやつる","そうる","あつる","みさおる"],
     explanation: "「操」訓讀「あやつ-る」→ あやつる。「そうる」是直接套音讀「そう」（如「操作」）的錯讀；「あつる」是縮短訓讀的造詞陷阱；「みさおる」是把名詞「操」（みさお＝節操）誤當動詞訓讀。",
     explanationI18n: { "ja": "「操」の訓読みは「あやつ-る」で、「あやつる」となります。「そうる」は音読みの「そう」（例：操作）をそのまま当てた誤読、「あつる」は訓読みを縮めた造語のひっかけ、「みさおる」は名詞の「操（みさお＝節操）」を動詞の訓読みと取り違えたものです。", "en": "「操」has the kun'yomi「あやつ-る」→ あやつる. 「そうる」wrongly applies the on'yomi「そう」directly (as in「操作」). 「あつる」is a made-up trap using a shortened kun'yomi. 「みさおる」mistakenly turns the noun「操」(みさお = integrity) into a kun-read verb." },
@@ -2630,6 +2645,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "たいのう",
     exampleJapanese: "家賃の滞納が三ヶ月続いている。",
     exampleMeaningZh: "房租已經拖欠了三個月。",
+    exampleMeaningI18n: { "ja": "家賃の支払いが三か月も遅れたままになっています。", "en": "The rent has been overdue for three months now." },
     options: ["たいのう","とどこおりおさめ","たいなん","ちのう"],
     explanation: "「滞」音讀「たい」、「納」音讀「のう」→ たいのう。「とどこおりおさめ」是把兩字訓讀拼起來的陷阱；「たいなん」是「納」誤讀為「なん」；「ちのう」是「滞」誤讀為「ち」。注意 N1 也常考「滞る」的訓讀「とどこお-る」，是同字多音的典型。",
     explanationI18n: { "ja": "「滞」は音読みで「たい」、「納」は音読みで「のう」なので「たいのう」となります。「とどこおりおさめ」は二字の訓読みをつなげたひっかけ、「たいなん」は「納」を「なん」と誤読したもの、「ちのう」は「滞」を「ち」と誤読したものです。なお、N1では「滞る」の訓読み「とどこお-る」もよく問われ、同じ字で読みが複数ある典型例です。", "en": "「滞」has the on'yomi「たい」and「納」has the on'yomi「のう」→ たいのう. 「とどこおりおさめ」is a trap stringing together the kun'yomi of both characters. 「たいなん」misreads「納」as「なん」. 「ちのう」misreads「滞」as「ち」. Note that N1 also frequently tests the kun'yomi「とどこお-る」for「滞る」— a classic case of one character having multiple readings." },
@@ -2650,6 +2666,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "てっかい",
     exampleJapanese: "彼は前言を撤回した。",
     exampleMeaningZh: "他撤回了之前說過的話。",
+    exampleMeaningI18n: { "ja": "彼は前に言ったことを取り消しました。", "en": "He retracted what he had said earlier." },
     options: ["てっかい","てつかい","ちょっかい","てっき"],
     explanation: "「撤」音讀「てつ」＋ 「回」音讀「かい」，連音促音化後 → てっかい。「てつかい」是漏掉促音的錯讀；「ちょっかい」是不相關的常見詞（騷擾義）陷阱；「てっき」是「回」誤為「き」。",
     explanationI18n: { "ja": "「撤」の音読み「てつ」と「回」の音読み「かい」が連なり、促音化して「てっかい」となります。「てつかい」は促音を落とした誤読、「ちょっかい」は無関係な既存語（「干渉・いたずら」の意）のひっかけ、「てっき」は「回」を「き」と誤ったものです。", "en": "「撤」has the on'yomi「てつ」and「回」has the on'yomi「かい」; with the sound change to a geminate consonant → てっかい. 「てつかい」is a wrong reading that drops the small tsu. 「ちょっかい」is a trap using an unrelated common word (meaning \"meddling/harassment\"). 「てっき」misreads「回」as「き」." },
@@ -2670,6 +2687,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "こうみょう",
     exampleJapanese: "犯人の巧妙な手口に警察は手を焼いている。",
     exampleMeaningZh: "罪犯巧妙的手法讓警方很頭疼。",
+    exampleMeaningI18n: { "ja": "犯人の巧みな手口に、警察は手を焼いています。", "en": "The criminal's clever tricks have the police struggling." },
     options: ["こうみょう","ぎょうみょう","こうべん","たくみょう"],
     explanation: "「巧」音讀「こう」＋ 「妙」音讀「みょう」→ こうみょう。「ぎょうみょう」是「巧」誤讀為「ぎょう」（字形相似的混淆）；「こうべん」是「妙」誤讀；「たくみょう」是「巧」混入訓讀「たくみ」（巧み）的錯讀。",
     explanationI18n: { "ja": "「巧」の音読み「こう」と「妙」の音読み「みょう」で「こうみょう」となります。「ぎょうみょう」は「巧」を「ぎょう」と誤読したもの（字形の似た字との混同）、「こうべん」は「妙」の誤読、「たくみょう」は「巧」に訓読みの「たくみ（巧み）」を混ぜた誤読です。", "en": "「巧」has the on'yomi「こう」and「妙」has the on'yomi「みょう」→ こうみょう. 「ぎょうみょう」misreads「巧」as「ぎょう」(confusion with a similar-looking character). 「こうべん」misreads「妙」. 「たくみょう」wrongly mixes in the kun'yomi「たくみ」(巧み) for「巧」." },
@@ -2690,6 +2708,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "かたよらない",
     exampleJapanese: "意見が一方に偏らないよう、複数の専門家に意見を聞いた。",
     exampleMeaningZh: "為了不讓意見偏向一方，徵詢了多位專家的意見。",
+    exampleMeaningI18n: { "ja": "意見が一方にかたよらないように、複数の専門家に意見を聞きました。", "en": "To keep opinions from leaning to one side, we consulted several experts." },
     options: ["かたよらない","へんよらない","かたまらない","へんらない"],
     explanation: "「偏」訓讀「かたよ-る」→ かたよらない（ない形）。「へんよらない」是直接套音讀「へん」（如「偏見」）的錯讀；「かたまらない」是「固まらない」（凝固，訓讀接近但不同字）；「へんらない」是音讀＋無訓尾的陷阱。",
     explanationI18n: { "ja": "「偏」の訓読みは「かたよ-る」で、ない形は「かたよらない」です。「へんよらない」は音読みの「へん」（例：偏見）をそのまま当てた誤読、「かたまらない」は「固まらない」（訓読みは近いが別字）、「へんらない」は音読みに訓読みの語尾を欠いたひっかけです。", "en": "「偏」has the kun'yomi「かたよ-る」→ かたよらない (negative form). 「へんよらない」wrongly applies the on'yomi「へん」directly (as in「偏見」). 「かたまらない」is「固まらない」(to harden — close in kun'yomi but a different kanji). 「へんらない」is a trap using the on'yomi with no kun-ending." },
@@ -2710,6 +2729,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "そこなう",
     exampleJapanese: "信頼を損なうような行動は慎むべきだ。",
     exampleMeaningZh: "應該避免做出損害信任的行為。",
+    exampleMeaningI18n: { "ja": "信頼を傷つけるような行動は控えるべきです。", "en": "You should refrain from actions that would damage trust." },
     options: ["そこなう","そんなう","そこわす","うしなう"],
     explanation: "「損」訓讀「そこ-なう」→ そこなう。「そんなう」是直接套音讀「そん」（如「損失」）的錯讀；「そこわす」是訓尾「なう」誤為「わす」；「うしなう」是「失う」（失去，同義字但不同字）。",
     explanationI18n: { "ja": "「損」の訓読みは「そこ-なう」で、「そこなう」となります。「そんなう」は音読みの「そん」（例：損失）をそのまま当てた誤読、「そこわす」は訓読みの語尾「なう」を「わす」と誤ったもの、「うしなう」は「失う」（同義だが別字）です。", "en": "「損」has the kun'yomi「そこ-なう」→ そこなう. 「そんなう」wrongly applies the on'yomi「そん」directly (as in「損失」). 「そこわす」mistakes the kun-ending「なう」for「わす」. 「うしなう」is「失う」(to lose — a synonym written with a different kanji)." },
@@ -2730,6 +2750,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "したって",
     exampleJapanese: "彼は今でも亡き恩師を心から慕っている。",
     exampleMeaningZh: "他至今仍打從心底懷念已故的恩師。",
+    exampleMeaningI18n: { "ja": "彼は今でも亡くなった恩師を心から敬愛し、なつかしんでいます。", "en": "Even now, he cherishes the memory of his late mentor from the bottom of his heart." },
     options: ["したって","ぼって","おもって","あがめって"],
     explanation: "「慕」訓讀「した-う」→ したって（て形）。「ぼって」是直接套音讀「ぼ」（如「思慕」）的錯讀；「おもって」是「思って」（不同字）；「あがめって」是把「崇める（あがめる）」混入的造詞陷阱。",
     explanationI18n: { "ja": "「慕」の訓読みは「した-う」で、て形は「したって」です。「ぼって」は音読みの「ぼ」（例：思慕）をそのまま当てた誤読、「おもって」は「思って」（別字）、「あがめって」は「崇める（あがめる）」を混ぜた造語のひっかけです。", "en": "「慕」has the kun'yomi「した-う」→ したって (て-form). 「ぼって」wrongly applies the on'yomi「ぼ」directly (as in「思慕」). 「おもって」is「思って」(a different kanji). 「あがめって」is a made-up trap mixing in「崇める（あがめる）」." },
@@ -2750,6 +2771,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "になう",
     exampleJapanese: "若い世代が次の時代を担うのだ。",
     exampleMeaningZh: "由年輕世代來承擔下一個時代。",
+    exampleMeaningI18n: { "ja": "次の時代を支えていくのは若い世代です。", "en": "It is the younger generation that will carry the next era." },
     options: ["になう","かたぐう","たんがう","せおう"],
     explanation: "「担」訓讀「にな-う」→ になう。「かたぐう」是把「肩（かた）」混入的造詞陷阱；「たんがう」是直接套音讀「たん」（如「担当」）的錯讀；「せおう」是「背負う」（同義字但不同字）。",
     explanationI18n: { "ja": "「担」の訓読みは「にな-う」で、「になう」となります。「かたぐう」は「肩（かた）」を混ぜた造語のひっかけ、「たんがう」は音読みの「たん」（例：担当）をそのまま当てた誤読、「せおう」は「背負う」（同義だが別字）です。", "en": "「担」has the kun'yomi「にな-う」→ になう. 「かたぐう」is a made-up trap mixing in「肩（かた）」. 「たんがう」wrongly applies the on'yomi「たん」directly (as in「担当」). 「せおう」is「背負う」(a synonym written with a different kanji)." },
@@ -2770,6 +2792,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "もうける",
     exampleJapanese: "新しい部署を社内に設ける予定だ。",
     exampleMeaningZh: "預計在公司內部設立新部門。",
+    exampleMeaningI18n: { "ja": "社内に新しい部署を作る予定です。", "en": "We plan to set up a new department within the company." },
     options: ["もうける","せつける","もとめる","そなえる"],
     explanation: "「設」訓讀「もう-ける」→ もうける。「せつける」是直接套音讀「せつ」（如「設置」）的錯讀；「もとめる」是「求める」（不同字）；「そなえる」是「備える」（同義字但不同字）。注意同音字「儲ける」（賺錢）讀法相同但漢字不同。",
     explanationI18n: { "ja": "「設」の訓読みは「もう-ける」で、「もうける」となります。「せつける」は音読みの「せつ」（例：設置）をそのまま当てた誤読、「もとめる」は「求める」（別字）、「そなえる」は「備える」（同義だが別字）です。なお、同音の「儲ける」（お金をもうける）は読みは同じですが漢字が異なります。", "en": "「設」has the kun'yomi「もう-ける」→ もうける. 「せつける」wrongly applies the on'yomi「せつ」directly (as in「設置」). 「もとめる」is「求める」(a different kanji). 「そなえる」is「備える」(a synonym written with a different kanji). Note that the homophone「儲ける」(to earn money) has the same reading but a different kanji." },
@@ -2790,6 +2813,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "へだたった",
     exampleJapanese: "故郷から遠く隔たった場所で暮らしている。",
     exampleMeaningZh: "住在離故鄉很遠的地方。",
+    exampleMeaningI18n: { "ja": "故郷から遠く離れた場所で暮らしています。", "en": "I live in a place far removed from my hometown." },
     options: ["へだたった","へだてた","へだまった","かくたった"],
     explanation: "「隔」訓讀「へだ-たる」（自動詞）→ へだたった（た形）。「へだてた」是「隔てた」（他動詞「隔開」，訓讀對但語幹不同）；「へだまった」是訓尾誤；「かくたった」是直接套音讀「かく」（如「隔離」）的錯讀。「隔たる／隔てる」是自他成對動詞。",
     explanationI18n: { "ja": "「隔」の訓読みは「へだ-たる」（自動詞）で、た形は「へだたった」です。「へだてた」は「隔てた」（他動詞「隔てる＝間を空ける」で、訓読みは合うが語幹が異なる）、「へだまった」は語尾の誤り、「かくたった」は音読みの「かく」（例：隔離）をそのまま当てた誤読です。「隔たる／隔てる」は自他が対になった動詞です。", "en": "「隔」has the kun'yomi「へだ-たる」(intransitive) → へだたった (past form). 「へだてた」is「隔てた」(the transitive \"to separate\" — same kun'yomi but a different stem). 「へだまった」has a wrong kun-ending. 「かくたった」wrongly applies the on'yomi「かく」directly (as in「隔離」). 「隔たる／隔てる」are a paired intransitive/transitive set." },
@@ -2810,6 +2834,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "まかなって",
     exampleJapanese: "彼は奨学金で生活費を賄っている。",
     exampleMeaningZh: "他用獎學金來支付生活費。",
+    exampleMeaningI18n: { "ja": "彼は奨学金で生活費をやりくりしています。", "en": "He covers his living expenses with a scholarship." },
     options: ["まかなって","わいろって","おぎなって","やしなって"],
     explanation: "「賄」訓讀「まかな-う」→ まかなって（て形）。「わいろって」是把「賄賂（わいろ）」當動詞訓讀的陷阱（賄賂是名詞）；「おぎなって」是「補って」（補足，同義字但不同字）；「やしなって」是「養って」（撫養，相關但不同字）。",
     explanationI18n: { "ja": "「賄」の訓読みは「まかな-う」で、て形は「まかなって」です。「わいろって」は名詞の「賄賂（わいろ）」を動詞の訓読みと取り違えたひっかけ（賄賂は名詞）、「おぎなって」は「補って」（同義だが別字）、「やしなって」は「養って」（関連はあるが別字）です。", "en": "「賄」has the kun'yomi「まかな-う」→ まかなって (て-form). 「わいろって」is a trap treating「賄賂（わいろ）」as a kun-read verb (賄賂 is a noun). 「おぎなって」is「補って」(to supplement — a synonym written with a different kanji). 「やしなって」is「養って」(to raise/support — related but a different kanji)." },
@@ -2830,6 +2855,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "いちじるしい",
     exampleJapanese: "技術の進歩が著しい業界では、常に学び続ける必要がある。",
     exampleMeaningZh: "在技術進步顯著的業界，必須持續學習。",
+    exampleMeaningI18n: { "ja": "技術の進歩がめざましい業界では、常に学び続ける必要があります。", "en": "In an industry where technology advances remarkably fast, you need to keep learning at all times." },
     options: ["いちじるしい","ちょしい","あらわしい","めずらしい"],
     explanation: "「著」訓讀「いちじる-しい」→ いちじるしい。「ちょしい」是直接套音讀「ちょ」（如「著名」）的錯讀；「あらわしい」是把「著す（あらわす）」的訓讀套形容詞語尾的造詞錯誤；「めずらしい」是「珍しい」（不同字）。",
     explanationI18n: { "ja": "「著」の訓読みは「いちじる-しい」で、「いちじるしい」となります。「ちょしい」は音読みの「ちょ」（例：著名）をそのまま当てた誤読、「あらわしい」は「著す（あらわす）」の訓読みに形容詞の語尾を付けた造語の誤り、「めずらしい」は「珍しい」（別字）です。", "en": "「著」has the kun'yomi「いちじる-しい」→ いちじるしい. 「ちょしい」wrongly applies the on'yomi「ちょ」directly (as in「著名」). 「あらわしい」is a made-up error tacking an adjective ending onto the kun'yomi of「著す（あらわす）」. 「めずらしい」is「珍しい」(a different kanji)." },
@@ -2850,6 +2876,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "すこやか",
     exampleJapanese: "子供たちは健やかに育っている。",
     exampleMeaningZh: "孩子們健康地成長著。",
+    exampleMeaningI18n: { "ja": "子どもたちは元気にすくすくと育っています。", "en": "The children are growing up healthy and strong." },
     options: ["すこやか","けんやか","けんこうやか","おだやか"],
     explanation: "「健」訓讀「すこ-やか」→ すこやか。「けんやか」是直接套音讀「けん」（如「健康」）的錯讀；「けんこうやか」是把熟語「健康」拆出來再加訓尾的陷阱；「おだやか」是「穏やか」（不同字，平穩）。",
     explanationI18n: { "ja": "「健」の訓読みは「すこ-やか」で、「すこやか」となります。「けんやか」は音読みの「けん」（例：健康）をそのまま当てた誤読、「けんこうやか」は熟語「健康」を分けて訓読みの語尾を付けたひっかけ、「おだやか」は「穏やか」（別字・「おだやか」）です。", "en": "「健」has the kun'yomi「すこ-やか」→ すこやか. 「けんやか」wrongly applies the on'yomi「けん」directly (as in「健康」). 「けんこうやか」is a trap pulling apart the compound「健康」and adding a kun-ending. 「おだやか」is「穏やか」(a different kanji, meaning \"calm\")." },
@@ -2870,6 +2897,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "あざやか",
     exampleJapanese: "夕日が空を鮮やかに染めていた。",
     exampleMeaningZh: "夕陽將天空染上了鮮豔的色彩。",
+    exampleMeaningI18n: { "ja": "夕日が空をあざやかな色に染めていました。", "en": "The setting sun dyed the sky in vivid colors." },
     options: ["あざやか","せんやか","あらやか","つややか"],
     explanation: "「鮮」訓讀「あざ-やか」→ あざやか。「せんやか」是直接套音讀「せん」（如「新鮮」）的錯讀；「あらやか」是「新やか」式的造詞陷阱；「つややか」是「艶やか」（光澤，不同字）。",
     explanationI18n: { "ja": "「鮮」の訓読みは「あざ-やか」で、「あざやか」となります。「せんやか」は音読みの「せん」（例：新鮮）をそのまま当てた誤読、「あらやか」は「新やか」風の造語のひっかけ、「つややか」は「艶やか」（別字・つや）です。", "en": "「鮮」has the kun'yomi「あざ-やか」→ あざやか. 「せんやか」wrongly applies the on'yomi「せん」directly (as in「新鮮」). 「あらやか」is a made-up trap on the pattern of「新やか」. 「つややか」is「艶やか」(glossy — a different kanji)." },
@@ -2890,6 +2918,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "いつわって",
     exampleJapanese: "経歴を偽って就職するのは犯罪だ。",
     exampleMeaningZh: "偽造履歷去就職是犯罪行為。",
+    exampleMeaningI18n: { "ja": "経歴をごまかして就職するのは犯罪です。", "en": "Getting a job by falsifying your credentials is a crime." },
     options: ["いつわって","ぎって","うそって","ぎぞうって"],
     explanation: "「偽」訓讀「いつわ-る」→ いつわって（て形）。「ぎって」是直接套音讀「ぎ」（如「偽物」）的錯讀；「うそって」是把名詞「嘘（うそ）」當動詞訓讀的陷阱；「ぎぞうって」是把熟語「偽造」拆出來的錯讀。",
     explanationI18n: { "ja": "「偽」の訓読みは「いつわ-る」で、て形は「いつわって」です。「ぎって」は音読みの「ぎ」（例：偽物）をそのまま当てた誤読、「うそって」は名詞の「嘘（うそ）」を動詞の訓読みと取り違えたひっかけ、「ぎぞうって」は熟語「偽造」を分けて当てた誤読です。", "en": "「偽」has the kun'yomi「いつわ-る」→ いつわって (て-form). 「ぎって」wrongly applies the on'yomi「ぎ」directly (as in「偽物」). 「うそって」is a trap treating the noun「嘘（うそ）」as a kun-read verb. 「ぎぞうって」is a wrong reading pulled from the compound「偽造」." },
@@ -2910,6 +2939,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "はずんで",
     exampleJapanese: "話が弾んで、つい時間を忘れてしまった。",
     exampleMeaningZh: "聊得很起勁，不知不覺忘了時間。",
+    exampleMeaningI18n: { "ja": "会話が盛り上がって、つい時間を忘れてしまいました。", "en": "The conversation got so lively that we completely lost track of time." },
     options: ["はずんで","だんで","たまんで","とんで"],
     explanation: "「弾」訓讀「はず-む」→ はずんで（て形）。「だんで」是直接套音讀「だん」（如「爆弾」）的錯讀；「たまんで」是把名詞「弾（たま＝彈丸）」當動詞訓讀的陷阱；「とんで」是「飛んで」（不同字）。注意「弾む」可接「話／ボール／体／心」等廣泛主語。",
     explanationI18n: { "ja": "「弾」の訓読みは「はず-む」で、て形は「はずんで」です。「だんで」は音読みの「だん」（例：爆弾）をそのまま当てた誤読、「たまんで」は名詞の「弾（たま＝弾丸）」を動詞の訓読みと取り違えたひっかけ、「とんで」は「飛んで」（別字）です。なお「弾む」は「話／ボール／体／心」など幅広い主語を取ります。", "en": "「弾」has the kun'yomi「はず-む」→ はずんで (て-form). 「だんで」wrongly applies the on'yomi「だん」directly (as in「爆弾」). 「たまんで」is a trap treating the noun「弾（たま = bullet）」as a kun-read verb. 「とんで」is「飛んで」(a different kanji). Note that「弾む」can take a wide range of subjects — 話／ボール／体／心 and so on." },
@@ -3610,6 +3640,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "こばむ",
     exampleJapanese: "彼は最後まで条件の変更を拒む姿勢を崩さなかった。",
     exampleMeaningZh: "他直到最後都沒有改變拒絕變更條件的態度。",
+    exampleMeaningI18n: { "ja": "彼は最後まで、条件の変更を受け入れない姿勢を変えなかった。", "en": "Right up to the very end, he never wavered in his refusal to change the conditions." },
     options: ["こばむ", "はばむ", "そむく", "ふせぐ"],
     explanation: "「拒」訓讀「こば-む」→ こばむ。「はばむ」是「阻む」（阻擋、妨礙，字形相近但訓讀不同）；「そむく」是「背く」（違背、背叛，不同字）；「ふせぐ」是「防ぐ」（防止，不同字）。表「拒絕」的「拒む」讀作 こばむ。",
     explanationI18n: { "ja": "「拒」の訓読みは「こば-む」→ こばむ。「はばむ」は「阻む」（さえぎる・妨げる。字形は似るが訓読みが異なる）、「そむく」は「背く」（そむく・裏切る。別の字）、「ふせぐ」は「防ぐ」（防止する。別の字）。「拒否する」意味の「拒む」は こばむ と読む。", "en": "拒 has the kun'yomi 「こば-む」 → こばむ. 「はばむ」 is 「阻む」 (to block, obstruct—similar-looking kanji but a different kun'yomi); 「そむく」 is 「背く」 (to go against, betray—a different kanji); 「ふせぐ」 is 「防ぐ」 (to prevent—a different kanji). 拒む, meaning \"to refuse,\" is read こばむ." },
@@ -3670,6 +3701,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "とどこおる",
     exampleJapanese: "申請が一部の部署で滞ると、全体の承認スケジュールにも影響が出る。",
     exampleMeaningZh: "申請若在部分部門卡住，整體的審核時程也會受影響。",
+    exampleMeaningI18n: { "ja": "申請が一部の部署で止まってしまうと、全体の承認スケジュールにも影響が出る。", "en": "If applications get held up in some departments, the overall approval schedule is affected as well." },
     options: ["とどこおる", "とどまる", "たちどまる", "とどける"],
     explanation: "「滞」訓讀「とどこお-る」→ とどこおる，指手續、付款的進行受阻而停滯。「とどまる」是「留まる／止まる」（停留，同字根 とど- 但不同字）；「たちどまる」是「立ち止まる」（停下腳步，不同字）；「とどける」是「届ける」（送達，同字根的混淆陷阱）。",
     explanationI18n: { "ja": "「滞」の訓読みは「とどこお-る」→ とどこおる。手続きや支払いの進行が妨げられて停滞することを指す。「とどまる」は「留まる／止まる」（とどまる。同じ とど- の語根だが別の字）、「たちどまる」は「立ち止まる」（歩みを止める。別の字）、「とどける」は「届ける」（送り届ける。同じ語根に見える混同の罠）。", "en": "滞 has the kun'yomi 「とどこお-る」 → とどこおる, referring to a procedure or payment being held up and stalling. 「とどまる」 is 「留まる／止まる」 (to remain, stop—shares the とど- root but is a different kanji); 「たちどまる」 is 「立ち止まる」 (to stop in one's tracks—a different kanji); 「とどける」 is 「届ける」 (to deliver—a same-root trap)." },
@@ -3690,6 +3722,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "したわれて",
     exampleJapanese: "その医師は誠実な人柄で、地域の人々から長く慕われてきた。",
     exampleMeaningZh: "那位醫師為人誠懇，長年受到當地居民的愛戴。",
+    exampleMeaningI18n: { "ja": "その医師は誠実な人柄で、長年にわたり地域の人々に敬愛されてきた。", "en": "That doctor's sincere character has earned the lasting affection of the local community." },
     options: ["したわれて", "うやまわれて", "おそれられて", "ねたまれて"],
     explanation: "「慕」訓讀「した-う」，受身形「慕われて」→ したわれて。「うやまわれて」是「敬われて」（被尊敬，近義字但不同字）；「おそれられて」是「恐れられて」（被畏懼，意思相反）；「ねたまれて」是「妬まれて」（被嫉妒，意思相反）。",
     explanationI18n: { "ja": "「慕」の訓読みは「した-う」で、受身形「慕われて」→ したわれて。「うやまわれて」は「敬われて」（尊敬される。近い意味だが別の字）、「おそれられて」は「恐れられて」（畏れられる。意味が逆）、「ねたまれて」は「妬まれて」（ねたまれる。意味が逆）。", "en": "慕 has the kun'yomi 「した-う」, and the passive form 「慕われて」 → したわれて. 「うやまわれて」 is 「敬われて」 (to be respected—a near-synonym but a different kanji); 「おそれられて」 is 「恐れられて」 (to be feared—the opposite meaning); 「ねたまれて」 is 「妬まれて」 (to be envied—the opposite meaning)." },
@@ -3710,6 +3743,7 @@ export const n1Items: PracticeQuestion[] = [
     expectedAnswer: "したう",
     exampleJapanese: "故郷を慕う気持ちは、何年海外で暮らしても薄れなかった。",
     exampleMeaningZh: "懷念故鄉的心情，在海外住了多少年也未曾淡去。",
+    exampleMeaningI18n: { "ja": "故郷を恋しく思う気持ちは、何年海外で暮らしても薄れることがなかった。", "en": "My longing for my hometown never faded, no matter how many years I lived abroad." },
     options: ["したう", "ねがう", "うたう", "さそう"],
     explanation: "「慕」訓讀「した-う」→ したう，亦可用於懷念故鄉或往昔。「ねがう」是「願う」（祈願）；「うたう」是「歌う／謳う」（歌詠，韻母近似的陷阱）；「さそう」是「誘う」（邀約），三者皆不同字。",
     explanationI18n: { "ja": "「慕」の訓読みは「した-う」→ したう。故郷や昔を懐かしむ意味でも使える。「ねがう」は「願う」（祈願する）、「うたう」は「歌う／謳う」（うたう。母音が近く紛らわしい罠）、「さそう」は「誘う」（さそう）。いずれも別の字。", "en": "慕 has the kun'yomi 「した-う」 → したう, which can also mean yearning for one's hometown or the past. 「ねがう」 is 「願う」 (to wish, pray); 「うたう」 is 「歌う／謳う」 (to sing, extol—a trap with a similar vowel sound); 「さそう」 is 「誘う」 (to invite)—all three are different kanji." },
@@ -4072,7 +4106,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「慕う」訓讀「した-う」，「慕っている」讀作「したっている」。「したがっている」是「従っている」（順從）；「うやまっている」是「敬っている」（尊敬）；「あこがれている」是「憧れている」（憧憬），三者皆為別字的讀音，唯「したっている」正確。",
     explanationI18n: { "ja": "「慕う」は訓読みで「した-う」、「慕っている」は「したっている」と読む。「したがっている」は「従っている」(服従する)、「うやまっている」は「敬っている」(尊敬する)、「あこがれている」は「憧れている」(憧れる)で、いずれも別の語の読みであり、正しいのは「したっている」だけ。", "en": "「慕う」has the kun reading 「した-う」, so 「慕っている」is read 「したっている」. 「したがっている」is 「従っている」(to obey); 「うやまっている」is 「敬っている」(to respect); 「あこがれている」is 「憧れている」(to yearn for) — all three are readings of different kanji, so only 「したっている」is correct." },
     exampleJapanese: "卒業後も、多くの学生がその先生を慕っている。",
-    exampleMeaningZh: "畢業之後，許多學生仍敬慕著那位老師。"
+    exampleMeaningZh: "畢業之後，許多學生仍敬慕著那位老師。",
+    exampleMeaningI18n: { "ja": "卒業した後も、多くの学生がその先生を敬愛し続けている。", "en": "Even after graduating, many students still look up to that teacher with affection." },
   }),
   examQuestion({
     id: "issue79-grammar-sobakara-mistake",
@@ -4192,7 +4227,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「漸減」讀作「ぜんげん」，指一點一點地減少。「ざんげん」是把「漸」誤讀成「ざん」的語頭誤讀；「ぜんけん」是把後半「減（げん）」清濁讀錯；「ぜんしょう」是混入「減少（げんしょう）」等別的語形。唯「ぜんげん」正確。",
     explanationI18n: { "ja": "「漸減」は「ぜんげん」と読み、少しずつ減っていくことを指す。「ざんげん」は「漸」を「ざん」と読み間違えた語頭の誤読、「ぜんけん」は後半の「減(げん)」の清濁を読み間違えたもの、「ぜんしょう」は「減少(げんしょう)」など別の語形が混じったもの。正しいのは「ぜんげん」だけ。", "en": "「漸減」is read 「ぜんげん」, meaning to decrease little by little. 「ざんげん」misreads the initial 「漸」as 「ざん」; 「ぜんけん」gets the voicing wrong on the latter part 「減（げん）」; 「ぜんしょう」mixes in a different word form like 「減少（げんしょう）」. Only 「ぜんげん」is correct." },
     exampleJapanese: "人口は十年前をピークに漸減している。",
-    exampleMeaningZh: "人口以十年前為高峰，正逐漸減少。"
+    exampleMeaningZh: "人口以十年前為高峰，正逐漸減少。",
+    exampleMeaningI18n: { "ja": "人口は十年前をピークに、少しずつ減り続けている。", "en": "The population peaked ten years ago and has been gradually declining ever since." },
   }),
   examQuestion({
     id: "reinforce-stubborn-nishiro-estimate",
@@ -6694,7 +6730,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「心がける」＝平時刻意去做（習慣性的努力），後接「自己要做的行為」。①養成每天走路的習慣＝正解。②注意腳下是「気をつける」。③祈求合格是「願う」。④把恩情記在心上是「心に留める」。",
     explanationI18n: { "ja": "「心がける」＝ふだんから意識して行う（習慣的な努力）で、後には「自分がしようとする行為」が来ます。①毎日歩く習慣を身につける＝正解。②足元に注意するのは「気をつける」。③合格を祈るのは「願う」。④受けた親切を心に留めるのは「心に留める」。", "en": "「心がける」 = deliberately doing something as a matter of habit (a habitual effort), followed by \"an action one intends to do oneself.\" (1) Making a point of walking every day = the correct answer. (2) Watching your step is 「気をつける」. (3) Wishing to pass is 「願う」. (4) Keeping a kindness in mind is 「心に留める」." },
     exampleJapanese: "健康のため、毎日歩くことを心がけている。",
-    exampleMeaningZh: "為了健康，我留心每天走路。"
+    exampleMeaningZh: "為了健康，我留心每天走路。",
+    exampleMeaningI18n: { "ja": "健康のために、毎日歩くことを日ごろから意識している。", "en": "For my health, I make a point of walking every day." },
   }),
   examQuestion({
     id: "n1-usage-kojitsukeru",
@@ -6716,7 +6753,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「こじつける」＝牽強附會（硬把不相干的道理/理由扯在一起）。①為遲到硬掰牽強的理由＝正解。②勉強讓機器運轉是「だましだまし／工夫して」。③把兩張桌子拼起來是「くっつける」。④用鐵橇撬開門是「こじ開ける」（近形詞）。「こじつける」對象是理由/道理，不用於物理動作。",
     explanationI18n: { "ja": "「こじつける」＝無理に理屈や理由をつける（関係のないものを無理やり結びつける）。①遅刻のために苦しい理由を無理につける＝正解。②機械をなんとか動かすのは「だましだまし／工夫して」。③二つの机を合わせるのは「くっつける」。④バールで扉を開けるのは「こじ開ける」（似た形の語）。「こじつける」の対象は理由や理屈で、物理的な動作には使いません。", "en": "「こじつける」 = to force a connection (forcibly tying together unrelated reasoning/excuses). (1) Trumping up a strained reason for being late = the correct answer. (2) Getting a machine to run somehow is 「だましだまし／工夫して」. (3) Joining two desks together is 「くっつける」. (4) Prying a door open with a crowbar is 「こじ開ける」 (a similar-looking word). The object of 「こじつける」 is a reason or line of reasoning; it isn't used for physical actions." },
     exampleJapanese: "彼は遅刻の言い訳に、苦しい理由をこじつけた。",
-    exampleMeaningZh: "他為遲到的藉口硬掰了個牽強的理由。"
+    exampleMeaningZh: "他為遲到的藉口硬掰了個牽強的理由。",
+    exampleMeaningI18n: { "ja": "彼は遅刻の言い訳として、無理やり苦しい理由をひねり出した。", "en": "He cooked up a strained, far-fetched excuse for being late." },
   }),
   examQuestion({
     id: "n1-usage-misebirakasu",
@@ -6738,7 +6776,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「見せびらかす」＝得意地炫耀。①逢人就炫耀新錶＝正解。②指路而出示地圖是「見せる」。③在法庭提出證據是「提示する」。④不好意思露臉是「見せられない」。帶炫耀語感，不用於中性出示。",
     explanationI18n: { "ja": "「見せびらかす」＝得意になって見せつける。①会う人ごとに新しい腕時計を自慢げに見せる＝正解。②道案内で地図を示すのは「見せる」。③法廷で証拠を出すのは「提示する」。④恥ずかしくて顔を出せないのは「見せられない」。誇示のニュアンスがあり、中立的に「見せる」場面には使いません。", "en": "「見せびらかす」 = to flaunt with satisfaction. (1) Showing off a new watch to everyone he meets = the correct answer. (2) Showing a map to give directions is 「見せる」. (3) Presenting evidence in court is 「提示する」. (4) Being too embarrassed to show one's face is 「見せられない」. It carries a boastful nuance and isn't used for neutral displaying." },
     exampleJapanese: "彼は新しい腕時計を、会う人ごとに見せびらかした。",
-    exampleMeaningZh: "他逢人就炫耀他的新手錶。"
+    exampleMeaningZh: "他逢人就炫耀他的新手錶。",
+    exampleMeaningI18n: { "ja": "彼は会う人ごとに、新しい腕時計を自慢して見せた。", "en": "He showed off his new watch to everyone he met." },
   }),
   examQuestion({
     id: "n1-usage-uchiakeru",
@@ -6760,7 +6799,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「打ち明ける」＝把藏在心裡的秘密/煩惱坦白傾訴，對象是私人心事。①向摯友吐露煩惱＝正解。②天亮是「夜が明ける」。③播報速報是「伝える／報じる」（速報是公開播報，非私下吐露）。④拉開窗簾是「開ける」。",
     explanationI18n: { "ja": "「打ち明ける」＝心の中の秘密や悩みを正直に打ち明けることで、対象は個人的な心の内です。①親友に悩みを打ち明ける＝正解。②夜が明けるのは「夜が明ける」。③速報を伝えるのは「伝える／報じる」（速報は公に伝えるもので、私的な告白ではありません）。④カーテンを開けるのは「開ける」。", "en": "「打ち明ける」 = to frankly confide a secret or worry hidden in one's heart, with a private, personal matter as the object. (1) Confiding one's worries to a close friend = the correct answer. (2) Daybreak is 「夜が明ける」. (3) Broadcasting a bulletin is 「伝える／報じる」 (a bulletin is a public broadcast, not a private confidence). (4) Drawing back the curtains is 「開ける」." },
     exampleJapanese: "彼女は誰にも言えなかった悩みを、親友に打ち明けた。",
-    exampleMeaningZh: "她把無法對人啟齒的煩惱向摯友吐露了。"
+    exampleMeaningZh: "她把無法對人啟齒的煩惱向摯友吐露了。",
+    exampleMeaningI18n: { "ja": "彼女は誰にも言えなかった悩みを、親友に正直に話した。", "en": "She confided to her best friend the worries she hadn't been able to tell anyone." },
   }),
   examQuestion({
     id: "n1-usage-iiharu",
@@ -6782,7 +6822,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「言い張る」＝不顧反對、固執地堅稱（自己的主張）。①堅稱自己無辜＝正解。②大聲說是「言う／叫ぶ」。③提問是「質問する」。④致詞是「述べる」。帶「強硬不退讓」語感，不用於一般陳述。",
     explanationI18n: { "ja": "「言い張る」＝反対されても頑固に（自分の主張を）言い通す。①自分は無実だと言い張る＝正解。②大声で言うのは「言う／叫ぶ」。③質問するのは「質問する」。④スピーチをするのは「述べる」。「強硬に引き下がらない」というニュアンスがあり、ふつうの陳述には使いません。", "en": "「言い張る」 = to stubbornly insist (on one's own claim) despite opposition. (1) Insisting he is innocent = the correct answer. (2) Speaking loudly is 「言う／叫ぶ」. (3) Asking a question is 「質問する」. (4) Giving a speech is 「述べる」. It carries a nuance of \"forcefully refusing to back down\" and isn't used for ordinary statements." },
     exampleJapanese: "彼は最後まで、自分は無実だと言い張った。",
-    exampleMeaningZh: "他到最後都堅稱自己是無辜的。"
+    exampleMeaningZh: "他到最後都堅稱自己是無辜的。",
+    exampleMeaningI18n: { "ja": "彼は最後まで、自分は無実だと主張し続けた。", "en": "He insisted to the very end that he was innocent." },
   }),
   examQuestion({
     id: "n1-usage-kuichigau",
@@ -6804,7 +6845,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「食い違う」＝（內容/說法/意見）彼此不一致、有出入。①兩人證詞有出入＝正解。②鈕扣扣錯是「掛け違える」。③錯過碰面是「行き違う」。④搭錯車是「乗り間違える」。指抽象內容對不上，不用於物理動作之「錯」。",
     explanationI18n: { "ja": "「食い違う」＝（内容や言い分、意見が）互いに一致しない、食い違いがある。①二人の証言が食い違う＝正解。②ボタンをかけ間違えるのは「掛け違える」。③待ち合わせですれ違うのは「行き違う」。④電車を乗り間違えるのは「乗り間違える」。抽象的な内容が合わないことを指し、物理的な「間違い」には使いません。", "en": "「食い違う」 = (of content/accounts/opinions) to be at odds with each other, to differ. (1) The two people's testimonies don't match = the correct answer. (2) Buttoning something up wrong is 「掛け違える」. (3) Missing each other at a meeting spot is 「行き違う」. (4) Boarding the wrong train is 「乗り間違える」. It refers to abstract content that doesn't line up, not a physical \"getting it wrong.\"" },
     exampleJapanese: "二人の証言が食い違っていて、どちらが本当か分からない。",
-    exampleMeaningZh: "兩人的證詞有出入，不知道哪邊才是真的。"
+    exampleMeaningZh: "兩人的證詞有出入，不知道哪邊才是真的。",
+    exampleMeaningI18n: { "ja": "二人の証言が一致せず、どちらが本当なのか分からない。", "en": "The two people's testimonies contradict each other, and there's no telling which one is true." },
   }),
   examQuestion({
     id: "n1-usage-iiwatasu",
@@ -6826,7 +6868,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「言い渡す」＝（上對下、正式地）宣告、宣判（判決/處分/命令）。①法官宣判＝正解。②跟朋友聊近況是「話す」（近況不是可「宣告」的決定/命令）。③向記者公布是「発表する」。④告知路怎麼走是「教える」。「言い渡す」帶正式、由上而下的宣告語感，不用於平輩閒談或對外發表。",
     explanationI18n: { "ja": "「言い渡す」＝（上の立場から下へ、正式に）宣告する、言い渡す（判決・処分・命令）。①裁判官が判決を言い渡す＝正解。②友人と近況を話すのは「話す」（近況は「言い渡す」ような決定や命令ではありません）。③記者に公表するのは「発表する」。④道順を教えるのは「教える」。「言い渡す」は正式で、上から下へ告げるニュアンスがあり、対等な相手との雑談や対外的な発表には使いません。", "en": "「言い渡す」 = to (formally, from a superior to a subordinate) pronounce or hand down (a verdict/penalty/order). (1) A judge handing down a sentence = the correct answer. (2) Catching up on recent news with a friend is 「話す」 (recent news isn't a decision or order that can be \"pronounced\"). (3) Announcing to reporters is 「発表する」. (4) Telling someone the way to a place is 「教える」. 「言い渡す」 carries a formal, top-down nuance and isn't used for chatting among equals or making a public announcement." },
     exampleJapanese: "裁判官は被告に、懲役三年の判決を言い渡した。",
-    exampleMeaningZh: "法官對被告宣判了三年有期徒刑。"
+    exampleMeaningZh: "法官對被告宣判了三年有期徒刑。",
+    exampleMeaningI18n: { "ja": "裁判官は被告に、懲役三年の判決を正式に告げた。", "en": "The judge sentenced the defendant to three years in prison." },
   }),
   examQuestion({
     id: "n1-syn-arakajime",
@@ -7148,7 +7191,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「踏まえる」＝以（事實/經驗/前提）為依據、立足於某基礎之上。①以前次的反省為基礎重訂計畫＝正解。②③④皆把「踏まえる」當成物理上的「踩」：踩扁空缶、踩到小石、踩到別人的腳，這些都是「踏む／踏みつける」。「踏まえる」是抽象的「以…為前提」，不用於用腳踩踏實物。",
     explanationI18n: { "ja": "「踏まえる」＝（事実・経験・前提を）土台・よりどころとすること。①前回の反省を土台に計画を立て直す＝正解。②③④はいずれも「踏まえる」を物理的に「踏む」意味で使っています。空き缶を踏みつぶす、小石を踏む、人の足を踏むは、すべて「踏む／踏みつける」です。「踏まえる」は抽象的な「…を前提にする」であって、足で実物を踏む意味では使いません。", "en": "「踏まえる」means to base something on (a fact/experience/premise), to build on a foundation. Sentence ① revises the plan based on the previous reflection = correct. Sentences ②③④ all treat 「踏まえる」as physically \"stepping on\"—crushing a can, stepping on a pebble, stepping on someone's foot—which are 「踏む／踏みつける」. 「踏まえる」is the abstract \"taking as a premise\" and is not used for physically stepping on objects." },
     exampleJapanese: "前回の反省を踏まえて、今回の計画を立て直した。",
-    exampleMeaningZh: "記取上次的反省，重新擬定了這次的計畫。"
+    exampleMeaningZh: "記取上次的反省，重新擬定了這次的計畫。",
+    exampleMeaningI18n: { "ja": "前回の反省を土台にして、今回の計画を立て直した。", "en": "Taking the lessons from last time on board, we redrew the plan for this round." },
   }),
   examQuestion({
     id: "n1-usage-hakadoru",
@@ -7170,7 +7214,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「はかどる」＝（工作/作業）進展順利、效率高地往前推進，主語是「事情/作業」。①工作進展順利＝正解。②自行車前進不了是「進まない」（物體位移）。③上樓梯吃力是「きつい／つらい」（體力）。④車流動不了是「進まない」。「はかどる」針對作業的進度，不用於物體本身的移動。",
     explanationI18n: { "ja": "「はかどる」＝（仕事・作業が）順調に、効率よく進むことで、主語は「物事・作業」です。①仕事が順調に進んだ＝正解。②自転車が前に進めないのは「進まない」（物体の移動）。③階段を上るのが大変なのは「きつい／つらい」（体力）。④車が動かないのは「進まない」。「はかどる」は作業の進み具合を表し、物体そのものの移動には使いません。", "en": "「はかどる」means (of work/a task) to progress smoothly and efficiently, with the subject being \"the task.\" Sentence ① has work progressing well = correct. In ②, a bicycle not moving forward is 「進まない」(physical movement of an object). In ③, struggling up stairs is 「きつい／つらい」(physical strain). In ④, traffic not moving is 「進まない」. 「はかどる」refers to a task's progress, not to the movement of an object itself." },
     exampleJapanese: "静かな環境のおかげで、今日は仕事がずいぶんはかどった。",
-    exampleMeaningZh: "多虧環境安靜，今天工作進展了不少。"
+    exampleMeaningZh: "多虧環境安靜，今天工作進展了不少。",
+    exampleMeaningI18n: { "ja": "静かな環境のおかげで、今日は仕事がどんどん進んだ。", "en": "Thanks to the quiet surroundings, I got a lot of work done today." },
   }),
   examQuestion({
     id: "n1-usage-kuisagaru",
@@ -7192,7 +7237,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「食い下がる」＝不輕言放棄、緊咬不放地與對手周旋追問。①記者不服而緊追大臣不放＝正解。②埋頭大吃是「食らいつく／がつがつ食べる」。③猴子攀掛在樹枝上是「ぶら下がる」（近形詞）。④放棄購買是「あきらめた／見送った」，與「食い下がる（不放棄）」語意相反。「食い下がる」是面對對手的不退讓糾纏。",
     explanationI18n: { "ja": "「食い下がる」＝簡単に引き下がらず、しつこく相手にくらいついて追及すること。①記者が納得せず大臣に食い付いて離れない＝正解。②夢中でがつがつ食べるのは「食らいつく／がつがつ食べる」。③猿が枝にぶら下がっているのは「ぶら下がる」（形の似た語）。④購入をあきらめたのは「あきらめた／見送った」で、「食い下がる（あきらめない）」とは意味が逆です。「食い下がる」は相手に対して引かずに粘ることを表します。", "en": "「食い下がる」means to refuse to give up easily, clinging on and pressing an opponent. Sentence ① has the reporter, unconvinced, doggedly pursuing the minister = correct. In ②, wolfing down food is 「食らいつく／がつがつ食べる」. In ③, a monkey clinging to a branch is 「ぶら下がる」(a similar-looking word). In ④, giving up on a purchase is 「あきらめた／見送った」, the opposite of 「食い下がる」(not giving up). 「食い下がる」is about tenaciously refusing to yield when facing an opponent." },
     exampleJapanese: "記者は納得せず、大臣にしつこく食い下がって質問を続けた。",
-    exampleMeaningZh: "記者不服氣，緊咬著大臣不放繼續追問。"
+    exampleMeaningZh: "記者不服氣，緊咬著大臣不放繼續追問。",
+    exampleMeaningI18n: { "ja": "記者は納得できず、大臣に粘り強く質問を重ね続けた。", "en": "Unconvinced, the reporter doggedly pressed the minister and kept firing questions." },
   }),
   examQuestion({
     id: "n1-usage-tashinameru",
@@ -7214,7 +7260,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「たしなめる」＝（對不當言行）委婉地規勸、責備。①母親委婉勸誡吵鬧的孩子＝正解。②有茶道書道的素養是「たしなむ」（嗜好/有造詣，近形他動詞）。③慢慢品味一杯酒也是「たしなむ」。④繼續前進是「続けた」。「たしなめる」是勸戒他人，與表「愛好/有修養」的「たしなむ」是不同的詞，勿混。",
     explanationI18n: { "ja": "「たしなめる」＝（不適切な言動を）やんわりと注意する・叱ること。①母親が騒ぐ子どもをやんわり注意する＝正解。②茶道や書道の心得があるのは「たしなむ」（趣味・素養がある。形の似た他動詞）。③一杯の酒をゆっくり味わうのも「たしなむ」。④前進を続けたのは「続けた」。「たしなめる」は他人を戒めることで、「好む・素養がある」を表す「たしなむ」とは別の語なので混同しないようにしましょう。", "en": "「たしなめる」means to gently reprove or admonish (improper words or actions). Sentence ① has the mother gently admonishing the noisy child = correct. In ②, being accomplished in tea ceremony and calligraphy is 「たしなむ」(to have as a hobby / be skilled in—a similar-looking transitive verb). In ③, slowly savoring a drink is also 「たしなむ」. In ④, continuing forward is 「続けた」. 「たしなめる」is admonishing others—a different word from 「たしなむ」(\"to enjoy / be cultivated in\"); don't confuse them." },
     exampleJapanese: "騒ぐ子どもを、母親が「静かにしなさい」とやんわりたしなめた。",
-    exampleMeaningZh: "母親委婉地告誡吵鬧的孩子要安靜。"
+    exampleMeaningZh: "母親委婉地告誡吵鬧的孩子要安靜。",
+    exampleMeaningI18n: { "ja": "母親は騒ぐ子どもに、静かにするようやんわりと注意した。", "en": "The mother gently admonished her noisy child to quiet down." },
   }),
   examQuestion({
     id: "n1-usage-moteamasu",
@@ -7236,7 +7283,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「もてあます」＝（多到/難搞到）無法妥善處理而傷腦筋、不知如何是好。①退休後多出的時間多得不知怎麼打發＝正解。②心懷感謝是「感謝して」。③用心款待客人應是「もてなした」（近形詞，此處誤用了「もてあます」）。④拿去存起來是「回す／充てる」。「もてあます」帶「處理不來而困擾」的負面語感，不表款待，也不表正面運用。",
     explanationI18n: { "ja": "「もてあます」＝（多すぎて／手に負えず）うまく処理できずに困る・どうしてよいか分からないこと。①退職後にあり余る時間をどう過ごせばよいか困る＝正解。②感謝の気持ちを抱くのは「感謝して」。③客を心を込めてもてなすのは「もてなした」（形の似た語。ここでは誤って「もてあます」を使っている）。④貯金に充てるのは「回す／充てる」。「もてあます」は「処理しきれず困る」という否定的なニュアンスがあり、もてなしや前向きな活用は表しません。", "en": "「もてあます」means to be at a loss, unable to handle something properly (because there is too much of it or it is too troublesome). Sentence ① has one unsure how to fill the excess time after retirement = correct. In ②, feeling grateful is 「感謝して」. In ③, wholeheartedly hosting a guest should be 「もてなした」(a similar-looking word; here 「もてあます」is used by mistake). In ④, setting money aside is 「回す／充てる」. 「もてあます」carries the negative sense of \"being troubled by not being able to handle it,\" and does not mean hosting or a positive use." },
     exampleJapanese: "退職してから、有り余る時間をもてあましている。",
-    exampleMeaningZh: "退休之後，多出來的時間多得不知如何打發。"
+    exampleMeaningZh: "退休之後，多出來的時間多得不知如何打發。",
+    exampleMeaningI18n: { "ja": "退職してから、あり余る時間の使い道に困っている。", "en": "Since retiring, I've had more free time on my hands than I know what to do with." },
   }),
   examQuestion({
     id: "n1-usage-wakimaeru",
@@ -7258,7 +7306,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「わきまえる」＝懂得分寸、明辨（場合/立場/道理）並照此行事。①懂得自身立場、不踰矩＝正解。②分門別類整理是「分ける／仕分ける」。③還沒決定是「決めていない／迷っている」。④把空氣吸入胸中是「吸い込む」。「わきまえる」的對象是場合、立場、是非分寸等抽象判斷，不用於分類物品或物理動作。",
     explanationI18n: { "ja": "「わきまえる」＝分別を持ち、（場・立場・道理を）見分けてそれに従って行動すること。①自分の立場を心得て出過ぎたことをしない＝正解。②種類ごとに整理するのは「分ける／仕分ける」。③まだ決めていないのは「決めていない／迷っている」。④空気を胸に吸い込むのは「吸い込む」。「わきまえる」の対象は場・立場・善悪といった抽象的な判断であり、物の分類や物理的な動作には使いません。", "en": "「わきまえる」means to know one's bounds, to discern (the situation/one's position/what is right) and act accordingly. Sentence ① has him knowing his place and not overstepping = correct. In ②, sorting things by category is 「分ける／仕分ける」. In ③, not yet having decided is 「決めていない／迷っている」. In ④, drawing air into one's chest is 「吸い込む」. The object of 「わきまえる」is abstract judgment—the situation, one's position, right and wrong—not sorting objects or physical actions." },
     exampleJapanese: "彼は立場をわきまえ、出すぎたまねは決してしない。",
-    exampleMeaningZh: "他清楚自己的本分，絕不做逾越的事。"
+    exampleMeaningZh: "他清楚自己的本分，絕不做逾越的事。",
+    exampleMeaningI18n: { "ja": "彼は自分の立場をよく理解していて、出過ぎたことは決してしない。", "en": "He knows his place and never oversteps his bounds." },
   }),
   examQuestion({
     id: "n1-usage-mihakarau",
@@ -7280,7 +7329,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「見計らう」＝（看準）斟酌、抓準適當的時機/分量。①看準對方心情好的時機才開口＝正解。②看清腳下是「確かめる／注意する」。③再次核對是「見直す／確かめる」。④目測山高是「見積もる／目測する」。「見計らう」核心在「抓準時機/恰當程度」，不用於確認對錯或單純估算數值。",
     explanationI18n: { "ja": "「見計らう」＝（見きわめて）適当な時機・加減を見はからうこと。①相手の機嫌がよさそうな頃合いをとらえてから切り出す＝正解。②足元を見きわめるのは「確かめる／注意する」。③もう一度照合するのは「見直す／確かめる」。④山の高さを目測するのは「見積もる／目測する」。「見計らう」の核心は「時機・程度をとらえる」ことにあり、正誤の確認や単なる数値の見積もりには使いません。", "en": "「見計らう」means to gauge or judge the right timing/amount. Sentence ① has one waiting for the moment when the other person seems to be in a good mood before speaking = correct. In ②, watching one's footing is 「確かめる／注意する」. In ③, checking again is 「見直す／確かめる」. In ④, estimating a mountain's height is 「見積もる／目測する」. 「見計らう」centers on \"gauging the right timing/degree,\" not on confirming correctness or simply estimating a figure." },
     exampleJapanese: "相手の機嫌がよさそうな頃合いを見計らって、話を切り出した。",
-    exampleMeaningZh: "瞄準對方似乎心情不錯的時候，才開口談起。"
+    exampleMeaningZh: "瞄準對方似乎心情不錯的時候，才開口談起。",
+    exampleMeaningI18n: { "ja": "相手の機嫌がよさそうなタイミングを選んで、話を切り出した。", "en": "I waited for a moment when the other person seemed to be in a good mood before bringing up the subject." },
   }),
   examQuestion({
     id: "n1-usage-azamuku",
@@ -7302,7 +7352,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「あざむく」＝欺騙、蒙蔽（使人信以為真）。①以巧言欺騙交易對象詐財＝正解。②為自己感到羞愧是「恥じた」。③大為光火是「怒っていた／憤慨していた」。④嚇得縮起身子是「すくめた／こわばらせた」。「あざむく」是「使人受騙」，與羞愧、憤怒、身體反應均無關。",
     explanationI18n: { "ja": "「あざむく」＝欺く・だます（本当だと信じ込ませる）こと。①巧みな嘘で取引相手をだまして金を取る＝正解。②自分を情けなく思うのは「恥じた」。③ひどく腹を立てるのは「怒っていた／憤慨していた」。④びくっと身をすくめるのは「すくめた／こわばらせた」。「あざむく」は「人をだます」ことで、羞恥や怒り、身体の反応とは関係ありません。", "en": "「あざむく」means to deceive or mislead (making someone believe something false). Sentence ① has him deceiving a trading partner with clever lies to swindle money = correct. In ②, feeling ashamed of oneself is 「恥じた」. In ③, being furious is 「怒っていた／憤慨していた」. In ④, flinching in fright is 「すくめた／こわばらせた」. 「あざむく」is \"making someone fall for a deception,\" unrelated to shame, anger, or physical reactions." },
     exampleJapanese: "彼は巧みな嘘で取引相手をあざむき、大金をだまし取った。",
-    exampleMeaningZh: "他用巧妙的謊言瞞騙交易對象，騙走了大筆金錢。"
+    exampleMeaningZh: "他用巧妙的謊言瞞騙交易對象，騙走了大筆金錢。",
+    exampleMeaningI18n: { "ja": "彼は巧みな嘘で取引相手をだまし、大金を奪い取った。", "en": "He deceived his business partner with clever lies and swindled them out of a large sum of money." },
   }),
   examQuestion({
     id: "n1-syn-tekkiri",
@@ -7644,7 +7695,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「見極める」＝看到底、徹底辨明本質或真偽（對象是真假、好壞、實情等抽象判斷）。①在混亂情報中冷靜辨明何者為真＝正解。②記住約定時間是「確かめる」（時間不是『辨明真偽』的對象，搭配不符）。③終於找到鑰匙是「見つける」（找出實物，方向不對）。④瞄準遠處的靶是「狙う／見定める」（『見極める』不用於用眼瞄準目標物）。三個干擾皆把抽象的『徹底辨明』錯用為確認時間、找物、瞄準等具體動作，放進去語意不通。",
     explanationI18n: { "ja": "「見極める」＝最後まで見て本質や真偽を徹底的に見分けること（対象は真偽・善し悪し・実情などの抽象的な判断）。①錯綜した情報の中で冷静に何が真実かを見分ける＝正解。②約束の時間を覚えておくのは「確かめる」（時間は『真偽を見分ける』対象ではなく、組み合わせが合わない）。③ようやく鍵を見つけるのは「見つける」（実物を見つけ出すことで方向が違う）。④遠くの的をねらうのは「狙う／見定める」（『見極める』は目で目標物をねらう意味には使わない）。三つの誤答はいずれも抽象的な『徹底的に見分ける』を、時間の確認・物探し・照準といった具体的な動作に誤用しており、当てはめても意味が通りません。", "en": "「見極める」means to see to the bottom of something, to thoroughly discern its true nature or veracity (the object is an abstract judgment—truth vs. falsehood, good vs. bad, the real situation, etc.). Sentence 1, calmly discerning what is true amid a tangle of information, is the correct answer. Sentence 2, remembering an appointment time, should be 「確かめる」 (a time is not something whose \"truth is discerned,\" so the collocation is wrong). Sentence 3, finally finding a key, should be 「見つける」 (locating a physical object—wrong direction). Sentence 4, taking aim at a distant target, should be 「狙う／見定める」 (「見極める」 is not used for visually aiming at a target object). All three distractors misapply the abstract \"thorough discernment\" to concrete actions like confirming a time, finding an object, or aiming, and make no sense when inserted." },
     exampleJapanese: "情報が錯綜する中、何が真実なのかを冷静に見極める必要がある。",
-    exampleMeaningZh: "在情報錯綜之中，必須冷靜地辨明何者才是真相。"
+    exampleMeaningZh: "在情報錯綜之中，必須冷靜地辨明何者才是真相。",
+    exampleMeaningI18n: { "ja": "情報が入り乱れる中で、何が真実なのかを冷静に判断して確かめる必要がある。", "en": "Amid a tangle of conflicting information, you have to calmly discern what is actually true." },
   }),
   examQuestion({
     id: "n1-usage-tsukitomeru",
@@ -7666,7 +7718,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「突き止める」＝經追查而查明、找出（原因、犯人、下落等隱藏的真相）。①追查到案件的犯人＝正解。②追回被吹走的帽子是「追いかけて取り戻す」（追實物，搭配不符）。③拒絕無理要求是「断る／突っぱねる」（『突き止める』與拒絕無關，方向相反）。④把計畫延後是「先延ばしにする」（延期是『推遲』，與『查明』語意不通）。三個干擾分別把『查明真相』誤用為追物、拒絕、延期，放入句中皆不成立。",
     explanationI18n: { "ja": "「突き止める」＝追及して、原因・犯人・行方などの隠れた真相を明らかにし、探り当てること。①捜査の末に事件の犯人を探り当てる＝正解。②飛ばされた帽子を追うのは「追いかけて取り戻す」（実物を追うことで、組み合わせが合わない）。③理不尽な要求を退けるのは「断る／突っぱねる」（『突き止める』は拒絶とは無関係で、方向が逆）。④計画を先送りにするのは「先延ばしにする」（延期は『先へ延ばす』ことで、『明らかにする』とは意味が通らない）。三つの誤答はそれぞれ『真相を明らかにする』を、物を追う・拒絶する・延期するに誤用しており、当てはめても成立しません。", "en": "「突き止める」means to ascertain or find out through investigation (a hidden truth such as a cause, culprit, or whereabouts). Sentence 1, tracking down the culprit of the case, is the correct answer. Sentence 2, retrieving a hat blown away, should be 「追いかけて取り戻す」 (chasing a physical object—wrong collocation). Sentence 3, refusing an unreasonable demand, should be 「断る／突っぱねる」 (「突き止める」 has nothing to do with refusing—opposite direction). Sentence 4, postponing a plan, should be 「先延ばしにする」 (postponing is \"delaying,\" which makes no sense as \"ascertaining\"). The three distractors respectively misapply \"ascertaining the truth\" to chasing an object, refusing, and postponing, and none hold up when inserted." },
     exampleJapanese: "警察は粘り強い捜査の末、事件の犯人をついに突き止めた。",
-    exampleMeaningZh: "警方歷經鍥而不捨的偵辦，終於查出了案件的犯人。"
+    exampleMeaningZh: "警方歷經鍥而不捨的偵辦，終於查出了案件的犯人。",
+    exampleMeaningI18n: { "ja": "警察は粘り強い捜査の末、事件の犯人をついに特定した。", "en": "After a tenacious investigation, the police finally tracked down the culprit in the case." },
   }),
   examQuestion({
     id: "n1-usage-torihakarau",
@@ -7688,7 +7741,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「取り計らう」＝（為使事情順利）酌情妥善地安排、處置事務。①為避免大家受損而妥善安排＝正解。②合力搬運重物是「運ぶ」（搬東西不是『安排事務』，搭配不符）。③堅持反對意見是「押し通す／突っぱねる」（『取り計らう』是設法調處，與固執己見方向相反）。④快速算出是「計算する」（『取り計らう』非算數，雖含『計』字仍語意不通）。三個干擾皆非『安排調處事務』，放進句中不成立。",
     explanationI18n: { "ja": "「取り計らう」＝（物事がうまく運ぶように）状況に応じて適切に事務を手配・処置すること。①皆が損をしないようにうまく手配する＝正解。②力を合わせて重い荷物を運ぶのは「運ぶ」（物を運ぶことは『事務を手配する』ことではなく、組み合わせが合わない）。③反対意見を押し通すのは「押し通す／突っぱねる」（『取り計らう』はうまく調整して処置することで、自説に固執するのとは方向が逆）。④素早く計算するのは「計算する」（『取り計らう』は計算ではなく、『計』の字を含んでいても意味が通らない）。三つの誤答はいずれも『事務を手配・調整する』ではなく、当てはめても成立しません。", "en": "「取り計らう」means to arrange and handle affairs appropriately and at one's discretion (so that things go smoothly). Sentence 1, making arrangements so that no one suffers a loss, is the correct answer. Sentence 2, joining forces to carry a heavy load, should be 「運ぶ」 (carrying an object is not \"arranging affairs\"—wrong collocation). Sentence 3, sticking to one's opposing view, should be 「押し通す／突っぱねる」 (「取り計らう」 means to mediate and arrange, the opposite of stubbornly insisting). Sentence 4, quickly working out a calculation, should be 「計算する」 (「取り計らう」 is not arithmetic; despite containing the character 「計」 it still makes no sense). None of the three distractors is about \"arranging and handling affairs,\" so they do not hold up when inserted." },
     exampleJapanese: "ご事情は理解しましたので、皆様に不利益が出ないよう取り計らいます。",
-    exampleMeaningZh: "您的情況我已明白，會盡力安排好，不讓各位蒙受任何損失。"
+    exampleMeaningZh: "您的情況我已明白，會盡力安排好，不讓各位蒙受任何損失。",
+    exampleMeaningI18n: { "ja": "ご事情は理解しましたので、皆様に不利益が生じないよう、うまく対処いたします。", "en": "I understand your situation, and I will see to it that none of you comes to any disadvantage." },
   }),
   examQuestion({
     id: "n1-usage-mokuromu",
@@ -7710,7 +7764,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「もくろむ」＝（多為不正當地）暗中策劃、圖謀（計畫、陰謀）。①團夥圖謀大膽的犯案＝正解。②發呆望窗外是「ぼんやりする」（『もくろむ』是有意圖地謀劃，與放空相反）。③拚命爬坡是「あえぐ／頑張る」（爬坡是體力動作，非謀劃，搭配不符）。④曬太陽打盹是「うとうとする／くつろぐ」（與『圖謀』語意不通）。三個干擾皆無『暗中謀劃』之意，放入句中明顯不成立。",
     explanationI18n: { "ja": "「もくろむ」＝（多くは不正なことを）ひそかにたくらみ、企てること（計画・陰謀）。①一味が大胆な犯行をたくらむ＝正解。②窓の外をぼんやり眺めるのは「ぼんやりする」（『もくろむ』は意図をもって企てることで、ぼんやりするのとは逆）。③必死に坂を登るのは「あえぐ／頑張る」（坂登りは体力を使う動作で企てではなく、組み合わせが合わない）。④日差しを浴びてうとうとするのは「うとうとする／くつろぐ」（『たくらむ』とは意味が通らない）。三つの誤答はいずれも『ひそかに企てる』意味を持たず、当てはめると明らかに成立しません。", "en": "「もくろむ」means to plot or scheme secretly (a plan or conspiracy), usually in an illicit sense. Sentence 1, the gang plotting a bold crime, is the correct answer. Sentence 2, blankly gazing out the window, should be 「ぼんやりする」 (「もくろむ」 is deliberate scheming, the opposite of spacing out). Sentence 3, desperately climbing a slope, should be 「あえぐ／頑張る」 (climbing is a physical exertion, not scheming—wrong collocation). Sentence 4, dozing in the sun, should be 「うとうとする／くつろぐ」 (makes no sense as \"scheming\"). None of the three distractors carries the sense of \"secret plotting,\" so they clearly do not hold up when inserted." },
     exampleJapanese: "その一味は、銀行の金庫を破る大胆な犯行をもくろんでいた。",
-    exampleMeaningZh: "那一夥人正圖謀著要撬開銀行金庫的大膽犯案。"
+    exampleMeaningZh: "那一夥人正圖謀著要撬開銀行金庫的大膽犯案。",
+    exampleMeaningI18n: { "ja": "その一味は、銀行の金庫を破るという大胆な犯行を計画していた。", "en": "The gang was scheming a bold crime: breaking into the bank's vault." },
   }),
   examQuestion({
     id: "n1-usage-tajirogu",
@@ -7732,7 +7787,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「たじろぐ」＝（受對方氣勢或壓力而）畏縮、退卻、為之氣餒。①被對方逼人氣勢震得一瞬畏縮＝正解。②開心得不得了是「喜ぶ／はしゃぐ」（高興與畏縮相反，方向不對）。③睡得香甜是「眠る」（『たじろぐ』與睡眠無關，搭配不符）。④洋洋得意是「得意になる」（得意自滿與退縮相反）。三個干擾分別為喜悅、熟睡、自得，都與『受壓畏縮』相反或不相干，放入句中不成立。",
     explanationI18n: { "ja": "「たじろぐ」＝（相手の勢いや圧力に）気おされてひるみ、後ずさりし、気持ちがくじけること。①相手の迫力に気おされて一瞬ひるむ＝正解。②うれしくてたまらないのは「喜ぶ／はしゃぐ」（喜びとひるみは逆で、方向が違う）。③ぐっすり眠るのは「眠る」（『たじろぐ』は睡眠とは無関係で、組み合わせが合わない）。④得意になるのは「得意になる」（得意満面とひるみは逆）。三つの誤答はそれぞれ喜び・熟睡・得意で、いずれも『気おされてひるむ』とは逆か無関係であり、当てはめても成立しません。", "en": "「たじろぐ」means to flinch, shrink back, or lose one's nerve (under another's force or pressure). Sentence 1, momentarily flinching at the other party's intimidating force, is the correct answer. Sentence 2, being overjoyed, should be 「喜ぶ／はしゃぐ」 (joy is the opposite of flinching—wrong direction). Sentence 3, sleeping soundly, should be 「眠る」 (「たじろぐ」 has nothing to do with sleep—wrong collocation). Sentence 4, being smug, should be 「得意になる」 (self-satisfaction is the opposite of shrinking back). The three distractors—joy, deep sleep, and smugness—are each opposite to or unrelated to \"shrinking under pressure,\" so they do not hold up when inserted." },
     exampleJapanese: "相手の鋭い剣幕に、さすがの彼も一瞬たじろいだ。",
-    exampleMeaningZh: "面對對方凌厲的氣勢，連他也一瞬間怯了陣。"
+    exampleMeaningZh: "面對對方凌厲的氣勢，連他也一瞬間怯了陣。",
+    exampleMeaningI18n: { "ja": "相手のすさまじい剣幕に、さすがの彼も一瞬ひるんでしまった。", "en": "Faced with the other party's fierce intensity, even he flinched for a moment." },
   }),
   examQuestion({
     id: "n1-usage-negirau",
@@ -7754,7 +7810,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「ねぎらう」＝慰勞、犒賞（對方付出的辛勞），帶上對下感謝其努力的暖意。①社長慰勞通宵工作的員工＝正解。②嚴厲斥責部下是「叱る／戒める」（責備與慰勞相反，方向不對）。③為前途憂慮是「思い悩む／案じる」（『ねぎらう』是體恤他人辛勞，與自己煩惱無關）。④把價錢殺到半價是「値切る」（議價與慰勞語意不通，搭配不符）。三個干擾皆非『體恤慰勞辛勞』，放進句中不成立。",
     explanationI18n: { "ja": "「ねぎらう」＝（相手が尽くした苦労を）いたわり、その労にむくいることで、上の者が下の者の努力に感謝する温かみを伴います。①社長が徹夜で働いた社員をねぎらう＝正解。②部下を厳しく叱るのは「叱る／戒める」（叱責といたわりは逆で、方向が違う）。③将来を憂えるのは「思い悩む／案じる」（『ねぎらう』は他人の苦労をいたわることで、自分が悩むのとは無関係）。④値段を半額まで下げるのは「値切る」（値引き交渉といたわりは意味が通らず、組み合わせが合わない）。三つの誤答はいずれも『苦労をいたわる』ものではなく、当てはめても成立しません。", "en": "「ねぎらう」means to thank or reward someone for their hard work, carrying the warmth of a superior appreciating a subordinate's effort. Sentence 1, the president thanking employees who worked through the night, is the correct answer. Sentence 2, harshly scolding a subordinate, should be 「叱る／戒める」 (reproach is the opposite of appreciation—wrong direction). Sentence 3, worrying about one's future, should be 「思い悩む／案じる」 (「ねぎらう」 is about appreciating another's effort, not one's own worries). Sentence 4, haggling down a price, should be 「値切る」 (bargaining makes no sense as appreciation—wrong collocation). None of the three distractors is about \"appreciating and rewarding effort,\" so they do not hold up when inserted." },
     exampleJapanese: "社長は徹夜で働いた社員一人ひとりに、その労をねぎらった。",
-    exampleMeaningZh: "社長對每一位徹夜工作的員工表達了慰勞之意。"
+    exampleMeaningZh: "社長對每一位徹夜工作的員工表達了慰勞之意。",
+    exampleMeaningI18n: { "ja": "社長は徹夜で働いた社員一人ひとりに、その苦労をいたわる言葉をかけた。", "en": "The company president personally thanked each employee who had worked through the night for their hard work." },
   }),
   examQuestion({
     id: "n1-usage-odateru",
@@ -7776,7 +7833,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「おだてる」＝（為使對方得意而順其意去做）吹捧、奉承慫恿。①被旁人一捧就得意地接下幹事＝正解。②激烈批評上司是「非難する／責める」（吹捧與責難相反，方向不對）。③用柱子撐住快倒的牆是「支える」（『おだてる』非物理支撐，搭配不符）。④擔心計畫失敗是「心配する／案じる」（與『捧高慫恿』語意不通）。三個干擾分別為責難、支撐、擔憂，皆無『奉承慫恿』之意，放入句中不成立。",
     explanationI18n: { "ja": "「おだてる」＝（相手を得意にさせて思うように動かそうと）持ち上げてほめそやし、けしかけること。①周りに持ち上げられてその気になり幹事を引き受ける＝正解。②上司を激しく批判するのは「非難する／責める」（おだてと非難は逆で、方向が違う）。③倒れそうな塀を柱で支えるのは「支える」（『おだてる』は物理的に支えることではなく、組み合わせが合わない）。④計画の失敗を心配するのは「心配する／案じる」（『持ち上げてけしかける』とは意味が通らない）。三つの誤答はそれぞれ非難・支え・心配で、いずれも『おだててその気にさせる』意味を持たず、当てはめても成立しません。", "en": "「おだてる」means to flatter and butter up (to make someone feel good and go along with something). Sentence 1, being buttered up and gladly taking on the organizer role, is the correct answer. Sentence 2, harshly criticizing one's boss, should be 「非難する／責める」 (flattery is the opposite of criticism—wrong direction). Sentence 3, propping up a collapsing wall with a beam, should be 「支える」 (「おだてる」 is not physical support—wrong collocation). Sentence 4, worrying that a plan might fail, should be 「心配する／案じる」 (makes no sense as \"flattering to egg on\"). The three distractors—criticizing, propping up, and worrying—none carry the sense of \"flattering to egg on,\" so they do not hold up when inserted." },
     exampleJapanese: "周りがうまくおだてるので、彼はその気になって幹事を引き受けた。",
-    exampleMeaningZh: "旁人巧妙地一捧，他就得意起來接下了幹事的工作。"
+    exampleMeaningZh: "旁人巧妙地一捧，他就得意起來接下了幹事的工作。",
+    exampleMeaningI18n: { "ja": "周りが上手にほめて持ち上げたので、彼はその気になって幹事を引き受けた。", "en": "With everyone around him laying on the flattery, he got carried away and agreed to be the organizer." },
   }),
   examQuestion({
     id: "n1-usage-tatekaeru",
@@ -7798,7 +7856,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「立て替える」＝（替別人）先行墊付款項，事後再收回。①暫時替大家墊付聚餐費＝正解。②拆掉舊房重蓋是「建て替える」（同音近形詞，指『重建房屋』，非墊錢）。③把書架靠牆固定是「立てかける」（近形詞，指斜靠，搭配不符）。④把會議改到隔天是「延期する／ずらす」（更改日程與墊款語意不通）。三個干擾分別誤用為重建、斜靠、改期，皆非『代為墊付款項』，放進句中不成立。",
     explanationI18n: { "ja": "「立て替える」＝（他人の代わりに）代金を先に払っておき、あとで回収すること。①とりあえず皆の飲み会代を立て替える＝正解。②古い家を壊して建て直すのは「建て替える」（同音で字形も近い語で、『建物を建て直す』意味であり、金を払うことではない）。③本棚を壁に立てて固定するのは「立てかける」（字形の近い語で、斜めに寄りかからせる意味であり、組み合わせが合わない）。④会議を翌日に移すのは「延期する／ずらす」（日程を変えることは立て替えとは意味が通らない）。三つの誤答はそれぞれ建て直し・立てかけ・日程変更に誤用しており、いずれも『代金を立て替える』ではなく、当てはめても成立しません。", "en": "「立て替える」means to pay on someone's behalf up front and collect it back later. Sentence 1, temporarily covering the party bill for everyone, is the correct answer. Sentence 2, tearing down an old house and rebuilding it, should be 「建て替える」 (a homophone with a similar spelling meaning \"to rebuild a house,\" not to advance money). Sentence 3, propping a bookcase against the wall, should be 「立てかける」 (a similar-looking word meaning to lean at an angle—wrong collocation). Sentence 4, moving a meeting to the next day, should be 「延期する／ずらす」 (changing a schedule makes no sense as advancing money). The three distractors are respectively misused as rebuilding, leaning, and rescheduling, none of which is \"paying on someone's behalf,\" so they do not hold up when inserted." },
     exampleJapanese: "今は手持ちがないので、飲み会の代金はとりあえず私が立て替えておく。",
-    exampleMeaningZh: "我現在身上沒帶錢，聚餐的費用就先由我代付。"
+    exampleMeaningZh: "我現在身上沒帶錢，聚餐的費用就先由我代付。",
+    exampleMeaningI18n: { "ja": "手元にお金がないため、飲み会の代金はとりあえず私が代わりに払っておく。", "en": "There's no cash on hand right now, so I'll front the money for the get-together for the time being." },
   }),
   examQuestion({
     id: "n1-usage-habakaru",
@@ -7820,7 +7879,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「はばかる」＝有所顧忌、忌憚而不敢放開（在意他人眼光、有所收斂）。①顧忌旁人目光而避人相會＝正解。②毫不顧忌地直言應是「はばからず」（句中『少しもはばかって口にする』語意自相矛盾，正確要用否定）。③聲音響徹會場是「響き渡る」（『はばかる』非聲音擴散，搭配不符）。④堤防擋住濁流是「せき止める／防ぐ」（攔阻水流是物理動作，與『心理顧忌』語意不通）。三個干擾皆非『顧忌收斂』，放入句中不成立。",
     explanationI18n: { "ja": "「はばかる」＝遠慮し、気兼ねして思い切ってできないこと（他人の目を気にして控えめになる）。①周囲の目をはばかって人目を避けて会う＝正解。②少しも遠慮せずに言うのは「はばからず」（文中の『少しもはばかって口にする』は意味が自己矛盾しており、正しくは否定形を使う）。③声が会場に響き渡るのは「響き渡る」（『はばかる』は音が広がることではなく、組み合わせが合わない）。④堤防が濁流をせき止めるのは「せき止める／防ぐ」（水流をせき止めるのは物理的な動作で、『心理的な気兼ね』とは意味が通らない）。三つの誤答はいずれも『遠慮して控える』ものではなく、当てはめても成立しません。", "en": "「はばかる」means to hold back out of reserve or hesitation (being mindful of others' eyes and restraining oneself). Sentence 1, being mindful of others' eyes and meeting away from public view, is the correct answer. Sentence 2, speaking one's mind without any hesitation, should use 「はばからず」 (in the sentence 「少しもはばかって口にする」 is self-contradictory in meaning; the negative form is required). Sentence 3, a voice resounding across the venue, should be 「響き渡る」 (「はばかる」 is not about sound spreading—wrong collocation). Sentence 4, a levee blocking muddy water, should be 「せき止める／防ぐ」 (holding back a current is a physical action, which makes no sense as \"psychological reserve\"). None of the three distractors is about \"holding back out of reserve,\" so they do not hold up when inserted." },
     exampleJapanese: "周囲の目をはばかって、二人は人目につかない店で会っていた。",
-    exampleMeaningZh: "顧忌著周遭的眼光，兩人總在不顯眼的店裡碰面。"
+    exampleMeaningZh: "顧忌著周遭的眼光，兩人總在不顯眼的店裡碰面。",
+    exampleMeaningI18n: { "ja": "周囲の目を気にして、二人は人目につかない店で会っていた。", "en": "Wary of the eyes of those around them, the two always met in out-of-the-way places where they wouldn't be noticed." },
   }),
   examQuestion({
     id: "n1-usage-mitsukurou",
@@ -7842,7 +7902,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「見繕う」＝（衡量場合、需要而）斟酌挑選、酌量張羅出合適的東西。①酌情挑選討喜的伴手禮＝正解。②修理壞掉的鐘是「修理する／直す」（『見繕う』非修繕，搭配不符）。③再三核對有無錯誤是「見直す／確認する」（檢查與挑選張羅語意不通）。④看清人臉是「見分ける／識別する」（辨認與酌量挑選不同，方向不對）。三個干擾分別誤用為修理、核對、辨認，皆非『斟酌挑選張羅』，放進句中不成立。",
     explanationI18n: { "ja": "「見繕う」＝（場や必要を見計らって）適当なものを選び、見計らって用意すること。①喜ばれそうな土産を適当に見繕う＝正解。②壊れた時計を修理するのは「修理する／直す」（『見繕う』は修繕することではなく、組み合わせが合わない）。③誤りがないか何度も確かめるのは「見直す／確認する」（点検と、見計らって用意することは意味が通らない）。④人の顔をはっきり見分けるのは「見分ける／識別する」（識別と見計らって選ぶことは異なり、方向が違う）。三つの誤答はそれぞれ修理・点検・識別に誤用しており、いずれも『見計らって選び用意する』ではなく、当てはめても成立しません。", "en": "「見繕う」means to select and put together suitable items at one's discretion (judging the occasion and what is needed). Sentence 1, picking out pleasing souvenirs at one's discretion, is the correct answer. Sentence 2, repairing a broken clock, should be 「修理する／直す」 (「見繕う」 is not repairing—wrong collocation). Sentence 3, checking over and over for errors, should be 「見直す／確認する」 (checking makes no sense as selecting and putting together). Sentence 4, seeing a person's face clearly, should be 「見分ける／識別する」 (recognizing differs from discerningly selecting—wrong direction). The three distractors are respectively misused as repairing, checking, and recognizing, none of which is \"discerningly selecting and putting together,\" so they do not hold up when inserted." },
     exampleJapanese: "予算は任せるので、お土産に喜ばれそうな品を適当に見繕ってください。",
-    exampleMeaningZh: "預算就交給你，麻煩斟酌挑些當伴手禮會討喜的東西。"
+    exampleMeaningZh: "預算就交給你，麻煩斟酌挑些當伴手禮會討喜的東西。",
+    exampleMeaningI18n: { "ja": "予算は任せるので、お土産として喜ばれそうな品物をほどよく選んでください、という意味。", "en": "I'll leave the budget to you, so please use your judgment and pick out some items that would make well-received souvenirs." },
   }),
   examQuestion({
     id: "n1-syn-assari",
@@ -8184,7 +8245,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「おびただしい」表示數量極多，代回「非常に多い数の段ボール箱（非常多的紙箱）」自然成立，故正解為「非常に多い」。「騒がしい（吵鬧）」是聲音層面，箱子不會吵，語境不通。「慌ただしい（匆忙慌亂）」描述時間或氣氛上的忙亂，無法修飾箱子的數量。「微々たる（微不足道、極少）」與「數量極多」恰為相反，代回後語意完全顛倒，明確不成立。四者皆形容詞性質，僅「非常に多い」成立。",
     explanationI18n: { "ja": "「おびただしい」は数量が非常に多いことを表し、「非常に多い数の段ボール箱」と入れ替えても自然に成立するため、正解は「非常に多い」。「騒がしい」は音の面のことで、箱が騒ぐことはなく文脈が通らない。「慌ただしい」は時間や雰囲気の面での慌ただしさを表し、箱の数量を修飾できない。「微々たる」はごくわずか・取るに足らないことで、「数量が非常に多い」とは正反対であり、入れ替えると意味が完全に逆転して明らかに成立しない。四つとも形容詞的な語だが、「非常に多い」のみが成立する。", "en": "「おびただしい」 indicates an extremely large quantity, and substituting it gives a natural 「非常に多い数の段ボール箱」 (a very large number of boxes), so the correct answer is 「非常に多い」. 「騒がしい」 (noisy) is about sound, and boxes can't be noisy, so it doesn't fit the context. 「慌ただしい」 (hurried and hectic) describes busyness of time or atmosphere and cannot modify the quantity of boxes. 「微々たる」 (trivial, minuscule) is exactly the opposite of \"extremely numerous,\" and substituting it flips the meaning entirely, so it clearly fails. All four are adjectival in nature, but only 「非常に多い」 works." },
     exampleJapanese: "倉庫には、まだ仕分けされていない非常に多い数の段ボール箱が積み上げられていた。",
-    exampleMeaningZh: "倉庫裡堆積著大量尚未分類的紙箱。"
+    exampleMeaningZh: "倉庫裡堆積著大量尚未分類的紙箱。",
+    exampleMeaningI18n: { "ja": "倉庫には、まだ仕分けされていない非常に多くの段ボール箱が積み上げられていた。", "en": "An enormous number of cardboard boxes, still unsorted, were piled up in the warehouse." },
   }),
   examQuestion({
     id: "n1-usage-ichigaini",
@@ -8206,7 +8268,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "正解：「悪いとは一概に言えない」表示不能籠統地一概斷定，後接否定，是「一概に」的典型用法，母語者完全接受。干擾一「一概に遅れてきて」要表達「總是、每次」應用「いつも／決まって」，「一概に」無此義，搭配不成立。干擾二「一概に治る」要表達「一定、必定」應用「必ず／きっと」，「一概に」不能修飾肯定的必然結果。干擾三「傘を一概に持って」要表達「以防萬一、姑且」應用「一応／念のため」，與「一概に」毫無關係。三個干擾語意/搭配均明確不成立。",
     explanationI18n: { "ja": "正解：「悪いとは一概に言えない」は、大ざっぱに一括りにして断定はできないことを表し、後ろに否定を伴う「一概に」の典型的な用法で、母語話者も完全に受け入れる。誤答一「一概に遅れてきて」は「いつも・毎回」を表したいのであり「いつも／決まって」を使うべきで、「一概に」にその意味はなく、結びつかない。誤答二「一概に治る」は「必ず・きっと」を表したいのであり「必ず／きっと」を使うべきで、「一概に」は肯定的な必然の結果を修飾できない。誤答三「傘を一概に持って」は「念のため・とりあえず」を表したいのであり「一応／念のため」を使うべきで、「一概に」とは無関係である。三つの誤答はいずれも意味・結びつきが明らかに成立しない。", "en": "Correct: 「悪いとは一概に言えない」 means you can't sweepingly conclude something across the board; followed by a negative, this is the typical use of 「一概に」, fully accepted by native speakers. Distractor 1, 「一概に遅れてきて」, wants to say \"always / every time\" and should use 「いつも／決まって」; 「一概に」 has no such meaning and doesn't collocate. Distractor 2, 「一概に治る」, wants to say \"definitely / for sure\" and should use 「必ず／きっと」; 「一概に」 cannot modify an affirmative certain outcome. Distractor 3, 「傘を一概に持って」, wants to say \"just in case / for now\" and should use 「一応／念のため」, unrelated to 「一概に」. All three distractors clearly fail in meaning or collocation." },
     exampleJapanese: "残業が多いからといって、その会社が悪いとは一概に言えない。",
-    exampleMeaningZh: "雖說加班多，但也不能就此一概斷定那家公司不好。"
+    exampleMeaningZh: "雖說加班多，但也不能就此一概斷定那家公司不好。",
+    exampleMeaningI18n: { "ja": "残業が多いからといって、その会社が悪いと単純に決めつけることはできない、という意味。", "en": "Just because there's a lot of overtime doesn't mean you can flatly conclude that the company is a bad one." },
   }),
   examQuestion({
     id: "n1-usage-nagori",
@@ -8228,7 +8291,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "正解：「城があったことを示す名残だ」表示過去事物留存下來的痕跡，是「名残」的典型用法，母語者接受。干擾一「名残もなく働き続けて」要表達「不間斷地、毫不停歇」應用「休みなく／絶え間なく」，「名残もなく」無此義，搭配不成立。干擾二「名残を取ってから」要表達「取得許可／聯絡確認」應用「許可を取って／連絡を取って」，「名残を取る」不成詞。干擾三「名残をもって取り組む」要表達「慎重、認真」應用「慎重に／真剣に」，「名残をもって」無此義。三個干擾搭配均明確不成立。",
     explanationI18n: { "ja": "正解：「城があったことを示す名残だ」は、過去の事物が残した痕跡を表し、「名残」の典型的な用法で、母語話者も受け入れる。誤答一「名残もなく働き続けて」は「途切れることなく・絶え間なく」を表したいのであり「休みなく／絶え間なく」を使うべきで、「名残もなく」にその意味はなく、結びつかない。誤答二「名残を取ってから」は「許可を取る／連絡して確認する」を表したいのであり「許可を取って／連絡を取って」を使うべきで、「名残を取る」は語として成り立たない。誤答三「名残をもって取り組む」は「慎重に・真剣に」を表したいのであり「慎重に／真剣に」を使うべきで、「名残をもって」にその意味はない。三つの誤答はいずれも結びつきが明らかに成立しない。", "en": "Correct: 「城があったことを示す名残だ」 means a trace left behind by something from the past, the typical use of 「名残」, accepted by native speakers. Distractor 1, 「名残もなく働き続けて」, wants to say \"without a break / ceaselessly\" and should use 「休みなく／絶え間なく」; 「名残もなく」 has no such meaning and doesn't collocate. Distractor 2, 「名残を取ってから」, wants to say \"get permission / make contact to confirm\" and should use 「許可を取って／連絡を取って」; 「名残を取る」 is not a real phrase. Distractor 3, 「名残をもって取り組む」, wants to say \"carefully / seriously\" and should use 「慎重に／真剣に」; 「名残をもって」 has no such meaning. All three distractors clearly fail as collocations." },
     exampleJapanese: "この古い石垣は、かつてここに城があったことを示す名残だ。",
-    exampleMeaningZh: "這道古老的石牆，是從前此地曾有城堡留下的遺跡。"
+    exampleMeaningZh: "這道古老的石牆，是從前此地曾有城堡留下的遺跡。",
+    exampleMeaningI18n: { "ja": "この古い石垣は、かつてここに城があったことを今に伝える、昔の面影を残すものだ。", "en": "This old stone wall is a remnant showing that a castle once stood here." },
   }),
   examQuestion({
     id: "n1-context-tokoroka",
@@ -8270,7 +8334,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「応酬」指雙方針鋒相對地互相反駁、你來我往的激烈對答，最接近「やり取り」（你來我往的對答、往返交鋒），且搭「激しい」自然成立。「打ち合わせ」是事前的協商討論，氣氛是合作而非對立，語意明確不符；「問い合わせ」是向對方詢問、查詢，只有單向發問沒有互相往來，方向錯誤；「話し合い」是平和地商量、協商，缺乏「応酬」所含的激烈交鋒色彩，與「激しい」搭配時語意偏弱、不對等。故唯一正解為「やり取り」。",
     explanationI18n: { "ja": "「応酬」は、双方が真っ向から互いに言い返し合う、激しいやり取りを指し、「やり取り（言葉のやり取り、行き交い）」が最も近く、「激しい」とも自然に結びついて成立する。「打ち合わせ」は事前の相談・協議で、雰囲気は対立ではなく協力であり、意味が明らかに合わない。「問い合わせ」は相手に尋ねる・照会することで、一方的に問うだけで互いのやり取りがなく、方向が誤っている。「話し合い」は穏やかに相談・協議することで、「応酬」の持つ激しい応戦の色合いを欠き、「激しい」と結びつくと意味が弱く、対等ではない。したがって唯一の正解は「やり取り」である。", "en": "「応酬」 refers to a fierce exchange in which two sides rebut each other tit for tat, back and forth, closest to 「やり取り」 (a back-and-forth exchange), and it naturally combines with 「激しい」. 「打ち合わせ」 is a prior consultation/discussion, cooperative rather than confrontational in tone, clearly not matching. 「問い合わせ」 is inquiring of / querying the other party, only one-directional questioning with no mutual back-and-forth, the wrong direction. 「話し合い」 is a peaceful discussion/consultation, lacking the fierce clash 「応酬」 carries, and pairs weakly and unevenly with 「激しい」. Therefore the only correct answer is 「やり取り」." },
     exampleJapanese: "討論会では、両者の激しいやり取りが一時間以上も続いた。",
-    exampleMeaningZh: "在討論會上，雙方激烈的你來我往持續了一個多小時。"
+    exampleMeaningZh: "在討論會上，雙方激烈的你來我往持續了一個多小時。",
+    exampleMeaningI18n: { "ja": "討論会では、両者の激しい言葉のやり取りが一時間以上も続いた。", "en": "At the debate, the heated back-and-forth between the two sides went on for more than an hour." },
   }),
   examQuestion({
     id: "n1-syn-kanyo",
@@ -8292,7 +8357,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「寛容」指能容忍他人過失、不苛責的寬厚態度，最接近「寛大」（寬大、度量大）。「厳格」是嚴格、不留情面，與「寛容」正好相反，明確不成立；「慎重」是謹慎小心，描述的是做事態度而非對人過失的容忍度，語意不對應；「誠実」是誠實、真摯，講的是品格的正直，與「容忍他人錯誤」毫無關係。故唯一正解為「寛大」。",
     explanationI18n: { "ja": "「寛容」は、他人の過ちを受け入れとがめだてしない、心の広い態度を指し、「寛大（心が広く度量が大きい）」が最も近い。「厳格」は厳しく容赦しないことで、「寛容」とは正反対であり、明らかに成立しない。「慎重」は注意深く用心することで、物事に取り組む態度を表し、他人の過ちに対する寛容さとは対応しない。「誠実」は誠実・真摯なことで、人柄の正直さを言うものであり、「他人の過ちを受け入れる」こととは無関係である。したがって唯一の正解は「寛大」である。", "en": "「寛容」 refers to a generous attitude that tolerates others' faults without harsh reproach, closest to 「寛大」 (magnanimous, big-hearted). 「厳格」 is strict and unsparing, exactly the opposite of 「寛容」, clearly failing. 「慎重」 is cautious and careful, describing how one does things rather than tolerance of others' faults, so it doesn't correspond. 「誠実」 is sincere and earnest, about integrity of character, with no relation to tolerating others' mistakes. Therefore the only correct answer is 「寛大」." },
     exampleJapanese: "彼は部下のミスに対して非常に寛大な上司だ。",
-    exampleMeaningZh: "他是一位對下屬犯錯非常寬大的主管。"
+    exampleMeaningZh: "他是一位對下屬犯錯非常寬大的主管。",
+    exampleMeaningI18n: { "ja": "彼は、部下のミスを厳しく責めない、心の広い上司だ。", "en": "He is a boss who is very forgiving of his subordinates' mistakes." },
   }),
   examQuestion({
     id: "n1-syn-zehi",
@@ -8314,7 +8380,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「是非を問う」是固定用法，指追究、質問某事的對錯與正當與否，最接近「善し悪しを問う」（追問好壞、是非）。「見通しを問う」是詢問對未來的預測、展望，講的是前景而非對錯判斷，語意不符；「手応えを問う」是問做某事後感受到的反應、回饋手感，與「對錯」無關；「成り行きを問う」是問事情自然發展的趨勢、結果走向，並非評斷其正當與否。把整個述部「を問う」放入選項後，唯一等義的是「善し悪しを問う」。",
     explanationI18n: { "ja": "「是非を問う」は決まった言い方で、ある事の正しさ・正当性の是非を追及・問いただすことを指し、「善し悪しを問う（良いか悪いか、是非を問う）」が最も近い。「見通しを問う」は将来の予測・展望を尋ねることで、先行きを言うものであり是非の判断ではないため、意味が合わない。「手応えを問う」は何かをした後に感じた反応・手応えを問うことで、「正しさ」とは無関係である。「成り行きを問う」は物事が自然に進む流れ・結果の行方を問うことで、その正当性を評価するものではない。述部「を問う」まで含めて選択肢に入れると、等しい意味になるのは「善し悪しを問う」のみである。", "en": "「是非を問う」 is a fixed expression meaning to probe/question the rightness and justification of something, closest to 「善し悪しを問う」 (to question the good and bad, the rights and wrongs). 「見通しを問う」 is asking about a forecast/outlook for the future, about prospects rather than a judgment of right and wrong, so it doesn't match. 「手応えを問う」 is asking about the response/feedback felt after doing something, unrelated to \"right and wrong.\" 「成り行きを問う」 is asking about the natural trend/course an event takes, not judging its legitimacy. Placing the whole predicate 「を問う」 into the options, the only equivalent is 「善し悪しを問う」." },
     exampleJapanese: "委員会では、この政策の善し悪しを問う声が上がった。",
-    exampleMeaningZh: "委員會上，出現了質問這項政策好壞（是非）的聲音。"
+    exampleMeaningZh: "委員會上，出現了質問這項政策好壞（是非）的聲音。",
+    exampleMeaningI18n: { "ja": "委員会では、この政策の良し悪し（是か非か）を問いただす声が上がった。", "en": "At the committee meeting, voices were raised questioning the merits (the rights and wrongs) of this policy." },
   }),
   examQuestion({
     id: "n1-usage-tekozuru",
@@ -8336,7 +8403,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「てこずる」＝（某件事）難搞、處理起來費盡工夫。①軟體操作複雜，設定費了好大勁＝正解。②感受到雙親的溫暖是「触れた／ほっとした」，てこずる不能搭配正面情緒。③考上第一志願是「合格した」，てこずる沒有「達成目標」之意。④被精彩演奏吸引而聽得入神是「聞き入った／聞きほれた」，てこずる沒有「陶醉、入迷」之意。てこずる的對象是難對付的事情或人，不用於情感體驗或達成成果。",
     explanationI18n: { "ja": "「てこずる」は、あることが扱いにくく、処理に手間がかかることを表す。①ソフトの操作が複雑で、設定にひどく手こずった＝正解。②両親の温かさを感じるのは「触れた／ほっとした」であり、てこずるは肯定的な感情には結びつかない。③第一志望に受かるのは「合格した」であり、てこずるに「目標を達成する」意味はない。④見事な演奏に引き込まれ聞き入るのは「聞き入った／聞きほれた」であり、てこずるに「陶酔・夢中になる」意味はない。てこずるの対象は扱いにくい物事や人であり、感情の体験や成果の達成には使わない。", "en": "「てこずる」 means (something) is hard to handle and takes great effort to deal with. ① The software is complex to operate and setup took a huge struggle = correct. ② Feeling the warmth of one's parents is 「触れた／ほっとした」; 「てこずる」 cannot pair with a positive emotion. ③ Getting into one's first-choice university is 「合格した」; 「てこずる」 has no sense of \"achieving a goal.\" ④ Being drawn in and absorbed by a splendid performance is 「聞き入った／聞きほれた」; 「てこずる」 has no sense of \"being enthralled / captivated.\" The object of 「てこずる」 is a hard-to-handle matter or person, not used for emotional experiences or achieving results." },
     exampleJapanese: "新しいソフトの操作が複雑で、設定にすっかりてこずってしまった。",
-    exampleMeaningZh: "新軟體的操作很複雜，設定時費了好大一番工夫。"
+    exampleMeaningZh: "新軟體的操作很複雜，設定時費了好大一番工夫。",
+    exampleMeaningI18n: { "ja": "新しいソフトの操作が複雑で、設定にすっかり手間取ってしまった、という意味。", "en": "The new software is so complicated to operate that I had a real struggle getting it set up." },
   }),
   examQuestion({
     id: "n1-usage-mikubiru",
@@ -8358,7 +8426,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「見くびる」＝把對方的實力或難度估得太低、瞧不起。①把對手當外行而小看，結果反被逆襲＝正解。②費力辨認遠處招牌的字是「見定めた／読み取った」，見くびる沒有「辨視」之意。③逐一核對來客姓名是「見て／照合して」，見くびる不是「確認」。④為了卸責而掩飾自己的過失是「ごまかした／隠した」，見くびる的對象是別人的本領，不能用在「自己的失敗」上。見くびる帶「低估而失算」的語感，不用於物理觀看或掩飾。",
     explanationI18n: { "ja": "「見くびる」は、相手の実力や難しさを実際より低く見積もる・見くだすことを表す。①相手を素人だと見くびり、逆に反撃を食らった＝正解。②遠くの看板の字をやっとのことで読み取るのは「見定めた／読み取った」であり、見くびるに「見分ける」意味はない。③来客の名前を一人ずつ照らし合わせるのは「見て／照合して」であり、見くびるは「確認する」ではない。④責任逃れのため自分の過失をごまかすのは「ごまかした／隠した」であり、見くびるの対象は他人の力量であって「自分の失敗」には使えない。見くびるは「低く見積もって当てが外れる」という語感を持ち、物理的に見ることやごまかしには使わない。", "en": "「見くびる」 means to estimate the other party's strength or the difficulty too low, to look down on them. ① Underestimating the opponent as an amateur and then getting counterattacked = correct. ② Straining to make out the letters on a distant sign is 「見定めた／読み取った」; 「見くびる」 has no sense of \"discerning by sight.\" ③ Checking visitors' names one by one is 「見て／照合して」; 「見くびる」 is not \"confirming.\" ④ Covering up one's own failure to dodge responsibility is 「ごまかした／隠した」; the object of 「見くびる」 is another's ability, and it cannot be used on \"one's own failure.\" 「見くびる」 carries the nuance of \"miscalculating by underestimating,\" not used for physical viewing or covering up." },
     exampleJapanese: "相手を素人だと見くびっていたら、思わぬ反撃にあって負けた。",
-    exampleMeaningZh: "我把對手當成外行而小看，結果遭到意想不到的反擊輸掉了。"
+    exampleMeaningZh: "我把對手當成外行而小看，結果遭到意想不到的反擊輸掉了。",
+    exampleMeaningI18n: { "ja": "相手を素人だと軽く見ていたら、思いがけない反撃を受けて負けてしまった、という意味。", "en": "I dismissed my opponent as an amateur, only to be hit by an unexpected counterattack and lose." },
   }),
   examQuestion({
     id: "n1-context-woiikotoni",
@@ -8440,7 +8509,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「いざこざ」指小規模的爭執、糾紛，與「もめごと」(爭吵、紛爭) 意思最接近，代回「些細なことでもめごとが絶えず」完全自然。「うわさ」是傳聞、流言，部門之間傳聞不斷與「對應に追われる」搭不上，語意不同。「へだたり」是距離、隔閡，指的是差距而非衝突事件，無法說「へだたりが絶えず、その対応に追われる」。「ふけいき」是不景氣、生意蕭條，與部門間摩擦完全無關。四者只有「もめごと」成立。",
     explanationI18n: { "ja": "「いざこざ」は小規模ないさかい・もめごとを指し、「もめごと（いさかい、紛争）」と意味が最も近く、「ささいなことでもめごとが絶えず」に入れ替えても完全に自然である。「うわさ」は伝聞・風説で、部署間でうわさが絶えないのでは「対応に追われる」とかみ合わず、意味が異なる。「へだたり」は距離・隔たりで、差を指すもので衝突の出来事ではなく、「へだたりが絶えず、その対応に追われる」とは言えない。「ふけいき」は不景気・商売の落ち込みで、部署間の摩擦とはまったく無関係である。四つのうち「もめごと」のみが成立する。", "en": "「いざこざ」 refers to small-scale quarrels and disputes, closest in meaning to 「もめごと」 (squabbles, disputes), and substituting it gives a fully natural 「些細なことでもめごとが絶えず」. 「うわさ」 is rumor/gossip; constant rumors between departments don't fit 「対応に追われる」, so the meaning differs. 「へだたり」 is distance/estrangement, referring to a gap rather than a clash event, and one cannot say 「へだたりが絶えず、その対応に追われる」. 「ふけいき」 is a recession / poor business, entirely unrelated to inter-department friction. Of the four, only 「もめごと」 works." },
     exampleJapanese: "隣の部署とは些細なことでもめごとが絶えず、課長はその対応に追われている。",
-    exampleMeaningZh: "和隔壁部門為了一些小事糾紛不斷，課長忙於應對。"
+    exampleMeaningZh: "和隔壁部門為了一些小事糾紛不斷，課長忙於應對。",
+    exampleMeaningI18n: { "ja": "隣の部署とはささいなことでもめ事が絶えず、課長はその対応に追われている。", "en": "There are constant squabbles with the neighboring department over trivial matters, and the section chief is kept busy dealing with them." },
   }),
   examQuestion({
     id: "n1-syn-netsuzou",
@@ -8462,7 +8532,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「でっち上げる」指無中生有地編造假的事實或數據，與「ねつ造する（捏造、偽造）」意思最接近，代回「データをねつ造していた」完全成立且同為刻意造假。「言い訳して」是辯解、找藉口，研究者並非在辯解而是偽造數據，方向不對。「思い込んで」是主觀認定、先入為主，屬於誤判而非蓄意造假，語意不同。「勘違いして」是誤會、弄錯，是無意的失誤，與「発覚し追放された」所暗示的故意不當行為矛盾。只有「ねつ造して」與蓄意造假的語意一致。",
     explanationI18n: { "ja": "「でっち上げる」は、何もないところから偽の事実やデータを作り上げることを指し、「ねつ造する（捏造・偽造する）」と意味が最も近く、「データをねつ造していた」に入れ替えても完全に成立し、ともに意図的な作り物である。「言い訳して」は弁解・口実で、研究者は弁解しているのではなくデータを偽造しており、方向が違う。「思い込んで」は主観的な決めつけ・先入観で、誤った判断であって意図的な偽造ではなく、意味が異なる。「勘違いして」は誤解・取り違えで、無意識の過失であり、「発覚し追放された」が示す故意の不正行為と矛盾する。「ねつ造して」のみが意図的な偽造という意味と一致する。", "en": "「でっち上げる」 means to concoct false facts or data out of nothing, closest in meaning to 「ねつ造する」 (to fabricate, to forge), and substituting it gives a fully valid 「データをねつ造していた」, both being deliberate falsification. 「言い訳して」 is to make excuses / offer justifications; the researcher wasn't excusing himself but forging data, the wrong direction. 「思い込んで」 is to be subjectively convinced / have a preconception, a misjudgment rather than deliberate fabrication, so the meaning differs. 「勘違いして」 is to misunderstand / get something wrong, an unintentional slip, which contradicts the deliberate wrongdoing implied by 「発覚し追放された」. Only 「ねつ造して」 matches the sense of deliberate falsification." },
     exampleJapanese: "その研究者は実験データをねつ造していたことが発覚し、学界を追放された。",
-    exampleMeaningZh: "那名研究者捏造實驗數據的事被揭發，遭學界驅逐。"
+    exampleMeaningZh: "那名研究者捏造實驗數據的事被揭發，遭學界驅逐。",
+    exampleMeaningI18n: { "ja": "その研究者は、実験データを偽って作り上げていたことが発覚し、学界から追放された。", "en": "It came to light that the researcher had fabricated experimental data, and he was expelled from the academic community." },
   }),
   examQuestion({
     id: "n1-usage-kigane",
@@ -8484,7 +8555,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "正解句：「近所に気兼ねする必要がなくなった」＝不必再顧慮鄰居、放得開地行動，這正是「気兼ね」（顧慮他人、拘束自己、不好意思）的典型用法，搭配「〜に気兼ねする」助詞與語境完全成立。「初心者には気兼ねしないように」＝這裡要表達的是「不要因不懂而退縮／不要慌」，但「気兼ね」是顧慮他人感受，對著說明書並無他人需顧慮，語意不通，應改用「気後れ」「物怖じ」等。「結果が気兼ねで一睡もできなかった」＝這是擔心、掛念結果，應為「気がかり」；「気兼ね」不表示心中掛念某事，且「結果が気兼ね」搭配不成立。「思わず気兼ねするほど美しかった」＝面對美景的反應應是「息をのむ」「見とれる」，「気兼ね」與美景無關，語意完全錯置。故僅有正解句的「顧慮他人而拘束」情境成立。",
     explanationI18n: { "ja": "正解の文：「近所に気兼ねする必要がなくなった」は、もう近所に遠慮せずのびのび行動できるという意味で、これはまさに「気兼ね」（他人に遠慮し、自分を窮屈にし、気詰まりに思うこと）の典型的な用法であり、「～に気兼ねする」という助詞も文脈も完全に成立する。「初心者には気兼ねしないように」は、ここで表したいのは「わからなくて尻込みしない／慌てない」ことだが、「気兼ね」は他人の気持ちへの遠慮であって、説明書に対しては遠慮すべき他人がおらず、文意が通らない。「気後れ」「物怖じ」などを使うべきである。「結果が気兼ねで一睡もできなかった」は、結果を心配し気にかけているのであって「気がかり」とすべきで、「気兼ね」は心中で何かを気にかける意味ではなく、「結果が気兼ね」という結びつきも成立しない。「思わず気兼ねするほど美しかった」は、美しい景色への反応は「息をのむ」「見とれる」であるべきで、「気兼ね」は美しい景色とは無関係で、意味が完全にずれている。したがって正解の文の「他人に遠慮して窮屈になる」場面のみが成立する。", "en": "Correct sentence: 「近所に気兼ねする必要がなくなった」 = no longer having to be self-conscious about the neighbors, acting freely — the typical use of 「気兼ね」 (being mindful of others, constraining oneself, feeling awkward), with the particle collocation 「〜に気兼ねする」 and the context fully valid. 「初心者には気兼ねしないように」: here the intended meaning is \"don't shy away or panic because you don't understand,\" but 「気兼ね」 is being mindful of others' feelings, and there is no other person to consider before a manual, so it makes no sense; use 「気後れ」 or 「物怖じ」 instead. 「結果が気兼ねで一睡もできなかった」: this is worrying/being anxious about the result, which should be 「気がかり」; 「気兼ね」 does not mean fretting over something in one's mind, and 「結果が気兼ね」 doesn't collocate. 「思わず気兼ねするほど美しかった」: the reaction to beautiful scenery should be 「息をのむ」 or 「見とれる」; 「気兼ね」 is unrelated to scenery, entirely misplaced. So only the correct sentence's \"being constrained out of consideration for others\" scenario works." },
     exampleJapanese: "一戸建てに引っ越してからは、夜中にピアノを弾いても近所に気兼ねする必要がなくなった。",
-    exampleMeaningZh: "搬進獨棟房子後，半夜彈鋼琴也不必再顧慮鄰居了。"
+    exampleMeaningZh: "搬進獨棟房子後，半夜彈鋼琴也不必再顧慮鄰居了。",
+    exampleMeaningI18n: { "ja": "一戸建てに引っ越してからは、夜中にピアノを弾いても近所に遠慮する必要がなくなった、という意味。", "en": "Since moving into a detached house, I no longer have to worry about the neighbors even when I play the piano in the middle of the night." },
   }),
   examQuestion({
     id: "n1-usage-tachigie",
@@ -8506,7 +8578,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "正解句：「合併話は…いつのまにか立ち消えになってしまった」＝原本熱烈的計畫／話題在中途無疾而終、不了了之，正是「立ち消え」最典型的抽象用法（多搭配計畫・話題・企画），語意與搭配完全成立。干擾1「世界的な評価へと立ち消えになった」＝研究獲得高評價是正向結果，與「無疾而終」語意相反，應用「結実する」「至る」等；「立ち消え」帶負面消失之意，方向矛盾。干擾2「かかとがすっかり立ち消えになった」＝鞋跟磨損應用「すり減る」，物理上的磨損與「（計畫）無疾而終」的「立ち消え」毫無關係，搭配完全不成立。干擾3「約束の時間に立ち消えになりそう」＝這是怕來不及、要遲到，應用「遅れる」「間に合わない」；「立ち消え」不能修飾「趕不上時間」，搭配不成立。故僅正解句的「計畫不了了之」情境成立。",
     explanationI18n: { "ja": "正解の文：「合併話は…いつのまにか立ち消えになってしまった」は、盛り上がっていた計画や話題が途中でうやむやになり終わることで、まさに「立ち消え」の最も典型的な抽象的用法（多く計画・話題・企画と結びつく）であり、意味も結びつきも完全に成立する。誤答1「世界的な評価へと立ち消えになった」は、研究が高い評価を得るのは前向きな結果で、「うやむやに終わる」とは意味が逆であり「結実する」「至る」などを使うべきで、「立ち消え」は否定的に消える意味であって方向が矛盾する。誤答2「かかとがすっかり立ち消えになった」は、靴のかかとがすり減るのは「すり減る」を使うべきで、物理的なすり減りと「（計画が）うやむやに終わる」意味の「立ち消え」とはまったく無関係で、結びつきが全く成立しない。誤答3「約束の時間に立ち消えになりそう」は、間に合わない・遅れることを心配しているのであり「遅れる」「間に合わない」を使うべきで、「立ち消え」は「時間に間に合わない」ことを修飾できず、結びつきが成立しない。したがって正解の文の「計画がうやむやに終わる」場面のみが成立する。", "en": "Correct sentence: 「合併話は…いつのまにか立ち消えになってしまった」 = a once-lively plan/topic ending midway with nothing coming of it — exactly the most typical abstract use of 「立ち消え」 (usually with plans, topics, or projects), fully valid in meaning and collocation. Distractor 1, 「世界的な評価へと立ち消えになった」: the research earning high acclaim is a positive outcome, the opposite of \"fizzling out\"; use 「結実する」 or 「至る」; 「立ち消え」 carries a negative sense of disappearing, the wrong direction. Distractor 2, 「かかとがすっかり立ち消えになった」: worn-down heels should be 「すり減る」; physical wear has no relation to the \"(plan) fizzling out\" of 「立ち消え」, and the collocation entirely fails. Distractor 3, 「約束の時間に立ち消えになりそう」: this is fearing being late / not making it, which should be 「遅れる」 or 「間に合わない」; 「立ち消え」 cannot modify \"not making it in time,\" so the collocation fails. So only the correct sentence's \"a plan coming to nothing\" scenario works." },
     exampleJapanese: "あれほど盛り上がった両社の合併話は、責任者の交代を機にいつのまにか立ち消えになってしまった。",
-    exampleMeaningZh: "曾經那麼熱烈的兩家公司合併案，隨著負責人換人，不知不覺就無疾而終了。"
+    exampleMeaningZh: "曾經那麼熱烈的兩家公司合併案，隨著負責人換人，不知不覺就無疾而終了。",
+    exampleMeaningI18n: { "ja": "あれほど盛り上がっていた両社の合併話は、責任者の交代をきっかけに、いつのまにか実現しないまま消えてしまった、という意味。", "en": "The merger talks between the two companies, once so full of momentum, quietly fizzled out after the person in charge was replaced." },
   }),
   examQuestion({
     id: "n1-context-tewahabakaranai",
@@ -8588,7 +8661,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「如実に」意為「如實地、毫不掩飾地反映真實樣貌」，與「ありのままに（照原樣、真實地）」最接近，正解成立。干擾一「おおざっぱに（粗略地、大致地）」語意相反，統計是精確反映而非粗略，明確不成立。干擾二「ひそかに（暗中地、偷偷地）」指隱密進行，與「如實呈現於眾」方向相反，不成立。干擾三「意外にも（出乎意料地）」帶有驚訝/反預期語感，原句只是客觀陳述資料真實反映現況，並無意外之意，不成立。四者皆為副詞、詞性一致。",
     explanationI18n: { "ja": "「如実に」は『ありのままに、少しも飾らず真実の姿を映し出して』という意味で、「ありのままに（そのまま、真実のとおりに）」に最も近く、正解となる。誤答一「おおざっぱに（大まかに、ざっと）」は意味が逆で、統計は正確に反映するものであって大まかにではないため明らかに不成立。誤答二「ひそかに（こっそりと、密かに）」は隠れて行うことを指し、『真実を人前に映し出す』とは方向が逆で不成立。誤答三「意外にも（予想に反して）」は驚き・予想外のニュアンスを帯びるが、原文はデータが現状を客観的に反映していると述べているだけで意外性はなく不成立。四つはいずれも副詞で品詞は一致している。", "en": "「如実に」 means 'faithfully, reflecting the true state of things without concealment,' which is closest to 「ありのままに (as it is, truthfully)」, so this is the answer. Distractor one, 「おおざっぱに (roughly, in broad strokes)」, means the opposite—statistics reflect things precisely, not roughly—so it clearly doesn't work. Distractor two, 「ひそかに (secretly, covertly)」, refers to doing something in a hidden way, the opposite direction from 'faithfully presenting to everyone,' so it doesn't work. Distractor three, 「意外にも (unexpectedly)」, carries a sense of surprise or something counter to expectation, but the original sentence merely states objectively that the data truthfully reflects the current situation, with no sense of surprise, so it doesn't work. All four are adverbs, matching in part of speech." },
     exampleJapanese: "この統計は、地方の人口減少という問題をありのままに物語っている。",
-    exampleMeaningZh: "這份統計如實地（照原樣地）道出了地方人口減少這個問題。"
+    exampleMeaningZh: "這份統計如實地（照原樣地）道出了地方人口減少這個問題。",
+    exampleMeaningI18n: { "ja": "この統計は、地方の人口減少という問題を、事実そのまま（ありのままに）物語っている。", "en": "These statistics vividly convey (show exactly as it is) the problem of rural population decline." },
   }),
   examQuestion({
     id: "n1-syn-uttetsuke",
@@ -8610,7 +8684,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「うってつけ」意為「再適合不過、正好合適」，與「最適（最適合）」意思最接近，正解成立。干擾一「不向き（不合適、不適任）」語意完全相反，原句是稱讚他適合此工作，不成立。干擾二「無関心（漠不關心）」描述的是態度而非適合度，與「性格適合工作」的脈絡不符，不成立。干擾三「見当違い（估計錯誤、搞錯方向）」指判斷有誤，原句並無判斷失準之意，且與「適合」無同義關係，不成立。四者皆為名詞性（ナ形容詞用法）、詞性一致。",
     explanationI18n: { "ja": "「うってつけ」は『これ以上ないほど適している、ちょうどよくぴったりだ』という意味で、「最適（最も適している）」に最も近く、正解となる。誤答一「不向き（適していない、向いていない）」は意味が正反対で、原文は彼がこの仕事に適していると称賛しているので不成立。誤答二「無関心（まったく関心がない）」は適性ではなく態度を表すもので、『性格が仕事に適している』という文脈に合わず不成立。誤答三「見当違い（見込み違い、方向を誤る）」は判断の誤りを指し、原文には判断の誤りという意味はなく、また「適している」と同義の関係にもないため不成立。四つはいずれも名詞的（ナ形容詞用法）で品詞は一致している。", "en": "「うってつけ」 means 'perfectly suited, just right,' which is closest in meaning to 「最適 (most suitable)」, so this is the answer. Distractor one, 「不向き (unsuited, ill-suited)」, is the complete opposite in meaning—the original sentence praises how well he fits the job—so it doesn't work. Distractor two, 「無関心 (indifferent)」, describes an attitude rather than suitability, which doesn't match the context of 'a personality suited to the work,' so it doesn't work. Distractor three, 「見当違い (a wrong guess, off the mark)」, refers to a mistaken judgment, but the original sentence has no sense of misjudgment and is not a synonym for 'suitable,' so it doesn't work. All four are nominal (used as na-adjectives), matching in part of speech." },
     exampleJapanese: "彼の冷静で几帳面な性格は、経理の仕事に最適だ。",
-    exampleMeaningZh: "他冷靜又一絲不苟的性格，對會計工作來說最適合不過。"
+    exampleMeaningZh: "他冷靜又一絲不苟的性格，對會計工作來說最適合不過。",
+    exampleMeaningI18n: { "ja": "彼の冷静で几帳面な性格は、経理の仕事にこの上なく向いている。", "en": "His calm, meticulous personality makes him a perfect fit for accounting work." },
   }),
   examQuestion({
     id: "n1-context-ngatameni",
@@ -8692,7 +8767,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「真に受ける」＝把本不必當真的話（玩笑、客套、謊言）信以為真。①把單純的玩笑當真而動了真火＝正解。②認真承接被託付的工作應是「引き受ける／真剣に取り組む」，受け持つ責任不是「真に受ける」。③埋頭認真讀書是「真面目に」，「真に受ける」不修飾讀書態度。④把老師的說明仔細抄到筆記上是「書き留める／そのまま写す」，這裡並非「把可疑的話信以為真」，故不成立。三個干擾都把「真に」誤當成「認真地」，但「真に受ける」是固定慣用，只用於『輕信不該信的話』。",
     explanationI18n: { "ja": "「真に受ける」＝本気にする必要のない言葉（冗談・社交辞令・嘘）を本当のことだと思い込むこと。①単なる冗談を本気にして本当に怒ってしまった＝正解。②頼まれた仕事を責任をもって引き受けるのは「引き受ける／真剣に取り組む」であって、任された責任を担うことは「真に受ける」ではない。③一日中机に向かって熱心に勉強するのは「真面目に」であり、「真に受ける」は勉強の態度を修飾しない。④先生の説明を丁寧にノートに書き写すのは「書き留める／そのまま写す」であって、ここは『疑わしい言葉を本当だと思い込む』場面ではないため不成立。三つの誤答はいずれも「真に」を『真剣に』と取り違えているが、「真に受ける」は固定した慣用表現で、『信じるべきでない言葉を軽々しく信じる』ときにしか使わない。", "en": "「真に受ける」 ＝ to take words that shouldn't be taken seriously (jokes, pleasantries, lies) as literally true. ① Taking a simple joke seriously and genuinely getting angry ＝ the answer. ② Earnestly taking on entrusted work should be 「引き受ける／真剣に取り組む」; bearing responsibility isn't 「真に受ける」. ③ Studying hard with one's head down is 「真面目に」; 「真に受ける」 doesn't modify a study attitude. ④ Carefully copying the teacher's explanation into notes is 「書き留める／そのまま写す」; this is not 'taking dubious words as true,' so it doesn't work. All three distractors mistake 「真に」 for 'earnestly,' but 「真に受ける」 is a fixed idiom used only for 'gullibly believing what shouldn't be believed.'" },
     exampleJapanese: "ただの冗談を真に受けて、彼は本気で怒ってしまった。",
-    exampleMeaningZh: "他把單純的玩笑當真，竟然真的生氣了。"
+    exampleMeaningZh: "他把單純的玩笑當真，竟然真的生氣了。",
+    exampleMeaningI18n: { "ja": "ただの冗談を本当のことだと受け取って、彼は本気で怒ってしまった、という意味。", "en": "He took a simple joke at face value and actually got angry." },
   }),
   examQuestion({
     id: "n1-usage-ninoashiwofumu",
@@ -8714,7 +8790,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「二の足を踏む」＝因猶豫、顧慮而遲遲無法踏出第二步、下不了決心。①條件太不利，誰都對簽約躊躇不前＝正解。②在暗路沒注意到落差差點跌倒，是「踏み外す」，與『猶豫』無關，靠語境鎖死。③重蹈覆轍、再次犯同樣的錯是「二の舞を演じる」這個近形慣用句，並非『猶豫』之意。④懊悔得在地上又跺又叫是「地団駄を踏む」，表示憤恨跺腳，方向與『躊躇』相反。三個干擾都含『足／踏む』類意象來誘導，但唯有①是『因顧慮而遲疑』的語境。",
     explanationI18n: { "ja": "「二の足を踏む」＝ためらいや懸念からなかなか二歩目が踏み出せず、決心がつかないこと。①条件があまりに不利で、誰もが契約にためらった＝正解。②暗い道で段差に気づかず転びそうになったのは「踏み外す」であって『ためらう』とは無関係で、文脈で判別できる。③同じ失敗を繰り返し、再び同じ過ちを犯すのは「二の舞を演じる」という似た形の慣用句であって、『ためらう』の意味ではない。④悔しさのあまり地面で足を踏み鳴らして叫ぶのは「地団駄を踏む」で、怒りや悔しさで足を踏み鳴らすことを表し、『ためらう』とは方向が逆。三つの誤答はいずれも『足／踏む』系のイメージで誘導しているが、『懸念からためらう』文脈なのは①だけである。", "en": "「二の足を踏む」 ＝ to hesitate and be unable to take the second step, unable to make up one's mind, due to wavering or misgivings. ① The conditions are too unfavorable, so everyone hesitates over signing ＝ the answer. ② Almost tripping on a step in the dark without noticing is 「踏み外す」, which has nothing to do with 'hesitating'—ruled out by context. ③ Repeating the same mistake, making the same error again, is the similar-looking idiom 「二の舞を演じる」, not 'hesitating.' ④ Stamping the ground and crying out in frustration is 「地団駄を踏む」, expressing angry foot-stamping, the opposite direction from 'hesitating.' All three distractors use imagery involving 「足／踏む」 to mislead, but only ① fits the context of 'hesitating out of misgivings.'" },
     exampleJapanese: "条件があまりに不利で、契約には誰もが二の足を踏んだ。",
-    exampleMeaningZh: "條件實在太不利，無論是誰都對簽約躊躇不前。"
+    exampleMeaningZh: "條件實在太不利，無論是誰都對簽約躊躇不前。",
+    exampleMeaningI18n: { "ja": "条件があまりに不利だったので、誰もが契約をためらった、という意味。", "en": "The terms were so unfavorable that everyone balked at signing the contract." },
   }),
   examQuestion({
     id: "n1-kanji-hakanai",
@@ -8734,7 +8811,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「儚い」讀作「はかない」,意為短暫虛幻、轉瞬即逝。「はがない」把第二音節濁化,「ばかない」把首音節濁化,「はかなえ」改了詞尾,三者皆非此字的讀法,故唯一正解為「はかない」。",
     explanationI18n: { "ja": "「儚い」は「はかない」と読み、束の間で幻のよう、あっという間に消えてしまうという意味。「はがない」は第二音節を濁らせたもの、「ばかない」は最初の音節を濁らせたもの、「はかなえ」は語尾を変えたもので、いずれもこの字の読み方ではないため、唯一の正解は「はかない」。", "en": "「儚い」 is read 「はかない」, meaning fleeting and ephemeral, gone in an instant. 「はがない」 voices the second syllable, 「ばかない」 voices the first syllable, and 「はかなえ」 changes the ending—none is a valid reading of this word, so the only answer is 「はかない」." },
     exampleJapanese: "夜空に開いた花火の光は「儚い」からこそ、心に深く残るのだと思う。",
-    exampleMeaningZh: "我想,夜空中綻放的花火之光正因為短暫,才會深深留在心裡。"
+    exampleMeaningZh: "我想,夜空中綻放的花火之光正因為短暫,才會深深留在心裡。",
+    exampleMeaningI18n: { "ja": "夜空に開く花火の光は、すぐに消えてしまうものだからこそ、心に深く残るのだと思う。", "en": "I think it's precisely because the light of fireworks blooming in the night sky is so fleeting that it lingers so deeply in the heart." },
   }),
   examQuestion({
     id: "n1-kanji-hisomu",
@@ -8754,7 +8832,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「潜む」讀作「ひそむ」,指某種事物隱藏、潛藏於內部不外顯,此處形容執著潛伏在溫柔背後。「ひそぶ」是把詞尾錯讀成濁音的誤導;「しずむ」是近形漢字「沈む」(下沉)的讀音,語境不成立;「ひしむ」為近形拼讀的非詞。",
     explanationI18n: { "ja": "「潜む」は「ひそむ」と読み、あるものが内部に隠れて表に出ないことを指し、ここでは執着が優しさの裏に潜んでいることを表す。「ひそぶ」は語尾を誤って濁音にした引っ掛け、「しずむ」は字形の近い「沈む」の読みで文脈上成立しない、「ひしむ」は近い綴りの実在しない語である。", "en": "「潜む」 is read 「ひそむ」, referring to something hidden or lurking within without showing outwardly; here it describes obsession lurking behind gentleness. 「ひそぶ」 is a misreading that voices the ending; 「しずむ」 is the reading of the similar-looking kanji 「沈む (to sink)」, which doesn't fit the context; 「ひしむ」 is a non-word formed from a similar-looking spelling." },
     exampleJapanese: "優しい言葉の裏に「潜む」執着に、彼女はようやく気づいた。",
-    exampleMeaningZh: "她終於察覺到,潛藏在那些溫柔話語背後的執著。"
+    exampleMeaningZh: "她終於察覺到,潛藏在那些溫柔話語背後的執著。",
+    exampleMeaningI18n: { "ja": "優しい言葉の裏に隠れていた執着に、彼女はようやく気づいた。", "en": "She finally noticed the obsession lurking behind those gentle words." },
   }),
   examQuestion({
     id: "n1-kanji-norou",
@@ -8774,7 +8853,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「呪う」讀作「のろう」,意為詛咒、對命運懷恨,符合此處對奪走戀人之命運的怨恨。「のろお」是把語尾「う」誤拼成長音「お」;「ころう」把首音清濁/子音換成誤導非詞;「のうろ」是音節順序錯置的近形誤導。",
     explanationI18n: { "ja": "「呪う」は「のろう」と読み、呪う・運命に恨みを抱くという意味で、ここでは恋人の命を奪った運命への恨みに合う。「のろお」は語尾の「う」を長音「お」と誤って綴ったもの、「ころう」は最初の音の清濁や子音を変えた誤りの非語、「のうろ」は音節の順序を入れ替えた近い形の引っ掛けである。", "en": "「呪う」 is read 「のろう」, meaning to curse or to bear a grudge against fate, fitting the resentment here toward the fate that took away her beloved. 「のろお」 mistakes the ending 「う」 for a long vowel 「お」; 「ころう」 is a misleading non-word that changes the first syllable's voicing/consonant; 「のうろ」 is a misleading form with the syllable order scrambled." },
     exampleJapanese: "彼を奪った運命を「呪う」ほど、その想いは深く濁っていった。",
-    exampleMeaningZh: "深到甚至想詛咒那奪走他的命運,這份情感就這樣愈發混濁。"
+    exampleMeaningZh: "深到甚至想詛咒那奪走他的命運,這份情感就這樣愈發混濁。",
+    exampleMeaningI18n: { "ja": "彼を奪った運命を恨まずにはいられないほど、その想いは深く濁っていった。", "en": "Deep enough to make her curse the fate that took him from her, those feelings grew ever murkier." },
   }),
   examQuestion({
     id: "n1-kanji-kattou",
@@ -8794,7 +8874,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「葛藤」讀作「かっとう」,指內心相反欲求並存而難以取捨的矛盾,此處正是想離開卻離不開的心理糾葛。「かつとう」漏掉促音;「がっとう」首音誤加濁音;「かつどう」是近形熟語「活動」的讀音,語境不成立。",
     explanationI18n: { "ja": "「葛藤」は「かっとう」と読み、心の中で相反する欲求が併存して割り切れない矛盾を指し、ここはまさに離れたいのに離れられない心の葛藤である。「かつとう」は促音が抜けている、「がっとう」は最初の音に濁音を誤って加えている、「かつどう」は字形の近い熟語「活動」の読みで文脈上成立しない。", "en": "「葛藤」 is read 「かっとう」, referring to the inner conflict of opposing desires coexisting and being hard to choose between; here it is exactly the psychological conflict of wanting to leave but being unable to. 「かつとう」 drops the geminate consonant; 「がっとう」 wrongly voices the first syllable; 「かつどう」 is the reading of the similar-looking compound 「活動 (activity)」, which doesn't fit the context." },
     exampleJapanese: "離れたいのに離れられない「葛藤」に、夜ごと胸を締めつけられた。",
-    exampleMeaningZh: "想離開卻離不開的糾葛,每晚都讓胸口被緊緊揪住。"
+    exampleMeaningZh: "想離開卻離不開的糾葛,每晚都讓胸口被緊緊揪住。",
+    exampleMeaningI18n: { "ja": "離れたいのに離れられない、心の中のせめぎ合いに、毎晩胸を締めつけられた。", "en": "The inner conflict of wanting to leave yet being unable to gripped my chest tight night after night." },
   }),
   examQuestion({
     id: "n1-kanji-mujun",
@@ -8814,7 +8895,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「矛盾」讀作「むじゅん」。「矛」音讀為む、「盾」音讀為じゅん。干擾項「むしゅん」把濁音じゅ誤清化為しゅ;「ぼうじゅん」把「矛」誤讀成形近的「ぼう」;「むじゅう」把語尾ん誤拉成長音う,均非此詞讀法。",
     explanationI18n: { "ja": "「矛盾」は「むじゅん」と読む。「矛」は音読みで「む」、「盾」は音読みで「じゅん」。誤答「むしゅん」は濁音の「じゅ」を誤って清音の「しゅ」にしたもの、「ぼうじゅん」は「矛」を字形の近い「ぼう」と誤って読んだもの、「むじゅう」は語尾の「ん」を誤って長音「う」に伸ばしたもので、いずれもこの語の読みではない。", "en": "「矛盾」 is read 「むじゅん」. 「矛」 has the on-reading む, and 「盾」 has the on-reading じゅん. The distractor 「むしゅん」 wrongly unvoices じゅ to しゅ; 「ぼうじゅん」 misreads 「矛」 as the similar-looking 「ぼう」; 「むじゅう」 wrongly stretches the final ん into a long vowel う—none is a valid reading of this word." },
     exampleJapanese: "天使でいたいのに堕ちたいと願う自分の矛盾を、誰にも見せないまま抱えている。",
-    exampleMeaningZh: "明明想當天使卻又渴望墜落,我把自身的矛盾藏著,不讓任何人看見。"
+    exampleMeaningZh: "明明想當天使卻又渴望墜落,我把自身的矛盾藏著,不讓任何人看見。",
+    exampleMeaningI18n: { "ja": "天使でいたいのに堕ちたいと願う、自分の中のつじつまの合わない気持ちを、誰にも見せないまま抱えている。", "en": "Wanting to remain an angel yet longing to fall—I carry that contradiction inside me, letting no one see it." },
   }),
   examQuestion({
     id: "n1-kanji-shoudou",
@@ -8834,7 +8916,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「衝動」讀作「しょうどう」。「衝」音讀為しょう(含長音)、「動」音讀為どう。干擾項「しょどう」脫落了長音う;「しょうとう」把濁音どう誤清化為とう;「じょうどう」把しょう誤濁化為じょう,皆不成立。",
     explanationI18n: { "ja": "「衝動」は「しょうどう」と読む。「衝」は音読みで「しょう」（長音を含む）、「動」は音読みで「どう」。誤答「しょどう」は長音の「う」が脱落している、「しょうとう」は濁音の「どう」を誤って清音の「とう」にしている、「じょうどう」は「しょう」を誤って濁音の「じょう」にしており、いずれも成立しない。", "en": "「衝動」 is read 「しょうどう」. 「衝」 has the on-reading しょう (with a long vowel), and 「動」 has the on-reading どう. The distractor 「しょどう」 drops the long vowel う; 「しょうとう」 wrongly unvoices どう to とう; 「じょうどう」 wrongly voices しょう to じょう—none works." },
     exampleJapanese: "甘い言葉の奥に潜む毒へ手を伸ばしたくなる衝動を、夜ごと懸命に抑え込んでいる。",
-    exampleMeaningZh: "對藏在甜言蜜語深處的毒,那股想伸手的衝動,我每晚都拚命壓抑著。"
+    exampleMeaningZh: "對藏在甜言蜜語深處的毒,那股想伸手的衝動,我每晚都拚命壓抑著。",
+    exampleMeaningI18n: { "ja": "甘い言葉の奥に潜む毒へ、思わず手を伸ばしたくなる強い気持ちを、毎晩懸命に抑え込んでいる。", "en": "Night after night, I desperately hold back the urge to reach for the poison hidden deep within those sweet words." },
   }),
   examQuestion({
     id: "n1-kanji-kirameku",
@@ -8854,7 +8937,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「煌めく」讀作「きらめく」，正貼合星屑在夜空閃爍生輝的意象。其餘干擾項讀音相近、字尾同為「めく」：「ひらめく」「ざわめく」「うごめく」皆與「煌」字無對應，代回句中唯有「きらめく」自然成立。",
     explanationI18n: { "ja": "「煌めく」は「きらめく」と読み、星屑が夜空できらきらと輝くイメージにぴったり合う。ほかの誤答は読みが近く、語尾も同じ「めく」である。「ひらめく」「ざわめく」「うごめく」はいずれも「煌」の字に対応せず、文に戻して自然に成立するのは「きらめく」だけである。", "en": "「煌めく」 is read 「きらめく」, matching the image of stardust sparkling in the night sky. The other distractors have similar readings and share the 「めく」 ending: 「ひらめく」「ざわめく」「うごめく」 none correspond to the character 「煌」, and substituting them back into the sentence, only 「きらめく」 works naturally." },
     exampleJapanese: "君のいない夜空に煌めく星屑を、ただひとつの願いのように数えていたい。",
-    exampleMeaningZh: "在沒有你的夜空，把閃爍的星塵當作唯一的願望般細數著。"
+    exampleMeaningZh: "在沒有你的夜空，把閃爍的星塵當作唯一的願望般細數著。",
+    exampleMeaningI18n: { "ja": "あなたのいない夜空に光る星くずを、たったひとつの願いのように数えていたい。", "en": "In a night sky without you, I want to keep counting the glittering stardust as if it were my one and only wish." },
   }),
   examQuestion({
     id: "n1-kanji-nijimu",
@@ -8874,7 +8958,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「滲む」讀作「にじむ」,指光因淚水而暈開、滲染顯得模糊,契合「涙で光が滲む」的抒情畫面。干擾項「ひそむ(潜む/潛藏)」表示隱匿不現,與光暈染開來的意象相反;「うらむ(恨む/怨恨)」是情緒動詞,主語不可為光;「からむ(絡む/纏繞、糾纏)」指交纏,光線在此並非互相纏繞。逐一代回,僅「にじむ」描述光暈染成立。",
     explanationI18n: { "ja": "「滲む」は「にじむ」と読み、光が涙でぼやけて広がりかすんで見えることを指し、「涙で光が滲む」という抒情的な情景に合う。誤答「ひそむ（潜む）」は隠れて表に出ないことを表し、光が広がるイメージと逆、「うらむ（恨む）」は感情の動詞で主語が光にはなり得ない、「からむ（絡む）」は絡み合うことを指すが、ここで光線が互いに絡み合っているわけではない。一つずつ戻してみると、光がにじむと描写できるのは「にじむ」だけである。", "en": "「滲む」 is read 「にじむ」, referring to light blurring and bleeding into haze because of tears, fitting the lyrical image of 「涙で光が滲む」. The distractor 「ひそむ (潜む/to lurk)」 means to hide unseen, the opposite of light bleeding out; 「うらむ (恨む/to resent)」 is an emotion verb whose subject cannot be light; 「からむ (絡む/to entwine, to entangle)」 refers to intertwining, but the light here is not entwining with anything. Substituting each back in, only 「にじむ」 describes light blurring, so it works." },
     exampleJapanese: "涙で滲むプラネタリウムの光は、もう届かない夢のようだろうか。",
-    exampleMeaningZh: "因淚水而暈染開來的星象儀光芒,是否就像再也觸不到的夢呢。"
+    exampleMeaningZh: "因淚水而暈染開來的星象儀光芒,是否就像再也觸不到的夢呢。",
+    exampleMeaningI18n: { "ja": "涙でぼやけて広がるプラネタリウムの光は、もう届かない夢のようなものなのだろうか。", "en": "Is the planetarium's light, blurring through my tears, like a dream that can no longer be reached?" },
   }),
   examQuestion({
     id: "n1-kanji-samayou",
@@ -8894,7 +8979,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「彷徨う」讀作「さまよう」,意為無目的地徘徊、漂泊,正合「行く先も知らぬまま果てを彷徨う」的流浪意象。干擾項「ただよう(漂う/飄盪)」雖語意相近,卻是「漂」字的讀音,不能當「彷徨」的讀法(且本句強調無目的遊走而非隨波飄浮);「うるおう(潤う/滋潤)」與漂泊無關;「つくろう(繕う/修補、掩飾)」意思完全不同。唯有「さまよう」為「彷徨う」之正讀。",
     explanationI18n: { "ja": "「彷徨う」は「さまよう」と読み、あてもなくさまよい漂うという意味で、「行く先も知らぬまま果てを彷徨う」という放浪のイメージにぴったり合う。誤答「ただよう（漂う）」は語意こそ近いが「漂」の字の読みであって「彷徨」の読みにはならない（しかもこの文はあてもなく歩き回ることを強調しており、波に任せて漂うことではない）。「うるおう（潤う）」は漂うことと無関係、「つくろう（繕う）」は意味がまったく異なる。「彷徨う」の正しい読みは「さまよう」だけである。", "en": "「彷徨う」 is read 「さまよう」, meaning to wander aimlessly or drift, fitting the roaming image of 「行く先も知らぬまま果てを彷徨う」. The distractor 「ただよう (漂う/to float)」, though close in meaning, is the reading of the character 「漂」 and cannot serve as the reading of 「彷徨」 (and this sentence emphasizes aimless roaming rather than floating with the current); 「うるおう (潤う/to be moistened)」 has nothing to do with drifting; 「つくろう (繕う/to mend, to gloss over)」 has a completely different meaning. Only 「さまよう」 is the correct reading of 「彷徨う」." },
     exampleJapanese: "行く先も知らぬまま銀河の果てを彷徨う流れ星に、わたしはなりたい。",
-    exampleMeaningZh: "我想成為那不知去向、在銀河盡頭漂泊徘徊的流星。"
+    exampleMeaningZh: "我想成為那不知去向、在銀河盡頭漂泊徘徊的流星。",
+    exampleMeaningI18n: { "ja": "行き先も分からないまま銀河の果てをあてもなくさすらう流れ星に、わたしはなりたい。", "en": "I want to become a shooting star that wanders the far edge of the galaxy, not knowing where it is headed." },
   }),
   examQuestion({
     id: "n1-kanji-matataku",
@@ -8914,7 +9000,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「瞬く」在此意為星光忽明忽暗地閃爍,讀作「またたく」。干擾項「まだたく」是第二音誤濁、「またたぐ」是字尾誤濁、「まなたく」是中段母音偏移,三者皆非「瞬」字的實際讀音,母語者都不會接受,故唯一正解為「またたく」。",
     explanationI18n: { "ja": "「瞬く」はここでは星の光が明滅してきらめくという意味で、「またたく」と読む。誤答「まだたく」は第二音を誤って濁らせたもの、「またたぐ」は語尾を誤って濁らせたもの、「まなたく」は中間の母音がずれたもので、いずれも「瞬」の字の実際の読みではなく、母語話者なら受け入れないため、唯一の正解は「またたく」である。", "en": "「瞬く」 here means starlight twinkling on and off, read 「またたく」. The distractor 「まだたく」 wrongly voices the second syllable, 「またたぐ」 wrongly voices the ending, and 「まなたく」 shifts the middle vowel—none is an actual reading of the character 「瞬」, and no native speaker would accept them, so the only answer is 「またたく」." },
     exampleJapanese: "遠い夜空で瞬く星のように、あなたの名を呼びたい。",
-    exampleMeaningZh: "想像遙遠夜空裡閃爍的星星那樣,輕喚你的名字。"
+    exampleMeaningZh: "想像遙遠夜空裡閃爍的星星那樣,輕喚你的名字。",
+    exampleMeaningI18n: { "ja": "遠い夜空でちらちらと光る星のように、あなたの名前を呼びたい。", "en": "I want to call your name softly, like a star twinkling in the distant night sky." },
   }),
   examQuestion({
     id: "n1-kanji-furuu",
@@ -8934,7 +9021,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「奮う」讀作「ふるう」,意為振奮、鼓起、發揮。「ふくう」「ふろう」為近形誤讀,「ぶるう」誤加濁音,皆非此字讀法。",
     explanationI18n: { "ja": "「奮う」は「ふるう」と読み、ふるい起こす・発揮するという意味。「ふくう」「ふろう」は字形の近い誤読、「ぶるう」は濁音を誤って加えたもので、いずれもこの字の読みではない。", "en": "「奮う」 is read 「ふるう」, meaning to rouse, to summon up, to wield. 「ふくう」 and 「ふろう」 are misreadings based on similar forms, and 「ぶるう」 wrongly adds a voiced consonant—none is a valid reading of this word." },
     exampleJapanese: "今日のライブは仲間が見てる、ここで勇気を奮うしかないと、汗まみれの僕は前を向いた。",
-    exampleMeaningZh: "今天的演唱會夥伴正看著,我滿身大汗地心想此刻唯有鼓起勇氣,然後抬頭向前。"
+    exampleMeaningZh: "今天的演唱會夥伴正看著,我滿身大汗地心想此刻唯有鼓起勇氣,然後抬頭向前。",
+    exampleMeaningI18n: { "ja": "今日のライブは仲間が見ている。ここで勇気を出すしかないと、汗まみれの僕は前を向いた。", "en": "My bandmates are watching today's live show—drenched in sweat, I told myself this was the moment to summon my courage, and faced forward." },
   }),
   examQuestion({
     id: "n1-kanji-idomu",
@@ -8954,7 +9042,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「挑む」讀作「いどむ」,意為挑戰、發起進攻。「いとむ」清音化、「いどぶ」「いどう」皆為近形誤讀,均非正確讀音。",
     explanationI18n: { "ja": "「挑む」は「いどむ」と読み、挑む・立ち向かうという意味。「いとむ」は清音化、「いどぶ」「いどう」はいずれも字形の近い誤読で、正しい読みではない。", "en": "「挑む」 is read 「いどむ」, meaning to challenge or to take on. 「いとむ」 unvoices the consonant, and 「いどぶ」「いどう」 are both misreadings based on similar forms—none is the correct reading." },
     exampleJapanese: "あの夢の頂きに、もう一度本気で挑むと決めたあの夜、僕らは駆け上がる覚悟を交わした。",
-    exampleMeaningZh: "在決定要再一次認真地向那夢想之巔挑戰的那個夜晚,我們交換了一路衝上去的覺悟。"
+    exampleMeaningZh: "在決定要再一次認真地向那夢想之巔挑戰的那個夜晚,我們交換了一路衝上去的覺悟。",
+    exampleMeaningI18n: { "ja": "あの夢の頂きにもう一度本気で立ち向かうと決めたあの夜、僕らは駆け上がる覚悟を交わし合った。", "en": "On the night we decided to take on the summit of that dream in earnest once more, we pledged to each other our resolve to race all the way up." },
   }),
   examQuestion({
     id: "n1-kanji-kidou",
@@ -8974,7 +9063,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「軌道」讀作「きどう」,指運行的路線、正軌。干擾「きとう」少了濁音(且為「祈祷」之音)、「ぎどう」首音誤濁、「けいどう」誤把「軌」當「径」類字音,在此語境皆不成立。",
     explanationI18n: { "ja": "「軌道」は「きどう」と読み、運行の経路・正しい道筋を指す。誤答「きとう」は濁音が抜けており（しかも「祈祷」の読み）、「ぎどう」は最初の音を誤って濁らせたもの、「けいどう」は「軌」を「径」の類の字と誤って読んだもので、この文脈ではいずれも成立しない。", "en": "「軌道」 is read 「きどう」, referring to a course of motion or the right track. The distractor 「きとう」 lacks the voiced consonant (and is the reading of 「祈祷」); 「ぎどう」 wrongly voices the first syllable; 「けいどう」 mistakes 「軌」 for a character read like 「径」—none works in this context." },
     exampleJapanese: "幾度も崩れては立ち上がり、わたしたちはようやく自分の軌道へと帰っていく。",
-    exampleMeaningZh: "幾度崩塌又重新站起,我們終於回到自己的軌道上。"
+    exampleMeaningZh: "幾度崩塌又重新站起,我們終於回到自己的軌道上。",
+    exampleMeaningI18n: { "ja": "何度も崩れては立ち上がり、わたしたちはようやく自分の進むべき道筋へと帰っていく。", "en": "After crumbling and rising again time after time, we are finally returning to an orbit of our own." },
   }),
   examQuestion({
     id: "n1-kanji-senkou",
@@ -8994,7 +9084,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「閃光」讀作「せんこう」。干擾項「せんごう」尾音誤濁、「ぜんこう」首音誤濁、「せんこ」缺長音,皆不成立,只有「せんこう」正確。",
     explanationI18n: { "ja": "「閃光」は「せんこう」と読む。誤答「せんごう」は語尾を誤って濁らせたもの、「ぜんこう」は最初の音を誤って濁らせたもの、「せんこ」は長音が抜けており、いずれも成立せず、正しいのは「せんこう」だけである。", "en": "「閃光」 is read 「せんこう」. The distractor 「せんごう」 wrongly voices the final syllable, 「ぜんこう」 wrongly voices the first syllable, and 「せんこ」 lacks the long vowel—none works, and only 「せんこう」 is correct." },
     exampleJapanese: "灰の底から跳ね上がった瞬間、夜明けを切り裂く一筋の閃光になりたかった。",
-    exampleMeaningZh: "從灰燼底部躍起的那一瞬,只想成為劃破黎明的一道閃光。"
+    exampleMeaningZh: "從灰燼底部躍起的那一瞬,只想成為劃破黎明的一道閃光。",
+    exampleMeaningI18n: { "ja": "灰の底から跳ね上がったその一瞬、夜明けを切り裂くひとすじの光になりたかった。", "en": "In the instant I leapt up from the bottom of the ashes, all I wanted was to become a single flash of light tearing through the dawn." },
   }),
   examQuestion({
     id: "n1-kanji-tsubasa",
@@ -9014,7 +9105,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「翼」訓讀作「つばさ」,意為翅膀。干擾「つばめ」為「燕」、「つるぎ」為「剣」、「つぼみ」為「蕾」,皆是近形或同氛圍的別字之讀,在「展開飛向天空」的語境下唯有「つばさ」成立。",
     explanationI18n: { "ja": "「翼」は訓読みで「つばさ」と読み、翼を意味する。誤答「つばめ」は「燕」、「つるぎ」は「剣」、「つぼみ」は「蕾」で、いずれも字形の近い、あるいは同じ雰囲気の別の字の読みであり、「翼を広げて空へ飛ぶ」という文脈で成立するのは「つばさ」だけである。", "en": "「翼」 has the kun-reading 「つばさ」, meaning wings. The distractor 「つばめ」 is 「燕 (swallow)」, 「つるぎ」 is 「剣 (sword)」, and 「つぼみ」 is 「蕾 (bud)」—all readings of similar-looking or similar-mood characters, and in the context of 'spreading wings to fly into the sky,' only 「つばさ」 works." },
     exampleJapanese: "焦げついた過去さえ風に変えて、わたしは新しい翼を広げて空へ駆け上がる。",
-    exampleMeaningZh: "連燒焦的過去也化作風,我展開嶄新的雙翼朝天空奔躍而上。"
+    exampleMeaningZh: "連燒焦的過去也化作風,我展開嶄新的雙翼朝天空奔躍而上。",
+    exampleMeaningI18n: { "ja": "焦げついた過去さえ風に変えて、私は真新しい羽を大きく広げ、空へと駆け上がっていく。", "en": "Turning even my scorched past into wind, I spread my brand-new wings and soar up into the sky." },
   }),
   examQuestion({
     id: "n1-kanji-hitomi",
@@ -9034,7 +9126,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「瞳」訓讀為「ひとみ」，指眼眸、瞳孔。「ひどみ」是濁音化的誤讀；「ひとめ」是「一目」的讀音，意思與字形不符；「ひだみ」為近形捏造讀音，均不成立。語境描述拭淚後眼中的光芒，唯有「ひとみ」成立。",
     explanationI18n: { "ja": "「瞳」は訓読みで「ひとみ」と読み、目・瞳を指す。「ひどみ」は濁音化した誤読、「ひとめ」は「一目」の読みで意味が字形と合わない、「ひだみ」は字形の近い作り物の読みで、いずれも成立しない。涙をぬぐったあとの目に宿る光を描く文脈で成立するのは「ひとみ」だけである。", "en": "「瞳」 has the kun-reading 「ひとみ」, referring to the eyes or pupil. 「ひどみ」 is a voiced misreading; 「ひとめ」 is the reading of 「一目」, whose meaning doesn't match the character; 「ひだみ」 is a fabricated reading from a similar form—none works. The context describes the light in her eyes after wiping away tears, so only 「ひとみ」 works." },
     exampleJapanese: "涙をぬぐったその瞳には、もう迷いはなく、闇を貫くほどの強い光が宿っていた。",
-    exampleMeaningZh: "她拭去淚水後的那雙眼眸裡，已無迷惘，棲宿著足以貫穿黑暗的強光。"
+    exampleMeaningZh: "她拭去淚水後的那雙眼眸裡，已無迷惘，棲宿著足以貫穿黑暗的強光。",
+    exampleMeaningI18n: { "ja": "涙を拭いた後の彼女のその目には、もう迷いはなく、闇を貫くほどの強い光が宿っていた。", "en": "In those eyes, once the tears were wiped away, there was no hesitation left—only a light strong enough to pierce the darkness." },
   }),
   examQuestion({
     id: "n1-kanji-chikau",
@@ -9054,7 +9147,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「誓う」訓讀為「ちかう」。「ちがう」是「違う」的讀音（濁音之差）；「ちこう」為長音化的誤讀；「ちかる」為近形捏造讀音，皆非「誓う」的正確讀法，唯「ちかう」成立。",
     explanationI18n: { "ja": "「誓う」は訓読みで「ちかう」と読む。「ちがう」は「違う」の読み（濁音の違い）、「ちこう」は長音化した誤読、「ちかる」は字形の近い作り物の読みで、いずれも「誓う」の正しい読みではなく、成立するのは「ちかう」だけである。", "en": "「誓う」 has the kun-reading 「ちかう」. 「ちがう」 is the reading of 「違う」 (differing by a voiced consonant); 「ちこう」 is a misreading with a lengthened vowel; 「ちかる」 is a fabricated reading from a similar form—none is the correct reading of 「誓う」, so only 「ちかう」 works." },
     exampleJapanese: "大切な人を必ず守り抜くと、星空の下で彼女は静かに誓うのだった。",
-    exampleMeaningZh: "她在星空下靜靜地發誓，一定要守護住最珍視的人到底。"
+    exampleMeaningZh: "她在星空下靜靜地發誓，一定要守護住最珍視的人到底。",
+    exampleMeaningI18n: { "ja": "星空の下、彼女はいちばん大切な人を最後まで守り抜くと、静かに固く心に約束した。", "en": "Under the starry sky, she quietly vowed to protect the person she treasured most, no matter what." },
   }),
   examQuestion({
     id: "n1-kanji-kuyamu",
@@ -9074,7 +9168,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「悔やむ」讀作「くやむ」,意為懊悔、後悔。干擾項中「くゆむ」是把第二音節誤讀為近形假名、「くやす」誤把語尾改成他動詞風的「す」、「ぐやむ」則誤加濁點;三者皆非該字讀音,語境裡只有「くやむ」成立。",
     explanationI18n: { "ja": "「悔やむ」は「くやむ」と読み、後悔する・悔しく思うという意味です。誤答のうち「くゆむ」は第二音節を形の似た仮名に読み違えたもの、「くやす」は語尾を他動詞風の「す」に変えたもの、「ぐやむ」は濁点を余分に付けたもので、いずれもこの字の読みではありません。この文脈で成り立つのは「くやむ」だけです。", "en": "「悔やむ」is read くやむ, meaning to regret or feel remorse. Among the distractors, くゆむ misreads the second syllable as a similar-looking kana; くやす wrongly swaps the ending to a transitive-verb-style す; and ぐやむ mistakenly adds a dakuten. None of these is a valid reading of the character, and only くやむ fits the context." },
     exampleJapanese: "転んで遅れたあの日を悔やむより、今すぐ立ち上がって走り出したい。",
-    exampleMeaningZh: "與其懊悔那個跌倒又遲到的日子,不如現在就站起來奔跑出發。"
+    exampleMeaningZh: "與其懊悔那個跌倒又遲到的日子,不如現在就站起來奔跑出發。",
+    exampleMeaningI18n: { "ja": "転んで遅刻してしまったあの日を後悔するより、今すぐ立ち上がって走り出したい。", "en": "Rather than regretting that day I fell and showed up late, I want to get up right now and start running." },
   }),
   examQuestion({
     id: "n1-kanji-sasayaku",
@@ -9094,7 +9189,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「囁く」讀作「ささやく」,意為低聲耳語。「さざやく」清濁有誤、「ささらく」與「さらやく」皆為近形捏造讀音,在此語境都不成立,故唯一正解為「ささやく」。",
     explanationI18n: { "ja": "「囁く」は「ささやく」と読み、小声でそっと話す・ひそひそ言うという意味です。「さざやく」は清濁を誤ったもの、「ささらく」「さらやく」はともに形の似た仮名を並べた作り物の読みで、この文脈では成り立ちません。よって正解は「ささやく」だけです。", "en": "「囁く」is read ささやく, meaning to whisper. さざやく has the wrong voicing, while ささらく and さらやく are made-up readings based on similar-looking kana; none of them work in this context, so the only correct answer is ささやく." },
     exampleJapanese: "このままでいいじゃないかと、怠けたいわたしの内側で誰かが甘く囁く夜は長い。",
-    exampleMeaningZh: "「就這樣下去也不錯吧」——在想偷懶的我心底,有誰甜甜地低語著,這樣的夜晚格外漫長。"
+    exampleMeaningZh: "「就這樣下去也不錯吧」——在想偷懶的我心底,有誰甜甜地低語著,這樣的夜晚格外漫長。",
+    exampleMeaningI18n: { "ja": "「このままでいいじゃないか」――怠けたい私の心の奥で、誰かが甘い声でそっとつぶやいてくる。そんな夜はとりわけ長い。", "en": "\"Isn't it fine to stay just like this?\"—the nights feel endless when someone whispers sweetly like that deep inside the part of me that wants to slack off." },
   }),
   examQuestion({
     id: "n1-syn-hokorashii",
@@ -9116,7 +9212,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「誇らしい」表示因某事而感到值得驕傲、想抬頭挺胸。「鼻が高い」正是「感到光榮、有面子」的慣用同義表達,主語是因夥伴的成就而與有榮焉的說話者,與語境完全契合。干擾項:「気が引ける」是感到不好意思、退縮;「肩身が狭い」是抬不起頭、覺得丟臉;「気が滅入る」是心情低落沮喪——三者皆與「驕傲」相反或無關,在此語境明確不成立。",
     explanationI18n: { "ja": "「誇らしい」は、あることを立派だと感じ、胸を張りたくなるような気持ちを表します。「鼻が高い」はまさに「名誉に思う・面目が立つ」という意味の慣用的な同義表現で、仲間の活躍を自分のことのように誇りに思う話し手の気持ちにぴったり合います。誤答について、「気が引ける」は気後れして遠慮する気持ち、「肩身が狭い」は引け目を感じて恥ずかしく思うこと、「気が滅入る」は気分が沈んで落ち込むことで、いずれも「誇らしさ」とは反対か無関係であり、この文脈では明らかに成り立ちません。", "en": "「誇らしい」means feeling proud of something and wanting to hold your head high. 「鼻が高い」is exactly the idiomatic synonym for feeling honored and proud; here the speaker shares in the glory of a friend's accomplishment, which fits the context perfectly. As for the distractors: 「気が引ける」means feeling awkward or hesitant; 「肩身が狭い」means feeling ashamed and unable to hold your head up; 「気が滅入る」means feeling down and depressed. All three are the opposite of or unrelated to pride and clearly do not work in this context." },
     exampleJapanese: "あんなに練習を重ねてきた仲間が大舞台に立つのを見て、自分のことのように鼻が高くなった。",
-    exampleMeaningZh: "看著一起反覆苦練的夥伴登上大舞台,我彷彿與有榮焉,覺得臉上特別有光。"
+    exampleMeaningZh: "看著一起反覆苦練的夥伴登上大舞台,我彷彿與有榮焉,覺得臉上特別有光。",
+    exampleMeaningI18n: { "ja": "あれほど練習を重ねてきた仲間が大きな舞台に立つのを見て、まるで自分のことのように誇らしい気持ちになった。", "en": "Watching the friends I had practiced so hard with step onto the big stage, I swelled with pride, as if the moment were my own." },
   }),
   examQuestion({
     id: "n1-vocab-otome",
@@ -9196,7 +9293,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「鼓動」讀作「こどう」,指心臟的跳動。干擾項「ごどう」是首音濁化錯誤;「ことう」未將第二字濁化(「動」此處讀どう非とう);「こどお」是長音寫法錯誤(應為どう非どお)。語境「胸の奥で刻まれ続ける」明確指心跳,唯有こどう成立。",
     explanationI18n: { "ja": "「鼓動」は「こどう」と読み、心臓の脈打つ動きを指します。誤答のうち「ごどう」は語頭を濁らせた誤り、「ことう」は二文字目を濁らせておらず（ここでの「動」は「とう」ではなく「どう」）、「こどお」は長音の書き方の誤り（「どお」ではなく「どう」）です。「胸の奥で刻まれ続ける」という文脈は明らかに心臓の鼓動を指しており、成り立つのは「こどう」だけです。", "en": "「鼓動」is read こどう, referring to the beating of the heart. The distractor ごどう wrongly voices the first sound; ことう fails to voice the second character (「動」is read どう here, not とう); こどお uses the wrong long-vowel spelling (it should be どう, not どお). The context 「胸の奥で刻まれ続ける」clearly points to a heartbeat, and only こどう works." },
     exampleJapanese: "誰かの先入観に揺さぶられそうになるたび、胸の奥で確かに刻まれ続ける鼓動に手を当て、これだけは本物だと信じ直した。",
-    exampleMeaningZh: "每當快要被別人的成見動搖,我便把手按在胸口深處那持續確實刻印著的心跳上,重新相信唯有這個是真實的。"
+    exampleMeaningZh: "每當快要被別人的成見動搖,我便把手按在胸口深處那持續確實刻印著的心跳上,重新相信唯有這個是真實的。",
+    exampleMeaningI18n: { "ja": "誰かの先入観に揺さぶられそうになるたびに、胸の奥で確かに刻み続けている心臓の音に手を当て、「これだけは本物だ」ともう一度信じ直した。", "en": "Whenever other people's preconceptions threatened to shake me, I would press a hand to the heartbeat still pulsing steadily deep in my chest and remind myself that this, at least, was real." },
   }),
   examQuestion({
     id: "n1-kanji-tsumugu",
@@ -9216,7 +9314,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「紡ぐ」讀作「つむぐ」，本義為把纖維捻成線，引申為將語言、回憶細細編織起來，呼應把思念化作話語寄向遠星的情境。「つぐむ」是「噤む」（閉口不言）、「つむる」是「瞑る」（閉眼）、「つくろぐ」並非通行詞，皆與此語境不符，故唯一正解為「つむぐ」。",
     explanationI18n: { "ja": "「紡ぐ」は「つむぐ」と読み、本来は繊維をより合わせて糸にすることを指し、そこから言葉や記憶を丁寧に織り上げるという意味に広がります。思いを言葉に変えて遠い星へ送るという情景に呼応します。「つぐむ」は「噤む」（口を閉ざす）、「つむる」は「瞑る」（目を閉じる）、「つくろぐ」は通用しない語で、いずれもこの文脈には合いません。よって正解は「つむぐ」だけです。", "en": "「紡ぐ」is read つむぐ. Its literal sense is to twist fibers into thread, extended to carefully weaving together words and memories, which fits the scene of turning longing into words sent to a distant star. 「つぐむ」is 「噤む」(to keep silent), 「つむる」is 「瞑る」(to close one's eyes), and 「つくろぐ」is not a real word; none fits this context, so the only correct answer is つむぐ." },
     exampleJapanese: "遠い星にだけ届くようにと、過ぎた日々の記憶を一つずつ言葉に紡ぐ夜があった。",
-    exampleMeaningZh: "曾有那樣的夜，只願能傳到那顆遙遠的星，便把逝去的日子一點一點地編織成話語。"
+    exampleMeaningZh: "曾有那樣的夜，只願能傳到那顆遙遠的星，便把逝去的日子一點一點地編織成話語。",
+    exampleMeaningI18n: { "ja": "あの遠い星にだけ届くようにと、過ぎ去った日々の思い出を一つひとつ言葉に織り上げていく、そんな夜があった。", "en": "There were nights when, hoping they might reach that faraway star, I spun the memories of days gone by into words, one by one." },
   }),
   examQuestion({
     id: "n1-kanji-itoshii",
@@ -9236,7 +9335,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「愛しい」讀作「いとしい」，表示對某人深切的憐愛與珍重，契合相隔遙遠仍滿懷思念的情境。「いやしい」是「卑しい」（卑賤、貪婪）為反義語感、「おしい」是「惜しい」（可惜）、「いとなしい」並非通行詞，皆不成立，故唯一正解為「いとしい」。",
     explanationI18n: { "ja": "「愛しい」は「いとしい」と読み、ある人を深く愛おしく大切に思う気持ちを表し、遠く離れていてもなお思い続ける情景に合います。「いやしい」は「卑しい」（下品・貪欲）で反対の語感、「おしい」は「惜しい」（もったいない）、「いとなしい」は通用しない語で、いずれも成り立ちません。よって正解は「いとしい」だけです。", "en": "「愛しい」is read いとしい, expressing deep affection and cherishing for someone, which fits the scene of longing across a vast distance. 「いやしい」is 「卑しい」(base, greedy), an opposite in tone; 「おしい」is 「惜しい」(regrettable); and 「いとなしい」is not a real word. None works, so the only correct answer is いとしい." },
     exampleJapanese: "何光年も隔てた先にいる人を、それでも愛しいと呼べることだけが救いだった。",
-    exampleMeaningZh: "即便對方在隔著好幾光年的彼方，仍能稱之為憐愛之人——光是這一點，便是唯一的救贖。"
+    exampleMeaningZh: "即便對方在隔著好幾光年的彼方，仍能稱之為憐愛之人——光是這一點，便是唯一的救贖。",
+    exampleMeaningI18n: { "ja": "何光年も隔てた彼方にいる人を、それでも愛おしいと呼べる――そのことだけが唯一の救いだった。", "en": "Even with them light-years away, I could still call them beloved—and that alone was my one salvation." },
   }),
   examQuestion({
     id: "n1-vocab-sasai",
@@ -9278,7 +9378,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「もがく」指在困境或苦痛中拚命掙扎、想要脫離,「あがく」同樣指身陷不利處境時竭力掙脫、垂死奮鬥,兩者最接近。「ためらう」是猶豫遲疑,與奮力掙扎相反;「くつろぐ」是放鬆休憩,語境完全不成立;「とどまる」是停留不動,與拚命掙扎前進相反。",
     explanationI18n: { "ja": "「もがく」は苦境や苦痛の中で必死に抜け出そうとしてあがくことを指し、「あがく」も同じく不利な状況に陥ったときに懸命に抜け出そうとして踏ん張ることを指すため、両者が最も近いです。「ためらう」は迷ってぐずぐずすることで、必死にあがくのとは反対です。「くつろぐ」はリラックスして休むことで、この文脈ではまったく成り立ちません。「とどまる」はその場に留まって動かないことで、必死にもがいて進むのとは反対です。", "en": "「もがく」means to struggle desperately in hardship or pain, trying to break free, and 「あがく」likewise means to struggle to escape an unfavorable situation, to fight on against the odds; the two are closest in meaning. 「ためらう」means to hesitate, the opposite of struggling hard; 「くつろぐ」means to relax and rest, which doesn't fit the context at all; 「とどまる」means to stay put, the opposite of struggling forward with all one's might." },
     exampleJapanese: "何度転んでも、夢を諦めきれずに泥まみれであがく彼の姿に胸を打たれた。",
-    exampleMeaningZh: "看著他即使一再跌倒,仍不肯放棄夢想、滿身泥濘地拚命掙扎的身影,我深受觸動。"
+    exampleMeaningZh: "看著他即使一再跌倒,仍不肯放棄夢想、滿身泥濘地拚命掙扎的身影,我深受觸動。",
+    exampleMeaningI18n: { "ja": "何度転んでも夢をあきらめきれず、泥だらけになりながら必死にもがき続ける彼の姿に、深く心を打たれた。", "en": "I was deeply moved by the sight of him struggling on, covered in mud, refusing to give up on his dream no matter how many times he fell." },
   }),
   examQuestion({
     id: "n1-kanji-uzumaku",
@@ -9298,7 +9399,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「渦巻く」讀作「うずまく」,意為如漩渦般翻騰、盤旋洶湧。「渦」訓讀為「うず」,「巻く」為「まく」。干擾項「うずめく」「うすまく」「うずわく」皆非此詞的正確語形:「うずめく」尾音作「めく」、「うすまく」少了濁音、「うずわく」中段作「わく」,三者在語境中皆不成立。",
     explanationI18n: { "ja": "「渦巻く」は「うずまく」と読み、渦のように激しく巻いてうねるという意味です。「渦」は訓読みで「うず」、「巻く」は「まく」です。誤答の「うずめく」「うすまく」「うずわく」はいずれも正しい語形ではなく、「うずめく」は語尾が「めく」、「うすまく」は濁音が抜け、「うずわく」は中ほどが「わく」となっており、この文脈ではいずれも成り立ちません。", "en": "「渦巻く」is read うずまく, meaning to surge and spiral like a whirlpool. 「渦」has the kun reading うず, and 「巻く」is まく. The distractors うずめく, うすまく, and うずわく are all incorrect forms of the word: うずめく ends in めく, うすまく drops the dakuten, and うずわく has わく in the middle. None of them works in this context." },
     exampleJapanese: "台風の影響で、川の水が激しく渦巻くのが見えた。",
-    exampleMeaningZh: "颱風影響下,可以看到河水劇烈地翻騰盤旋。"
+    exampleMeaningZh: "颱風影響下,可以看到河水劇烈地翻騰盤旋。",
+    exampleMeaningI18n: { "ja": "台風の影響で、川の水が激しく渦を巻いて流れているのが見えた。", "en": "Because of the typhoon, you could see the river water churning and swirling violently." },
   }),
   examQuestion({
     id: "n1-vocab-saikai",
@@ -9358,7 +9460,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「駆ける」讀作「かける」，意為奔跑、疾馳。干擾項:「ぬける」對應「抜ける」(穿過/脫落);「かげる」對應「陰る」(轉暗/蒙上陰影);「かかる」對應「掛かる」等(花費/掛上);三者皆為他字之讀音，於本句語境不成立。只有「かける」在此語境成立。",
     explanationI18n: { "ja": "「駆ける」は「かける」と読み、走る・疾走するという意味です。誤答について、「ぬける」は「抜ける」（通り抜ける／抜け落ちる）、「かげる」は「陰る」（暗くなる／かげがさす）、「かかる」は「掛かる」など（費やす／掛ける）に対応する読みで、いずれも別の字の読みであり、この文脈では成り立ちません。ここで成り立つのは「かける」だけです。", "en": "「駆ける」is read かける, meaning to run or dash. The distractors: 「ぬける」corresponds to 「抜ける」(to pass through / to fall out); 「かげる」corresponds to 「陰る」(to darken / to be overshadowed); 「かかる」corresponds to 「掛かる」and the like (to take / to hang). All three are readings of other characters and don't work in this sentence. Only 「かける」fits here." },
     exampleJapanese: "始業のチャイムが鳴り終えた今、後悔より先に脚が動き、息を切らしながら教室へ駆ける自分が、不思議と誇らしかった。",
-    exampleMeaningZh: "上課鈴已響完的此刻，懊悔還來不及，腿卻先動了起來;喘著氣朝教室疾奔的自己，竟有種說不出的自豪。"
+    exampleMeaningZh: "上課鈴已響完的此刻，懊悔還來不及，腿卻先動了起來;喘著氣朝教室疾奔的自己，竟有種說不出的自豪。",
+    exampleMeaningI18n: { "ja": "始業のチャイムが鳴り終わった今、後悔するより先に脚が動き出し、息を切らして教室まで全力で走っていく自分が、不思議と誇らしかった。", "en": "The moment the class bell finished ringing, my legs moved before regret could catch up—and strangely enough, I felt proud of myself, panting as I dashed toward the classroom." },
   }),
   examQuestion({
     id: "n1-kanji-saku",
@@ -9378,7 +9481,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「裂く」讀作「さく」，原意為撕開、撕裂，「二人の仲を裂く」是慣用表現，指離間、拆散兩人的關係。干擾「ぬく」是「抜く」、「わく」是「湧く／沸く」、「はく」是「履く／吐く」的讀音，皆非「裂」字的讀法，在此語境也不成立。",
     explanationI18n: { "ja": "「裂く」は「さく」と読み、本来は引き裂くという意味で、「二人の仲を裂く」は仲を引き離す・引き裂くことを表す慣用的な言い回しです。誤答の「ぬく」は「抜く」、「わく」は「湧く／沸く」、「はく」は「履く／吐く」の読みで、いずれも「裂」の字の読みではなく、この文脈でも成り立ちません。", "en": "「裂く」is read さく, originally meaning to tear apart, and 「二人の仲を裂く」is an idiomatic expression meaning to drive a wedge between two people and break up their relationship. The distractors ぬく is 「抜く」, わく is 「湧く／沸く」, and はく is 「履く／吐く」; none of these is a reading of 「裂」, and none works in this context." },
     exampleJapanese: "二人の仲を裂くような根も葉もない噂が、いつの間にか広まっていた。",
-    exampleMeaningZh: "一個足以離間兩人、毫無根據的謠言，不知不覺間散布了開來。"
+    exampleMeaningZh: "一個足以離間兩人、毫無根據的謠言，不知不覺間散布了開來。",
+    exampleMeaningI18n: { "ja": "二人の仲を引き離すような、根も葉もないうわさが、いつの間にか広まっていた。", "en": "Before anyone noticed, a completely groundless rumor had spread—one that threatened to tear the two of them apart." },
   }),
   examQuestion({
     id: "n1-vocab-maboroshi",
@@ -9418,7 +9522,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「弾ける」讀作「はじける」，意為迸開、綻放迸發，呼應光芒在夜空一齊炸開的絢爛瞬間。「はぜける」混用了近義詞「爆ぜる（はぜる）」的讀法，並非「弾ける」的讀音；「ほどける」是「解ける」（鬆開）；「くだける」是「砕ける」（粉碎），語境皆不成立，唯一正解為「はじける」。",
     explanationI18n: { "ja": "「弾ける」は「はじける」と読み、ぱっと弾ける・弾け咲くという意味で、光が夜空で一斉に炸裂する華やかな一瞬に呼応します。「はぜける」は近い意味の「爆ぜる（はぜる）」の読みを混ぜたもので、「弾ける」の読みではありません。「ほどける」は「解ける」（ほどける）、「くだける」は「砕ける」（砕ける）で、いずれも文脈に合わず、正解は「はじける」だけです。", "en": "「弾ける」is read はじける, meaning to burst or bloom outward, echoing the dazzling moment of lights exploding together in the night sky. 「はぜける」mixes in the reading of the near-synonym 「爆ぜる（はぜる）」and is not the reading of 「弾ける」; 「ほどける」is 「解ける」(to come loose); 「くだける」is 「砕ける」(to shatter). None fits the context, and the only correct answer is はじける." },
     exampleJapanese: "夜空に打ち上がった光が一斉に弾けるその一瞬、胸の高鳴りも溢れ出した。",
-    exampleMeaningZh: "絢爛的光在夜空中一齊綻放迸發的那一刻，心中的悸動也滿溢而出。"
+    exampleMeaningZh: "絢爛的光在夜空中一齊綻放迸發的那一刻，心中的悸動也滿溢而出。",
+    exampleMeaningI18n: { "ja": "夜空に打ち上げられた光が一斉にぱっと開いて飛び散るその一瞬、胸の高鳴りもあふれ出した。", "en": "The instant the dazzling lights burst open all at once in the night sky, the pounding in my chest overflowed as well." },
   }),
   examQuestion({
     id: "n1-kanji-sumu",
@@ -9438,7 +9543,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「澄む」讀作「すむ」，意為澄澈透明，呼應流星劃過後一片清澈的夜空。「にじむ」是「滲む」（暈染滲開）、「かすむ」是「霞む」（朦朧），二者與「澄澈」語意相反；「ひずむ」是「歪む」（扭曲變形），皆不成立。四個選項皆為辭書形、互異，唯一正解為「すむ」。",
     explanationI18n: { "ja": "「澄む」は「すむ」と読み、澄みわたる・透き通るという意味で、流星が流れたあとの一面清らかな夜空に呼応します。「にじむ」は「滲む」（にじみ広がる）、「かすむ」は「霞む」（ぼんやりかすむ）で、いずれも「澄む」とは意味が反対です。「ひずむ」は「歪む」（ゆがみ変形する）で、いずれも成り立ちません。四つの選択肢はすべて辞書形で互いに異なり、正解は「すむ」だけです。", "en": "「澄む」is read すむ, meaning to be clear and transparent, echoing the crystalline night sky after a meteor streaks by. 「にじむ」is 「滲む」(to blur, to seep), and 「かすむ」is 「霞む」(to be hazy); both are opposite in meaning to 'clear.' 「ひずむ」is 「歪む」(to warp, to distort); none works. All four options are dictionary forms and distinct, and the only correct answer is すむ." },
     exampleJapanese: "流れ星が消えたあと、夜空が果てしなく澄むほど、願いだけが胸に残った。",
-    exampleMeaningZh: "流星消失之後，夜空澄澈到無邊無際，只留下了那個願望。"
+    exampleMeaningZh: "流星消失之後，夜空澄澈到無邊無際，只留下了那個願望。",
+    exampleMeaningI18n: { "ja": "流れ星が消えた後、夜空は果てしなく澄みわたり、胸にはあの願いだけが残った。", "en": "After the shooting star vanished, the night sky grew endlessly clear, and only that wish stayed in my heart." },
   }),
   examQuestion({
     id: "n1-vocab-tenmetsu",
@@ -9478,7 +9584,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「静寂」唸作「せいじゃく」,指萬籟俱寂的寂靜。「せいせき」清音化錯讀且非此義;「しずじゃく」誤把「静」當訓讀;「せいじゃか」末尾濁音/清音與長音皆錯。四者僅「せいじゃく」於此夜空靜謐之境成立。",
     explanationI18n: { "ja": "「静寂」は「せいじゃく」と読み、しんと静まりかえった静けさを指します。「せいせき」は清音化して読み違えたうえに意味も異なり、「しずじゃく」は「静」を訓読みしてしまった誤り、「せいじゃか」は末尾の清濁と長音がともに誤っています。四つのうち、この夜空の静けさの情景に成り立つのは「せいじゃく」だけです。", "en": "「静寂」is read せいじゃく, meaning utter silence. 「せいせき」wrongly reads it with a plain (unvoiced) sound and isn't this meaning; 「しずじゃく」wrongly takes 「静」as a kun reading; 「せいじゃか」has the wrong voicing/unvoicing and long vowel at the end. Of the four, only せいじゃく works in this hushed night-sky scene." },
     exampleJapanese: "深夜、ひとり夜空を見上げると、銀色の月の光が地面に降りそそぎ、街の音が消えた静寂の中で胸の奥がそっとほどけていった。",
-    exampleMeaningZh: "深夜獨自仰望夜空,銀色月光灑落地面,在街聲消失的寂靜中,心底深處悄然鬆開。"
+    exampleMeaningZh: "深夜獨自仰望夜空,銀色月光灑落地面,在街聲消失的寂靜中,心底深處悄然鬆開。",
+    exampleMeaningI18n: { "ja": "深夜にひとり夜空を見上げると、銀色の月の光が地面に降り注ぎ、街の音が消えた静けさの中で、心の奥がそっとほどけていった。", "en": "Late at night, gazing up at the sky alone, silver moonlight pouring down onto the ground, I felt something deep in my chest quietly come undone in the stillness where the sounds of the town had faded away." },
   }),
   examQuestion({
     id: "n1-kanji-iyasu",
@@ -9498,7 +9605,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「癒す」唸作「いやす」,意為療癒、撫平傷痛。「いえす」「ゆやす」「くやす」皆非「癒す」的正確讀音:「いえす」混淆相關自動詞「癒える(いえる)」且尾音錯;「ゆやす」首音誤讀;「くやす」為形近的胡亂讀法。在撫平記憶之痛的語境中,唯「いやす」成立且活用形相符。",
     explanationI18n: { "ja": "「癒す」は「いやす」と読み、癒す・傷や痛みを和らげるという意味です。「いえす」「ゆやす」「くやす」はいずれも「癒す」の正しい読みではありません。「いえす」は関連する自動詞「癒える（いえる）」と混同したうえ語尾も誤っており、「ゆやす」は語頭の読み違い、「くやす」は形の似た仮名を並べたでたらめな読みです。記憶の痛みを和らげるという文脈では、活用形も合致する「いやす」だけが成り立ちます。", "en": "「癒す」is read いやす, meaning to heal or soothe pain. 「いえす」, 「ゆやす」, and 「くやす」are none of them the correct reading of 「癒す」: 「いえす」confuses it with the related intransitive verb 「癒える（いえる）」and has the wrong ending; 「ゆやす」misreads the first sound; 「くやす」is a nonsense reading based on look-alike shapes. In the context of soothing the pain of memory, only いやす works and matches the conjugated form." },
     exampleJapanese: "見えない鎖でつながった君を思いながら、こぼれ落ちた月光のかけらを拾い集めれば、ばらばらだった記憶の痛みを少しずつ癒すことができる気がした。",
-    exampleMeaningZh: "想著與被看不見的鎖鏈相連的你,把灑落的月光碎片拾起,彷彿就能一點一點撫平那些零散記憶裡的疼痛。"
+    exampleMeaningZh: "想著與被看不見的鎖鏈相連的你,把灑落的月光碎片拾起,彷彿就能一點一點撫平那些零散記憶裡的疼痛。",
+    exampleMeaningI18n: { "ja": "見えない鎖でつながった君を思いながら、こぼれ落ちた月光のかけらを拾い集めれば、ばらばらになった記憶の痛みを少しずつ和らげられる気がした。", "en": "Thinking of you, joined to me by an invisible chain, I gathered up the fallen shards of moonlight, and it felt as though I could soothe, little by little, the pain in those scattered memories." },
   }),
   examQuestion({
     id: "n1-vocab-tabiji",
@@ -9538,7 +9646,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「漂う」讀作「ただよう」,意為飄盪、漂浮、瀰漫,此處描寫香煙在空中靜靜飄散的意象,活用為「漂って(ただよって)」。干擾項:「滞って(とどこおって)」意為停滯、淤積,與煙裊裊飄散的流動感矛盾;「潤って(うるおって)」意為濕潤、滋潤,語境不成立;「繕って(つくろって)」意為修補、掩飾,與此景無關。四者活用形一致,僅「ただよって」符合香煙瀰漫的語境,為唯一正解。",
     explanationI18n: { "ja": "「漂う」は「ただよう」と読み、ただよう・浮かぶ・立ちこめるという意味で、ここでは香の煙が空中に静かに漂う様子を描いており、活用して「漂って（ただよって）」となります。誤答について、「滞って（とどこおって）」は停滞する・たまるという意味で、煙がゆらゆらと漂う流れる感じと矛盾します。「潤って（うるおって）」は湿る・潤うという意味で、この文脈では成り立ちません。「繕って（つくろって）」は繕う・取りつくろうという意味で、この情景とは無関係です。四つは活用形が一致しており、香の煙が立ちこめる文脈に合うのは「ただよって」だけなので、これが唯一の正解です。", "en": "「漂う」is read ただよう, meaning to drift, float, or waft, here depicting incense smoke wafting quietly through the air, conjugated as 「漂って（ただよって）」. The distractors: 「滞って（とどこおって）」means to stagnate or accumulate, contradicting the flowing sense of smoke wafting up; 「潤って（うるおって）」means to be moist or nourished, which doesn't fit the context; 「繕って（つくろって）」means to mend or gloss over, unrelated to this scene. All conjugate consistently, and only ただよって fits the context of drifting incense smoke, making it the sole correct answer." },
     exampleJapanese: "終わりの見えない旅路の途中、私の周りには香の煙が静かに漂っていて、移ろい続ける世界の中で変わらぬ祈りだけを探していた。",
-    exampleMeaningZh: "在看不見盡頭的旅途中,香煙在四周靜靜地飄盪,而我在不停流轉的世界裡只尋找著永不改變的祈願。"
+    exampleMeaningZh: "在看不見盡頭的旅途中,香煙在四周靜靜地飄盪,而我在不停流轉的世界裡只尋找著永不改變的祈願。",
+    exampleMeaningI18n: { "ja": "終わりの見えない旅の途中、私の周りではお香の煙が静かにゆらゆらと浮かんでいて、移ろい続ける世界の中で、変わらない祈りだけを探していた。", "en": "Partway through a journey with no end in sight, incense smoke drifted quietly around me, and in this ever-shifting world I searched only for a prayer that would never change." },
   }),
   examQuestion({
     id: "n1-kanji-fuujiru",
@@ -9558,7 +9667,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「封じる」唸作「ふうじる」,此處活用為「封じて」即「ふうじて」,意為把脆弱壓制、封鎖在心底。四個選項都保留相同的送假名「〜て」,只在「封」字的音上設陷阱:「ほうじて」把首音「ふ」誤讀成「ほ」;「ふうちて」把濁音「じ」清音化又近形誤成「ち」;「ぶうじて」把首音濁化成「ぶ」。三者皆非「封じる」的正確讀音,唯一正解為「ふうじて」。",
     explanationI18n: { "ja": "「封じる」は「ふうじる」と読み、ここでは活用して「封じて」すなわち「ふうじて」となり、弱さを心の奥に抑え込み封じ込めるという意味です。四つの選択肢はいずれも同じ送り仮名「〜て」を保ち、「封」の字の音だけに罠を仕掛けています。「ほうじて」は語頭の「ふ」を「ほ」に読み違えたもの、「ふうちて」は濁音の「じ」を清音化したうえ形の似た「ち」に誤ったもの、「ぶうじて」は語頭を濁らせて「ぶ」にしたものです。三つはいずれも「封じる」の正しい読みではなく、正解は「ふうじて」だけです。", "en": "「封じる」is read ふうじる, conjugated here as 「封じて」, i.e. ふうじて, meaning to suppress and seal one's weakness deep in the heart. All four options keep the same okurigana 「〜て」and set the trap only on the sound of the character 「封」: 「ほうじて」misreads the first sound ふ as ほ; 「ふうちて」unvoices the voiced 「じ」and further misreads it as the look-alike 「ち」; 「ぶうじて」voices the first sound into 「ぶ」. None of these is the correct reading of 「封じる」, and the only correct answer is ふうじて." },
     exampleJapanese: "悪夢から目を覚ました明け方、僕は震える弱さを胸の奥に固く封じて、白く光る空へ一歩を踏み出した。",
-    exampleMeaningZh: "從惡夢中醒來的破曉時分,我把顫抖的脆弱牢牢封進心底,朝著泛白發光的天空邁出一步。"
+    exampleMeaningZh: "從惡夢中醒來的破曉時分,我把顫抖的脆弱牢牢封進心底,朝著泛白發光的天空邁出一步。",
+    exampleMeaningI18n: { "ja": "悪夢から目覚めた明け方、僕は震える弱さを胸の奥深くに固く閉じ込めて、白く光る空へ一歩を踏み出した。", "en": "At daybreak, waking from a nightmare, I sealed my trembling weakness firmly away deep in my chest and took a step toward the whitening, glowing sky." },
   }),
   examQuestion({
     id: "n1-vocab-konton",
@@ -9618,7 +9728,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「捧げる」讀作「ささげる」,意為「獻上、奉獻」,此處指把真誠的心意奉獻交付給對方。四個選項都保留相同的送假名「〜げる」,只在前段設陷阱:「さざげる」把第二音「さ」誤濁化成「ざ」;「ささける」把濁音「げ」清音化成「け」;「しさげる」把首音「さ」誤讀成「し」。三者皆非「捧げる」的正確讀音,唯一正解為「ささげる」。",
     explanationI18n: { "ja": "「捧げる」は「ささげる」と読み、差し出す・ささげ尽くすという意味で、ここでは真心をそのまま相手に捧げ差し出すことを表す。四つの選択肢はいずれも同じ送り仮名「〜げる」を保ちつつ、前半に罠を仕掛けている。「さざげる」は二音目の「さ」を誤って濁音「ざ」にしたもの。「ささける」は濁音「げ」を清音「け」にしたもの。「しさげる」は語頭の「さ」を誤って「し」と読んだもの。いずれも「捧げる」の正しい読みではなく、唯一の正解は「ささげる」。", "en": "捧げる is read ささげる, meaning 'to offer up, to dedicate.' Here it refers to offering one's sincere feelings to another person. All four options keep the same okurigana 「〜げる」 and set their traps only in the earlier part: さざげる wrongly voices the second syllable 「さ」 into 「ざ」; ささける de-voices the voiced 「げ」 into 「け」; しさげる misreads the first syllable 「さ」 as 「し」. None of these is the correct reading of 捧げる, so the only correct answer is ささげる." },
     exampleJapanese: "嘘をつく大人にはなりたくないから、まっすぐな気持ちをそのまま君に捧げると決めた。",
-    exampleMeaningZh: "因為不想成為說謊的大人,所以決定把這份筆直的心意原原本本地獻給你。"
+    exampleMeaningZh: "因為不想成為說謊的大人,所以決定把這份筆直的心意原原本本地獻給你。",
+    exampleMeaningI18n: { "ja": "嘘をつく大人にはなりたくないから、このまっすぐな気持ちをそのまま君に差し出そうと決めた。", "en": "Because I don't want to become the kind of adult who lies, I decided to offer you these honest, unbending feelings exactly as they are." },
   }),
   examQuestion({
     id: "n1-kanji-kogasu",
@@ -9638,7 +9749,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「焦がす」讀作「こがす」,意為燒焦、烤焦。此處描寫正午烈日把肌膚曬得發燙的夏日意象。四個選項都保留相同的送假名「〜がす」結尾,只在「焦」字音與清濁上設陷阱:「ごがす」把首音「こ」誤濁化成「ご」;「こがず」把結尾「す」誤濁化成「ず」;「くがす」把首音「こ」誤讀成「く」。三者皆非此字的正確讀法,故唯一正解為「こがす」。",
     explanationI18n: { "ja": "「焦がす」は「こがす」と読み、焼き焦がすという意味。ここでは真昼の強い日差しが肌を焼くように熱くする夏のイメージを描いている。四つの選択肢はいずれも同じ送り仮名「〜がす」で終わり、「焦」の音や清濁に罠を仕掛けている。「ごがす」は語頭の「こ」を誤って濁音「ご」にしたもの。「こがず」は語末の「す」を誤って濁音「ず」にしたもの。「くがす」は語頭の「こ」を誤って「く」と読んだもの。いずれもこの字の正しい読みではなく、唯一の正解は「こがす」。", "en": "焦がす is read こがす, meaning 'to scorch, to burn.' Here it paints a summer image of the noon sun searing the skin hot. All four options keep the same ending okurigana 「〜がす」 and set their traps only on the sound and voicing of 「焦」: ごがす wrongly voices the first syllable 「こ」 into 「ご」; こがず wrongly voices the final 「す」 into 「ず」; くがす misreads the first syllable 「こ」 as 「く」. None of these is the correct reading, so the only correct answer is こがす." },
     exampleJapanese: "真上から照りつける正午の日差しが、僕の素肌をじりじりと焦がすほど、夏の鼓動が熱く高鳴っていた。",
-    exampleMeaningZh: "從正上方直射而下的正午陽光,熱得幾乎要把我的肌膚烤焦,夏天的心跳也滾燙地高鳴著。"
+    exampleMeaningZh: "從正上方直射而下的正午陽光,熱得幾乎要把我的肌膚烤焦,夏天的心跳也滾燙地高鳴著。",
+    exampleMeaningI18n: { "ja": "真上から照りつける正午の日差しは、僕の素肌をじりじりと焼くほど強く、夏の鼓動も熱く高鳴っていた。", "en": "The midday sun beating straight down was hot enough to all but scorch my bare skin, and the heartbeat of summer pounded just as fiercely." },
   }),
   examQuestion({
     id: "n1-vocab-fumihazusu",
@@ -9678,7 +9790,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「切り開く」讀作「きりひらく」,意為開闢、闖出一條路。四個選項都保留相同的「きり〜く」骨架,只在中段與首音設陷阱:「きりびらく」把「ひ」誤濁化成「び」;「きりはらく」把「ひら」誤讀成近形的「はら」;「ぎりひらく」把首音「き」誤濁化成「ぎ」。三者皆非此字的正確讀音,唯有「きりひらく」在此「在荒地硬闢出一條路」的語境下成立。",
     explanationI18n: { "ja": "「切り開く」は「きりひらく」と読み、道を切り開く・開拓する意味。四つの選択肢はいずれも同じ「きり〜く」の骨格を保ちつつ、中ほどと語頭に罠を仕掛けている。「きりびらく」は「ひ」を誤って濁音「び」にしたもの。「きりはらく」は「ひら」を誤って形の近い「はら」と読んだもの。「ぎりひらく」は語頭の「き」を誤って濁音「ぎ」にしたもの。いずれもこの字の正しい読みではなく、「荒れ地に一本の道を切り開く」というこの文脈で成立するのは「きりひらく」のみ。", "en": "切り開く is read きりひらく, meaning 'to open up, to carve out a path.' All four options keep the same 「きり〜く」 frame and set their traps in the middle and the first sound: きりびらく wrongly voices 「ひ」 into 「び」; きりはらく misreads the similar-looking 「ひら」 as 「はら」; ぎりひらく wrongly voices the first syllable 「き」 into 「ぎ」. None of these is the correct reading, so only きりひらく works in this context of forcibly carving out a path across barren ground." },
     exampleJapanese: "目の前の高い壁に体当たりした俺は、誰も通ったことのない荒れ地に、自分の手で一本の道を切り開くと決めた。",
-    exampleMeaningZh: "撞向眼前高牆的我,決意要在無人走過的荒地上,用自己的雙手闢出一條路。"
+    exampleMeaningZh: "撞向眼前高牆的我,決意要在無人走過的荒地上,用自己的雙手闢出一條路。",
+    exampleMeaningI18n: { "ja": "目の前の高い壁に体当たりした俺は、誰も通ったことのない荒れ地に、自分の手で一本の道を作り出すと心に決めた。", "en": "Throwing myself against the high wall in front of me, I resolved to carve out a path with my own two hands across a wasteland no one had ever crossed." },
   }),
   examQuestion({
     id: "n1-kanji-gyakkyou",
@@ -9698,7 +9811,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「逆境」讀作「ぎゃっきょう」。「逆」在此為促音化的「ぎゃっ」,「境」讀「きょう」。其餘三個只改了「逆」的音(長音化、無促音、清音化),送假名相同但讀法不成立。",
     explanationI18n: { "ja": "「逆境」は「ぎゃっきょう」と読む。「逆」はここでは促音化して「ぎゃっ」、「境」は「きょう」と読む。他の三つはいずれも「逆」の音だけを変えたもの（長音化・促音なし・清音化）で、送り仮名は同じでも読み方として成立しない。", "en": "逆境 is read ぎゃっきょう. Here 「逆」 takes the geminated (small-tsu) form 「ぎゃっ」, and 「境」 is read 「きょう」. The other three only alter the reading of 「逆」 (lengthening it, dropping the geminate, or de-voicing it); the okurigana is the same but the readings don't hold up." },
     exampleJapanese: "どんな逆境に置かれても、君なら必ず光をつかめると信じている。",
-    exampleMeaningZh: "無論身陷怎樣的逆境,我都相信你一定能抓住屬於自己的光。"
+    exampleMeaningZh: "無論身陷怎樣的逆境,我都相信你一定能抓住屬於自己的光。",
+    exampleMeaningI18n: { "ja": "どんなに苦しい状況に置かれても、君ならきっと自分の光をつかめると信じている。", "en": "No matter what adversity you find yourself in, I believe you will surely seize a light of your own." },
   }),
   examQuestion({
     id: "n1-kanji-shiren",
@@ -9718,7 +9832,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「試練」讀作「しれん」。「試」讀「し」,「練」讀「れん」。其餘三個分別把「試」濁音化、把「練」改成別的音(し→じ、れん→えん/れい),送假名一致但讀法不成立。",
     explanationI18n: { "ja": "「試練」は「しれん」と読む。「試」は「し」、「練」は「れん」。他の三つはそれぞれ「試」を濁音化したり、「練」を別の音に変えたり（し→じ、れん→えん／れい）したもので、送り仮名は同じでも読み方として成立しない。", "en": "試練 is read しれん. 「試」 is read 「し」 and 「練」 is read 「れん」. The other three respectively voice 「試」 or change 「練」 to a different sound (し→じ, れん→えん/れい); the okurigana matches but the readings don't hold up." },
     exampleJapanese: "仲間と分け合った試練の日々が、今の自分を主役にしてくれた。",
-    exampleMeaningZh: "與同伴一同分擔的那些試煉歲月,造就了如今成為主角的自己。"
+    exampleMeaningZh: "與同伴一同分擔的那些試煉歲月,造就了如今成為主角的自己。",
+    exampleMeaningI18n: { "ja": "仲間と分かち合った厳しい試練の日々が、今、主役として立つ自分を作ってくれた。", "en": "Those days of trials shared with my companions are what made me the protagonist I am today." },
   }),
   examQuestion({
     id: "n1-vocab-zenshinzenrei",
@@ -9758,7 +9873,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「邁進」讀作「まいしん」,意為奮力向前、勇往直前。「邁」音讀為「まい」,「進」音讀為「しん」。干擾項「ばいしん」把「邁」誤讀成濁音、「まいじん」把「進」誤讀成濁音、「めいしん」則把「邁」的「まい」誤讀為母音相近的「めい」,皆非正確讀音。",
     explanationI18n: { "ja": "「邁進」は「まいしん」と読み、ひたむきに前進する・勇往邁進する意味。「邁」の音読みは「まい」、「進」の音読みは「しん」。誤答の「ばいしん」は「邁」を誤って濁音に、「まいじん」は「進」を誤って濁音に、「めいしん」は「邁」の「まい」を母音の近い「めい」と誤読したもので、いずれも正しい読みではない。", "en": "邁進 is read まいしん, meaning 'to forge ahead, to press forward boldly.' 「邁」 is read 「まい」 and 「進」 is read 「しん」. The distractor ばいしん wrongly voices 「邁」; まいじん wrongly voices 「進」; and めいしん misreads 「まい」 in 「邁」 as the vowel-similar 「めい」 — none are the correct reading." },
     exampleJapanese: "見えない明日が怖くても、君となら刺激にできる。だから僕は夢へ邁進する。",
-    exampleMeaningZh: "即使看不見的明天令人害怕,只要和你在一起就能化為刺激。所以我朝著夢想奮力向前。"
+    exampleMeaningZh: "即使看不見的明天令人害怕,只要和你在一起就能化為刺激。所以我朝著夢想奮力向前。",
+    exampleMeaningI18n: { "ja": "見えない明日が怖くても、君と一緒なら刺激に変えられる。だから僕は夢に向かってひたすら突き進む。", "en": "Even if the unseen tomorrow is frightening, with you it turns into a thrill. That is why I press forward toward my dream." },
   }),
   examQuestion({
     id: "n1-vocab-toushindai",
@@ -9798,7 +9914,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「仰ぐ」讀作「あおぐ」,意為仰望、抬頭看。其餘三項皆保留送假名「ぐ」,只更動漢字部分的讀音以製造近形誤讀:「あうぐ」把「お」誤拉成「う」段音、「あごぐ」把「お」混作濁音「ご」、「あよぐ」把「お」誤作や行的「よ」,三者作為「仰ぐ」的讀音皆不成立。",
     explanationI18n: { "ja": "「仰ぐ」は「あおぐ」と読み、見上げる・上を向いて見る意味。他の三つはいずれも送り仮名「ぐ」を残しつつ、漢字部分の読みだけを変えて形の近い誤読を作っている。「あうぐ」は「お」を誤って「う」段の音に、「あごぐ」は「お」を濁音「ご」と取り違え、「あよぐ」は「お」を誤ってや行の「よ」にしたもので、いずれも「仰ぐ」の読みとして成立しない。", "en": "仰ぐ is read あおぐ, meaning 'to look up at, to gaze upward.' The other three all keep the okurigana 「ぐ」 and only alter the reading of the kanji part to create look-alike misreadings: あうぐ stretches 「お」 into a 「う」-column sound, あごぐ confuses 「お」 with the voiced 「ご」, and あよぐ mistakes 「お」 for the ya-row 「よ」 — none holds up as a reading of 仰ぐ." },
     exampleJapanese: "傘を投げ捨て、紺碧の空を仰ぐと、不安も少し軽くなった。",
-    exampleMeaningZh: "扔開傘、仰望紺碧的天空,不安也稍稍減輕了些。"
+    exampleMeaningZh: "扔開傘、仰望紺碧的天空,不安也稍稍減輕了些。",
+    exampleMeaningI18n: { "ja": "傘を投げ捨てて紺碧の空を見上げると、不安も少し軽くなった。", "en": "Tossing my umbrella aside and looking up at the deep-blue sky, I felt my anxiety lighten just a little." },
   }),
   examQuestion({
     id: "n1-vocab-konpeki",
@@ -9918,7 +10035,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「彩る」讀作「いろどる」，意為點綴、增添色彩。其餘三項皆保留送假名「る」，只更動漢字部分的讀音：「いるどる」把「ろ」誤成「る」、「いろとる」把濁音「ど」誤成清音「と」、「えろどる」把首音「い」誤成母音相近的「え」，皆不成立，故唯一正解為「いろどる」。",
     explanationI18n: { "ja": "「彩る」は「いろどる」と読み、色をつけて飾る・いろどりを添える意味。他の三つはいずれも送り仮名「る」を残しつつ、漢字部分の読みだけを変えている。「いるどる」は「ろ」を誤って「る」に、「いろとる」は濁音「ど」を誤って清音「と」に、「えろどる」は語頭の「い」を母音の近い「え」に誤ったもので、いずれも成立しない。したがって唯一の正解は「いろどる」。", "en": "彩る is read いろどる, meaning 'to color, to add color.' The other three all keep the okurigana 「る」 and only alter the reading of the kanji part: いるどる mistakes 「ろ」 for 「る」, いろとる changes the voiced 「ど」 to the voiceless 「と」, and えろどる changes the first sound 「い」 to the vowel-similar 「え」 — none holds up, so the only correct answer is いろどる." },
     exampleJapanese: "相談に乗っているうちに、春の日差しが部屋を彩るように、わたしの胸も明るくなった。",
-    exampleMeaningZh: "在替人做諮詢的過程中，就像春日的陽光為房間增添色彩般，我的心也變得明亮起來。"
+    exampleMeaningZh: "在替人做諮詢的過程中，就像春日的陽光為房間增添色彩般，我的心也變得明亮起來。",
+    exampleMeaningI18n: { "ja": "相談に乗っているうちに、春の日差しが部屋に色を添えるように、私の心も明るくなっていった。", "en": "As I listened to someone's troubles, my heart brightened too, the way spring sunlight brings color to a room." },
   }),
   examQuestion({
     id: "n1-kanji-ikizuku",
@@ -9938,7 +10056,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「息づく」讀作「いきづく」，意為（如生命般）生氣勃勃地存在、呼吸。其餘三項皆保留送假名形式（〜づく/ずく），只更動漢字部分的讀音：「いきずく」把「づ」誤成同音近形的「ず」、「いぎづく」把清音「き」誤成濁音「ぎ」、「いきぢく」把「づ」誤成同行近形的「ぢ」，皆不成立，故唯一正解為「いきづく」。",
     explanationI18n: { "ja": "「息づく」は「いきづく」と読み、（命あるかのように）生き生きと存在する・呼吸する意味。他の三つはいずれも送り仮名の形（〜づく／ずく）を残しつつ、漢字部分の読みだけを変えている。「いきずく」は「づ」を同音で形の近い「ず」に、「いぎづく」は清音「き」を濁音「ぎ」に、「いきぢく」は「づ」を同行で形の近い「ぢ」に誤ったもので、いずれも成立しない。したがって唯一の正解は「いきづく」。", "en": "息づく is read いきづく, meaning 'to be alive with vitality, to breathe.' The other three all keep the okurigana form (〜づく/ずく) and only alter the reading of the kanji part: いきずく mistakes 「づ」 for the homophonous, look-alike 「ず」; いぎづく voices the voiceless 「き」 into 「ぎ」; and いきぢく mistakes 「づ」 for the same-row look-alike 「ぢ」 — none holds up, so the only correct answer is いきづく." },
     exampleJapanese: "放課後の窓辺で、芽生えたばかりの気持ちが静かに息づくのを感じた。",
-    exampleMeaningZh: "放學後在窗邊，我感覺到剛萌生的心情正靜靜地、彷彿有了生命般存在著。"
+    exampleMeaningZh: "放學後在窗邊，我感覺到剛萌生的心情正靜靜地、彷彿有了生命般存在著。",
+    exampleMeaningI18n: { "ja": "放課後の窓辺で、芽生えたばかりの気持ちが、静かに息をするように確かに生きているのを感じた。", "en": "By the window after school, I could feel a newly budding feeling quietly stirring, as if it had come to life." },
   }),
   examQuestion({
     id: "n1-kanji-eigou",
@@ -9958,7 +10077,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「永劫」讀作「えいごう」。「えきごう」誤把「永(えい)」讀成入聲式的「えき」;「えいごお」把長音的假名拼錯(應作「ごう」非「ごお」);「えいこう」把「劫(ごう)」清音化讀成「こう」。四者皆全平假名且互異,只有「えいごう」在此語境成立,為唯一正解。",
     explanationI18n: { "ja": "「永劫」は「えいごう」と読む。「えきごう」は「永（えい）」を入声風の「えき」と誤読したもの。「えいごお」は長音の仮名を書き誤ったもの（「ごう」であって「ごお」ではない）。「えいこう」は「劫（ごう）」を清音化して「こう」と読んだもの。四つとも全て平仮名で互いに異なるが、この文脈で成立するのは「えいごう」のみで、唯一の正解。", "en": "永劫 is read えいごう. えきごう wrongly reads 「永(えい)」 as the entering-tone-like 「えき」; えいごお misspells the long vowel in kana (it should be 「ごう」, not 「ごお」); えいこう de-voices 「劫(ごう)」 into 「こう」. All four are fully in hiragana and mutually distinct, but only えいごう works in this context, making it the sole correct answer." },
     exampleJapanese: "この惑星が永劫の昔から繰り返してきた営みを、彼は静かに語り続けた。",
-    exampleMeaningZh: "他靜靜地不斷述說著這顆行星自極遙遠的過去以來反覆進行的活動。"
+    exampleMeaningZh: "他靜靜地不斷述說著這顆行星自極遙遠的過去以來反覆進行的活動。",
+    exampleMeaningI18n: { "ja": "この惑星が果てしなく遠い昔から繰り返してきた営みを、彼は静かに語り続けた。", "en": "He went on quietly recounting the workings this planet has repeated since time immemorial." },
   }),
   examQuestion({
     id: "n1-vocab-manuke",
@@ -10078,7 +10198,8 @@ export const n1Items: PracticeQuestion[] = [
     explanation: "「木漏れ日」是熟字訓：木＝こ、漏れ＝もれ、日濁化＝び，讀「こもれび」。「きもれび」誤把木讀成き；「こもれひ」漏掉日的濁音；「こぼれび」把漏れ(もれ)誤成こぼれ(零れ)。",
     explanationI18n: { "ja": "「木漏れ日」は熟字訓で、木＝こ、漏れ＝もれ、日は連濁して＝びとなり、「こもれび」と読みます。「きもれび」は木を「き」と読んでしまった誤り。「こもれひ」は日の連濁（濁点）が抜けています。「こぼれび」は漏れ（もれ）を「こぼれ（零れ）」と取り違えたものです。", "en": "「木漏れ日」is a special compound reading (熟字訓): 木＝こ, 漏れ＝もれ, and 日 becomes voiced to び, giving こもれび. 「きもれび」wrongly reads 木 as き; 「こもれひ」drops the voicing on 日; 「こぼれび」mistakes 漏れ (もれ) for こぼれ (零れ)." },
     exampleJapanese: "森の中を歩くと、木漏れ日がとてもきれいだった。",
-    exampleMeaningZh: "走在森林裡，從樹葉間灑落的陽光很美。"
+    exampleMeaningZh: "走在森林裡，從樹葉間灑落的陽光很美。",
+    exampleMeaningI18n: { "ja": "森の中を歩いていると、木の葉の間から差し込む日の光がとてもきれいだった。", "en": "Walking through the forest, the sunlight filtering down through the leaves was beautiful." },
   }),
   examQuestion({
     id: "niarumajiki-wk1-1",

--- a/src/domain/exam/items/n2.ts
+++ b/src/domain/exam/items/n2.ts
@@ -687,6 +687,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "説明を 簡単に するため、専門用語を 省いた。",
     exampleJapanese: "説明を 簡単に するため、専門用語を 省いた。",
     exampleMeaningZh: "為了讓說明簡單，省略了專業術語。",
+    exampleMeaningI18n: { "ja": "説明を簡単にするために、専門用語を取り除いた。", "en": "To keep the explanation simple, the technical terms were left out." },
     options: [
       "説明を 簡単に するため、専門用語を 省いた。",
       "時間を 省くため、急いで 食事を した。",
@@ -714,6 +715,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "判断に 迷ったので、上司に 助言を 求めた。",
     exampleJapanese: "判断に 迷ったので、上司に 助言を 求めた。",
     exampleMeaningZh: "因為拿不定主意，所以向上司請求建議。",
+    exampleMeaningI18n: { "ja": "どう判断すべきか迷ったので、上司にアドバイスをお願いした。", "en": "Unable to make up my mind, I asked my boss for advice." },
     options: [
       "判断に 迷ったので、上司に 助言を 求めた。",
       "なくした 指輪を 一日中 求めた。",
@@ -741,6 +743,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "急な 誘いだったので、丁寧に 断った。",
     exampleJapanese: "急な 誘いだったので、丁寧に 断った。",
     exampleMeaningZh: "因為是突然的邀約，所以禮貌地拒絕了。",
+    exampleMeaningI18n: { "ja": "突然の誘いだったので、失礼のないように断りの返事をした。", "en": "Since it was a last-minute invitation, I politely declined." },
     options: [
       "急な 誘いだったので、丁寧に 断った。",
       "強い 雨に 断られて、外出を やめた。",
@@ -768,6 +771,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "大量の 荷物が なんとか この 箱に 収まった。",
     exampleJapanese: "大量の 荷物が なんとか この 箱に 収まった。",
     exampleMeaningZh: "大量行李勉強塞進這個箱子。",
+    exampleMeaningI18n: { "ja": "たくさんの荷物が、なんとかこの箱に全部入った。", "en": "The huge pile of luggage just barely fit into this box." },
     options: [
       "大量の 荷物が なんとか この 箱に 収まった。",
       "風邪が 収まって、薬を 飲んだ。",
@@ -1201,6 +1205,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "かいぜん",
     exampleJapanese: "業務の流れを徹底的に改善する必要がある。",
     exampleMeaningZh: "必須徹底改善業務流程。",
+    exampleMeaningI18n: { "ja": "仕事の流れを根本から見直して、より良くする必要がある。", "en": "The workflow needs to be thoroughly improved." },
     options: ["かいぜん", "かいせん", "がいぜん", "こうぜん"],
     explanation: "「改」音讀「かい」，「善」音讀「ぜん」→ かいぜん。「かいせん」是「回線／改選」（清濁混淆）；「がいぜん」是「蓋然」（首字濁音化）；「こうぜん」是「公然」（首字錯讀）。",
     explanationI18n: { "ja": "「改」は音読みで「かい」、「善」は音読みで「ぜん」なので、「かいぜん」となります。「かいせん」は「回線／改選」(清濁の混同)、「がいぜん」は「蓋然」(最初の字が濁音化)、「こうぜん」は「公然」(最初の字の読み間違い)です。", "en": "「改」reads 「かい」and 「善」reads 「ぜん」→ かいぜん. 「かいせん」is 「回線／改選」(voiced/unvoiced confusion); 「がいぜん」is 「蓋然」(first syllable wrongly voiced); 「こうぜん」is 「公然」(first syllable misread)." },
@@ -1221,6 +1226,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "けんとう",
     exampleJapanese: "提案の内容を慎重に検討します。",
     exampleMeaningZh: "我們會慎重研議提案內容。",
+    exampleMeaningI18n: { "ja": "提案の内容を、時間をかけて慎重に考えます。", "en": "We will carefully consider the contents of the proposal." },
     options: ["けんとう", "けんどう", "げんとう", "けんと"],
     explanation: "「検」音讀「けん」，「討」音讀「とう」→ けんとう。「けんどう」是「剣道」（次字濁音）；「げんとう」是「幻灯」（首字濁音）；「けんと」是缺長音（長音脫落）。",
     explanationI18n: { "ja": "「検」は音読みで「けん」、「討」は音読みで「とう」なので、「けんとう」となります。「けんどう」は「剣道」(二字目が濁音)、「げんとう」は「幻灯」(一字目が濁音)、「けんと」は長音が抜けたもの(長音の脱落)です。", "en": "「検」reads 「けん」and 「討」reads 「とう」→ けんとう. 「けんどう」is 「剣道」(second syllable voiced); 「げんとう」is 「幻灯」(first syllable voiced); 「けんと」drops the long vowel." },
@@ -1241,6 +1247,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "おさえる",
     exampleJapanese: "怒りを抑えるのは大変な努力が必要だ。",
     exampleMeaningZh: "壓抑怒氣需要極大的努力。",
+    exampleMeaningI18n: { "ja": "怒りの気持ちをがまんするには、大変な努力が必要だ。", "en": "Holding back your anger takes a great deal of effort." },
     options: ["おさえる", "おしえる", "つかえる", "おそえる"],
     explanation: "「抑」訓讀「おさ-える」→ おさえる。「おしえる」是「教える」（同形不同字混淆）；「つかえる」是「仕える／使える」；「おそえる」是錯誤的母音變體（無此單字）。",
     explanationI18n: { "ja": "「抑」は訓読みで「おさ-える」なので、「おさえる」となります。「おしえる」は「教える」(似た形との混同)、「つかえる」は「仕える／使える」、「おそえる」は誤った母音の変形で、そのような単語はありません。", "en": "「抑」has the kun reading 「おさ-える」→ おさえる. 「おしえる」is 「教える」(confusion with a similar-looking form); 「つかえる」is 「仕える／使える」; 「おそえる」is an incorrect vowel variant (no such word)." },
@@ -1261,6 +1268,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "あわてる",
     exampleJapanese: "予期せぬ事態にも慌てることなく対応した。",
     exampleMeaningZh: "面對突發狀況也不慌不忙地應對。",
+    exampleMeaningI18n: { "ja": "思いがけない出来事にも、落ち着いて対応した。", "en": "They responded to the unexpected situation without panicking." },
     options: ["あわてる", "あばれる", "あおてる", "あつてる"],
     explanation: "「慌」訓讀「あわ-てる」→ あわてる。「あばれる」是「暴れる」（同義場景但字不同）；「あおてる」「あつてる」是無對應字的擬音陷阱。",
     explanationI18n: { "ja": "「慌」は訓読みで「あわ-てる」なので、「あわてる」となります。「あばれる」は「暴れる」(場面は似ていても字が違う)、「あおてる」「あつてる」は対応する漢字のない音のひっかけです。", "en": "「慌」has the kun reading 「あわ-てる」→ あわてる. 「あばれる」is 「暴れる」(a similar scenario but a different word); 「あおてる」and 「あつてる」are sound-alike traps with no corresponding kanji." },
@@ -1281,6 +1289,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "まぎらわしい",
     exampleJapanese: "この二つの表現は意味が紛らわしい。",
     exampleMeaningZh: "這兩個表達意思容易搞混。",
+    exampleMeaningI18n: { "ja": "この二つの言い方は意味がよく似ていて、混同しやすい。", "en": "These two expressions are easily confused in meaning." },
     options: ["まぎらわしい", "まきらわしい", "まずらわしい", "みぎらわしい"],
     explanation: "「紛」訓讀「まぎ-らわしい」→ まぎらわしい。「まきらわしい」是清濁混淆；「まずらわしい」是子音錯誤；「みぎらわしい」是首音母音錯誤。",
     explanationI18n: { "ja": "「紛」は訓読みで「まぎ-らわしい」なので、「まぎらわしい」となります。「まきらわしい」は清濁の混同、「まずらわしい」は子音の誤り、「みぎらわしい」は最初の母音の誤りです。", "en": "「紛」has the kun reading 「まぎ-らわしい」→ まぎらわしい. 「まきらわしい」has an unvoiced/voiced mix-up; 「まずらわしい」has a wrong consonant; 「みぎらわしい」has a wrong initial vowel." },
@@ -1301,6 +1310,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "しょうさい",
     exampleJapanese: "事件の詳細については明日発表される。",
     exampleMeaningZh: "事件詳情明天會公布。",
+    exampleMeaningI18n: { "ja": "事件のくわしい内容は、明日発表される。", "en": "The details of the incident will be announced tomorrow." },
     options: ["しょうさい", "しょさい", "しゅうさい", "しょうざい"],
     explanation: "「詳」音讀「しょう」，「細」音讀「さい」→ しょうさい。「しょさい」是「書斎」（長音脫落 → 撞到另一個詞）；「しゅうさい」是「秀才」（拗音換成 ゅう）；「しょうざい」是「商材」（次字濁音）。",
     explanationI18n: { "ja": "「詳」は音読みで「しょう」、「細」は音読みで「さい」なので、「しょうさい」となります。「しょさい」は「書斎」(長音の脱落で別の語とぶつかる)、「しゅうさい」は「秀才」(拗音が「ゅう」に変わったもの)、「しょうざい」は「商材」(二字目が濁音)です。", "en": "「詳」reads 「しょう」and 「細」reads 「さい」→ しょうさい. 「しょさい」is 「書斎」(the long vowel drops, colliding with another word); 「しゅうさい」is 「秀才」(the contracted sound is swapped for ゅう); 「しょうざい」is 「商材」(second syllable voiced)." },
@@ -2421,6 +2431,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "かたよって",
     exampleJapanese: "栄養が偏っていると、体調を崩しやすくなる。",
     exampleMeaningZh: "營養一旦失衡，就容易把身體搞壞。",
+    exampleMeaningI18n: { "ja": "栄養のバランスが崩れると、体調を悪くしやすい。", "en": "If your diet is unbalanced, it's easy to damage your health." },
     options: ["かたよって", "かたまって", "へだたって", "かたどって"],
     explanation: "「偏」訓讀「かたよ-る」→ て形「かたよって」。「かたまって」是「固まって」（凝固、聚成一塊，訓讀相近但不同字）；「へだたって」是「隔たって」（相隔、有距離，不同字）；「かたどって」是「象って／模って」（仿照外形，發音近似的陷阱）。表「營養失衡」的「偏って」讀作 かたよって。",
     explanationI18n: { "ja": "「偏」は訓読みで「かたよ-る」、そのて形が「かたよって」です。「かたまって」は「固まって」（凝固する・一か所に集まる。訓読みは似ているが別の字）、「へだたって」は「隔たって」（離れている・距離がある。別の字）、「かたどって」は「象って／模って」（形をまねる。発音が似ている引っかけ）です。「栄養が偏る」の「偏って」は、かたよって と読みます。", "en": "「偏」has the kun reading 「かたよ-る」→ te-form 「かたよって」. 「かたまって」is 「固まって」 (to harden or clump together — a similar reading but a different kanji); 「へだたって」is 「隔たって」 (to be separated or distant — a different kanji); 「かたどって」is 「象って／模って」 (to model after a shape — a similar-sounding trap). The 「偏って」meaning \"nutritionally unbalanced\" is read かたよって." },
@@ -2481,6 +2492,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "まぎらわしく",
     exampleJapanese: "説明書の図が紛らわしく、初心者には組み立て手順が分かりにくい。",
     exampleMeaningZh: "說明書的圖示容易讓人搞混，新手不易看懂組裝步驟。",
+    exampleMeaningI18n: { "ja": "説明書の図は見分けがつきにくく、初心者には組み立ての手順が理解しにくい。", "en": "The diagrams in the manual are confusing, making the assembly steps hard for beginners to follow." },
     options: ["まぎらわしく", "まじらわしく", "まぎれわしく", "まぐらわしく"],
     explanation: "「紛」訓讀「まぎ-らわしい」，連用形「紛らわしく」→ まぎらわしく。「まじらわしく」是「ぎ→じ」的子音錯誤；「まぎれわしく」是把語幹誤拆成「紛れ（まぎれ）」；「まぐらわしく」是「ぎ→ぐ」的母音錯誤。",
     explanationI18n: { "ja": "「紛」は訓読みで「まぎ-らわしい」、その連用形「紛らわしく」は まぎらわしく です。「まじらわしく」は「ぎ→じ」の子音の誤り、「まぎれわしく」は語幹を「紛れ（まぎれ）」と取り違えたもの、「まぐらわしく」は「ぎ→ぐ」の母音の誤りです。", "en": "「紛」has the kun reading 「まぎ-らわしい」, and the adverbial form 「紛らわしく」→ まぎらわしく. 「まじらわしく」has the consonant error 「ぎ→じ」; 「まぎれわしく」mistakenly splits the stem as 「紛れ（まぎれ）」; 「まぐらわしく」has the vowel error 「ぎ→ぐ」." },
@@ -2541,6 +2553,7 @@ export const n2Items: PracticeQuestion[] = [
     expectedAnswer: "かたよった",
     exampleJapanese: "偏った情報だけをもとに判断すると、結論を誤るおそれがある。",
     exampleMeaningZh: "若只憑偏頗的資訊作判斷，恐怕會導出錯誤的結論。",
+    exampleMeaningI18n: { "ja": "バランスを欠いた情報だけをもとに判断すると、誤った結論を出すおそれがある。", "en": "Judging based only on biased information can lead you to the wrong conclusion." },
     options: ["かたよった", "かたむいた", "へだたった", "かたまった"],
     explanation: "「偏」訓讀「かたよ-る」，た形「偏った」→ かたよった，指資訊或想法失衡、不公正。「かたむいた」是「傾いた」（傾斜，近義字但不同字）；「へだたった」是「隔たった」（相隔）；「かたまった」是「固まった」（凝固，訓讀相近的陷阱）。",
     explanationI18n: { "ja": "「偏」の訓読みは「かたよ-る」で、た形は「偏った」→ かたよった。情報や考え方がバランスを欠き、公平でないことを表します。「かたむいた」は「傾いた」（斜めになる。字は似ていますが別の漢字）。「へだたった」は「隔たった」（間が離れる）。「かたまった」は「固まった」（凝固する。訓読みが近い引っかけ）です。", "en": "「偏」has the kun reading \"かたよ-る\"; its た-form 「偏った」→ かたよった, referring to information or a viewpoint being unbalanced or unfair. \"かたむいた\" is 「傾いた」 (to tilt/lean — a similar-meaning but different kanji); \"へだたった\" is 「隔たった」 (to be far apart); \"かたまった\" is 「固まった」 (to harden/solidify — a trap with a similar-sounding kun reading)." },
@@ -3003,7 +3016,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「状」音讀「じょう」，「況」音讀「きょう」→ じょうきょう。「しょうきょう」是首字清濁混淆（じょう→しょう）；「じょうこう」是次字長音/拗音脫落（きょう→こう，撞「条項」）；「じょきょう」是首字長音脫落（じょう→じょ）。",
     explanationI18n: { "ja": "「状」は音読みで「じょう」、「況」は音読みで「きょう」なので、「じょうきょう」となります。「しょうきょう」は最初の字の清濁を取り違えたもの（じょう→しょう）、「じょうこう」は二文字目の長音・拗音が抜けたもの（きょう→こう、「条項」と紛らわしい）、「じょきょう」は最初の字の長音が抜けたもの（じょう→じょ）です。", "en": "「状」is read「じょう」and「況」is read「きょう」→ じょうきょう. 「しょうきょう」confuses voiced and voiceless in the first syllable (じょう→しょう); 「じょうこう」drops the long/contracted sound in the second syllable (きょう→こう, colliding with「条項」); 「じょきょう」drops the long vowel in the first syllable (じょう→じょ)." },
     exampleJapanese: "現在の状況を詳しく説明してください。",
-    exampleMeaningZh: "請詳細說明目前的狀況。"
+    exampleMeaningZh: "請詳細說明目前的狀況。",
+    exampleMeaningI18n: { "ja": "今どうなっているのかを、くわしく説明してほしい。", "en": "Please explain the current situation in detail." },
   }),
   examQuestion({
     id: "n2-kanji-shikyuu",
@@ -3023,7 +3037,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「支」音讀「し」，「給」音讀「きゅう」→ しきゅう。「じきゅう」是首字濁音（し→じ，撞「時給/自給」）；「しきょう」是次字拗音誤（きゅう→きょう）；「しきゅ」是長音脫落（きゅう→きゅ）。",
     explanationI18n: { "ja": "「支」は音読みで「し」、「給」は音読みで「きゅう」なので、「しきゅう」となります。「じきゅう」は最初の字を濁音にしたもの（し→じ、「時給・自給」と紛らわしい）、「しきょう」は二文字目の拗音を取り違えたもの（きゅう→きょう）、「しきゅ」は長音が抜けたもの（きゅう→きゅ）です。", "en": "「支」is read「し」and「給」is read「きゅう」→ しきゅう. 「じきゅう」voices the first syllable (し→じ, colliding with「時給/自給」); 「しきょう」misreads the contracted sound in the second syllable (きゅう→きょう); 「しきゅ」drops the long vowel (きゅう→きゅ)." },
     exampleJapanese: "交通費は来月まとめて支給される。",
-    exampleMeaningZh: "交通費下個月會一併發放。"
+    exampleMeaningZh: "交通費下個月會一併發放。",
+    exampleMeaningI18n: { "ja": "交通費は来月、まとめて支払われる。", "en": "Transportation expenses will be paid out all at once next month." },
   }),
   examQuestion({
     id: "n2-kanji-kisoku",
@@ -3043,7 +3058,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「規」音讀「き」，「則」音讀「そく」→ きそく。「ぎそく」是首字濁音（き→ぎ，撞「義足」）；「きぞく」是次字濁音（そく→ぞく，撞「貴族」）；「きさい」是次字誤讀（そく→さい，撞「記載」）。",
     explanationI18n: { "ja": "「規」は音読みで「き」、「則」は音読みで「そく」なので、「きそく」となります。「ぎそく」は最初の字を濁音にしたもの（き→ぎ、「義足」と紛らわしい）、「きぞく」は二文字目を濁音にしたもの（そく→ぞく、「貴族」と紛らわしい）、「きさい」は二文字目の読み違い（そく→さい、「記載」と紛らわしい）です。", "en": "「規」is read「き」and「則」is read「そく」→ きそく. 「ぎそく」voices the first syllable (き→ぎ, colliding with「義足」); 「きぞく」voices the second syllable (そく→ぞく, colliding with「貴族」); 「きさい」misreads the second syllable (そく→さい, colliding with「記載」)." },
     exampleJapanese: "会社の規則を守って行動してください。",
-    exampleMeaningZh: "請遵守公司的規則行動。"
+    exampleMeaningZh: "請遵守公司的規則行動。",
+    exampleMeaningI18n: { "ja": "会社のルールを守って行動してください。", "en": "Please act in accordance with the company rules." },
   }),
   examQuestion({
     id: "reinforce-stubborn-nagaramomo-young",
@@ -3125,7 +3141,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「おおむね」表示大致、大體上，最接近「だいたい」。「完全に」是完全；「少しずつ」是逐漸；「急に」是突然，皆不合。",
     explanationI18n: { "ja": "「おおむね」は「だいたい・おおよそ」という意味で、「だいたい」が最も近いです。「完全に」は完全に、「少しずつ」は徐々に、「急に」は突然という意味で、いずれも合いません。", "en": "「おおむね」means roughly or on the whole, closest to「だいたい」. 「完全に」means completely; 「少しずつ」means little by little; 「急に」means suddenly — none fit." },
     exampleJapanese: "新しい計画は、おおむね順調に進んでいる。",
-    exampleMeaningZh: "新計畫大致上進行得很順利。"
+    exampleMeaningZh: "新計畫大致上進行得很順利。",
+    exampleMeaningI18n: { "ja": "新しい計画は、ほぼ順調に進んでいる。", "en": "The new plan is going more or less smoothly." },
   }),
   examQuestion({
     id: "reinforce-round2-amari-presentation",
@@ -3245,7 +3262,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「状況」讀作「じょうきょう」。「しょうきょう」是語頭清濁誤讀；「じょうこう」是漏掉後半拗音的誤讀；「じょうぎょう」是後半清濁與讀音的混淆。",
     explanationI18n: { "ja": "「状況」は「じょうきょう」と読みます。「しょうきょう」は語頭の清濁を取り違えた誤り、「じょうこう」は後半の拗音が抜けた誤り、「じょうぎょう」は後半の清濁と読みを取り違えたものです。", "en": "「状況」is read「じょうきょう」. 「しょうきょう」misreads the voiced/voiceless distinction at the start; 「じょうこう」is a misreading that drops the contracted sound in the second half; 「じょうぎょう」confuses both the voicing and the reading of the second half." },
     exampleJapanese: "現場の状況を確認してから判断しましょう。",
-    exampleMeaningZh: "先確認現場的狀況再判斷吧。"
+    exampleMeaningZh: "先確認現場的狀況再判斷吧。",
+    exampleMeaningI18n: { "ja": "現場が今どうなっているかを確かめてから判断しよう。", "en": "Let's check the situation on site before making a decision." },
   }),
   examQuestion({
     id: "reinforce-round2-ageku-cancel",
@@ -6205,7 +6223,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「ふくむ」是「含む」的正確訓讀，表示包含、含有。「ふくぶ」把語尾濁化、「ふぐむ」把「く」濁化、「ぶくむ」把字首濁化，三者都不是實際存在的讀法，發音聽起來也不自然，母語者不會接受，故唯一正解為「ふくむ」。",
     explanationI18n: { "ja": "正解の「ふくむ」は「含む」の正しい訓読みで、含む・含んでいるという意味です。「ふくぶ」は語尾を濁らせ、「ふぐむ」は「く」を濁らせ、「ぶくむ」は語頭を濁らせたもので、三つとも実在しない読み方であり、発音も不自然で母語話者は受け入れません。したがって唯一の正解は「ふくむ」です。", "en": "The correct answer 「ふくむ」is the proper kun'yomi of 「含む」, meaning to include or contain. 「ふくぶ」voices the final syllable, 「ふぐむ」voices the 「く」, and 「ぶくむ」voices the initial syllable — none of these is an actual reading, and they sound unnatural to native speakers, who would not accept them. Thus the only correct answer is 「ふくむ」." },
     exampleJapanese: "この料金には税金も「含む」ので、追加で払う必要はありません。",
-    exampleMeaningZh: "這個費用已經含稅，所以不需要另外再付。"
+    exampleMeaningZh: "這個費用已經含稅，所以不需要另外再付。",
+    exampleMeaningI18n: { "ja": "この料金には税金も入っているので、追加で支払う必要はない。", "en": "This fee already includes tax, so there's no need to pay anything extra." },
   }),
   examQuestion({
     id: "n2-kanji-azukeru",
@@ -6225,7 +6244,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「あずける」是「預ける」的正確訓讀，表示把東西交給他人或某處保管。「あすける」把「ず」清音化、「あつける」把「ず」變成清音「つ」、「あづける」用了現代假名遣已不使用的「づ」寫法，三者都不是這個動詞的正確讀音，故唯一正解為「あずける」。",
     explanationI18n: { "ja": "正解の「あずける」は「預ける」の正しい訓読みで、物を他人やある場所に預けて保管してもらうという意味です。「あすける」は「ず」を清音にし、「あつける」は「ず」を清音の「つ」にし、「あづける」は現代仮名遣いでは使わない「づ」の表記を用いたもので、三つともこの動詞の正しい読み方ではありません。したがって唯一の正解は「あずける」です。", "en": "The correct answer 「あずける」is the proper kun'yomi of 「預ける」, meaning to hand something over to another person or place for safekeeping. 「あすける」unvoices the 「ず」, 「あつける」turns 「ず」 into the voiceless 「つ」, and 「あづける」uses the 「づ」 spelling that modern kana usage no longer employs — none of these is the correct reading of this verb. Thus the only correct answer is 「あずける」." },
     exampleJapanese: "旅行の間、荷物を駅のロッカーに「預ける」つもりです。",
-    exampleMeaningZh: "旅行期間打算把行李寄放在車站的置物櫃裡。"
+    exampleMeaningZh: "旅行期間打算把行李寄放在車站的置物櫃裡。",
+    exampleMeaningI18n: { "ja": "旅行の間、荷物を駅のロッカーに置いておくつもりだ。", "en": "I plan to leave my luggage in a station locker during the trip." },
   }),
   examQuestion({
     id: "n2-kanji-houmon",
@@ -6245,7 +6265,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「ほうもん」是「訪問」的正確音讀。「ぼうもん」把字首濁化、「ほおもん」用「お」拉長取代正確的長音「う」、「ほうも」漏掉了後半的「ん」，三者都不是「訪問」的讀音，故唯一正解為「ほうもん」。",
     explanationI18n: { "ja": "正解の「ほうもん」は「訪問」の正しい音読みです。「ぼうもん」は語頭を濁らせ、「ほおもん」は正しい長音「う」の代わりに「お」で伸ばし、「ほうも」は後半の「ん」を落としたもので、三つとも「訪問」の読み方ではありません。したがって唯一の正解は「ほうもん」です。", "en": "The correct answer 「ほうもん」is the proper on'yomi of 「訪問」. 「ぼうもん」voices the initial syllable, 「ほおもん」uses a lengthened 「お」 instead of the correct long vowel 「う」, and 「ほうも」drops the final 「ん」 — none of these is the reading of 「訪問」. Thus the only correct answer is 「ほうもん」." },
     exampleJapanese: "来週、取引先の会社を「訪問」する予定が入っています。",
-    exampleMeaningZh: "下週排定了去拜訪客戶公司的行程。"
+    exampleMeaningZh: "下週排定了去拜訪客戶公司的行程。",
+    exampleMeaningI18n: { "ja": "来週、取引先の会社を訪ねる予定が入っている。", "en": "I have a visit to a client's company scheduled for next week." },
   }),
   examQuestion({
     id: "n2-usage-enchou",
@@ -6267,7 +6288,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「延長」＝把時限或期限往後拉長。A 趕不上截止日而申請把提出期限往後延＝唯一正解。B 調大音量要用「上げて／大きくして」，「音量を延長」搭配不對；C 換新電池要用「交換した」，把電池「延長」說不通；D 開燈要用「つけた」，「電気を延長」不成立。三個干擾在語境中皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「延長」は、期限や期間を後ろに延ばすことです。Aは締め切りに間に合わず提出期限を後ろに延ばすよう申請しており、唯一の正解です。Bは音量を大きくするなら「上げて／大きくして」を使うべきで、「音量を延長」は組み合わせが不適切です。Cは電池を新しいものに換えるなら「交換した」を使うべきで、電池を「延長」するのは通りません。Dは電気をつけるなら「つけた」を使うべきで、「電気を延長」は成り立ちません。三つの誤答は文脈で成り立たず、Aだけが自然です。", "en": "「延長」means to push a time limit or deadline further back. In A, they can't make the deadline so they apply to move the submission deadline back — the only correct answer. In B, turning up the volume calls for 「上げて／大きくして」; 「音量を延長」is the wrong pairing. In C, replacing a battery calls for 「交換した」; \"extending\" a battery makes no sense. In D, turning on a light calls for 「つけた」; 「電気を延長」doesn't work. The three distractors don't hold up in context; only A is natural." },
     exampleJapanese: "締め切りに間に合いそうにないので、提出期限の延長をお願いした。",
-    exampleMeaningZh: "因為趕不上截止日，所以拜託對方延長繳交期限。"
+    exampleMeaningZh: "因為趕不上截止日，所以拜託對方延長繳交期限。",
+    exampleMeaningI18n: { "ja": "締め切りに間に合いそうにないため、提出期限を延ばしてもらえるようお願いした。", "en": "Since I didn't think I would make the deadline, I asked for an extension on the submission date." },
   }),
   examQuestion({
     id: "n2-usage-sekkyokuteki",
@@ -6289,7 +6311,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「積極的」＝主動、踴躍投入。A 雖是新人卻在會議上總是主動發言＝唯一正解。B 接續通，但「遅刻（遲到）」是消極失誤、沒人會「積極地遲到」，該說「しょっちゅう／つい」；C 帶傘是預防行為，該說「念のため」，「積極的に傘を持ってきた」搭配不對；D「日が当たらない積極的な場所」自相矛盾，背陰處該說「日陰の／暗い」，「積極的な場所」不成詞。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「積極的」は、自ら進んで前向きに取り組むことです。Aは新人でありながら会議でいつも自ら進んで発言しており、唯一の正解です。Bは接続は通りますが、「遅刻」は消極的な失敗で、誰も「積極的に遅刻」はしないので、「しょっちゅう／つい」と言うべきです。Cは傘を持つのは予防的な行動なので「念のため」と言うべきで、「積極的に傘を持ってきた」は組み合わせが不適切です。Dは「日が当たらない積極的な場所」は自己矛盾で、日陰なら「日陰の／暗い」と言うべきであり、「積極的な場所」という言い方は成り立ちません。三つの誤答はいずれも成り立たず、Aだけが自然です。", "en": "「積極的」means proactive, eagerly throwing oneself in. In A, though a newcomer, he always speaks up on his own initiative in meetings — the only correct answer. In B the connection is grammatically fine, but 「遅刻」 (being late) is a passive failing that no one does \"proactively\"; it should be 「しょっちゅう／つい」. In C, bringing an umbrella is a precaution and should be 「念のため」; 「積極的に傘を持ってきた」is the wrong pairing. In D, 「日が当たらない積極的な場所」is self-contradictory — a shady spot should be 「日陰の／暗い」, and 「積極的な場所」is not a valid phrase. All three distractors fail; only A is natural." },
     exampleJapanese: "新人ながら、彼は会議でいつも積極的に意見を述べる。",
-    exampleMeaningZh: "雖然是新人，他在會議上總是主動發表意見。"
+    exampleMeaningZh: "雖然是新人，他在會議上總是主動發表意見。",
+    exampleMeaningI18n: { "ja": "新人であるにもかかわらず、彼は会議でいつも自分から進んで意見を言う。", "en": "Even though he's a newcomer, he always speaks up with his opinions in meetings." },
   }),
   examQuestion({
     id: "n2-usage-soroeru",
@@ -6311,7 +6334,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「揃える」＝把該有的東西備齊、湊齊。A 把面試所需文件全部備齊後再出門＝唯一正解。B 發燒要說「熱を出して」，「熱を揃える」說不通；C 趕不上約定時間要說「間に合わなかった」，「時間に揃える」不成立；D 開窗要說「窓を開けて」，「窓を揃える」搭配不對。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「揃える」は、必要なものをそろえる・そろって用意することです。Aは面接に必要な書類をすべてそろえてから出かけており、唯一の正解です。Bは熱を出すなら「熱を出して」と言うべきで、「熱を揃える」は通りません。Cは約束の時間に間に合わなかったなら「間に合わなかった」と言うべきで、「時間に揃える」は成り立ちません。Dは窓を開けるなら「窓を開けて」と言うべきで、「窓を揃える」は組み合わせが不適切です。三つの誤答はいずれも成り立たず、Aだけが自然です。", "en": "「揃える」means to get all the required items ready, to gather them together. In A, she gathers all the documents needed for the interview before leaving — the only correct answer. In B, running a fever calls for 「熱を出して」; 「熱を揃える」makes no sense. In C, failing to make an appointment time calls for 「間に合わなかった」; 「時間に揃える」doesn't work. In D, opening a window calls for 「窓を開けて」; 「窓を揃える」is the wrong pairing. All three distractors fail; only A is natural." },
     exampleJapanese: "面接に必要な書類をすべて揃えてから家を出た。",
-    exampleMeaningZh: "把面試所需的文件全部備齊後才出門。"
+    exampleMeaningZh: "把面試所需的文件全部備齊後才出門。",
+    exampleMeaningI18n: { "ja": "面接に必要な書類をすべて用意してから家を出た。", "en": "I got all the documents needed for the interview together before leaving the house." },
   }),
   examQuestion({
     id: "n2-usage-tanomoshii",
@@ -6333,7 +6357,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「頼もしい」＝靠得住、讓人安心。A 遇到困難時一定伸出援手的人正是「頼もしい」＝唯一正解。B 椅子搖晃該說「不安だ／危ない」，搖晃卻「頼もしい」自相矛盾；C 陰沉的天空令人鬱悶，該說「うっとうしい」，與「頼もしい」不合；D 貴又量少令人失望，該說「物足りない」，不會用「頼もしい」。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「頼もしい」は、頼りになり安心できることです。Aは困ったときに必ず手を差し伸べてくれる人こそ「頼もしい」ので、唯一の正解です。Bは椅子がぐらつくなら「不安だ／危ない」と言うべきで、ぐらつくのに「頼もしい」は自己矛盾です。Cはどんよりした空は気が滅入るので「うっとうしい」と言うべきで、「頼もしい」とは合いません。Dは高くて量が少なくてがっかりなら「物足りない」と言うべきで、「頼もしい」は使いません。三つの誤答はいずれも成り立たず、Aだけが自然です。", "en": "「頼もしい」means dependable, someone who puts you at ease. In A, a person who always lends a hand when you're in trouble is exactly 「頼もしい」— the only correct answer. In B, a wobbly chair should be described as 「不安だ／危ない」; calling something wobbly 「頼もしい」is self-contradictory. In C, a gloomy sky is dispiriting and should be 「うっとうしい」, which doesn't fit 「頼もしい」. In D, expensive yet skimpy is disappointing and should be 「物足りない」, not 「頼もしい」. All three distractors fail; only A is natural." },
     exampleJapanese: "困ったときに必ず助けてくれる彼は、本当に頼もしい。",
-    exampleMeaningZh: "遇到困難時一定會幫忙的他，真的很可靠。"
+    exampleMeaningZh: "遇到困難時一定會幫忙的他，真的很可靠。",
+    exampleMeaningI18n: { "ja": "困ったときに必ず助けてくれる彼は、本当に信頼できる存在だ。", "en": "He always helps me out when I'm in trouble—he's truly dependable." },
   }),
   examQuestion({
     id: "n2-context-sokode",
@@ -6415,7 +6440,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「やむを得ず」指在沒有其他選擇的情況下被迫採取行動，與「しかたなく（沒辦法、只好）」同義，正解成立。「よろこんで（樂意地）」語意相反，搭末班車沒了的窘況不合理；「あらかじめ（事先）」是時間副詞，與「被迫」無關，且搭計程車是臨時決定非事先安排；「ぐうぜん（偶然、碰巧）」指意外發生，但此處是因末班車沒了而做的必然選擇，不成立。",
     explanationI18n: { "ja": "「やむを得ず」は他に選択肢がない状況でしかたなく行動することを指し、「しかたなく（どうしようもなく、しかたなく）」と同義なので正解です。「よろこんで（喜んで）」は意味が正反対で、終電がなくなった困った状況には合いません。「あらかじめ（前もって）」は時間を表す副詞で「余儀なくされる」こととは無関係であり、タクシーで帰るのはその場の決断で前もっての段取りではありません。「ぐうぜん（偶然、たまたま）」は思いがけず起こることを指しますが、ここは終電がなくなったための必然的な選択なので成り立ちません。", "en": "「やむを得ず」means being forced to act with no other choice, synonymous with 「しかたなく」 (with no choice, having no alternative), so it's the correct answer. 「よろこんで」 (gladly) is the opposite in meaning and doesn't make sense in the predicament of the last train being gone; 「あらかじめ」 (in advance) is a time adverb unrelated to being \"forced,\" and taking a taxi was a spur-of-the-moment decision, not something arranged beforehand; 「ぐうぜん」 (by chance, coincidentally) refers to something happening unexpectedly, but here it's a necessary choice made because the last train was gone, so it doesn't hold." },
     exampleJapanese: "終電がなくなったので、しかたなくタクシーで帰った。",
-    exampleMeaningZh: "因為末班車沒了，只好搭計程車回家。"
+    exampleMeaningZh: "因為末班車沒了，只好搭計程車回家。",
+    exampleMeaningI18n: { "ja": "終電がなくなってしまい、ほかに方法がなくタクシーで帰った。", "en": "The last train was gone, so I had no choice but to take a taxi home." },
   }),
   examQuestion({
     id: "n2-syn-tokkuni",
@@ -6437,7 +6463,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「とっくに」表示「很久以前就已經」，與「ずっと前に（很早以前）」同義，題幹加上「先月の時点で」這個過去時間錨，鎖死正解只能是「ずっと前に」。「まもなく（不久後、即將）」指向未來，與「先月就已賣完」的過去事實矛盾；「ようやく（好不容易才、終於）」帶有久候後實現的語感，售罄並非期盼之事，語意不合；「たまに（偶爾）」是頻率副詞，與「老早」的時間點無關。",
     explanationI18n: { "ja": "「とっくに」は「ずっと前にすでに」という意味で、「ずっと前に（かなり前に）」と同義です。設問には「先月の時点で」という過去の時間の手がかりが付いており、正解を「ずっと前に」に絞り込みます。「まもなく（もうすぐ、まもなく）」は未来を指すので、「先月にはもう売り切れていた」という過去の事実と矛盾します。「ようやく（やっと、ようやく）」は長く待って実現したというニュアンスをもちますが、売り切れは待ち望んだことではないので意味が合いません。「たまに（ときどき）」は頻度を表す副詞で、「とっくに」という時点とは無関係です。", "en": "「とっくに」means \"already, long ago,\" synonymous with 「ずっと前に」 (a long time ago). The clause adds the past time anchor 「先月の時点で」, which locks the correct answer to 「ずっと前に」. 「まもなく」 (soon, before long) points to the future and contradicts the past fact of \"already sold out last month\"; 「ようやく」 (finally, at last) carries the nuance of something realized after a long wait, but a sellout isn't something awaited, so it doesn't fit; 「たまに」 (occasionally) is a frequency adverb, unrelated to the time point of \"long ago.\"" },
     exampleJapanese: "その商品なら、先月の時点でずっと前に売り切れてしまいましたよ。",
-    exampleMeaningZh: "那件商品的話，上個月那時候就早在很久以前賣完了喔。"
+    exampleMeaningZh: "那件商品的話，上個月那時候就早在很久以前賣完了喔。",
+    exampleMeaningI18n: { "ja": "その商品なら、先月の時点で、もうずいぶん前に売り切れてしまっていましたよ。", "en": "That product had already sold out long before—it was gone as of last month." },
   }),
   examQuestion({
     id: "n2-syn-unzari",
@@ -6459,7 +6486,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「うんざり」指因反覆同樣事物而感到厭煩，與「あきあき（厭膩、膩透了）」同義，正解成立。「わくわく（興奮期待）」是正面情緒，與每天同樣菜色的厭倦感相反；「うっとり（陶醉、看得入迷）」表示被吸引而出神，語意正面不符；「のんびり（悠閒）」描述放鬆狀態，與「受夠了」的情緒無關。",
     explanationI18n: { "ja": "「うんざり」は同じ事の繰り返しで嫌気がさすことを指し、「あきあき（飽き飽きする、うんざりする）」と同義なので正解です。「わくわく（わくわくして期待する）」は前向きな感情で、毎日同じ料理という飽きの感覚とは正反対です。「うっとり（うっとりする、見とれる）」は魅了されて心を奪われることを表し、意味が前向きで合いません。「のんびり（のんびり）」はくつろいだ状態を表し、「うんざり」の感情とは無関係です。", "en": "「うんざり」means feeling fed up from the same thing repeated over and over, synonymous with 「あきあき」 (sick and tired, thoroughly bored), so it's the correct answer. 「わくわく」 (excited with anticipation) is a positive emotion, the opposite of weariness with the same daily meals; 「うっとり」 (enraptured, entranced) means being drawn in and spellbound, a positive sense that doesn't fit; 「のんびり」 (relaxed) describes a laid-back state, unrelated to the feeling of \"having had enough.\"" },
     exampleJapanese: "毎日同じ料理ばかりで、もうあきあきしている。",
-    exampleMeaningZh: "每天都是一樣的菜，已經膩透了。"
+    exampleMeaningZh: "每天都是一樣的菜，已經膩透了。",
+    exampleMeaningI18n: { "ja": "毎日同じ料理ばかりで、もうすっかり嫌になっている。", "en": "It's the same food every single day—I'm completely sick of it." },
   }),
   examQuestion({
     id: "n2-syn-arifureta",
@@ -6481,7 +6509,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「ありふれた」指隨處可見、毫不稀奇，與「ありきたりな（平庸、老套）」同義，且都能解釋「一點也不驚訝」，正解成立。「めずらしい（罕見的）」語意正相反，若結局罕見就不會「不驚訝」；「あやしい（可疑的）」指令人起疑，與「平凡」無關；「こまかい（細小的、瑣細的）」描述尺寸或細節程度，與「常見」不同義。",
     explanationI18n: { "ja": "「ありふれた」はどこにでもあって珍しくないことを指し、「ありきたりな（平凡な、ありきたりな）」と同義で、どちらも「少しも驚かなかった」ことを説明できるので正解です。「めずらしい（珍しい）」は意味が正反対で、結末が珍しければ「驚かない」はずがありません。「あやしい（怪しい）」は疑わしいことを指し、「平凡」とは無関係です。「こまかい（細かい、こまごました）」は大きさや細部の程度を表し、「ありふれた」とは同義ではありません。", "en": "「ありふれた」means commonplace and unremarkable, synonymous with 「ありきたりな」 (banal, clichéd); both can account for \"not surprised in the least,\" so it's the correct answer. 「めずらしい」 (rare, unusual) is the exact opposite — if the ending were rare, you would not be \"unsurprised\"; 「あやしい」 (suspicious) means arousing doubt and is unrelated to \"ordinary\"; 「こまかい」 (fine, minute, detailed) describes size or level of detail and is not synonymous with \"common.\"" },
     exampleJapanese: "その物語の結末はありきたりなもので、少しも驚かなかった。",
-    exampleMeaningZh: "那個故事的結局很老套，一點也不令人驚訝。"
+    exampleMeaningZh: "那個故事的結局很老套，一點也不令人驚訝。",
+    exampleMeaningI18n: { "ja": "その物語の結末はどこにでもあるようなもので、少しも驚かなかった。", "en": "The ending of that story was clichéd, and it didn't surprise me at all." },
   }),
   examQuestion({
     id: "n2-syn-ainiku",
@@ -6503,7 +6532,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「あいにく」表示事與願違、時機不湊巧，與「運悪く（運氣不好地、不巧）」同義，正解成立。「さっそく（立刻、馬上）」指迅速行動，與「不在」這種失望結果無關；「かならず（一定、務必）」表必然，但對方不在是意外狀況，矛盾；「しだいに（漸漸地）」描述程度逐步變化，與一次性的「不湊巧」不同義。",
     explanationI18n: { "ja": "「あいにく」は思いどおりにいかず、タイミングが悪いことを表し、「運悪く（運悪く、あいにく）」と同義なので正解です。「さっそく（さっそく、すぐに）」は素早く行動することを指し、「不在」という残念な結果とは無関係です。「かならず（必ず、きっと）」は必然を表しますが、相手が不在なのは思いがけない状況なので矛盾します。「しだいに（次第に）」は程度が徐々に変わることを表し、一度きりの「あいにく」とは同義ではありません。", "en": "「あいにく」means that things go contrary to one's wishes at an inopportune moment, synonymous with 「運悪く」 (unluckily, unfortunately), so it's the correct answer. 「さっそく」 (right away, promptly) refers to acting quickly and is unrelated to the disappointing outcome of them being out; 「かならず」 (certainly, without fail) expresses inevitability, but them being out is an unexpected circumstance, so it contradicts; 「しだいに」 (gradually) describes a step-by-step change in degree and is not synonymous with a one-time stroke of \"bad timing.\"" },
     exampleJapanese: "お訪ねしましたが、運悪くご不在でした。",
-    exampleMeaningZh: "我去拜訪了，但運氣不好對方不在。"
+    exampleMeaningZh: "我去拜訪了，但運氣不好對方不在。",
+    exampleMeaningI18n: { "ja": "訪ねて行ったのですが、間の悪いことにご不在でした。", "en": "I went to visit, but as luck would have it, they were out." },
   }),
   examQuestion({
     id: "n2-usage-tema",
@@ -6525,7 +6555,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「手間」＝做某事所需投入的工夫與勞力。A 從頭熬高湯很花工夫，所以忍不住用市售品＝唯一正解，「手間がかかる」是固定搭配。B 趕不上約定時間要說「間に合わなかった」，「手間が合う」不成詞；C 換到更大的房間要說「部屋／会議室」，「広い手間」說不通；D 一整天臥床要說「家／ベッドで寝ていた」，「手間で寝る」搭配不對。三個干擾在語境中皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「手間」＝何かをするのに必要な労力や手数のこと。A は「一から出汁を取るのは手間がかかるので、つい市販品を使ってしまう」で、「手間がかかる」は定番の言い回し。これが唯一の正解。B は約束の時間に遅れなかったなら「間に合わなかった」と言うべきで、「手間が合う」という語はない。C は広い部屋に変えるなら「部屋／会議室」と言うべきで、「広い手間」は意味をなさない。D は一日中横になっていたなら「家／ベッドで寝ていた」と言うべきで、「手間で寝る」は結び付かない。三つの選択肢は文脈上どれも成立せず、A だけが自然。", "en": "「手間」means the effort and labor needed to do something. A says making stock from scratch takes so much effort that you end up using the store-bought kind = the only correct answer, and 「手間がかかる」is a set phrase. In B, missing an agreed time should be 「間に合わなかった」;「手間が合う」is not a real expression. In C, moving to a bigger room needs 「部屋／会議室」;「広い手間」makes no sense. In D, staying in bed all day needs 「家／ベッドで寝ていた」;「手間で寝る」is the wrong collocation. All three distractors fail in context, so only A is natural." },
     exampleJapanese: "一から出汁を取るのは手間がかかるので、つい市販のものを使ってしまう。",
-    exampleMeaningZh: "從頭熬高湯很費工夫，所以總忍不住用市售現成的。"
+    exampleMeaningZh: "從頭熬高湯很費工夫，所以總忍不住用市售現成的。",
+    exampleMeaningI18n: { "ja": "一から出汁を取るのは時間と労力がかかるので、つい市販のものを使ってしまう。", "en": "Making dashi stock from scratch takes a lot of effort, so I always end up using the store-bought kind." },
   }),
   examQuestion({
     id: "n2-usage-medatsu",
@@ -6547,7 +6578,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「目立つ」＝在周圍襯托下格外搶眼、引人注意。A 眾人一身黑、唯獨他的紅外套格外搶眼＝唯一正解。B 肚子很餓要說「すいている」，「おなかが目立つ」搭配不對；C 想不出答案要說「答えが見つからない／出ない」，「答えが目立たない」說不通；D 指針不動了要說「止まって動かない」，「目立って動かない」語意不合。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「目立つ」＝周りとの対比で特に際立ち、人目を引くこと。A は皆が黒い中で彼の赤い上着だけが際立っていた、という文で唯一の正解。B は空腹なら「すいている」と言うべきで、「おなかが目立つ」は結び付かない。C は答えが分からないなら「答えが見つからない／出ない」と言うべきで、「答えが目立たない」は意味をなさない。D は針が動かないなら「止まって動かない」と言うべきで、「目立って動かない」は意味が合わない。三つの選択肢はいずれも成立せず、A だけが自然。", "en": "「目立つ」means to stand out and catch the eye against one's surroundings. A, where everyone is in black but his red jacket alone is striking = the only correct answer. In B, being very hungry should be 「すいている」;「おなかが目立つ」is the wrong collocation. In C, being unable to come up with an answer should be 「答えが見つからない／出ない」;「答えが目立たない」makes no sense. In D, a stopped clock hand should be 「止まって動かない」;「目立って動かない」doesn't fit the meaning. All three distractors fail, so only A is natural." },
     exampleJapanese: "みんなが黒いスーツの中で、彼の赤い上着はとても目立っていた。",
-    exampleMeaningZh: "在大家都穿黑西裝之中，他的紅外套格外搶眼。"
+    exampleMeaningZh: "在大家都穿黑西裝之中，他的紅外套格外搶眼。",
+    exampleMeaningI18n: { "ja": "みんなが黒いスーツを着ている中で、彼の赤い上着はひときわ人目を引いていた。", "en": "Among everyone in their black suits, his red jacket really stood out." },
   }),
   examQuestion({
     id: "n2-usage-sumaseru",
@@ -6569,7 +6601,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「済ませる」＝把該做的事處理完、辦妥。A 下午要出門，於是上午先把銀行的事辦完＝唯一正解，「用事を済ませる」是典型搭配。B 把臭味散掉要說「消した／逃がした」，「においを済ませる」說不通；C 開燈要說「電気をつけた」，「電気を済ませる」不成立；D 把水喝光要說「飲んだ／飲み干した」，「水を済ませる」搭配不對。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「済ませる」＝やるべきことを処理して終わらせること。A は午後に出かけるので、午前中に銀行の用事を片付けた、という文で「用事を済ませる」は典型的な組み合わせ。これが唯一の正解。B は臭いを消すなら「消した／逃がした」と言うべきで、「においを済ませる」は意味をなさない。C は電気をつけるなら「電気をつけた」と言うべきで、「電気を済ませる」は成立しない。D は水を飲み干すなら「飲んだ／飲み干した」と言うべきで、「水を済ませる」は結び付かない。三つの選択肢はいずれも成立せず、A だけが自然。", "en": "「済ませる」means to finish and take care of something that needs doing. A, where you finish the bank errands in the morning because you're going out in the afternoon = the only correct answer, and 「用事を済ませる」is a typical collocation. In B, airing out a smell should be 「消した／逃がした」;「においを済ませる」makes no sense. In C, turning on a light should be 「電気をつけた」;「電気を済ませる」doesn't work. In D, drinking up water should be 「飲んだ／飲み干した」;「水を済ませる」is the wrong collocation. All three distractors fail, so only A is natural." },
     exampleJapanese: "午後に出かけるので、銀行の用事を午前中に済ませておいた。",
-    exampleMeaningZh: "因為下午要出門，所以上午就先把銀行的事辦完了。"
+    exampleMeaningZh: "因為下午要出門，所以上午就先把銀行的事辦完了。",
+    exampleMeaningI18n: { "ja": "午後に出かけるので、銀行の用事を午前中に片づけておいた。", "en": "Since I was going out in the afternoon, I got my banking errands done in the morning." },
   }),
   examQuestion({
     id: "n2-usage-oitsuku",
@@ -6591,7 +6624,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「追いつく」＝趕上原本領先的進度或對象。A 請了一週假、要趕上班上落下的進度很吃力＝唯一正解。B 換新電池要說「交換した」，「電池に追いついた」說不通；C 調高冷氣溫度要說「上げた」，「温度を追いついた」搭配不對；D 始終無法贊成、堅持反對要說「反対した／意見が合わなかった」，「最後まで追いついた」語意不合。三個干擾皆不成立，唯 A 自然。",
     explanationI18n: { "ja": "「追いつく」＝先行していた進度や相手に届くこと。A は一週間休んで、クラスで遅れた授業に追いつくのが大変だった、という文で唯一の正解。B は電池を交換するなら「交換した」と言うべきで、「電池に追いついた」は意味をなさない。C は温度を上げるなら「上げた」と言うべきで、「温度を追いついた」は結び付かない。D は最後まで反対を貫くなら「反対した／意見が合わなかった」と言うべきで、「最後まで追いついた」は意味が合わない。三つの選択肢はいずれも成立せず、A だけが自然。", "en": "「追いつく」means to catch up to progress or a target that was ahead. A, where after a week off it's a struggle to catch up on the class you fell behind in = the only correct answer. In B, swapping in a new battery should be 「交換した」;「電池に追いついた」makes no sense. In C, turning the AC temperature up should be 「上げた」;「温度を追いついた」is the wrong collocation. In D, never being able to agree and holding out in opposition should be 「反対した／意見が合わなかった」;「最後まで追いついた」doesn't fit the meaning. All three distractors fail, so only A is natural." },
     exampleJapanese: "一週間休んだので、クラスの授業に追いつくのが大変だった。",
-    exampleMeaningZh: "因為請了一週假，要趕上班上的進度很辛苦。"
+    exampleMeaningZh: "因為請了一週假，要趕上班上的進度很辛苦。",
+    exampleMeaningI18n: { "ja": "一週間休んだので、クラスの授業の遅れを取り戻すのが大変だった。", "en": "Having been out for a week, it was hard to catch up with the rest of the class." },
   }),
   examQuestion({
     id: "n2-vocab-omoigakenai",
@@ -6651,7 +6685,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「ねんりょう」是「燃料」的正確音讀：「燃」音讀「ねん」、「料」音讀「りょう」。「ねんりょく」把「料（りょう）」誤讀成「りょく」（撞「念力」的尾音感），「料」並無「りょく」的讀法；「ねんりゅう」把拗音「りょう」誤成「りゅう」；「れんりょう」把字首「燃（ねん）」清音化成「れん」。三個干擾都不是「燃料」實際存在的讀音，母語者不會接受，故唯一正解為「ねんりょう」。",
     explanationI18n: { "ja": "正解の「ねんりょう」は「燃料」の正しい音読み。「燃」は音読みで「ねん」、「料」は音読みで「りょう」。「ねんりょく」は「料（りょう）」を「りょく」と誤読しており（「念力」の語尾に引きずられた形）、「料」に「りょく」という読みはない。「ねんりゅう」は拗音「りょう」を「りゅう」と誤ったもの。「れんりょう」は語頭の「燃（ねん）」を清音化して「れん」としたもの。三つの誤答はいずれも「燃料」に実在する読みではなく、母語話者は受け入れないため、正解は「ねんりょう」ただ一つ。", "en": "The correct answer 「ねんりょう」is the proper on'yomi of 「燃料」:「燃」is read 「ねん」and 「料」is read 「りょう」.「ねんりょく」misreads 「料（りょう）」as 「りょく」(echoing the ending of 「念力」), but 「料」has no 「りょく」reading;「ねんりゅう」turns the contracted sound 「りょう」into 「りゅう」;「れんりょう」unvoices the initial 「燃（ねん）」into 「れん」. None of the three distractors is an actual reading of 「燃料」, and a native speaker would not accept them, so the only correct answer is 「ねんりょう」." },
     exampleJapanese: "この発電所は、石炭を燃料として使っています。",
-    exampleMeaningZh: "這座發電廠把煤炭當作燃料來使用。"
+    exampleMeaningZh: "這座發電廠把煤炭當作燃料來使用。",
+    exampleMeaningI18n: { "ja": "この発電所では、エネルギー源として石炭を使っている。", "en": "This power plant uses coal as fuel." },
   }),
   examQuestion({
     id: "n2-kanji-boueki",
@@ -6671,7 +6706,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「ぼうえき」是「貿易」的正確音讀：「貿」音讀「ぼう」、「易」此處音讀「えき」。「ほうえき」把字首「貿（ぼう）」清音化成「ほう」；「ぼうえぎ」把「易（えき）」尾音濁化成「えぎ」；「ぼえき」漏掉了字首的長音「う」（ぼう→ぼ）。三個干擾都不是「貿易」的正確讀音，發音也不自然，母語者不會接受，故唯一正解為「ぼうえき」。",
     explanationI18n: { "ja": "正解の「ぼうえき」は「貿易」の正しい音読み。「貿」は音読みで「ぼう」、「易」はここでは音読みで「えき」。「ほうえき」は語頭の「貿（ぼう）」を清音化して「ほう」としたもの。「ぼうえぎ」は「易（えき）」の語尾を濁音化して「えぎ」としたもの。「ぼえき」は語頭の長音「う」を落としている（ぼう→ぼ）。三つの誤答はいずれも「貿易」の正しい読みではなく、発音としても不自然で母語話者は受け入れないため、正解は「ぼうえき」ただ一つ。", "en": "The correct answer 「ぼうえき」is the proper on'yomi of 「貿易」:「貿」is read 「ぼう」and 「易」is read 「えき」here.「ほうえき」unvoices the initial 「貿（ぼう）」into 「ほう」;「ぼうえぎ」voices the ending of 「易（えき）」into 「えぎ」;「ぼえき」drops the initial long vowel 「う」(ぼう→ぼ). None of the three distractors is a correct reading of 「貿易」and they sound unnatural too; a native speaker would not accept them, so the only correct answer is 「ぼうえき」." },
     exampleJapanese: "この国は外国との貿易で経済を支えています。",
-    exampleMeaningZh: "這個國家靠和外國的貿易支撐著經濟。"
+    exampleMeaningZh: "這個國家靠和外國的貿易支撐著經濟。",
+    exampleMeaningI18n: { "ja": "この国は、外国との取引によって経済を支えている。", "en": "This country's economy is supported by trade with other nations." },
   }),
   examQuestion({
     id: "n2-kanji-samatageru",
@@ -6691,7 +6727,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「さまたげる」是「妨げる」的正確訓讀。「さまたける」把語尾的濁音「げ」清音化成「け」；「さまだげる」把中間的「た」誤濁化成「だ」；「さまだける」同時犯了「た→だ」濁化與「げ→け」清音化兩個錯。三個干擾都不是這個動詞實際存在的讀法，母語者不會接受，故唯一正解為「さまたげる」。",
     explanationI18n: { "ja": "正解の「さまたげる」は「妨げる」の正しい訓読み。「さまたける」は語尾の濁音「げ」を清音化して「け」としたもの。「さまだげる」は途中の「た」を誤って濁音化し「だ」としたもの。「さまだける」は「た→だ」の濁音化と「げ→け」の清音化を同時に犯した誤り。三つの誤答はいずれもこの動詞に実在する読み方ではなく、母語話者は受け入れないため、正解は「さまたげる」ただ一つ。", "en": "The correct answer 「さまたげる」is the proper kun'yomi of 「妨げる」.「さまたける」unvoices the final 「げ」into 「け」;「さまだげる」wrongly voices the middle 「た」into 「だ」;「さまだける」makes both mistakes at once — voicing 「た→だ」and unvoicing 「げ→け」. None of the three distractors is an actual reading of this verb, and a native speaker would not accept them, so the only correct answer is 「さまたげる」." },
     exampleJapanese: "大きな音は子どもの睡眠を妨げることがあります。",
-    exampleMeaningZh: "很大的聲音有時會妨礙孩子的睡眠。"
+    exampleMeaningZh: "很大的聲音有時會妨礙孩子的睡眠。",
+    exampleMeaningI18n: { "ja": "大きな音は、子どもの眠りをじゃますることがある。", "en": "Loud noises can sometimes disturb a child's sleep." },
   }),
   examQuestion({
     id: "n2-syn-arakajime",
@@ -6713,7 +6750,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「あらかじめ」表示在事情發生之前就先做好，與「前もって（事先、預先）」語意最接近，代回「資料は前もって配っておいた」自然成立。「ただちに」是立刻、馬上，強調的是不拖延的即時性，而非事前準備，不成立。「やむをえず」是不得已、無可奈何地，帶有被迫的語感，與主動的事先準備不同，不成立。「思いがけず」是出乎意料地，與「事先計畫好」正好相反，語意不對。三個干擾都明確不同義，只有一解。",
     explanationI18n: { "ja": "「あらかじめ」は物事が起こる前に前もって済ませておくことを表し、「前もって（事前に・あらかじめ）」ともっとも意味が近い。「資料は前もって配っておいた」と置き換えても自然に成立する。「ただちに」は「すぐに・即座に」で、遅れずに対応する即時性を強調するもので、事前の準備とは異なり成立しない。「やむをえず」は「仕方なく」で、強いられた語感があり、自発的な事前準備とは違うので成立しない。「思いがけず」は「予想外に」で、「事前に計画しておく」とは正反対の意味となる。三つの誤答はいずれも明確に意味が異なり、正解は一つ。", "en": "「あらかじめ」means doing something ahead of time before an event, and is closest to 「前もって」(beforehand, in advance); substituting it, 「資料は前もって配っておいた」reads naturally. 「ただちに」means immediately/at once, stressing no delay rather than advance preparation, so it doesn't fit. 「やむをえず」means unavoidably/reluctantly, with a forced nuance, unlike proactive advance preparation, so it doesn't fit. 「思いがけず」means unexpectedly, the very opposite of planning ahead, so it's the wrong meaning. All three distractors clearly differ in meaning, so there is only one answer." },
     exampleJapanese: "会議で慌てないように、資料は前もって配っておいた。",
-    exampleMeaningZh: "為了在會議上不慌張，資料事先就發下去了。"
+    exampleMeaningZh: "為了在會議上不慌張，資料事先就發下去了。",
+    exampleMeaningI18n: { "ja": "会議で慌てないように、資料は事前に配っておいた。", "en": "To avoid any scrambling during the meeting, the materials were handed out in advance." },
   }),
   examQuestion({
     id: "n2-syn-omoni",
@@ -6735,7 +6773,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「主に」表示在整體當中佔最大比例、以此為中心，與「主として（主要、以……為主）」語意最接近，代回「主として自動車の部品を製造している」自然且意思相符。「たまに」是偶爾、頻率很低，與「主要、大量」相反，不成立。「今後は」是今後、從現在起，指未來時間，但句子描述的是現狀而非未來方針，不成立。「意外に」是出乎意料地，與比例多寡無關，語意完全不對。三個干擾都明確不同義，只有一解。",
     explanationI18n: { "ja": "「主に」は全体の中でもっとも大きな割合を占め、それを中心とすることを表し、「主として（主に・～を中心に）」ともっとも意味が近い。「主として自動車の部品を製造している」と置き換えても自然で意味も一致する。「たまに」は「時々・頻度が低い」で、「主に・大量に」とは逆であり成立しない。「今後は」は「これから」で未来の時間を指すが、文は現状を述べており未来の方針ではないので成立しない。「意外に」は「予想外に」で、割合の多寡とは無関係で意味がまったく合わない。三つの誤答はいずれも明確に意味が異なり、正解は一つ。", "en": "「主に」means making up the largest share of the whole, with that as the focus, and is closest to 「主として」(mainly, primarily); substituting it, 「主として自動車の部品を製造している」is natural and matches the meaning. 「たまに」means occasionally, at low frequency, the opposite of \"mainly, in large part,\" so it doesn't fit. 「今後は」means from now on, referring to future time, but the sentence describes the current state, not a future policy, so it doesn't fit. 「意外に」means unexpectedly, unrelated to proportion, and the meaning is completely off. All three distractors clearly differ in meaning, so there is only one answer." },
     exampleJapanese: "この工場では、主として自動車の部品を製造している。",
-    exampleMeaningZh: "這家工廠主要在製造汽車零件。"
+    exampleMeaningZh: "這家工廠主要在製造汽車零件。",
+    exampleMeaningI18n: { "ja": "この工場で製造しているのは、大部分が自動車の部品だ。", "en": "This factory mainly manufactures automobile parts." },
   }),
   examQuestion({
     id: "n2-syn-omoikiri",
@@ -6757,7 +6796,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「次第に」表示隨著時間一點一點地變化，與「だんだん」（逐漸、漸漸地）語意最接近，代回「痛みはだんだん和らいでいった」自然成立。「急に」是突然、一下子，與「逐漸」的緩慢過程相反，不成立。「すっかり」是完全、徹底地，強調結果的完成度而非過程的漸進，且與「いった」表示持續變化的語感不搭，不成立。「たまたま」是碰巧、偶然，與變化的快慢無關，語意完全不對。三個干擾都明確不同義，只有一解。",
     explanationI18n: { "ja": "「次第に」は時間とともに少しずつ変化していくことを表し、「だんだん（次第に・徐々に）」ともっとも意味が近い。「痛みはだんだん和らいでいった」と置き換えても自然に成立する。「急に」は「突然・一気に」で、「次第に」の緩やかな過程とは逆で成立しない。「すっかり」は「完全に・すっかり」で、過程の漸進性ではなく結果の完了度を強調し、継続的変化を表す「いった」とも合わないので成立しない。「たまたま」は「偶然・たまたま」で、変化の速さとは無関係で意味がまったく合わない。三つの誤答はいずれも明確に意味が異なり、正解は一つ。", "en": "「次第に」means changing bit by bit over time, and is closest to 「だんだん」(gradually, little by little); substituting it, 「痛みはだんだん和らいでいった」reads naturally. 「急に」means suddenly, all at once, the opposite of a slow, gradual process, so it doesn't fit. 「すっかり」means completely/thoroughly, stressing how finished the result is rather than a gradual process, and clashes with 「いった」's sense of ongoing change, so it doesn't fit. 「たまたま」means by chance/coincidentally, unrelated to the pace of change, and the meaning is completely off. All three distractors clearly differ in meaning, so there is only one answer." },
     exampleJapanese: "薬を飲み始めてから、痛みはだんだん和らいでいった。",
-    exampleMeaningZh: "開始吃藥之後，疼痛漸漸地緩和了下來。"
+    exampleMeaningZh: "開始吃藥之後，疼痛漸漸地緩和了下來。",
+    exampleMeaningI18n: { "ja": "薬を飲み始めてから、痛みは少しずつ和らいでいった。", "en": "After I started taking the medicine, the pain gradually eased." },
   }),
   examQuestion({
     id: "n2-usage-shimeru",
@@ -6779,7 +6819,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「占める」＝某事物在整體中佔有一定的比例或位置。正解句說海外輸出佔了公司營收一半以上的比例，搭配「売上の半分以上を」最自然，唯一成立。干擾一「本を段ボールに」要把書「裝進」紙箱，應用「詰めた」，「占めた」說不通；干擾二「ビルを」蓋大樓要用「建てる」，「占める」沒有「興建」之意；干擾三「考えをはっきりと」要表達意見應用「述べる／言う」，「占める」無此用法。三個干擾搭配皆不成立，故唯正解自然。",
     explanationI18n: { "ja": "「占める」＝あるものが全体の中で一定の割合や位置を占めること。正解の文は海外輸出が会社の売上の半分以上の割合を占めると述べており、「売上の半分以上を」と組み合わせるのがもっとも自然で唯一成立する。誤答一「本を段ボールに」は本を箱に「入れる」意なので「詰めた」を使うべきで、「占めた」は意味をなさない。誤答二「ビルを」は建物を建てるので「建てる」を使うべきで、「占める」に「建設する」の意はない。誤答三「考えをはっきりと」は意見を表明するので「述べる／言う」を使うべきで、「占める」にその用法はない。三つの誤答はいずれも結び付かず、正解だけが自然。", "en": "「占める」means that something takes up a certain proportion or position within a whole. The correct sentence says overseas exports account for more than half of the company's revenue, pairing most naturally with 「売上の半分以上を」— the only one that works. Distractor 1, packing books \"into\" a box, needs 「詰めた」;「占めた」makes no sense. Distractor 2, putting up a building, needs 「建てる」;「占める」has no \"construct\" meaning. Distractor 3, stating one's opinion clearly, needs 「述べる／言う」;「占める」has no such use. All three distractor collocations fail, so only the correct answer is natural." },
     exampleJapanese: "海外向けの輸出が、わが社の売上の半分以上を占めている。",
-    exampleMeaningZh: "面向海外的出口，佔了我們公司營收的一半以上。"
+    exampleMeaningZh: "面向海外的出口，佔了我們公司營收的一半以上。",
+    exampleMeaningI18n: { "ja": "海外への輸出が、会社の売上全体の半分以上に達している。", "en": "Exports to overseas markets account for more than half of our company's sales." },
   }),
   examQuestion({
     id: "n2-usage-tsumeru",
@@ -6801,7 +6842,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「詰める」＝把東西塞滿、裝進容器裡。正解句把飯和菜整齊地裝進便當盒，搭配「弁当箱に〜を」最自然，唯一成立。干擾一「約束の時間に」趕不上要用「間に合わなかった」，「詰めなかった」說不通；干擾二「温度を」調高溫度應用「上げた」，「詰めた」沒有調節之意；干擾三「資料を人数分」按人數準備份數應用「用意した／コピーした」，「詰めておいた」搭配不對。三個干擾皆不成立，故唯正解自然。",
     explanationI18n: { "ja": "「詰める」＝物を容器にぎっしり入れること。正解の文はご飯とおかずを弁当箱にきれいに入れるもので、「弁当箱に〜を」と組み合わせるのがもっとも自然で唯一成立する。誤答一「約束の時間に」は間に合わなかったなら「間に合わなかった」を使うべきで、「詰めなかった」は意味をなさない。誤答二「温度を」は温度を上げるなら「上げた」を使うべきで、「詰めた」に調節の意はない。誤答三「資料を人数分」は人数分そろえるなら「用意した／コピーした」を使うべきで、「詰めておいた」は結び付かない。三つの誤答はいずれも成立せず、正解だけが自然。", "en": "「詰める」means to pack things in to fill a container. The correct sentence, neatly packing rice and dishes into a lunch box, pairs most naturally with 「弁当箱に〜を」— the only one that works. Distractor 1, failing to make an agreed time, needs 「間に合わなかった」;「詰めなかった」makes no sense. Distractor 2, turning up the temperature, needs 「上げた」;「詰める」has no adjusting meaning. Distractor 3, preparing enough copies for everyone, needs 「用意した／コピーした」;「詰めておいた」is the wrong collocation. All three distractors fail, so only the correct answer is natural." },
     exampleJapanese: "母は弁当箱に、ご飯とおかずをきれいに詰めてくれた。",
-    exampleMeaningZh: "媽媽把飯和菜整整齊齊地裝進了便當盒。"
+    exampleMeaningZh: "媽媽把飯和菜整整齊齊地裝進了便當盒。",
+    exampleMeaningI18n: { "ja": "母が弁当箱に、ご飯とおかずをきれいに入れてくれた。", "en": "My mother neatly packed rice and side dishes into the lunch box for me." },
   }),
   examQuestion({
     id: "n2-usage-nakami",
@@ -6823,7 +6865,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「中身」＝容器或包裝裡面所裝的東西。正解句打開寄到的箱子，發現裡頭的東西全壞了，搭配「箱を開けたら〜が壊れて」最自然，唯一成立。干擾一「会議の」遲到要表達抵達晚了應用「会議に遅れて」，會議沒有「中身（內容物）」可遲到；干擾二「この道を」沿著路直走應用「道をまっすぐ」，路沒有「中身」；干擾三「部屋が暑い」房間裡面熱要用「部屋の中（なか）」，「中身」指裝入物而非空間內部。三個干擾皆不成立，故唯正解自然。",
     explanationI18n: { "ja": "「中身」＝容器や包装の中に入っているもの。正解の文は届いた箱を開けたら中のものが全部壊れていたというもので、「箱を開けたら〜が壊れて」と組み合わせるのがもっとも自然で唯一成立する。誤答一「会議の」は遅刻して到着したなら「会議に遅れて」と言うべきで、会議に遅れられる「中身（中に入っているもの）」はない。誤答二「この道を」は道に沿ってまっすぐ進むなら「道をまっすぐ」と言うべきで、道に「中身」はない。誤答三「部屋が暑い」は部屋の中が暑いなら「部屋の中（なか）」と言うべきで、「中身」は空間の内部ではなく入っているものを指す。三つの誤答はいずれも成立せず、正解だけが自然。", "en": "「中身」means the things held inside a container or package. The correct sentence, opening the delivered box to find everything inside broken, pairs most naturally with 「箱を開けたら〜が壊れて」— the only one that works. Distractor 1, arriving late to a meeting, needs 「会議に遅れて」; a meeting has no 「中身（contents）」to be late to. Distractor 2, going straight down a road, needs 「道をまっすぐ」; a road has no 「中身」. Distractor 3, the room being hot inside, needs 「部屋の中（なか）」;「中身」refers to what's packed in, not the interior space. All three distractors fail, so only the correct answer is natural." },
     exampleJapanese: "届いた箱を開けてみたら、中身がすっかり壊れていた。",
-    exampleMeaningZh: "打開寄到的箱子一看，裡頭的東西全都碎了。"
+    exampleMeaningZh: "打開寄到的箱子一看，裡頭的東西全都碎了。",
+    exampleMeaningI18n: { "ja": "届いた箱を開けてみたら、中に入っていた物がすっかり壊れていた。", "en": "When I opened the box that had arrived, the contents were completely broken." },
   }),
   examQuestion({
     id: "n2-context-suruto",
@@ -6885,7 +6928,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「あいまい」表示「含糊、不明確」，與「不明確（不清楚、不確定）」意思最接近，代入後句意通順：他的回答總是不明確。「厳しい（嚴格、嚴厲）」描述態度或標準苛刻，與「不明確」無關，不成立。「正直な（誠實坦率）」反而表示直率明白，與「あいまい」語意相反，不成立。「丁寧な（有禮貌、仔細）」描述態度恭敬周到，與是否明確無關，且後句「不知道他想怎樣」也無法銜接，不成立。",
     explanationI18n: { "ja": "「あいまい」は「はっきりしない・不明確」を表し、「不明確（はっきりしない・確かでない）」ともっとも意味が近く、置き換えても後続が通る（彼の返事はいつも不明確だ）。「厳しい（厳格・厳しい）」は態度や基準が厳しいことを表し、「不明確」とは無関係で成立しない。「正直な（正直で率直）」はむしろ率直で分かりやすいことを表し、「あいまい」とは反対の意味で成立しない。「丁寧な（礼儀正しい・入念）」は態度が丁寧であることを表し、明確かどうかとは無関係で、後続の「どうしたいのか分からない」ともつながらず成立しない。", "en": "「あいまい」means \"vague, unclear,\" closest to 「不明確」(indefinite, uncertain); substituting it, the sentence reads smoothly: his answers are always unclear. 「厳しい」(strict, harsh) describes a demanding attitude or standard, unrelated to \"unclear,\" so it doesn't fit. 「正直な」(honest, straightforward) actually suggests being direct and clear, the opposite of 「あいまい」, so it doesn't fit. 「丁寧な」(polite, careful) describes a courteous, thorough manner, unrelated to clarity, and can't connect to the follow-up \"can't tell what he wants,\" so it doesn't fit." },
     exampleJapanese: "彼の返事はいつも不明確で、結局どうしたいのか分からない。",
-    exampleMeaningZh: "他的回答總是不明確，到頭來搞不清楚他到底想怎樣。"
+    exampleMeaningZh: "他的回答總是不明確，到頭來搞不清楚他到底想怎樣。",
+    exampleMeaningI18n: { "ja": "彼の返事はいつもはっきりせず、結局どうしたいのか分からない。", "en": "His answers are always vague, so in the end you can't tell what he actually wants to do." },
   }),
   examQuestion({
     id: "n2-syn-toriaezu",
@@ -6907,7 +6951,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「とりあえず」表示「暫且、總之先」，與「ひとまず（暫且、先）」意思最接近，代入後句意自然：細節之後再談，總之先去吃飯。「ますます（越來越）」表程度遞增，無法搭配「先去吃飯」的提議，不成立。「せっかく（難得、特意）」表示好不容易的機會或費心，與「暫且」語意不同，代入後不自然，不成立。「いよいよ（終於、越發）」表示事態到了關鍵或最後階段，與「先暫時吃個飯」的隨意語感矛盾，不成立。",
     explanationI18n: { "ja": "「とりあえず」は「ひとまず・まず先に」を表し、「ひとまず（とりあえず・先に）」ともっとも意味が近く、置き換えても後続が自然（細かい話は後にして、ひとまず食事に行こう）。「ますます（だんだん強く）」は程度の増大を表し、「先に食事に行こう」という提案とは組み合わせられず成立しない。「せっかく（わざわざ・貴重な機会）」はなかなか得がたい機会や手間を表し、「とりあえず」とは意味が異なり、置き換えると不自然で成立しない。「いよいよ（ついに・ますます）」は事態が大詰めや最終段階に至ったことを表し、「先にひとまず食事でも」という気軽な語感と矛盾し成立しない。", "en": "「とりあえず」means \"for now, first of all,\" closest to 「ひとまず」(for now, first); substituting it, the sentence reads naturally: leave the details for later, for now let's go eat. 「ますます」(increasingly) marks a rising degree and can't pair with the suggestion \"let's go eat first,\" so it doesn't fit. 「せっかく」(with effort, specially) refers to a hard-won chance or trouble taken, different in meaning from \"for now,\" and reads unnaturally when substituted, so it doesn't fit. 「いよいよ」(finally, more and more) marks matters reaching a critical or final stage, contradicting the casual tone of \"let's just grab a quick bite for now,\" so it doesn't fit." },
     exampleJapanese: "細かい話は後にして、ひとまずみんなで食事に行こう。",
-    exampleMeaningZh: "細節之後再說，總之大家先去吃飯吧。"
+    exampleMeaningZh: "細節之後再說，總之大家先去吃飯吧。",
+    exampleMeaningI18n: { "ja": "細かい話は後にして、まずはみんなで食事に行こう。", "en": "Let's save the details for later — for now, let's all go get something to eat." },
   }),
   examQuestion({
     id: "n2-usage-hikiukeru",
@@ -6929,7 +6974,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解は「引き受ける（承擔／接下責任、工作）」。句意為「沒人想做的麻煩工作，他一人接了下來」，承擔工作的用法完全成立。干擾一「電車誤點趕不上約定時間」應用「遅れる／間に合わない」，「引き受けた」在此語意不通；干擾二「機器壞掉終於……」應用「壊れる／動かなくなる」，承擔不能描述機器故障；干擾三「把房間空氣換新」應用「入れ替える」，「引き受ける」不能表示更換。三者皆語意不成立，唯有第一句自然。",
     explanationI18n: { "ja": "正解は「引き受ける（責任・仕事を担う・引き受ける）」。文意は「誰もやりたがらない面倒な仕事を彼が一人で引き受けた」で、仕事を引き受ける用法が完全に成立する。誤答一「電車が遅れて約束の時間に」は「遅れる／間に合わない」を使うべきで、ここで「引き受けた」は意味が通らない。誤答二「機械が壊れてついに…」は「壊れる／動かなくなる」を使うべきで、引き受けるでは機械の故障を表せない。誤答三「部屋の空気を新しく」は「入れ替える」を使うべきで、「引き受ける」に交換の意はない。三つはいずれも意味が成立せず、最初の文だけが自然。", "en": "The correct answer is 「引き受ける」(to take on/take over a responsibility or job). The sentence means \"he took on, by himself, the troublesome job nobody wanted,\" and the usage of taking on work works perfectly. Distractor 1, missing an agreed time because the train was late, needs 「遅れる／間に合わない」;「引き受けた」makes no sense here. Distractor 2, a machine breaking down at last, needs 「壊れる／動かなくなる」; taking on can't describe a machine failing. Distractor 3, refreshing the room's air, needs 「入れ替える」;「引き受ける」can't mean to replace. All three fail in meaning, so only the first sentence is natural." },
     exampleJapanese: "誰もやりたがらない面倒な仕事を、彼が一人で引き受けてくれた。",
-    exampleMeaningZh: "沒人想做的麻煩工作，他一個人接了下來。"
+    exampleMeaningZh: "沒人想做的麻煩工作，他一個人接了下來。",
+    exampleMeaningI18n: { "ja": "誰もやりたがらない面倒な仕事を、彼が一人でやってくれることになった。", "en": "He single-handedly took on the troublesome job that nobody else wanted to do." },
   }),
   examQuestion({
     id: "n2-usage-omoikomu",
@@ -6951,7 +6997,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解是「思い込む（不加確認地深信、誤以為）」。句意為「他一口咬定考試是明天，結果記錯日子」，誤信導致出錯的用法成立。干擾一「把當天的事寫進日記」應用「書き込む／記録する」，「思い込む」不能表示寫入；干擾二「仔細思考後再作答」應用「考える／よく考えてから」，「思い込む」帶有主觀誤信之意、與冷靜思考相反；干擾三「認真考慮未來決定出路」應用「考える／思案する」，此處需要審慎權衡而非片面深信。三個干擾語意明確不對，僅第一句自然。",
     explanationI18n: { "ja": "正解は「思い込む（確かめずに信じ込む・勘違いする）」。文意は「彼は試験が明日だと思い込んでいて、日にちを間違えた」で、誤って信じ込んだ結果ミスをする用法が成立する。誤答一「その日にあったことを日記に」は「書き込む／記録する」を使うべきで、「思い込む」で書き込むことは表せない。誤答二「よく〜てから答えを出した」は「考える／よく考えてから」を使うべきで、「思い込む」は主観的な思い込みの意で、冷静に考えることとは逆。誤答三「将来のことを真剣に〜て進路を決めた」は「考える／思案する」を使うべきで、ここは慎重に検討することが必要で一方的に信じ込むことではない。三つの誤答は意味が明らかに合わず、最初の文だけが自然。", "en": "The correct answer is 「思い込む」(to be convinced without checking, to be mistakenly sure). The sentence means \"he was sure the exam was tomorrow and got the date wrong,\" and the usage of a mistaken belief leading to an error works. Distractor 1, writing the day's events in a diary, needs 「書き込む／記録する」;「思い込む」can't mean to write in. Distractor 2, thinking carefully before answering, needs 「考える／よく考えてから」;「思い込む」carries a nuance of subjective misbelief, the opposite of calm thought. Distractor 3, seriously considering the future to decide one's path, needs 「考える／思案する」; here you need careful weighing, not one-sided conviction. The three distractors are clearly wrong in meaning, so only the first sentence is natural." },
     exampleJapanese: "彼は試験が明日だと思い込んでいて、日にちを間違えてしまった。",
-    exampleMeaningZh: "他一口咬定考試是明天，結果把日子搞錯了。"
+    exampleMeaningZh: "他一口咬定考試是明天，結果把日子搞錯了。",
+    exampleMeaningI18n: { "ja": "彼は試験が明日だとすっかり信じていて、日にちを間違えてしまった。", "en": "He was convinced the exam was tomorrow and ended up getting the date wrong." },
   }),
   examQuestion({
     id: "n2-syn-isseini",
@@ -6973,7 +7020,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「いっせいに」指眾人在同一時間一起做出同一動作，與「同時に」（同時地）意思最接近，合図一響全部選手同一刻起跑。「順番に」是「依序、一個接一個」，與「同時」相反，選手若依序出發就不公平，語境不成立。「ひそかに」是「偷偷地、暗中」，起跑是公開動作，與情境完全不符。「次第に」是「漸漸地」，描述緩慢變化的過程，但起跑是瞬間動作，無法套用。故唯一正解為「同時に」。",
     explanationI18n: { "ja": "「いっせいに」は大勢が同じ時刻に一緒に同じ動作をすることを指し、「同時に（同時に）」ともっとも意味が近く、合図が鳴ると全選手が同じ瞬間にスタートする。「順番に」は「順を追って・一人ずつ」で、「同時に」とは逆であり、選手が順に出発したら不公平で文脈が成立しない。「ひそかに」は「こっそり・密かに」で、スタートは公然の動作であり場面にまったく合わない。「次第に」は「だんだんと」で、ゆるやかな変化の過程を表すが、スタートは瞬間的な動作なので当てはまらない。したがって正解は「同時に」ただ一つ。", "en": "「いっせいに」means many people doing the same action together at the same moment, closest to 「同時に」(simultaneously): the moment the signal sounds, all the runners start at once. 「順番に」means \"in turn, one after another,\" the opposite of \"at the same time\"; if the runners started in sequence it would be unfair, so it doesn't fit the context. 「ひそかに」means \"secretly, covertly,\" but starting a race is a public action and completely mismatches the scene. 「次第に」means \"gradually,\" describing a slow process of change, but a start is an instantaneous action, so it can't apply. Thus the only correct answer is 「同時に」." },
     exampleJapanese: "合図とともに、選手たちは同時に走り出した。",
-    exampleMeaningZh: "隨著信號，選手們同時起跑了。"
+    exampleMeaningZh: "隨著信號，選手們同時起跑了。",
+    exampleMeaningI18n: { "ja": "合図とともに、選手たちはそろって走り出した。", "en": "At the signal, the runners all took off at once." },
   }),
   examQuestion({
     id: "n2-syn-mekkiri",
@@ -6995,7 +7043,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「めっきり」用於描述變化幅度很大、變得很明顯，與「ずいぶん」（相當地、大幅地）意思最接近，表示天氣涼了很多。「わずかに」是「些微、只有一點點」，幅度小，與「めっきり」所強調的大幅變化相反。「たまたま」是「碰巧、偶然」，講的是事情發生的偶然性，而非變化的程度，語意方向不對。「やや」是「稍微」，程度輕微，同樣與「明顯、大幅」矛盾。故唯一正解為「ずいぶん」。",
     explanationI18n: { "ja": "「めっきり」は変化の幅が大きく、はっきりと変わった様子を表し、「ずいぶん（かなり・大きく）」ともっとも意味が近く、気温がかなり下がったことを表す。「わずかに」は「少しだけ・ほんの少し」で幅が小さく、「めっきり」が強調する大きな変化とは逆。「たまたま」は「偶然・たまたま」で、変化の程度ではなく物事の偶然性を述べるもので方向が違う。「やや」は「少し」で程度が軽く、これも「はっきり・大きく」とは矛盾する。したがって正解は「ずいぶん」ただ一つ。", "en": "「めっきり」describes a large, clearly noticeable degree of change, closest to 「ずいぶん」(considerably, greatly): the weather has turned much cooler. 「わずかに」means \"slightly, just a little,\" a small degree, the opposite of the large change 「めっきり」stresses. 「たまたま」means \"by chance, coincidentally,\" about the randomness of an event rather than the degree of change, so the meaning heads the wrong way. 「やや」means \"somewhat,\" a slight degree, likewise contradicting \"marked, large-scale.\" Thus the only correct answer is 「ずいぶん」." },
     exampleJapanese: "十月に入ってから、朝晩はずいぶん涼しくなった。",
-    exampleMeaningZh: "進入十月後，早晚變得相當涼了。"
+    exampleMeaningZh: "進入十月後，早晚變得相當涼了。",
+    exampleMeaningI18n: { "ja": "十月に入ってから、朝晩はかなり涼しくなった。", "en": "Since October began, the mornings and evenings have turned noticeably cooler." },
   }),
   examQuestion({
     id: "n2-syn-dounika",
@@ -7017,7 +7066,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「どうにか」指經過一番努力、勉強設法達成某事，與「なんとか」（好不容易、設法）意思最接近，表示趕在截止前勉強寫完。「まったく」後接否定才成立（まったく〜ない），且意為「完全（不）」，在肯定句「書き上げた」前語意是「完全寫好」，與「勉強完成」的吃力感矛盾。「すっかり」是「完全、徹底」，強調毫無剩餘地完成，缺少「勉強、好不容易」的語感，與情境的緊迫吃力不符。「うっかり」是「不小心、疏忽地」，帶失誤義，把報告「不小心寫完」不合邏輯。故唯一正解為「なんとか」。",
     explanationI18n: { "ja": "「どうにか」は苦労を重ねて、なんとか物事をやり遂げることを指し、「なんとか（どうにか・やっとのことで）」ともっとも意味が近く、締め切り前になんとか書き上げたことを表す。「まったく」は否定を伴って初めて成立し（まったく〜ない）、意味も「完全に（〜ない）」で、肯定文「書き上げた」の前では「完全に書き上げた」となり、「苦労して仕上げた」大変さと矛盾する。「すっかり」は「完全に・すっかり」で、残らずやり終えたことを強調し、「なんとか・やっとのことで」の語感を欠くため、切迫した苦労の状況に合わない。「うっかり」は「不注意で・うっかり」で失敗の意を含み、報告書を「うっかり書き上げた」では筋が通らない。したがって正解は「なんとか」ただ一つ。", "en": "「どうにか」means managing to accomplish something with some effort, just barely, closest to 「なんとか」(somehow, managing to): finishing the report just in time before the deadline. 「まったく」only works with a negative (まったく〜ない) and means \"completely (not)\"; before the affirmative 「書き上げた」it would mean \"completely finished,\" contradicting the strained sense of \"barely managed.\" 「すっかり」means \"completely, thoroughly,\" stressing finishing with nothing left, lacking the \"barely, with effort\" nuance and not matching the pressured, difficult situation. 「うっかり」means \"carelessly, absentmindedly,\" with a sense of slip-up; finishing a report \"by accident\" is illogical. Thus the only correct answer is 「なんとか」." },
     exampleJapanese: "締め切りぎりぎりだったが、報告書をなんとか書き上げた。",
-    exampleMeaningZh: "雖然快到截止時間了，但好不容易把報告寫完了。"
+    exampleMeaningZh: "雖然快到截止時間了，但好不容易把報告寫完了。",
+    exampleMeaningI18n: { "ja": "締め切りぎりぎりだったが、やっとのことで報告書を書き上げた。", "en": "It was right down to the deadline, but I somehow managed to finish writing the report." },
   }),
   examQuestion({
     id: "n2-usage-kigasumu",
@@ -7039,7 +7089,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解は「気が済む（做到自己能接受的程度才安心、罷休）」。句意為「他不親自確認到最後就無法罷休的個性」，描述非做到滿意不肯停手，用法完全成立。干擾一「天氣好就想出去散步」表心情上想做某事，應用「気が向く（一時興起想做）」，「気が済む」無法表示興致，不成立。干擾二「看似難的工作，漸漸湧起想試試的念頭」應用「気が進む／やる気が出る」，「気が済む」不能表示意願上升，不成立。干擾三「長會結束終於……」要表示緊張鬆懈，應用「気が緩む／緊張がほぐれる」，「緊張が気が済む」搭配不通，不成立。三個干擾語意明確不對，僅第一句自然。",
     explanationI18n: { "ja": "正解は「気が済む（自分の納得する程度までやって安心する・満足する）」。文意は「彼は自分で最後まで確認しないと気が済まない性格だ」で、満足するまでやらないと止められない様子を表し、用法が完全に成立する。誤答一「天気がいい日は外を散歩したいと」は気分的に何かしたい意で、「気が向く（ふと〜したくなる）」を使うべきで、「気が済む」に意欲の意はなく成立しない。誤答二「難しそうな仕事だがやってみようと」は「気が進む／やる気が出る」を使うべきで、「気が済む」は意欲の高まりを表せず成立しない。誤答三「長い会議が終わってようやく…」は緊張がほぐれる意で「気が緩む／緊張がほぐれる」を使うべきで、「緊張が気が済む」は結び付かず成立しない。三つの誤答は意味が明らかに合わず、最初の文だけが自然。", "en": "The correct answer is 「気が済む」(to feel at ease/satisfied only after doing something to a degree one accepts). The sentence means \"he's the type who can't rest until he checks everything to the end himself,\" describing not stopping until satisfied — the usage works perfectly. Distractor 1, wanting to walk outside on a nice day, expresses a passing urge to do something and needs 「気が向く」(to feel like doing on a whim);「気が済む」can't express such an impulse, so it doesn't fit. Distractor 2, gradually feeling like trying a job that looks hard, needs 「気が進む／やる気が出る」;「気が済む」can't express rising motivation, so it doesn't fit. Distractor 3, tension finally easing after a long meeting, needs 「気が緩む／緊張がほぐれる」;「緊張が気が済む」is an unworkable collocation, so it doesn't fit. The three distractors are clearly wrong in meaning, so only the first sentence is natural." },
     exampleJapanese: "彼は自分で最後まで確認しないと気が済まない性格だ。",
-    exampleMeaningZh: "他是那種不親自確認到最後就靜不下心的個性。"
+    exampleMeaningZh: "他是那種不親自確認到最後就靜不下心的個性。",
+    exampleMeaningI18n: { "ja": "彼は、自分で最後まで確認しないと落ち着かない性格だ。", "en": "He's the type who can't rest easy unless he checks everything through to the end himself." },
   }),
   examQuestion({
     id: "n2-usage-uchikesu",
@@ -7061,7 +7112,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解は「打ち消す（否認、極力否定；消除謠言、念頭）」。句意為「他斬釘截鐵地否認了要辭職的傳聞」，否定流言的用法完全成立。干擾一「煩惱許久後把真心話告訴朋友」是吐露心聲，應用「打ち明ける（坦白傾訴）」，「打ち消す」反而是否定、抹去，與說出真心話矛盾，不成立。干擾二「兩人就下週行程仔細……」是事前商量，應用「打ち合わせる（事前商議）」，「打ち消す」不能表示討論，不成立。干擾三「訂錯了趕緊……」要表示取消預約，應用「取り消す（取消）」，「打ち消す」用於否定言論而非撤銷手續，不成立。三個干擾語意明確不對，僅第一句自然。",
     explanationI18n: { "ja": "正解は「打ち消す（否定する、強く打ち消す。うわさや思いを消す）」。文意は「彼は退職するといううわさをきっぱりと否定した」で、流言を否定する用法として完全に成立します。誤答1「悩んだ末に本当の気持ちを友人に打ち消した」は心の内を吐露する場面で、「打ち明ける（本心を打ち明ける）」を使うべきところ。「打ち消す」はむしろ否定して消す意味なので、本心を語ることと矛盾し不適切です。誤答2「二人で来週の予定について細かく打ち消した」は事前の相談で、「打ち合わせる（事前に相談する）」を使うべきところ。「打ち消す」は話し合いを表せず不適切です。誤答3「予約を間違えたので急いで打ち消した」は予約の取り消しなので「取り消す（キャンセルする）」を使うべきところ。「打ち消す」は発言を否定する語で手続きの撤回には使えず不適切です。三つの誤答はいずれも意味がはっきり合わず、自然なのは最初の文だけです。", "en": "The answer is 「打ち消す」 (to deny, to flatly refute; to dispel a rumor or a thought). The sentence means \"He flatly denied the rumor that he was going to resign,\" and using it to refute a rumor works perfectly. Distractor 1, \"after much worry, he told his true feelings to a friend,\" is about opening up, which calls for 「打ち明ける」 (to confide, to speak frankly); 「打ち消す」 means the opposite—to deny or erase—so it contradicts confessing true feelings and doesn't work. Distractor 2, \"the two of them ... in detail about next week's schedule,\" is discussing something in advance, which calls for 「打ち合わせる」 (to arrange beforehand); 「打ち消す」 cannot express discussing, so it doesn't work. Distractor 3, \"since I booked it by mistake, I hurriedly ...,\" needs to express cancelling a reservation, which calls for 「取り消す」 (to cancel); 「打ち消す」 is used to refute a statement, not to cancel a procedure, so it doesn't work. All three distractors are clearly wrong in meaning, and only the first sentence is natural." },
     exampleJapanese: "彼は退職するといううわさをきっぱりと打ち消した。",
-    exampleMeaningZh: "他斬釘截鐵地否認了自己要辭職的傳聞。"
+    exampleMeaningZh: "他斬釘截鐵地否認了自己要辭職的傳聞。",
+    exampleMeaningI18n: { "ja": "彼は、退職するといううわさをきっぱりと否定した。", "en": "He flatly denied the rumor that he was going to resign." },
   }),
   examQuestion({
     id: "n2-grammar-tatanai",
@@ -7123,7 +7175,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「瞬く間に」指極短的時間內、轉眼就完成或消失，與「あっという間に」（一眨眼的工夫）同義。「今のうちに」是趁現在還來得及，指未來的時機而非已發生的迅速；「知らないうちに」是不知不覺、強調未察覺的過程而非速度之快；「それを限りに」是以那為界限、從此之後，表轉折時點，皆與「轉眼消失」不符。",
     explanationI18n: { "ja": "「瞬く間に」はごく短い時間で、あっという間に完了したり消えたりすることを指し、「あっという間に（まばたきするほどの短い間に）」と同義です。「今のうちに」は今ならまだ間に合ううちに、という未来の好機を指し、すでに起きた素早さではありません。「知らないうちに」はいつの間にか、という気づかない過程を強調するもので、速さそのものではありません。「それを限りに」はそれを区切りとして、それ以降、という転換の時点を表し、いずれも「あっという間に消える」とは合いません。", "en": "「瞬く間に」 refers to something being completed or vanishing within an extremely short time, in the blink of an eye—synonymous with 「あっという間に」 (in the time it takes to say \"ah\"). 「今のうちに」 means \"while there's still time now,\" pointing to a future opportunity rather than something that has already happened quickly; 「知らないうちに」 means \"before you know it,\" stressing an unnoticed process rather than the speed; 「それを限りに」 means \"as of that point, from then on,\" marking a turning point in time—none of these fit \"vanishing in an instant.\"" },
     exampleJapanese: "夜空に大きく開いた花火は、あっという間に消えて、後には煙だけが残った。",
-    exampleMeaningZh: "在夜空大大綻放的花火，一眨眼就消失了，之後只留下了煙。"
+    exampleMeaningZh: "在夜空大大綻放的花火，一眨眼就消失了，之後只留下了煙。",
+    exampleMeaningI18n: { "ja": "夜空に大きく開いた花火は、一瞬で消えて、後には煙だけが残った。", "en": "The fireworks that bloomed wide across the night sky vanished in the blink of an eye, leaving only smoke behind." },
   }),
   examQuestion({
     id: "n2-syn-omokage",
@@ -7145,7 +7198,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "此處「面影」指留存於記憶或浮現眼前的某人從前的身影、模樣，與「昔の姿」（過去的身影、舊時的樣子）最接近，明確帶「往昔、記憶中」的時間感。「足音」是腳步聲，屬聽覺上的跡象，並非浮現眼前的視覺形象，語意不同；「正体」是真面目、真實身分，語意完全不同；「見込み」是預期、可能性，指對未來的估計，皆不合「追尋記憶中身影」之意。",
     explanationI18n: { "ja": "ここでの「面影」は、記憶に残っていたり目の前に浮かんだりする、ある人の昔の姿・様子を指し、「昔の姿（過去の姿、かつての面影）」に最も近く、明らかに「昔・記憶の中」という時間の感覚を帯びています。「足音」は歩く音で、聴覚上の気配であり、目の前に浮かぶ視覚的なイメージではないので意味が異なります。「正体」は本当の姿・素性で、意味が全く異なります。「見込み」は見通し・可能性で、未来の予測を指し、いずれも「記憶の中の姿を探し求める」意味には合いません。", "en": "Here 「面影」 refers to someone's former figure or appearance that lingers in memory or surfaces before one's eyes, closest to 「昔の姿」 (a figure from the past, one's former appearance), clearly carrying the sense of \"bygone days, in memory.\" 「足音」 means footsteps, an auditory trace rather than a visual image that surfaces before the eyes, so the meaning differs; 「正体」 means true nature or true identity, a completely different meaning; 「見込み」 means expectation or possibility, an estimate about the future—none of these fit \"searching for a figure in memory.\"" },
     exampleJapanese: "あの夏、二人で見上げた光の中に、今でも君の昔の姿を探してしまう。",
-    exampleMeaningZh: "在那年夏天兩人一起仰望的光裡，至今我仍會不由得尋找你昔日的身影。"
+    exampleMeaningZh: "在那年夏天兩人一起仰望的光裡，至今我仍會不由得尋找你昔日的身影。",
+    exampleMeaningI18n: { "ja": "あの夏、二人で見上げた光の中に、今でも君のかつての姿を探してしまう。", "en": "Even now, in the light we looked up at together that summer, I catch myself searching for traces of the you I once knew." },
   }),
   examQuestion({
     id: "n2-usage-akogareru",
@@ -7167,7 +7221,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解は「あんなふうに自然体でいられる彼女に、私はずっと憧れていた」。「憧れる」は理想とする人や姿に強く心が引かれる意味で、対象を助詞「に」で受けるこの文がもっとも自然。選択肢2は劣等感や落ち込みを表す文脈で、対象への肯定的な引かれを表す「憧れる」とは語意が逆で不自然。選択肢3は本来「ためらう／ひるむ」と言うべき場面で、「憧れる」では行動をためらう意味にならず誤り。選択肢4は無生物の自然現象に対して使っており、しかも「濡れる」結果ともつながらず意味が通らない。よって正しく使えているのは選択肢1のみ。",
     explanationI18n: { "ja": "正解は「あんなふうに自然体でいられる彼女に、私はずっと憧れていた」。「憧れる」は理想とする人や姿に強く心が引かれる意味で、対象を助詞「に」で受けるこの文がもっとも自然。選択肢2は劣等感や落ち込みを表す文脈で、対象への肯定的な引かれを表す「憧れる」とは語意が逆で不自然。選択肢3は本来「ためらう／ひるむ」と言うべき場面で、「憧れる」では行動をためらう意味にならず誤り。選択肢4は無生物の自然現象に対して使っており、しかも「濡れる」結果ともつながらず意味が通らない。よって正しく使えているのは選択肢1のみ。", "en": "The answer is 「あんなふうに自然体でいられる彼女に、私はずっと憧れていた」. 「憧れる」 means to be strongly drawn to a person or figure one holds as an ideal, and this sentence, which takes the object with the particle 「に」, is the most natural. Option 2 is in a context of inferiority and feeling down; that is the opposite of the positive attraction 「憧れる」 expresses, so it's unnatural. Option 3 is a situation where one should say 「ためらう／ひるむ」 (to hesitate / to flinch); 「憧れる」 doesn't mean to hesitate to act, so it's wrong. Option 4 uses it toward an inanimate natural phenomenon, and it doesn't even connect to the result 「濡れる」, so it makes no sense. Thus the only sentence that uses it correctly is Option 1." },
     exampleJapanese: "あんなふうに自然体でいられる彼女に、私はずっと憧れていた。",
-    exampleMeaningZh: "我一直很嚮往她那種能自然做自己的樣子。"
+    exampleMeaningZh: "我一直很嚮往她那種能自然做自己的樣子。",
+    exampleMeaningI18n: { "ja": "あんなふうに自然体でいられる彼女のようになりたいと、私はずっと思っていた。", "en": "I've always admired the way she can be so naturally herself." },
   }),
   examQuestion({
     id: "n2-usage-tamerau",
@@ -7189,7 +7244,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解は「送信ボタンを押そうとして、嫌われたらと思うとためらってしまった」。「ためらう」は迷って行動に踏み切れない心の動きを表し、不安から決断できないこの文がもっとも自然。選択肢2は気持ちが楽になり前向きになる文脈で、迷いを表す「ためらう」とは方向が逆で不自然。選択肢3は本来「走る／急ぐ」と言うべき移動の場面で、「ためらう」では全力で移動する意味にならず誤り。選択肢4は「開ける」と言うべきところで、窓を対象に「ためらう」とは言えず意味が通らない。したがって自然に使えているのは選択肢1のみ。",
     explanationI18n: { "ja": "正解は「送信ボタンを押そうとして、嫌われたらと思うとためらってしまった」。「ためらう」は迷って行動に踏み切れない心の動きを表し、不安から決断できないこの文がもっとも自然。選択肢2は気持ちが楽になり前向きになる文脈で、迷いを表す「ためらう」とは方向が逆で不自然。選択肢3は本来「走る／急ぐ」と言うべき移動の場面で、「ためらう」では全力で移動する意味にならず誤り。選択肢4は「開ける」と言うべきところで、窓を対象に「ためらう」とは言えず意味が通らない。したがって自然に使えているのは選択肢1のみ。", "en": "The answer is 「送信ボタンを押そうとして、嫌われたらと思うとためらってしまった」. 「ためらう」 describes the inner state of wavering and being unable to take the plunge into action, and this sentence—unable to decide out of anxiety—is the most natural. Option 2 is a context of feeling lighter and turning positive, the opposite direction from the wavering 「ためらう」 expresses, so it's unnatural. Option 3 is a scene of movement where one should say 「走る／急ぐ」 (to run / to hurry); 「ためらう」 doesn't mean to move at full speed, so it's wrong. Option 4 should use 「開ける」 (to open); you can't say 「ためらう」 with a window as its object, so it makes no sense. Therefore the only sentence that uses it naturally is Option 1." },
     exampleJapanese: "送信ボタンを押そうとして、嫌われたらと思うとためらってしまった。",
-    exampleMeaningZh: "正要按下傳送鍵,一想到會不會被討厭就猶豫了起來。"
+    exampleMeaningZh: "正要按下傳送鍵,一想到會不會被討厭就猶豫了起來。",
+    exampleMeaningI18n: { "ja": "送信ボタンを押そうとしたが、嫌われたらどうしようと思うと、なかなか押せなくなってしまった。", "en": "Just as I was about to hit the send button, the thought that I might be disliked made me hesitate." },
   }),
   examQuestion({
     id: "n2-grammar-tehajimete",
@@ -7251,7 +7307,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「思わず」是「沒有意圖、身體先於意識反應」之意，最接近的是同樣表「不知不覺、忍不住」的「つい」。「わざと」(故意)與「あえて」(刻意、明知仍為之)都帶意圖性，與無意識相反；「ようやく」(好不容易、終於)是時間上的勉強達成，意思完全不同。",
     explanationI18n: { "ja": "「思わず」は「意図せず、意識よりも先に体が反応する」意味で、最も近いのは同じく「知らず知らず、ついつい」を表す「つい」です。「わざと（故意に）」と「あえて（あえて、承知の上でする）」はどちらも意図性を帯び、無意識とは逆です。「ようやく（やっと、ついに）」は時間的にどうにか達成することで、意味が全く異なります。", "en": "「思わず」 means \"without intent, the body reacting before the mind,\" and the closest match is 「つい」, which likewise means \"before one knows it, can't help it.\" 「わざと」 (on purpose) and 「あえて」 (deliberately, knowingly doing so anyway) both carry intent, the opposite of being unconscious; 「ようやく」 (finally, with difficulty) is a hard-won achievement in terms of time, an entirely different meaning." },
     exampleJapanese: "あの人の横顔を見たとたん、つい息をのんでしまった。",
-    exampleMeaningZh: "看到那人側臉的瞬間，忍不住屏住了呼吸。"
+    exampleMeaningZh: "看到那人側臉的瞬間，忍不住屏住了呼吸。",
+    exampleMeaningI18n: { "ja": "あの人の横顔を見たとたん、無意識のうちに息をのんでしまった。", "en": "The moment I saw that person's profile, I couldn't help but catch my breath." },
   }),
   examQuestion({
     id: "n2-syn-nomerikomu",
@@ -7273,7 +7330,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「のめり込む」指失去分寸地沉溺、深陷，最接近「夢中になる」(著迷、入迷到忘我)。「我に返る」(回過神來)是脫離沉迷的相反方向；「うんざりする」(厭煩)與「見飽きる」(看膩)都是失去興趣，與越陷越深正好相反。",
     explanationI18n: { "ja": "「のめり込む」は節度を失って溺れ、深く入り込むことを指し、最も近いのは「夢中になる（我を忘れるほど熱中する）」です。「我に返る（正気に戻る）」は夢中から抜け出す逆の方向です。「うんざりする（うんざりする）」と「見飽きる（見飽きる）」はどちらも興味を失うことで、ますます深く入り込むのとはちょうど逆です。", "en": "「のめり込む」 means to be immersed and sink deep without a sense of measure, closest to 「夢中になる」 (to be so absorbed one loses oneself). 「我に返る」 (to come to one's senses) is the opposite direction, snapping out of immersion; 「うんざりする」 (to be fed up) and 「見飽きる」 (to grow tired of looking) both mean losing interest, the exact opposite of sinking ever deeper." },
     exampleJapanese: "気づいたときには、私はその人の歌声に夢中になっていた。",
-    exampleMeaningZh: "回過神來時，我已經深深著迷於那個人的歌聲了。"
+    exampleMeaningZh: "回過神來時，我已經深深著迷於那個人的歌聲了。",
+    exampleMeaningI18n: { "ja": "気づいたときには、私はその人の歌声にすっかり心を奪われていた。", "en": "Before I knew it, I had become utterly captivated by that person's singing voice." },
   }),
   examQuestion({
     id: "n2-grammar-makani",
@@ -7375,7 +7433,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「かけがえのない」是「無可取代、再也找不到第二個」之意，最接近「代わりのない（沒有替代品的）」，兩者都強調獨一無二、不可替換。「ありふれた」是「常見、不稀奇」屬反義；「あいまいな」是「模糊不清」與珍貴無關；「わずかな」是「少量、些微」也不成立。故唯一正解為「代わりのない」。",
     explanationI18n: { "ja": "「かけがえのない」は「取り換えがきかない、二つとない」という意味で、最も近いのは「代わりのない（代わりがない）」であり、どちらも唯一無二で取り換えられないことを強調します。「ありふれた」は「よくある、珍しくない」で反対の意味です。「あいまいな」は「はっきりしない」で大切さとは関係ありません。「わずかな」は「少量、わずかな」でこれも成立しません。よって唯一の正解は「代わりのない」です。", "en": "「かけがえのない」 means \"irreplaceable, impossible to find another,\" closest to 「代わりのない」 (having no substitute); both stress being one-of-a-kind and irreplaceable. 「ありふれた」 means \"common, unremarkable,\" an antonym; 「あいまいな」 means \"vague, unclear,\" unrelated to preciousness; 「わずかな」 means \"a small amount, slight,\" which also doesn't work. So the only correct answer is 「代わりのない」." },
     exampleJapanese: "夏の終わりに交わしたあの約束は、今でも私にとって代わりのない宝物だ。",
-    exampleMeaningZh: "在夏天結束時許下的那個約定，至今對我而言仍是無可取代的寶物。"
+    exampleMeaningZh: "在夏天結束時許下的那個約定，至今對我而言仍是無可取代的寶物。",
+    exampleMeaningI18n: { "ja": "夏の終わりに交わしたあの約束は、今でも私にとって何ものにも代えられない宝物だ。", "en": "That promise we exchanged at the end of summer is still an irreplaceable treasure to me." },
   }),
   examQuestion({
     id: "n2-vocab-miren",
@@ -7535,7 +7594,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「歳」音讀為「さい」(濁音「ざい」不成立),「月」在此熟語讀「げつ」。「さいけつ」缺濁音、「ざいげつ」首音誤濁、「せいげつ」首母音誤作え段,皆非此詞讀音,故唯一正解為「さいげつ」。",
     explanationI18n: { "ja": "「歳」の音読みは「さい」（濁音の「ざい」は成立しません）、「月」はこの熟語では「げつ」と読みます。「さいけつ」は濁音が抜け、「ざいげつ」は最初の音を誤って濁らせ、「せいげつ」は最初の母音を誤ってえ段にしており、いずれもこの語の読み方ではないため、唯一の正解は「さいげつ」です。", "en": "「歳」 is read 「さい」 in on'yomi (the voiced 「ざい」 doesn't work), and 「月」 in this compound is read 「げつ」. 「さいけつ」 lacks the voicing, 「ざいげつ」 wrongly voices the first sound, and 「せいげつ」 mistakes the first vowel for the え-row—none are the correct reading of this word, so the only correct answer is 「さいげつ」." },
     exampleJapanese: "あの坂道を上らなくなってから長い歳月が過ぎ、気づけば景色のほうが先に変わっていた。",
-    exampleMeaningZh: "自從不再走那條坡道後,漫長的歲月已然流逝,回過神來,反倒是景色先變了。"
+    exampleMeaningZh: "自從不再走那條坡道後,漫長的歲月已然流逝,回過神來,反倒是景色先變了。",
+    exampleMeaningI18n: { "ja": "あの坂道を上らなくなってから長い年月が過ぎ、気づけば景色のほうが先に変わっていた。", "en": "Long years have passed since I stopped climbing that hill road, and before I knew it, the scenery had changed before I did." },
   }),
   examQuestion({
     id: "n2-kanji-aseri",
@@ -7555,7 +7615,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "動詞「焦る」的名詞形為「あせり」。「あぜり」中間誤濁、「あっせり」誤加促音、「あせい」尾音誤作い段,皆不成立,故唯一正解為「あせり」。",
     explanationI18n: { "ja": "動詞「焦る」の名詞形が「あせり」です。「あぜり」は中間を誤って濁らせ、「あっせり」は誤って促音を加え、「あせい」は末尾の音を誤ってい段にしており、いずれも成立しないため、唯一の正解は「あせり」です。", "en": "The noun form of the verb 「焦る」 is 「あせり」. 「あぜり」 wrongly voices the middle sound, 「あっせり」 wrongly adds a geminate consonant, and 「あせい」 mistakes the final sound for the い-row—none work, so the only correct answer is 「あせり」." },
     exampleJapanese: "周りが先へ進んでいく音だけが耳に残り、誰にも言えない焦りが静かに胸を満たしていった。",
-    exampleMeaningZh: "只有旁人不斷向前的聲響留在耳邊,一種無法對任何人說出口的焦急,靜靜地充滿了心頭。"
+    exampleMeaningZh: "只有旁人不斷向前的聲響留在耳邊,一種無法對任何人說出口的焦急,靜靜地充滿了心頭。",
+    exampleMeaningI18n: { "ja": "周りの人たちが先へ進んでいく気配だけが耳に残り、誰にも打ち明けられない焦る気持ちが、静かに胸に広がっていった。", "en": "Only the sound of everyone else moving on ahead lingered in my ears, as an impatience I couldn't confess to anyone quietly filled my heart." },
   }),
   examQuestion({
     id: "n2-grammar-hodonai",
@@ -7597,7 +7658,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「切ない」指因思念或失落而胸口發酸、難以排解的悲傷;「やるせない」同樣表示這種無處宣洩、揪心難受的鬱悶悲傷,語感最接近。「そっけない」是冷淡、不近人情;「あつかましい」是厚臉皮、不知羞恥;「たのもしい」是可靠、令人安心——三者在這種對逝去戀情的心痛語境中都明顯不成立。",
     explanationI18n: { "ja": "「切ない」は、思いや喪失感から胸が締めつけられ、どうにも晴らせない悲しみを指します。「やるせない」も同じく、行き場のない、胸が締めつけられるようなやりきれない悲しみを表し、語感が最も近い一語です。「そっけない」は冷淡でよそよそしい、「あつかましい」は図々しく恥知らず、「たのもしい」は頼りがいがあり安心できるという意味で、この過ぎ去った恋への切なさの文脈ではいずれも明らかに成り立ちません。", "en": "「切ない」describes a stinging, hard-to-shake sadness in the chest brought on by longing or loss; 「やるせない」likewise expresses that pent-up, wrenching sorrow with no outlet, making it the closest in nuance. 「そっけない」means cold and standoffish; 「あつかましい」means brazen and shameless; 「たのもしい」means dependable and reassuring — all three clearly fail in this context of aching over a lost love." },
     exampleJapanese: "もう終わった恋なのに、君の名前を見るだけで「やるせなく」なる。",
-    exampleMeaningZh: "明明是已經結束的戀情,光是看到你的名字就覺得難受得無處宣洩。"
+    exampleMeaningZh: "明明是已經結束的戀情,光是看到你的名字就覺得難受得無處宣洩。",
+    exampleMeaningI18n: { "ja": "もう終わった恋なのに、君の名前を見るだけで、どこにもぶつけようのない苦しい気持ちになる。", "en": "The romance is already over, and yet just seeing your name fills me with a helpless ache." },
   }),
   examQuestion({
     id: "n2-kanji-mabushii",
@@ -7617,7 +7679,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「眩しい」形容光芒耀眼刺目,讀作「まぶしい」。干擾項「まずしい」是「貧しい」(貧窮),語意與耀眼星光相反、不成立;「まふしい」為清音化近形、「まぼしい」為母音偏移近形,二者均非實際讀音。流星發光的語境下唯有「まぶしい」成立。",
     explanationI18n: { "ja": "「眩しい」は光がまばゆく目を射るさまを表し、「まぶしい」と読みます。ほかの選択肢のうち「まずしい」は「貧しい」で、まばゆい星の光とは正反対の意味となって成り立たず、「まふしい」は清音化した近似形、「まぼしい」は母音がずれた近似形で、いずれも実際の読みではありません。流れ星が光る文脈では「まぶしい」だけが成り立ちます。", "en": "「眩しい」describes light that is dazzling and blinding, and is read「まぶしい」. The distractor「まずしい」is「貧しい」(poor), whose meaning is the opposite of dazzling starlight and doesn't work; 「まふしい」is a devoiced near-form and「まぼしい」is a vowel-shifted near-form, neither of which is a real reading. In the context of a shining shooting star, only「まぶしい」works." },
     exampleJapanese: "流れ星があまりに眩しいから、願いごとも忘れてしまうのだろう。",
-    exampleMeaningZh: "流星太過耀眼,大概連要許的願望都忘了吧。"
+    exampleMeaningZh: "流星太過耀眼,大概連要許的願望都忘了吧。",
+    exampleMeaningI18n: { "ja": "流れ星があまりに明るく強く輝いているから、肝心の願いごとまで忘れてしまうのだろう。", "en": "The shooting star is so dazzling that I'll probably even forget the wish I meant to make." },
   }),
   examQuestion({
     id: "n2-kanji-awai",
@@ -7637,7 +7700,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「淡い」形容光線淡薄柔和,讀作「あわい」。干擾項「あさい」是「浅い」(淺)、「あらい」是「荒い／粗い」(粗糙),皆非此字讀音且語意不合;「うすい」是「薄い」的讀音、非「淡」字,亦不成立。籠罩般的微光只接受「あわい」。",
     explanationI18n: { "ja": "「淡い」は光がうすくやわらかいさまを表し、「あわい」と読みます。ほかの選択肢のうち「あさい」は「浅い」、「あらい」は「荒い／粗い」で、どちらもこの字の読みではなく意味も合いません。「うすい」は「薄い」の読みで「淡」の字の読みではなく、これも成り立ちません。包み込むようなほのかな光には「あわい」だけがふさわしいです。", "en": "「淡い」describes light that is faint and soft, and is read「あわい」. The distractor「あさい」is「浅い」(shallow) and「あらい」is「荒い／粗い」(rough); neither is the reading of this character and neither fits the meaning; 「うすい」is the reading of「薄い」, not「淡」, so it doesn't work either. The enveloping soft glow admits only「あわい」." },
     exampleJapanese: "プラネタリウムの淡い光に包まれて、永遠を信じていたい。",
-    exampleMeaningZh: "被天象儀那淡淡的光包圍著,真想就這樣相信永恆。"
+    exampleMeaningZh: "被天象儀那淡淡的光包圍著,真想就這樣相信永恆。",
+    exampleMeaningI18n: { "ja": "プラネタリウムのほのかでやわらかい光に包まれて、このまま永遠を信じていたい。", "en": "Wrapped in the faint light of the planetarium, I want to keep on believing in forever." },
   }),
   examQuestion({
     id: "n2-kanji-koboreru",
@@ -7657,7 +7721,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「零れる」是自動詞,意為(光點)自然地灑落溢出,讀作「こぼれる」。干擾項「こぼせる」為他動詞「零す」的可能形、語感不符自然灑落;「こもれる」「こおれる」均非此字讀音,屬促音/長音近形干擾。從銀河灑落的語境下唯有「こぼれる」成立。",
     explanationI18n: { "ja": "「零れる」は自動詞で、（光の粒などが）自然にこぼれあふれ落ちる意味を表し、「こぼれる」と読みます。ほかの選択肢のうち「こぼせる」は他動詞「零す」の可能形で、自然にこぼれるという語感に合いません。「こもれる」「こおれる」はいずれもこの字の読みではなく、促音・長音の近似形による攪乱です。銀河からこぼれ落ちる文脈では「こぼれる」だけが成り立ちます。", "en": "「零れる」is an intransitive verb meaning (for points of light) to spill or overflow of their own accord, read「こぼれる」. The distractor「こぼせる」is the potential form of the transitive verb「零す」and doesn't match the nuance of natural spilling; 「こもれる」and「こおれる」are not readings of this character, being sokuon/long-vowel near-form distractors. In the context of light spilling from the galaxy, only「こぼれる」works." },
     exampleJapanese: "銀河から零れるひとしずくの光を、この手に受けとめたい。",
-    exampleMeaningZh: "想用這雙手,接住從銀河灑落的那一滴光。"
+    exampleMeaningZh: "想用這雙手,接住從銀河灑落的那一滴光。",
+    exampleMeaningI18n: { "ja": "銀河からしたたり落ちるひとしずくの光を、この手で受け止めたい。", "en": "I want to catch, in these hands, a single drop of light spilling from the galaxy." },
   }),
   examQuestion({
     id: "n2-vocab-hoshikuzu",
@@ -7719,7 +7784,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「果てしない」指範圍廣闊到沒有盡頭、無邊無際；四個選項皆為い形容詞，但只有「限りない」表示無窮無盡、沒有界限，與之同義。「もったいない」是可惜、浪費；「そっけない」是冷淡、不近人情；「あっけない」是過於簡單、轉眼即逝令人意猶未盡，皆與「無邊無際」的語意相反或無關，代回夜空一句皆不成立，故唯一正解為「限りない」。",
     explanationI18n: { "ja": "「果てしない」は、範囲が果てが見えないほど広く、際限がないさまを指します。四つの選択肢はいずれもい形容詞ですが、無限で限りがないことを表して同義になるのは「限りない」だけです。「もったいない」は惜しい・無駄だ、「そっけない」は冷淡でよそよそしい、「あっけない」は簡単すぎてあっという間に終わり物足りない意味で、いずれも「果てしない」とは反対か無関係で、夜空の一文に入れ替えると成り立ちません。したがって唯一の正解は「限りない」です。", "en": "「果てしない」means so vast that it has no end — boundless and limitless. All four options are い-adjectives, but only「限りない」means endless and without bound, making it the synonym. 「もったいない」means wasteful or a pity; 「そっけない」means cold and standoffish; 「あっけない」means over too quickly, anticlimactic — all opposite to or unrelated to「boundless,」and all fail when read back into the night-sky sentence, so the only correct answer is「限りない」." },
     exampleJapanese: "君と見上げた限りない夜空に、流れ星をひとつ、そっと願いに変えたい。",
-    exampleMeaningZh: "和你一起仰望那無邊無際的夜空，想把一顆流星，悄悄化成一個願望。"
+    exampleMeaningZh: "和你一起仰望那無邊無際的夜空，想把一顆流星，悄悄化成一個願望。",
+    exampleMeaningI18n: { "ja": "君と一緒に見上げた、どこまでも続く広い夜空で、流れ星をひとつ、そっと願いごとに変えたい。", "en": "Gazing up with you at that endless night sky, I want to quietly turn one shooting star into a wish." },
   }),
   examQuestion({
     id: "n2-grammar-karaniwa",
@@ -7761,7 +7827,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「ひたむき」指不分心、全心全意朝一件事努力的樣子,與「一心に」(專注於一件事)意思最接近。「気軽に」是輕鬆隨意、「適当に」是敷衍馬虎、「渋々」是不情願,三者都與全力投入的語感相反,代回句中皆與「何度も転んでも続けている」的努力畫面矛盾,故唯一正解為「一心に」。",
     explanationI18n: { "ja": "「ひたむき」は、よそに気を散らさず、一つのことに全力で打ち込むさまを指し、「一心に」（一つのことに集中して）と意味が最も近いです。「気軽に」は気楽で軽い調子、「適当に」はいいかげんで手を抜くさま、「渋々」はいやいやながらの意味で、三つとも全力で打ち込む語感とは反対であり、文に入れ替えると「何度も転んでも続けている」という努力の姿と矛盾します。したがって唯一の正解は「一心に」です。", "en": "「ひたむき」describes striving toward one thing with undivided, wholehearted focus, making it closest to「一心に」(concentrating on one thing). 「気軽に」means casually and lightly, 「適当に」means half-heartedly and sloppily, and 「渋々」means reluctantly — all three are the opposite of full devotion and, read back into the sentence, clash with the image of striving on「何度も転んでも続けている」, so the only correct answer is「一心に」." },
     exampleJapanese: "うまく踊れなくて何度も転んでも、あの子は誰よりも一心に練習を続けている。",
-    exampleMeaningZh: "就算跳不好、跌倒了好幾次,那孩子還是比誰都專注地持續練習著。"
+    exampleMeaningZh: "就算跳不好、跌倒了好幾次,那孩子還是比誰都專注地持續練習著。",
+    exampleMeaningI18n: { "ja": "うまく踊れなくて何度も転んでも、あの子は誰よりも真剣に、わき目もふらず練習を続けている。", "en": "Even though she can't get the dance right and has fallen over and over, that girl keeps practicing more single-mindedly than anyone." },
   }),
   examQuestion({
     id: "n2-vocab-funbaru",
@@ -7841,7 +7908,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「貫く」讀作「つらぬく」,意為把某個信念或目標堅持貫徹到底。促音/濁音的「つらぬぐ」、把ら誤成な的「つなぬく」、把ぬ誤成め的「つらめく」皆非此字讀音,語境中只有貫徹夢想的「つらぬく」成立。",
     explanationI18n: { "ja": "「貫く」は「つらぬく」と読み、ある信念や目標を最後まで貫き通す意味です。促音・濁音になった「つらぬぐ」、「ら」を「な」に誤った「つなぬく」、「ぬ」を「め」に誤った「つらめく」はいずれもこの字の読みではなく、この文脈では夢を貫き通す「つらぬく」だけが成り立ちます。", "en": "「貫く」is read「つらぬく」and means to carry a conviction or goal through to the very end. The sokuon/voiced「つらぬぐ」, the「つなぬく」that misreads ら as な, and the「つらめく」that misreads ぬ as め are all wrong readings; in this context only「つらぬく」, seeing the dream through, works." },
     exampleJapanese: "何度こけても、最初に仲間と決めたあの夢だけは貫くって、汗まみれの手をぎゅっと握りしめた。",
-    exampleMeaningZh: "就算跌倒再多次,我也要把當初和夥伴一起決定的那個夢堅持到底,於是緊緊握住了滿是汗水的手。"
+    exampleMeaningZh: "就算跌倒再多次,我也要把當初和夥伴一起決定的那個夢堅持到底,於是緊緊握住了滿是汗水的手。",
+    exampleMeaningI18n: { "ja": "何度転んでも、最初に仲間と決めたあの夢だけは最後までやり通そうと、汗まみれの手をぎゅっと握りしめた。", "en": "No matter how many times I stumble, I'll see through the dream my friends and I decided on back at the start — and with that thought, I clenched my sweat-soaked hands tight." },
   }),
   examQuestion({
     id: "n2-kanji-kagayakashii",
@@ -7861,7 +7929,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「輝かしい」讀作「かがやかしい」,形容前途或成果光輝燦爛。清音的「かかやかしい」、第三拍濁化的「かがやがしい」、把か誤成く的「かがやくしい」都不是正確讀音,語境中只有形容燦爛明天的「かがやかしい」成立。",
     explanationI18n: { "ja": "「輝かしい」は「かがやかしい」と読み、前途や成果が光り輝いているさまを表します。清音の「かかやかしい」、三拍目が濁った「かがやがしい」、「か」を「く」に誤った「かがやくしい」はいずれも正しい読みではなく、この文脈では輝かしい明日を形容する「かがやかしい」だけが成り立ちます。", "en": "「輝かしい」is read「かがやかしい」and describes a future or achievement that is radiant and brilliant. The devoiced「かかやかしい」, the third-mora-voiced「かがやがしい」, and the「かがやくしい」that misreads か as く are all incorrect readings; in this context only「かがやかしい」, describing a brilliant tomorrow, works." },
     exampleJapanese: "笑顔で困難を越えてきた俺たちには、きっとこの先も輝かしい明日が待ってるって、前を向いて走り出した。",
-    exampleMeaningZh: "相信靠著笑容一路越過難關的我們,往後也一定有燦爛的明天在等著,於是望著前方奔跑了起來。"
+    exampleMeaningZh: "相信靠著笑容一路越過難關的我們,往後也一定有燦爛的明天在等著,於是望著前方奔跑了起來。",
+    exampleMeaningI18n: { "ja": "笑顔で困難を乗り越えてきた俺たちには、この先もきっと明るくすばらしい明日が待っていると信じて、前を向いて走り出した。", "en": "Believing that a brilliant tomorrow surely awaits us, who have crossed every hardship with a smile, we faced forward and broke into a run." },
   }),
   examQuestion({
     id: "n2-vocab-gamushara",
@@ -7961,7 +8030,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「触れる」讀作「ふれる」,意為輕輕接觸、碰觸。「ぶれる」是晃動、模糊;「ほれる(惚れる)」是迷戀;「もれる(漏れる)」是洩漏。三者在此語境皆不成立,只有「ふれる」符合指尖碰觸對方的手這一情境。",
     explanationI18n: { "ja": "「触れる」は「ふれる」と読み、そっと接触する・触る意味です。「ぶれる」は揺れる・ぶれる、「ほれる（惚れる）」は惚れる、「もれる（漏れる）」は漏れるの意味で、三つともこの文脈では成り立たず、指先で相手の手に触れる場面に合うのは「ふれる」だけです。", "en": "「触れる」is read「ふれる」and means to touch or make light contact. 「ぶれる」is to shake or blur; 「ほれる(惚れる)」is to be smitten; 「もれる(漏れる)」is to leak. None of the three works in this context — only「ふれる」fits a fingertip touching someone's hand." },
     exampleJapanese: "車窓に流れる景色の中で、指先がそっとあなたの手に触れるだけで、心が未来へ走り出す。",
-    exampleMeaningZh: "在車窗外流動的景色之中,指尖只是輕輕碰到你的手,心便朝著未來奔馳而去。"
+    exampleMeaningZh: "在車窗外流動的景色之中,指尖只是輕輕碰到你的手,心便朝著未來奔馳而去。",
+    exampleMeaningI18n: { "ja": "車窓を流れていく景色の中、指先がそっとあなたの手に重なるだけで、心は未来に向かって走り出す。", "en": "Amid the scenery streaming past the train window, my fingertips only have to brush your hand for my heart to race off toward the future." },
   }),
   examQuestion({
     id: "n2-vocab-amae",
@@ -8161,7 +8231,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「叶う」讀作「かなう」,意為願望實現、如願。此處主語是「願い(願望)」自動實現,用自動詞「叶う(かなう)」。干擾項:「かのう」尾音作「のう」、「かなふ」尾音作「ふ」、「かまう」中段作「ま」,三者皆非「叶う」的正確讀音,清濁、音節皆與正解相近但錯誤,在此語境皆明確不成立,正解唯一。",
     explanationI18n: { "ja": "「叶う」は「かなう」と読み、願いが実現する、叶うという意味。ここでは主語が「願い」で、それが自動的に実現するため、自動詞「叶う(かなう)」を用いる。誤答の「かのう」は語尾が「のう」、「かなふ」は語尾が「ふ」、「かまう」は中ほどが「ま」で、いずれも「叶う」の正しい読みではない。清濁も音節も正解に近いが誤りであり、この文脈ではいずれも明らかに成立しない。正解は一つに定まる。", "en": "「叶う」is read「かなう」, meaning a wish comes true or is fulfilled. Here the subject is「願い(a wish)」realizing itself, so the intransitive verb「叶う(かなう)」is used. Distractors:「かのう」ends in「のう」,「かなふ」ends in「ふ」, and「かまう」has「ま」in the middle—none is the correct reading of「叶う」. Though close in voicing and syllables, all are wrong and clearly don't hold up in context, so the answer is unique." },
     exampleJapanese: "だれかを支えるために費やした日々の果てに、ずっと胸に抱いてきた願いがようやく叶う予感がした。",
-    exampleMeaningZh: "在為了支撐某個人而付出的日子盡頭,我感到一直深藏心中的願望終於就要實現了。"
+    exampleMeaningZh: "在為了支撐某個人而付出的日子盡頭,我感到一直深藏心中的願望終於就要實現了。",
+    exampleMeaningI18n: { "ja": "誰かを支えるために費やしてきた日々の果てに、ずっと胸に抱いてきた願いがようやく実現しそうな予感がした。", "en": "At the end of all those days spent holding someone else up, I had the feeling that the wish I'd carried in my heart for so long was finally about to come true." },
   }),
   examQuestion({
     id: "n2-vocab-unmei",
@@ -8203,7 +8274,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「むしろ」在此句表示「與其…倒不如…」的比較取捨,在「より…ほうがいい」的句式中,與「いっそ(乾脆、倒不如)」最接近——兩者都表示在權衡之後乾脆選擇後者。「たまたま」是偶然、「もしかして」是或許、「わざわざ」是特地,皆與比較取捨的語感不符,代入句中皆不成立。",
     explanationI18n: { "ja": "「むしろ」はこの文で「~するより、いっそ~したほうがよい」という比較・選択を表し、「より…ほうがいい」の構文の中では「いっそ(いっそのこと)」に最も近い——どちらも天秤にかけたうえで思い切って後者を選ぶことを表す。「たまたま」は偶然、「もしかして」はもしかすると、「わざわざ」はわざわざの意味で、いずれも比較・選択の語感に合わず、文中に入れても成立しない。", "en": "「むしろ」here expresses the comparative choice of \"rather than… it's better to…\"; within the「より…ほうがいい」pattern it is closest to「いっそ(just; rather)」—both express choosing the latter outright after weighing the options. 「たまたま」means \"by chance,\"「もしかして」means \"perhaps,\" and「わざわざ」means \"specially, going out of one's way\"; none matches the nuance of comparative choice, and none holds up when substituted into the sentence." },
     exampleJapanese: "泣いて過ごすより、いっそこの時間を自分磨きに使ったほうがいい。",
-    exampleMeaningZh: "與其哭著度過，倒不如乾脆把這段時間用來自我提升。"
+    exampleMeaningZh: "與其哭著度過，倒不如乾脆把這段時間用來自我提升。",
+    exampleMeaningI18n: { "ja": "泣いて過ごすより、思い切ってこの時間を自分磨きに使ったほうがいい。", "en": "Rather than spending this time in tears, I might as well use it to better myself." },
   }),
   examQuestion({
     id: "n2-vocab-sonzai",
@@ -8243,7 +8315,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「乱れる」讀作「みだれる」，意為紊亂、散亂、慌亂。此處指因他人言語而動搖紊亂的心緒；在鏡前慢慢平復、肯定活著的自己。干擾項「みなれる(見慣れる/看慣)」語境上指習慣某景象，與被擾動的心緒矛盾；「みたれる」「みだける」皆非實際存在的讀法，清濁與字形相近但不成立。",
     explanationI18n: { "ja": "「乱れる」は「みだれる」と読み、乱れる、散らばる、取り乱すという意味。ここでは、他人の言葉によって揺れ乱れた心を指し、鏡の前で少しずつ落ち着かせ、生きている自分を肯定する場面。誤答の「みなれる(見慣れる)」は文脈上ある光景に慣れる意味で、揺さぶられた心とは矛盾する。「みたれる」「みだける」はいずれも実在しない読み方で、清濁や字形は近いが成立しない。", "en": "「乱れる」is read「みだれる」, meaning to be disordered, scattered, or in turmoil. Here it refers to a heart thrown into turmoil by someone's words, which gradually calms before the mirror as she affirms being alive. The distractor「みなれる(見慣れる/to grow used to a sight)」refers to getting accustomed to a scene and contradicts the disturbed heart;「みたれる」and「みだける」are not real readings—close in voicing and shape but invalid." },
     exampleJapanese: "鏡の前に立つと、誰かの言葉に乱れる心がやっと静まって、生きている自分をそっと肯定できた。",
-    exampleMeaningZh: "站到鏡子前，被某人話語擾亂的心終於平靜下來，讓我得以輕輕地肯定活著的自己。"
+    exampleMeaningZh: "站到鏡子前，被某人話語擾亂的心終於平靜下來，讓我得以輕輕地肯定活著的自己。",
+    exampleMeaningI18n: { "ja": "鏡の前に立つと、誰かの言葉に揺さぶられていた心がやっと静まって、生きている自分をそっと肯定できた。", "en": "Standing before the mirror, my heart — thrown into disarray by someone's words — finally grew calm, and I could gently affirm the self that goes on living." },
   }),
   examQuestion({
     id: "n2-vocab-chiheisen",
@@ -8283,7 +8356,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「跳ぶ」讀作「とぶ」,意為跳、跳躍。干擾項中「とむ」「どぶ」「とおぶ」皆非此字的正確訓讀,清濁與長音皆不符,故唯一正解為「とぶ」。",
     explanationI18n: { "ja": "「跳ぶ」は「とぶ」と読み、跳ぶ、跳躍するという意味。誤答の「とむ」「どぶ」「とおぶ」はいずれもこの字の正しい訓読みではなく、清濁も長音も合わない。したがって唯一の正解は「とぶ」。", "en": "「跳ぶ」is read「とぶ」, meaning to jump or leap. Among the distractors,「とむ」,「どぶ」, and「とおぶ」are none the correct kun-reading of this character—the voicing and long vowel don't match—so「とぶ」is the only correct answer." },
     exampleJapanese: "灰になっても、また光をめざして跳ぶと決めた。",
-    exampleMeaningZh: "即使化為灰燼,也下定決心要再次朝著光躍起。"
+    exampleMeaningZh: "即使化為灰燼,也下定決心要再次朝著光躍起。",
+    exampleMeaningI18n: { "ja": "たとえ灰になっても、再び光を目指して身を躍らせようと心に決めた。", "en": "Even if I'm reduced to ashes, I've made up my mind to leap toward the light once more." },
   }),
   examQuestion({
     id: "n2-kanji-hibiku",
@@ -8303,7 +8377,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「響く」讀作「ひびく」，意為聲音傳開、迴盪。干擾項中:「ひらく」是「開く」(打開)，旋律不會「打開街道」，語境不成立;「うごく」是「動く」(移動)，「街じゅうに動く」不合;「かがやく」是「輝く」(閃耀)屬視覺，主語為「旋律」應為聲音傳播，皆不成立。故唯一正解為「ひびく」。",
     explanationI18n: { "ja": "「響く」は「ひびく」と読み、音が広がる、鳴りわたるという意味。誤答のうち「ひらく」は「開く」(あける)で、メロディーが「街を開く」ことはなく文脈が成立しない。「うごく」は「動く」(移動する)で、「街じゅうに動く」は合わない。「かがやく」は「輝く」(きらめく)で視覚的だが、主語が「メロディー」で音の伝わりであるべきだから、いずれも成立しない。したがって唯一の正解は「ひびく」。", "en": "「響く」is read「ひびく」, meaning for a sound to spread out and resound. Among the distractors:「ひらく」is「開く」(to open)—a melody can't \"open a town,\" so it doesn't hold up;「うごく」is「動く」(to move), and「街じゅうに動く」doesn't work;「かがやく」is「輝く」(to shine), which is visual, whereas the subject「旋律(melody)」involves sound spreading—none work. Thus the only correct answer is「ひびく」." },
     exampleJapanese: "寒い冬の朝、新しいメロディーが街じゅうに響くと、昨日までの悲しみが少しずつ溶けていった。",
-    exampleMeaningZh: "寒冷的冬日清晨，當嶄新的旋律響徹整座城市，昨日的悲傷便一點一點地融化了。"
+    exampleMeaningZh: "寒冷的冬日清晨，當嶄新的旋律響徹整座城市，昨日的悲傷便一點一點地融化了。",
+    exampleMeaningI18n: { "ja": "寒い冬の朝、新しいメロディーが街じゅうに鳴りわたると、昨日までの悲しみが少しずつ溶けていった。", "en": "On a cold winter morning, as a brand-new melody rang out across the whole city, the sorrows of yesterday melted away little by little." },
   }),
   examQuestion({
     id: "n2-vocab-ikari",
@@ -8505,7 +8580,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「なぞる」指順著既有的線條、輪廓一筆一筆描過去，最接近「(輪郭に)沿って描く」(順著輪廓描畫)——兩者都是依著原有的形狀重描。「塗りつぶす」(塗滿)是把整片填滿、覆蓋，並非沿著線條描，方向不同；「消し去る」(抹去、消除)是把痕跡擦掉，與描畫正好相反；「見落とす」(看漏、沒注意到)是視覺上的疏忽，與用指尖描摹的動作毫無關係。三個干擾代回句中皆不成立，故唯一正解為「沿って描く」。",
     explanationI18n: { "ja": "「なぞる」は既にある線や輪郭に沿って一筆一筆たどっていくことを指し、「(輪郭に)沿って描く」に最も近い——どちらも元々ある形に沿って描き直すこと。「塗りつぶす」は一面を埋めて覆うことで、線に沿ってたどるのとは方向が違う。「消し去る」は跡を消すことで、描くこととは正反対。「見落とす」は視覚的な見逃しで、指先でなぞる動作とはまったく関係がない。三つの誤答は文中に入れてもいずれも成立しないため、唯一の正解は「沿って描く」。", "en": "「なぞる」means to trace stroke by stroke along an existing line or outline, closest to「(輪郭に)沿って描く」(drawing along an outline)—both follow an existing shape to trace it over. 「塗りつぶす」(to fill in) means to fill or cover an entire area, not tracing along a line, a different direction;「消し去る」(to erase, remove) means to wipe away traces, the exact opposite of tracing;「見落とす」(to overlook) is a visual lapse, unrelated to tracing with a fingertip. None of the three distractors hold up when substituted into the sentence, so the only correct answer is「沿って描く」." },
     exampleJapanese: "届かない夜空のあの星の形を、指先でそっと沿って描くたびに、遠くのあなたを思い出す。",
-    exampleMeaningZh: "在搆不著的夜空下，每當用指尖輕輕順著那顆星的形狀描畫，就會想起遠方的你。"
+    exampleMeaningZh: "在搆不著的夜空下，每當用指尖輕輕順著那顆星的形狀描畫，就會想起遠方的你。",
+    exampleMeaningI18n: { "ja": "手の届かない夜空のあの星の形を、指先でそっと線を引くようにたどるたびに、遠くのあなたを思い出す。", "en": "Beneath a night sky I can never reach, each time I gently trace the shape of that star with my fingertip, I remember you, far away." },
   }),
   examQuestion({
     id: "n2-vocab-kanaeru",
@@ -8585,7 +8661,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「目覚める」讀作「めざめる」,此處活用為「目覚め」,讀作「めざめ」。「め」濁音為「ざ」非清音「さ」,故「めさめ」清濁有誤;「めぞめ」母音與濁化皆錯;「めざみ」末音節「め→み」變形不成立。語境為破曉中從惡夢睜眼覺醒,唯有表「醒來」的「めざめ」成立。",
     explanationI18n: { "ja": "「目覚める」は「めざめる」と読み、ここでは名詞化した「目覚め」なので「めざめ」と読みます。「め」の次は濁音の「ざ」で、清音の「さ」ではないため「めさめ」は清濁の誤り。「めぞめ」は母音も濁音の位置も誤り。「めざみ」は最後の「め→み」への変形が成り立ちません。夜明けのなか悪夢から目覚める文脈なので、「目が覚める」を表す「めざめ」だけが正解です。", "en": "「目覚める」is read「めざめる」, and here it is inflected to「目覚め」, read「めざめ」. The「め」takes the voiced「ざ」, not the unvoiced「さ」, so「めさめ」has the voicing wrong;「めぞめ」gets both the vowel and the voicing wrong; and「めざみ」invalidly changes the final syllable「め→み」. In the context of waking and awakening at daybreak from a nightmare, only「めざめ」meaning \"to wake up\" fits." },
     exampleJapanese: "悪夢にうなされていた長い夜がようやく明け、白み始めた空の下でわたしは目覚め、もう弱い自分を心の奥に閉じこめはしないと静かに決めた。",
-    exampleMeaningZh: "讓人輾轉難眠的漫漫惡夢之夜終於將盡,在泛白的天空下我醒了過來,靜靜決定不再把軟弱的自己鎖進心底。"
+    exampleMeaningZh: "讓人輾轉難眠的漫漫惡夢之夜終於將盡,在泛白的天空下我醒了過來,靜靜決定不再把軟弱的自己鎖進心底。",
+    exampleMeaningI18n: { "ja": "悪夢にうなされていた長い夜がようやく明けて、白み始めた空の下で眠りから覚めた私は、もう弱い自分を心の奥に閉じ込めないと静かに決めた。", "en": "The long night of tossing through nightmares was finally ending; beneath the paling sky I awoke, and quietly resolved never again to lock my weaker self away deep in my heart." },
   }),
   examQuestion({
     id: "n2-vocab-hakai",
@@ -8645,7 +8722,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「弾む」訓讀為「はずむ」,表示彈跳、(情緒)高漲。四個選項都保留「は〜む／ぶ」近形外觀,只在中段與結尾設陷阱:「はずぶ」把結尾「む」誤讀成「ぶ」;「はづむ」把「ず」誤寫成同音近形的「づ」(此字正規寫法為「ず」);「はすむ」把濁音「ず」清音化成「す」。三者皆非「弾む」的正確讀音,正解唯一為「はずむ」。",
     explanationI18n: { "ja": "「弾む」は訓読みで「はずむ」と読み、跳ねる・(気持ちが)高ぶるという意味です。四つの選択肢はどれも「は〜む／ぶ」の似た形を保ちつつ、中ほどと語尾に落とし穴を仕掛けています。「はずぶ」は語尾の「む」を「ぶ」と読み誤り、「はづむ」は「ず」を同音で形の似た「づ」と書き誤り(正しい表記は「ず」)、「はすむ」は濁音の「ず」を清音の「す」にしています。いずれも「弾む」の正しい読みではなく、正解は「はずむ」の一つだけです。", "en": "「弾む」has the kun reading「はずむ」, meaning to bounce or (of emotions) to soar. All four options keep the near-identical「は〜む／ぶ」shape, with traps in the middle and end:「はずぶ」misreads the ending「む」as「ぶ」;「はづむ」mis-writes「ず」as the homophonous look-alike「づ」(the standard spelling of this word is「ず」); and「はすむ」unvoices the voiced「ず」into「す」. None is the correct reading of「弾む」, so the only correct answer is「はずむ」." },
     exampleJapanese: "真上から照りつける真昼の光の下、足元の影が一番短くなる時間、汗ばむ肌とリズムに、僕の心は跳ねるように弾む。",
-    exampleMeaningZh: "在正上方灑落的正午光線下,腳邊影子最短的時刻,隨著沁汗的肌膚與節奏,我的心也像彈跳般雀躍起來。"
+    exampleMeaningZh: "在正上方灑落的正午光線下,腳邊影子最短的時刻,隨著沁汗的肌膚與節奏,我的心也像彈跳般雀躍起來。",
+    exampleMeaningI18n: { "ja": "真上から照りつける真昼の光の下、足元の影がいちばん短くなる時間、汗ばむ肌とリズムに合わせて、僕の心は跳ねるようにうきうきと高鳴る。", "en": "Under the midday light pouring straight down from above, at the hour when the shadow at my feet is shortest, with sweat on my skin and the rhythm all around, my heart springs up as if it were bouncing." },
   }),
   examQuestion({
     id: "n2-vocab-tachimukau",
@@ -8685,7 +8763,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「震える」唸作「ふるえる」,意為顫抖、發抖。干擾項「ふりえる」(母音 i 取代 u)、「ふろえる」(母音 o)、「ぶるえる」(濁音 ぶ)在此皆非該字的正確讀音,語境中只有「ふるえる」成立。",
     explanationI18n: { "ja": "「震える」は「ふるえる」と読み、身がふるえるという意味です。誤答の「ふりえる」(母音uをiに)、「ふろえる」(母音o)、「ぶるえる」(濁音ぶ)はどれもこの字の正しい読みではなく、文脈上成り立つのは「ふるえる」だけです。", "en": "「震える」is read「ふるえる」, meaning to tremble or shake. The distractors「ふりえる」(vowel i replacing u),「ふろえる」(vowel o), and「ぶるえる」(voiced ぶ) are none of them the correct reading of this word, and only「ふるえる」fits the context." },
     exampleJapanese: "頭で考えるのをやめて熱い胸の高鳴りに従うと決めた瞬間、私の指先は期待で震えるのを止められなかった。",
-    exampleMeaningZh: "在決定不再用腦袋思考、而是跟隨胸口熾熱悸動的那一刻,我的指尖因期待而忍不住顫抖起來。"
+    exampleMeaningZh: "在決定不再用腦袋思考、而是跟隨胸口熾熱悸動的那一刻,我的指尖因期待而忍不住顫抖起來。",
+    exampleMeaningI18n: { "ja": "頭で考えるのをやめて、胸の熱い高鳴りに従おうと決めた瞬間、私の指先は期待のあまり震えるのを止められなかった。", "en": "The moment I decided to stop thinking with my head and follow the burning pounding in my chest, my fingertips couldn't help trembling with anticipation." },
   }),
   examQuestion({
     id: "n2-vocab-jounetsu",
@@ -9005,7 +9084,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「宙」の読みは「ちゅう」。「宙に浮く」で気持ちが定まらず宙ぶらりんの状態を表す。「ちゅ」は長音欠落、「じゅう」は濁音化、「ちょう」は母音をずらした近形の誤読で、いずれも「宙」の読みではない。",
     explanationI18n: { "ja": "「宙」の読みは「ちゅう」。「宙に浮く」で気持ちが定まらず宙ぶらりんの状態を表す。「ちゅ」は長音欠落、「じゅう」は濁音化、「ちょう」は母音をずらした近形の誤読で、いずれも「宙」の読みではない。", "en": "The reading of「宙」is「ちゅう」. In「宙に浮く」it expresses feelings that are unsettled and left dangling in midair.「ちゅ」drops the long vowel,「じゅう」adds voicing, and「ちょう」is a look-alike misreading with the vowel shifted — none of them is the reading of「宙」." },
     exampleJapanese: "放課後の相談に乗っていたのに、いつのまにか自分の気持ちが宙に浮いていた。",
-    exampleMeaningZh: "明明在放學後幫人做諮詢,不知不覺間自己的心意卻懸在了半空中。"
+    exampleMeaningZh: "明明在放學後幫人做諮詢,不知不覺間自己的心意卻懸在了半空中。",
+    exampleMeaningI18n: { "ja": "放課後にだれかの相談に乗っていたのに、いつのまにか自分の気持ちのほうが、行き場のないまま空中に浮かんでいた。", "en": "I was supposed to be listening to someone's troubles after school, yet before I knew it my own feelings were left hanging in midair." },
   }),
   examQuestion({
     id: "n2-kanji-michibiku",
@@ -9025,7 +9105,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「導く」讀作「みちびく」,意為引導、帶領。選項保留送假名「く」,只改漢字部分的音:「みちひく」把濁音「び」誤讀為清音「ひ」、「みちひびく」多讀一拍誤加長音、「みちぶく」誤讀母音作「ぶ」,均非正解。",
     explanationI18n: { "ja": "「導く」は「みちびく」と読み、導く・案内するという意味です。選択肢は送り仮名の「く」を残し、漢字部分の音だけを変えています。「みちひく」は濁音の「び」を清音の「ひ」と読み誤り、「みちひびく」は一拍多く長音を加えた誤り、「みちぶく」は母音を「ぶ」と読み誤ったもので、いずれも正解ではありません。", "en": "「導く」is read「みちびく」, meaning to guide or lead. The options keep the okurigana「く」and change only the reading of the kanji part:「みちひく」misreads the voiced「び」as the unvoiced「ひ」,「みちひびく」adds an extra beat with a wrongly inserted long sound, and「みちぶく」misreads the vowel as「ぶ」— none is correct." },
     exampleJapanese: "銀色の月の光が、暗い夜道を歩く私を静かに導くように感じた。",
-    exampleMeaningZh: "感覺銀色的月光靜靜地在引導著走在昏暗夜路上的我。"
+    exampleMeaningZh: "感覺銀色的月光靜靜地在引導著走在昏暗夜路上的我。",
+    exampleMeaningI18n: { "ja": "銀色の月の光が、暗い夜道を歩く私に静かに道を示してくれているように感じた。", "en": "It felt as though the silver moonlight was quietly guiding me as I walked along the dark night road." },
   }),
   examQuestion({
     id: "n2-kanji-meguru",
@@ -9045,7 +9126,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「巡る」讀作「めぐる」,意為循環、輪轉。選項保留送假名「る」,只改漢字部分的音:「めくる」誤把「ぐ」清音化(且與『捲る』混淆)、「めぐうる」多插母音拉長、「めごる」誤讀母音,均非正解。",
     explanationI18n: { "ja": "「巡る」は「めぐる」と読み、循環する・めぐるという意味です。選択肢は送り仮名の「る」を残し、漢字部分の音だけを変えています。「めくる」は「ぐ」を清音化した誤り(かつ『捲る』と混同)、「めぐうる」は母音を挟んで伸ばした誤り、「めごる」は母音を読み誤ったもので、いずれも正解ではありません。", "en": "「巡る」is read「めぐる」, meaning to cycle or come round again. The options keep the okurigana「る」and change only the reading of the kanji part:「めくる」unvoices「ぐ」(and confuses it with『捲る』),「めぐうる」inserts an extra vowel to lengthen it, and「めごる」misreads the vowel — none is correct." },
     exampleJapanese: "季節が巡るたびに、夜空の月を見上げてあの約束を思い出す。",
-    exampleMeaningZh: "每當季節輪轉,就抬頭望著夜空的月亮,想起那個約定。"
+    exampleMeaningZh: "每當季節輪轉,就抬頭望著夜空的月亮,想起那個約定。",
+    exampleMeaningI18n: { "ja": "季節がひとまわりして戻ってくるたびに、夜空の月を見上げて、あの約束を思い出す。", "en": "Every time the seasons come around again, I look up at the moon in the night sky and remember that promise." },
   }),
   examQuestion({
     id: "n2-kanji-shibaru",
@@ -9065,7 +9147,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「縛る」讀作「しばる」,意為綑綁、束縛。干擾項「しまる」「ちばる」「じばる」皆改動了漢字部分的音(近形、清濁誤讀),保留送假名「る」,在此語境均不成立。",
     explanationI18n: { "ja": "「縛る」は「しばる」と読み、縛る・束縛するという意味です。誤答の「しまる」「ちばる」「じばる」はどれも漢字部分の音を変え(似た形や清濁の読み誤り)、送り仮名の「る」を残したもので、この文脈ではいずれも成り立ちません。", "en": "「縛る」is read「しばる」, meaning to tie up or constrain. The distractors「しまる」,「ちばる」, and「じばる」all alter the reading of the kanji part (look-alike or voiced/unvoiced misreadings) while keeping the okurigana「る」, and none works in this context." },
     exampleJapanese: "細かい規則が私たちを縛るのは、本当に自由のためなのだろうか。",
-    exampleMeaningZh: "瑣碎的規則束縛著我們,這真的是為了自由嗎?"
+    exampleMeaningZh: "瑣碎的規則束縛著我們,這真的是為了自由嗎?",
+    exampleMeaningI18n: { "ja": "細かい規則が私たちをきつく押さえつけているのは、本当に自由のためなのだろうか。", "en": "Are all these petty rules that bind us really there for the sake of freedom?" },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-001",
@@ -9087,7 +9170,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「影響」（影＝投射、響＝迴響）。「映響」把影誤成同音(えい)的映（映照）；「影郷」把響誤成同音(きょう)的郷（故鄉）；「映郷」兩字皆誤。四者皆讀えいきょう但只有「影響」正確。",
     explanationI18n: { "ja": "正解は「影響」（影＝投げかける、響＝反響）。「映響」は影を同音（えい）の映（映す）と取り違えたもの。「影郷」は響を同音（きょう）の郷（ふるさと）と取り違えたもの。「映郷」は二字とも誤り。四つとも「えいきょう」と読みますが、正しいのは「影響」だけです。", "en": "The correct answer is 「影響」 (影 = a cast shadow, 響 = an echo). 「映響」 mistakes 影 for the homophone (えい) 映 (to reflect); 「影郷」 mistakes 響 for the homophone (きょう) 郷 (hometown); 「映郷」 gets both characters wrong. All four are read えいきょう, but only 「影響」 is correct." },
     exampleJapanese: "新製品は売り上げに大きな影響を与えた。",
-    exampleMeaningZh: "新產品對銷售額帶來了很大的影響。"
+    exampleMeaningZh: "新產品對銷售額帶來了很大的影響。",
+    exampleMeaningI18n: { "ja": "新しい製品が売り上げを大きく左右した。", "en": "The new product had a major impact on sales." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-002",
@@ -9109,7 +9193,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「募集」（募＝徵募、集＝聚集）。「墓集」把募誤成同音(ぼ)的墓（墳墓）；「募週」把集誤成同音(しゅう)的週（週次）；「暮集」把募誤成同音(ぼ)的暮（日暮）。四者皆讀ぼしゅう但只有「募集」正確。",
     explanationI18n: { "ja": "正解は「募集」（募＝募る、集＝集める）。「墓集」は募を同音（ぼ）の墓（墓）と取り違えたもの。「募週」は集を同音（しゅう）の週（週次）と取り違えたもの。「暮集」は募を同音（ぼ）の暮（日暮れ）と取り違えたもの。四つとも「ぼしゅう」と読みますが、正しいのは「募集」だけです。", "en": "The correct answer is 「募集」 (募 = to solicit, 集 = to gather). 「墓集」 mistakes 募 for the homophone (ぼ) 墓 (grave); 「募週」 mistakes 集 for the homophone (しゅう) 週 (week); 「暮集」 mistakes 募 for the homophone (ぼ) 暮 (nightfall). All four are read ぼしゅう, but only 「募集」 is correct." },
     exampleJapanese: "会社が新しいアルバイトを募集している。",
-    exampleMeaningZh: "公司正在招募新的兼職人員。"
+    exampleMeaningZh: "公司正在招募新的兼職人員。",
+    exampleMeaningI18n: { "ja": "会社が、新しくアルバイトとして働いてくれる人を探して集めている。", "en": "The company is recruiting new part-time staff." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-003",
@@ -9131,7 +9216,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「提供」（提＝拿出、供＝給予）。「堤供」把提誤成形近且同音(てい)的堤（堤防）；「提共」把供誤成同音(きょう)的共（共同）；「程供」把提誤成同音(てい)的程（程度）。四者皆讀ていきょう但只有「提供」正確。",
     explanationI18n: { "ja": "正解は「提供」（提＝差し出す、供＝与える）。「堤供」は提を字形が似ていて同音（てい）の堤（堤防）と取り違えたもの。「提共」は供を同音（きょう）の共（共同）と取り違えたもの。「程供」は提を同音（てい）の程（程度）と取り違えたもの。四つとも「ていきょう」と読みますが、正しいのは「提供」だけです。", "en": "The correct answer is 「提供」 (提 = to put forward, 供 = to give). 「堤供」 mistakes 提 for the similar-looking homophone (てい) 堤 (embankment); 「提共」 mistakes 供 for the homophone (きょう) 共 (together); 「程供」 mistakes 提 for the homophone (てい) 程 (degree). All four are read ていきょう, but only 「提供」 is correct." },
     exampleJapanese: "この店は無料でWi-Fiを提供している。",
-    exampleMeaningZh: "這家店免費提供Wi-Fi。"
+    exampleMeaningZh: "這家店免費提供Wi-Fi。",
+    exampleMeaningI18n: { "ja": "この店では、無料でWi-Fiが使えるようにしてくれている。", "en": "This shop provides free Wi-Fi." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-004",
@@ -9153,7 +9239,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「検討」（検＝查驗、討＝討究）。「険討」把検誤成形近且同音(けん)的険（危險）；「検投」把討誤成同音(とう)的投（投擲）；「件討」把検誤成同音(けん)的件（案件）。四者皆讀けんとう但只有「検討」正確。",
     explanationI18n: { "ja": "正解は「検討」（検＝調べる、討＝つきつめる）。「険討」は検を字形が似ていて同音（けん）の険（危険）と取り違えたもの。「検投」は討を同音（とう）の投（投げる）と取り違えたもの。「件討」は検を同音（けん）の件（案件）と取り違えたもの。四つとも「けんとう」と読みますが、正しいのは「検討」だけです。", "en": "The correct answer is 「検討」 (検 = to inspect, 討 = to investigate). 「険討」 mistakes 検 for the similar-looking homophone (けん) 険 (danger); 「検投」 mistakes 討 for the homophone (とう) 投 (to throw); 「件討」 mistakes 検 for the homophone (けん) 件 (matter/case). All four are read けんとう, but only 「検討」 is correct." },
     exampleJapanese: "その提案については、もう一度検討します。",
-    exampleMeaningZh: "關於那個提案，會再評估一次。"
+    exampleMeaningZh: "關於那個提案，會再評估一次。",
+    exampleMeaningI18n: { "ja": "その提案がよいかどうか、もう一度よく調べて考えます。", "en": "As for that proposal, we will look into it once more." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-005",
@@ -9175,7 +9262,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「詳細」（詳＝詳盡、細＝細微）。「証細」把詳誤成同音(しょう)的証（證明）；「詳采」把細誤成同音(さい)的采（風采）；「詳済」把細誤成同音(さい)的済（救濟）。四者皆讀しょうさい但只有「詳細」正確。",
     explanationI18n: { "ja": "正解は「詳細」（詳＝詳しい、細＝細かい）。「証細」は詳を同音（しょう）の証（証明）と取り違えたもの。「詳采」は細を同音（さい）の采（風采）と取り違えたもの。「詳済」は細を同音（さい）の済（救済）と取り違えたもの。四つとも「しょうさい」と読みますが、正しいのは「詳細」だけです。", "en": "The correct answer is 「詳細」 (詳 = detailed, 細 = fine/minute). 「証細」 mistakes 詳 for the homophone (しょう) 証 (proof); 「詳采」 mistakes 細 for the homophone (さい) 采 (bearing/air); 「詳済」 mistakes 細 for the homophone (さい) 済 (to relieve). All four are read しょうさい, but only 「詳細」 is correct." },
     exampleJapanese: "イベントの詳細はホームページをご覧ください。",
-    exampleMeaningZh: "活動的詳細內容請看官網。"
+    exampleMeaningZh: "活動的詳細內容請看官網。",
+    exampleMeaningI18n: { "ja": "イベントの細かい内容については、ホームページで確認してください。", "en": "For details about the event, please see the official website." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-006",
@@ -9197,7 +9285,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「担当」（担＝承擔、当＝擔任）。「単当」把担誤成同音(たん)的単（單一）；「担党」把当誤成同音(とう)的党（政黨）；「胆当」把担誤成形近且同音(たん)的胆（膽量）。四者皆讀たんとう但只有「担当」正確。",
     explanationI18n: { "ja": "正解は「担当」（担＝担う、当＝受け持つ）。「単当」は担を同音（たん）の単（単一）と取り違えたもの。「担党」は当を同音（とう）の党（政党）と取り違えたもの。「胆当」は担を字形が似ていて同音（たん）の胆（度胸）と取り違えたもの。四つとも「たんとう」と読みますが、正しいのは「担当」だけです。", "en": "The correct answer is 「担当」 (担 = to shoulder, 当 = to take on). 「単当」 mistakes 担 for the homophone (たん) 単 (single); 「担党」 mistakes 当 for the homophone (とう) 党 (political party); 「胆当」 mistakes 担 for the similar-looking homophone (たん) 胆 (courage). All four are read たんとう, but only 「担当」 is correct." },
     exampleJapanese: "この件は私が担当しております。",
-    exampleMeaningZh: "這件事是由我負責。"
+    exampleMeaningZh: "這件事是由我負責。",
+    exampleMeaningI18n: { "ja": "この件は、私が受け持っております。", "en": "I am the one in charge of this matter." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-007",
@@ -9219,7 +9308,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「預金」（預＝寄存、金＝金錢）。「与金」把預誤成同音(よ)的与（給予）；「預菌」把金誤成同音(きん)的菌（細菌）；「余金」把預誤成同音(よ)的余（剩餘）。四者皆讀よきん但只有「預金」正確。",
     explanationI18n: { "ja": "正解は「預金」（預＝預ける、金＝お金）。「与金」は預を同音（よ）の与（与える）と取り違えたもの。「預菌」は金を同音（きん）の菌（細菌）と取り違えたもの。「余金」は預を同音（よ）の余（余り）と取り違えたもの。四つとも「よきん」と読みますが、正しいのは「預金」だけです。", "en": "The correct answer is 「預金」 (預 = to deposit, 金 = money). 「与金」 mistakes 預 for the homophone (よ) 与 (to give); 「預菌」 mistakes 金 for the homophone (きん) 菌 (bacteria); 「余金」 mistakes 預 for the homophone (よ) 余 (surplus). All four are read よきん, but only 「預金」 is correct." },
     exampleJapanese: "毎月、給料の一部を預金している。",
-    exampleMeaningZh: "每個月會把一部分薪水存起來。"
+    exampleMeaningZh: "每個月會把一部分薪水存起來。",
+    exampleMeaningI18n: { "ja": "毎月、給料の一部を銀行にためている。", "en": "Every month I put part of my salary into savings." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-008",
@@ -9241,7 +9331,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「依頼」（依＝依靠、頼＝託付）。「衣頼」把依誤成同音(い)的衣（衣服）；「依来」把頼誤成同音(らい)的来（前來）；「委頼」把依誤成同音(い)的委（委員）。四者皆讀いらい但只有「依頼」正確。",
     explanationI18n: { "ja": "正解は「依頼」（依＝たよる、頼＝頼む）。「衣頼」は依を同音（い）の衣（衣服）と取り違えたもの。「依来」は頼を同音（らい）の来（来る）と取り違えたもの。「委頼」は依を同音（い）の委（委員）と取り違えたもの。四つとも「いらい」と読みますが、正しいのは「依頼」だけです。", "en": "The correct answer is 「依頼」 (依 = to rely on, 頼 = to entrust). 「衣頼」 mistakes 依 for the homophone (い) 衣 (clothing); 「依来」 mistakes 頼 for the homophone (らい) 来 (to come); 「委頼」 mistakes 依 for the homophone (い) 委 (committee). All four are read いらい, but only 「依頼」 is correct." },
     exampleJapanese: "デザインの仕事を専門家に依頼した。",
-    exampleMeaningZh: "把設計工作委託給了專家。"
+    exampleMeaningZh: "把設計工作委託給了專家。",
+    exampleMeaningI18n: { "ja": "デザインの仕事を専門の人に任せた。", "en": "We entrusted the design work to a specialist." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-009",
@@ -9263,7 +9354,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「把握」（把＝抓、握＝握住）。「波握」把把誤成同音(は)的波（波浪）；「把悪」把握誤成同音(あく)的悪（惡）；「破握」把把誤成形近且同音(は)的破（破壞）。四者皆讀はあく但只有「把握」正確。",
     explanationI18n: { "ja": "正解は「把握」（把＝つかむ、握＝にぎる）。「波握」は把を同音（は）の波（波）と取り違えたもの。「把悪」は握を同音（あく）の悪（悪）と取り違えたもの。「破握」は把を字形が似ていて同音（は）の破（破壊）と取り違えたもの。四つとも「はあく」と読みますが、正しいのは「把握」だけです。", "en": "The correct answer is 「把握」 (把 = to grip, 握 = to hold). 「波握」 mistakes 把 for the homophone (は) 波 (wave); 「把悪」 mistakes 握 for the homophone (あく) 悪 (evil); 「破握」 mistakes 把 for the similar-looking homophone (は) 破 (to break). All four are read はあく, but only 「把握」 is correct." },
     exampleJapanese: "まず現状を正確に把握することが大切だ。",
-    exampleMeaningZh: "首先準確掌握現狀很重要。"
+    exampleMeaningZh: "首先準確掌握現狀很重要。",
+    exampleMeaningI18n: { "ja": "まず現状を正しくつかむことが大切だ。", "en": "It's important to first get an accurate grasp of the current situation." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-010",
@@ -9285,7 +9377,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「蓄積」（蓄＝儲蓄、積＝堆積）。「築積」把蓄誤成同音(ちく)的築（建築）；「蓄席」把積誤成同音(せき)的席（座席）；「畜積」把蓄誤成形近且同音(ちく)的畜（家畜）。四者皆讀ちくせき但只有「蓄積」正確。",
     explanationI18n: { "ja": "正解は「蓄積」（蓄＝蓄える、積＝積む）。「築積」は蓄を同音（ちく）の築（建築）と取り違えたもの。「蓄席」は積を同音（せき）の席（座席）と取り違えたもの。「畜積」は蓄を字形が似ていて同音（ちく）の畜（家畜）と取り違えたもの。四つとも「ちくせき」と読みますが、正しいのは「蓄積」だけです。", "en": "The correct answer is 「蓄積」 (蓄 = to save up, 積 = to pile up). 「築積」 mistakes 蓄 for the homophone (ちく) 築 (to build); 「蓄席」 mistakes 積 for the homophone (せき) 席 (seat); 「畜積」 mistakes 蓄 for the similar-looking homophone (ちく) 畜 (livestock). All four are read ちくせき, but only 「蓄積」 is correct." },
     exampleJapanese: "長年の経験が蓄積されている。",
-    exampleMeaningZh: "多年的經驗累積了下來。"
+    exampleMeaningZh: "多年的經驗累積了下來。",
+    exampleMeaningI18n: { "ja": "長年の経験が積み重ねられている。", "en": "Many years of experience have been built up." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-011",
@@ -9307,7 +9400,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「招待」（招＝招呼、待＝款待）。「紹待」把招誤成形近且同音(しょう)的紹（介紹）；「招対」把待誤成同音(たい)的対（對面）；「証待」把招誤成同音(しょう)的証（證明）。四者皆讀しょうたい但只有「招待」正確。",
     explanationI18n: { "ja": "正解は「招待」（招＝招く、待＝もてなす）。「紹待」は招を字形が似ていて同音（しょう）の紹（紹介）と取り違えたもの。「招対」は待を同音（たい）の対（向かい）と取り違えたもの。「証待」は招を同音（しょう）の証（証明）と取り違えたもの。四つとも「しょうたい」と読みますが、正しいのは「招待」だけです。", "en": "The correct answer is 「招待」 (招 = to beckon, 待 = to receive/host). 「紹待」 mistakes 招 for the similar-looking homophone (しょう) 紹 (to introduce); 「招対」 mistakes 待 for the homophone (たい) 対 (facing/opposite); 「証待」 mistakes 招 for the homophone (しょう) 証 (proof). All four are read しょうたい, but only 「招待」 is correct." },
     exampleJapanese: "友人を結婚式に招待した。",
-    exampleMeaningZh: "邀請了朋友來參加婚禮。"
+    exampleMeaningZh: "邀請了朋友來參加婚禮。",
+    exampleMeaningI18n: { "ja": "友人を結婚式に呼んだ。", "en": "I invited a friend to the wedding." },
   }),
   examQuestion({
     id: "n2-kanji-hyoki-012",
@@ -9329,7 +9423,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "正解「経済」（経＝經營、済＝接濟，此詞中「済」讀ざい）。「経剤」把済誤成同音(ざい)的剤（藥劑）；「経財」把済誤成同音(ざい)的財（財產）；「経材」把済誤成同音(ざい)的材（材料）。四者皆讀けいざい但只有「経済」正確。",
     explanationI18n: { "ja": "正解は「経済」（経＝経営する、済＝すくう。この語では「済」を「ざい」と読みます）。「経剤」は済を同音（ざい）の剤（薬剤）と取り違えたもの。「経財」は済を同音（ざい）の財（財産）と取り違えたもの。「経材」は済を同音（ざい）の材（材料）と取り違えたもの。四つとも「けいざい」と読みますが、正しいのは「経済」だけです。", "en": "The correct answer is 「経済」 (経 = to manage/run, 済 = to relieve; in this word 済 is read ざい). 「経剤」 mistakes 済 for the homophone (ざい) 剤 (pharmaceutical agent); 「経財」 mistakes 済 for the homophone (ざい) 財 (property/wealth); 「経材」 mistakes 済 for the homophone (ざい) 材 (material). All four are read けいざい, but only 「経済」 is correct." },
     exampleJapanese: "ニュースで日本の経済について話していた。",
-    exampleMeaningZh: "新聞在談論日本的經濟。"
+    exampleMeaningZh: "新聞在談論日本的經濟。",
+    exampleMeaningI18n: { "ja": "ニュースで、日本の景気やお金の動きについて取り上げていた。", "en": "The news was talking about Japan's economy." },
   }),
   examQuestion({
     id: "n2-kanji-mujaki",
@@ -9349,7 +9444,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "無＝む、邪＝じゃ、気＝き，讀「むじゃき」。「ぶじゃき」誤把無讀成ぶ；「むじゃけ」誤把気讀成け；「むしゃき」漏掉邪的濁音(じゃ→しゃ)。",
     explanationI18n: { "ja": "無＝む、邪＝じゃ、気＝き で「むじゃき」と読みます。「ぶじゃき」は無を「ぶ」と読み誤ったもの。「むじゃけ」は気を「け」と読み誤ったもの。「むしゃき」は邪の濁音を落としたもの（じゃ→しゃ）です。", "en": "無 = む, 邪 = じゃ, 気 = き, giving the reading 「むじゃき」. 「ぶじゃき」 wrongly reads 無 as ぶ; 「むじゃけ」 wrongly reads 気 as け; 「むしゃき」 drops the voicing on 邪 (じゃ → しゃ)." },
     exampleJapanese: "子どもの無邪気な笑顔に、思わずこちらも笑ってしまった。",
-    exampleMeaningZh: "看到孩子天真的笑容，不自覺也跟著笑了。"
+    exampleMeaningZh: "看到孩子天真的笑容，不自覺也跟著笑了。",
+    exampleMeaningI18n: { "ja": "子どものあどけない笑顔を見て、思わずこちらもつられて笑ってしまった。", "en": "Seeing the child's innocent smile, I couldn't help smiling along." },
   }),
   examQuestion({
     id: "n2-kanji-kiseki",
@@ -9369,7 +9465,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "奇＝き、跡＝せき，讀「きせき」。「ぎせき」誤把奇讀成濁音ぎ；「きぜき」誤把跡讀成濁音ぜき；「きせつ」把跡誤讀成つ(易與「季節」きせつ混淆)。",
     explanationI18n: { "ja": "奇＝き、跡＝せき で「きせき」と読みます。「ぎせき」は奇を濁音「ぎ」と読み誤ったもの。「きぜき」は跡を濁音「ぜき」と読み誤ったもの。「きせつ」は跡を「つ」と読み誤ったもので、「季節（きせつ）」と混同しやすい形です。", "en": "奇 = き, 跡 = せき, giving the reading 「きせき」. 「ぎせき」 wrongly voices 奇 as ぎ; 「きぜき」 wrongly voices 跡 as ぜき; 「きせつ」 misreads 跡 as つ (easily confused with 「季節」 きせつ, meaning season)." },
     exampleJapanese: "全員が無事だったのは奇跡としか言いようがない。",
-    exampleMeaningZh: "全員平安無事，只能說是奇蹟。"
+    exampleMeaningZh: "全員平安無事，只能說是奇蹟。",
+    exampleMeaningI18n: { "ja": "全員が無事だったのは、信じられないほど幸運なことだった。", "en": "That everyone came out unharmed can only be called a miracle." },
   }),
   examQuestion({
     id: "n2-syn-kakedasu",
@@ -9391,7 +9488,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「駆け出す」＝突然開始快跑，≒「走り出す」。「歩き出す」是開始走(慢)；「立ち止まる」是停下；「戻ってくる」是返回，皆與「快跑出去」不同。",
     explanationI18n: { "ja": "「駆け出す」は急に速く走り始めることで、「走り出す」に近い意味です。「歩き出す」はゆっくり歩き始めること。「立ち止まる」は立ち止まること。「戻ってくる」は引き返すことで、いずれも「勢いよく走り出す」とは異なります。", "en": "「駆け出す」 means to suddenly start running fast, ≒ 「走り出す」. 「歩き出す」 is to start walking (slow); 「立ち止まる」 is to come to a stop; 「戻ってくる」 is to come back — none matches \"to dash out at a run.\"" },
     exampleJapanese: "ベルが鳴ると、子どもたちは校庭へ走り出した。",
-    exampleMeaningZh: "鈴聲一響，孩子們就往操場跑了出去。"
+    exampleMeaningZh: "鈴聲一響，孩子們就往操場跑了出去。",
+    exampleMeaningI18n: { "ja": "ベルが鳴ったとたん、子どもたちは校庭へ飛び出していった。", "en": "The moment the bell rang, the children dashed out to the schoolyard." },
   }),
   examQuestion({
     id: "n2-syn-doshaburi",
@@ -9413,7 +9511,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「土砂降り」＝雨勢猛烈，≒「大雨」。「小雨」是小雨(反義)；「霧」是霧；「雪」是雪，皆與「猛烈的雨」不同。",
     explanationI18n: { "ja": "「土砂降り」は雨の勢いが激しいことで、「大雨」に近い意味です。「小雨」は弱い雨（反対の意味）。「霧」は霧。「雪」は雪で、いずれも「激しい雨」とは異なります。", "en": "「土砂降り」 means torrential rain, ≒ 「大雨」. 「小雨」 is light rain (the opposite); 「霧」 is fog; 「雪」 is snow — none matches \"violent rain.\"" },
     exampleJapanese: "駅に着く前に大雨になって、全身ずぶ濡れになった。",
-    exampleMeaningZh: "還沒到車站就下起大雨，全身濕透了。"
+    exampleMeaningZh: "還沒到車站就下起大雨，全身濕透了。",
+    exampleMeaningI18n: { "ja": "駅に着く前に激しい雨が降り出して、全身ずぶ濡れになってしまった。", "en": "It started pouring before I reached the station, and I got soaked from head to toe." },
   }),
   examQuestion({
     id: "n2-goker-ondanka",
@@ -9435,7 +9534,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「温暖＋化」＝温暖化，接尾詞「化」表示「變成某狀態」。「温暖性／温暖的／温暖感」都不構成這個固定詞。",
     explanationI18n: { "ja": "「温暖＋化」で「温暖化」となり、接尾語「化」は「ある状態に変わる」ことを表します。「温暖性・温暖的・温暖感」はいずれもこの決まった言葉になりません。", "en": "「温暖 + 化」 = 温暖化 (warming); the suffix 「化」 means \"turning into a certain state.\" 「温暖性／温暖的／温暖感」 do not form this fixed word." },
     exampleJapanese: "近年、地球の温暖化がますます深刻になっている。",
-    exampleMeaningZh: "近年地球暖化越來越嚴重。"
+    exampleMeaningZh: "近年地球暖化越來越嚴重。",
+    exampleMeaningI18n: { "ja": "ここ数年、地球の温暖化がますます深刻になっている。", "en": "In recent years, global warming has become more and more serious." },
   }),
   examQuestion({
     id: "n2-goker-juuyousei",
@@ -9457,7 +9557,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「重要＋性」＝重要性，接尾詞「性」把詞變成名詞「…的程度／性質」。「重要化／重要的／重要感」接在後面不成這個詞。",
     explanationI18n: { "ja": "「重要＋性」で「重要性」となり、接尾語「性」は語を「〜の程度・性質」を表す名詞にします。「重要化・重要的・重要感」は後ろに付けてもこの言葉になりません。", "en": "「重要 + 性」 = 重要性 (importance); the suffix 「性」 turns a word into a noun meaning \"the degree/quality of ….\" 「重要化／重要的／重要感」 do not form this word when attached here." },
     exampleJapanese: "この資料の重要性を、もう一度説明します。",
-    exampleMeaningZh: "我再說明一次這份資料的重要性。"
+    exampleMeaningZh: "我再說明一次這份資料的重要性。",
+    exampleMeaningI18n: { "ja": "この資料がどれほど重要かを、もう一度説明する。", "en": "Let me explain the importance of this document once more." },
   }),
   examQuestion({
     id: "n2-goker-sekkyokuteki",
@@ -9479,7 +9580,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「積極＋的」＋に＝積極的に（積極地），接尾詞「的」構成形容動詞，後接「に」當副詞。空格後是「に」，故選「的」。「性／化／感」接「に」不通。",
     explanationI18n: { "ja": "「積極＋的」＋に で「積極的に」となり、接尾語「的」が形容動詞をつくり、後ろに「に」を付けて副詞になります。空欄の後は「に」なので「的」を選びます。「性・化・感」は「に」に続けても成り立ちません。", "en": "「積極 + 的」 + に = 積極的に (actively); the suffix 「的」 forms a na-adjective, and adding 「に」 makes it adverbial. Since the blank is followed by 「に」, the answer is 「的」. 「性／化／感」 do not work before 「に」." },
     exampleJapanese: "彼はいつも会議で積極的に発言する。",
-    exampleMeaningZh: "他在會議上總是很積極地發言。"
+    exampleMeaningZh: "他在會議上總是很積極地發言。",
+    exampleMeaningI18n: { "ja": "彼は会議でいつも進んで発言している。", "en": "He always speaks up actively in meetings." },
   }),
   examQuestion({
     id: "n2-goker-manzokukan",
@@ -9501,7 +9603,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「満足＋感」＝満足感，接尾詞「感」表「…的感覺」。「満足性／満足化／満足的」接在後面不成這個固定詞。",
     explanationI18n: { "ja": "「満足＋感」で「満足感」となり、接尾語「感」は「〜の感じ」を表します。「満足性・満足化・満足的」は後ろに付けてもこの決まった言葉になりません。", "en": "「満足 + 感」 = 満足感 (a sense of satisfaction); the suffix 「感」 means \"the feeling of ….\" 「満足性／満足化／満足的」 do not form this fixed word when attached here." },
     exampleJapanese: "難しい仕事をやり終えて、大きな満足感を得た。",
-    exampleMeaningZh: "完成困難的工作後，得到很大的滿足感。"
+    exampleMeaningZh: "完成困難的工作後，得到很大的滿足感。",
+    exampleMeaningI18n: { "ja": "難しい仕事をやり遂げて、大きな満足感を得た。", "en": "After finishing a difficult job, I felt a great sense of satisfaction." },
   }),
   examQuestion({
     id: "n2-goker-fukanou",
@@ -9523,7 +9626,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「不＋可能」＝不可能，接頭詞「不」表否定。「無可能／未可能／非可能」皆非標準詞。",
     explanationI18n: { "ja": "「不＋可能」で「不可能」となり、接頭語「不」は否定を表します。「無可能・未可能・非可能」はいずれも標準的な言葉ではありません。", "en": "「不 + 可能」 = 不可能 (impossible); the prefix 「不」 marks negation. 「無可能／未可能／非可能」 are not standard words." },
     exampleJapanese: "今から準備しても、完成は不可能だろう。",
-    exampleMeaningZh: "現在才準備，大概不可能完成吧。"
+    exampleMeaningZh: "現在才準備，大概不可能完成吧。",
+    exampleMeaningI18n: { "ja": "今から準備を始めても、おそらく完成できないだろう。", "en": "Even if we start preparing now, finishing is probably impossible." },
   }),
   examQuestion({
     id: "n2-goker-muimi",
@@ -9545,7 +9649,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「無＋意味」＝無意味（沒意義、白費），接頭詞「無」表「沒有…」。「不意味／未意味／非意味」皆非標準詞。",
     explanationI18n: { "ja": "「無＋意味」で「無意味（意味がない・むだ）」となり、接頭語「無」は「〜がない」ことを表します。「不意味・未意味・非意味」はいずれも標準的な言葉ではありません。", "en": "「無 + 意味」 = 無意味 (meaningless, pointless); the prefix 「無」 means \"having no ….\" 「不意味／未意味／非意味」 are not standard words." },
     exampleJapanese: "そんなに急いでも、間に合わないなら無意味だ。",
-    exampleMeaningZh: "再怎麼趕，趕不上的話也是白費。"
+    exampleMeaningZh: "再怎麼趕，趕不上的話也是白費。",
+    exampleMeaningI18n: { "ja": "どんなに急いでも、間に合わないなら意味がない。", "en": "No matter how much you rush, if you can't make it in time, it's all pointless." },
   }),
   examQuestion({
     id: "n2-goker-kaigichuu",
@@ -9567,7 +9672,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「会議＋中」＝会議中，接尾詞「中」表「正在…」。「会議内／会議間／会議時」在此語境不通。",
     explanationI18n: { "ja": "「会議＋中」で「会議中」となり、接尾語「中」は「〜している最中」を表します。「会議内・会議間・会議時」はこの文脈では成り立ちません。", "en": "「会議 + 中」 = 会議中 (in a meeting); the suffix 「中」 means \"in the middle of ….\" 「会議内／会議間／会議時」 do not work in this context." },
     exampleJapanese: "部長はただいま会議中ですので、後ほどおかけ直しください。",
-    exampleMeaningZh: "部長現在正在開會，請稍後再撥。"
+    exampleMeaningZh: "部長現在正在開會，請稍後再撥。",
+    exampleMeaningI18n: { "ja": "部長は今ちょうど会議に出ているので、しばらくしてからかけ直してほしい。", "en": "The department manager is in a meeting right now; please call back later." },
   }),
   examQuestion({
     id: "n2-goker-sairiyou",
@@ -9589,7 +9695,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "「再＋利用」＝再利用，接頭詞「再」表「再一次」。「未利用」是「尚未利用」語意不同且不接「しよう」；「不利用／無利用」非自然詞。",
     explanationI18n: { "ja": "「再＋利用」で「再利用」となり、接頭語「再」は「もう一度」を表します。「未利用」は「まだ利用していない」という別の意味で、「しよう」にも続きません。「不利用・無利用」は自然な言葉ではありません。", "en": "「再 + 利用」 = 再利用 (reuse); the prefix 「再」 means \"once again.\" 「未利用」 means \"not yet used,\" which differs in meaning and doesn't take 「しよう」; 「不利用／無利用」 are not natural words." },
     exampleJapanese: "ごみを減らすため、使えるものは再利用しよう。",
-    exampleMeaningZh: "為了減少垃圾，能用的東西就再利用吧。"
+    exampleMeaningZh: "為了減少垃圾，能用的東西就再利用吧。",
+    exampleMeaningI18n: { "ja": "ごみを減らすために、まだ使えるものは繰り返し使おう。", "en": "To cut down on garbage, let's reuse whatever can still be used." },
   }),
   examQuestion({
     id: "n2-order-nuku",
@@ -9611,7 +9718,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "接尾「Vます語幹＋ぬく」（堅持到底）須「やり＋ぬく」緊接置句尾；呼應「どんなに〜ても」由「どんなに」領頭、「つらくても」緊隨。三個干擾都把語幹「やり」甩到句尾——連用形語幹無法單獨收句，且「ぬく」被拆離語幹而落空。唯一順序為『どんなに→つらくても→やり→ぬく』。",
     explanationI18n: { "ja": "接尾語「Vます語幹＋ぬく」（最後までやり通す）は、「やり＋ぬく」とつなげて文末に置く必要があります。これは「どんなに〜ても」に呼応し、「どんなに」が文頭に立ち、「つらくても」がすぐ後に続きます。三つの誤答はいずれも語幹「やり」を文末へ放り出しており、連用形の語幹は単独で文を締められず、「ぬく」も語幹から切り離されて宙に浮きます。正しい順序は『どんなに→つらくても→やり→ぬく』の一通りだけです。", "en": "The suffix 「Vます-stem + ぬく」 (to carry through to the end) requires 「やり + ぬく」 to stay joined at the end of the sentence; to answer 「どんなに〜ても」, 「どんなに」 leads and 「つらくても」 follows right after. All three distractors fling the stem 「やり」 to the end of the sentence — but a bare continuative stem can't close a sentence on its own, and 「ぬく」 is torn from its stem and left dangling. The only valid order is 『どんなに → つらくても → やり → ぬく』." },
     exampleJapanese: "どんなにつらくてもやりぬく。",
-    exampleMeaningZh: "不管多辛苦都要堅持做到最後。"
+    exampleMeaningZh: "不管多辛苦都要堅持做到最後。",
+    exampleMeaningI18n: { "ja": "どれほどつらくても、最後までやり通す。", "en": "No matter how hard it gets, I'll see it through to the end." },
   }),
   examQuestion({
     id: "n2-order-ippouda",
@@ -9633,7 +9741,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "句型「V辭書形＋一方だ」（一直…下去）須「上がる→一方→だ」依序相連成述部，主題「物価は」領頭。三個干擾都把「だ」從「上がる一方」拆開、錯置到句中（如「物価はだ」），述部「上がる一方だ」無法成形。唯一順序為『物価は→上がる→一方→だ』。",
     explanationI18n: { "ja": "文型「V辞書形＋一方だ」（ずっと…し続ける）は、「上がる→一方→だ」の順に連なって述部を作り、主題「物価は」が先頭に立ちます。三つの誤答はいずれも「だ」を「上がる一方」から切り離し、文中に置き違えており（例：「物価はだ」）、述部「上がる一方だ」が成立しません。正しい順序は『物価は→上がる→一方→だ』のみです。", "en": "The pattern \"V (dictionary form) + 一方だ\" (keeps on ...) needs 上がる → 一方 → だ to link up in that order to form the predicate, with the topic 物価は leading. All three distractors split だ away from 上がる一方 and misplace it mid-sentence (e.g., 物価はだ), so the predicate 上がる一方だ never comes together. The only valid order is 物価は → 上がる → 一方 → だ." },
     exampleJapanese: "物価は上がる一方だ。",
-    exampleMeaningZh: "物價只漲不跌、一直往上。"
+    exampleMeaningZh: "物價只漲不跌、一直往上。",
+    exampleMeaningI18n: { "ja": "物価は上がり続けるばかりで、下がる気配がない。", "en": "Prices just keep on rising, with no sign of coming down." },
   }),
   examQuestion({
     id: "n2-order-gachida",
@@ -9655,7 +9764,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "接尾「Vます語幹＋がちだ」（容易…）須「ひき＋がちだ」緊接置句尾，受詞「風邪を」緊接其動詞語幹。三個干擾都把語幹「ひき」甩到句尾——連用形語幹無法單獨收句，且「がちだ」被拆離語幹而落空。唯一順序為『冬は→風邪を→ひき→がちだ』。",
     explanationI18n: { "ja": "接尾語「Vます語幹＋がちだ」（…しやすい）は「ひき＋がちだ」とつながって文末に置かれ、目的語「風邪を」がその動詞語幹の直前に来ます。三つの誤答はいずれも語幹「ひき」を文末に放り出しており、連用形の語幹だけでは文を締めくくれず、しかも「がちだ」が語幹から切り離されて宙に浮きます。正しい順序は『冬は→風邪を→ひき→がちだ』のみです。", "en": "The suffix \"V (masu-stem) + がちだ\" (tend to ...) needs ひき + がちだ to join directly at the end of the sentence, with the object 風邪を right before its verb stem. All three distractors fling the stem ひき to the sentence-final position—a bare renyoukei stem can't close a sentence on its own, and がちだ is torn away from its stem, leaving it stranded. The only valid order is 冬は → 風邪を → ひき → がちだ." },
     exampleJapanese: "冬は風邪をひきがちだ。",
-    exampleMeaningZh: "冬天容易感冒。"
+    exampleMeaningZh: "冬天容易感冒。",
+    exampleMeaningI18n: { "ja": "冬は風邪をひきやすい。", "en": "In winter, people tend to catch colds." },
   }),
   examQuestion({
     id: "n2-order-kiru",
@@ -9677,7 +9787,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "接尾「Vます語幹＋きる」（徹底完成）須「走り＋きった」緊接置句尾，「マラソンを」為其受詞、「最後まで」為副詞。三個干擾都把語幹「走り」甩到句尾——連用形語幹無法單獨收句，且「きった」被拆離語幹而落空。唯一順序為『マラソンを→最後まで→走り→きった』。",
     explanationI18n: { "ja": "接尾語「Vます語幹＋きる」（最後までやり遂げる）は「走り＋きった」とつながって文末に置かれ、「マラソンを」がその目的語、「最後まで」が副詞になります。三つの誤答はいずれも語幹「走り」を文末に放り出しており、連用形の語幹だけでは文を締めくくれず、しかも「きった」が語幹から切り離されて宙に浮きます。正しい順序は『マラソンを→最後まで→走り→きった』のみです。", "en": "The suffix \"V (masu-stem) + きる\" (to do ... completely) needs 走り + きった to join directly at the end of the sentence, with マラソンを as its object and 最後まで as an adverb. All three distractors fling the stem 走り to the sentence-final position—a bare renyoukei stem can't close a sentence on its own, and きった is torn away from its stem, leaving it stranded. The only valid order is マラソンを → 最後まで → 走り → きった." },
     exampleJapanese: "マラソンを最後まで走りきった。",
-    exampleMeaningZh: "把馬拉松跑完了全程。"
+    exampleMeaningZh: "把馬拉松跑完了全程。",
+    exampleMeaningI18n: { "ja": "マラソンを最後まで走り通した。", "en": "I ran the marathon all the way to the finish." },
   }),
   examQuestion({
     id: "n2-order-gimida",
@@ -9699,7 +9810,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "接尾「Vます語幹＋ぎみだ」（略有…傾向）須「太り＋ぎみだ」緊接置句尾，「最近」「ちょっと」為副詞。三個干擾都把語幹「太り」甩到句尾——連用形語幹無法單獨收句，且「ぎみだ」被拆離語幹而落空。唯一順序為『最近→ちょっと→太り→ぎみだ』。",
     explanationI18n: { "ja": "接尾語「Vます語幹＋ぎみだ」（少し…気味だ）は「太り＋ぎみだ」とつながって文末に置かれ、「最近」「ちょっと」が副詞になります。三つの誤答はいずれも語幹「太り」を文末に放り出しており、連用形の語幹だけでは文を締めくくれず、しかも「ぎみだ」が語幹から切り離されて宙に浮きます。正しい順序は『最近→ちょっと→太り→ぎみだ』のみです。", "en": "The suffix \"V (masu-stem) + ぎみだ\" (slightly inclined to ...) needs 太り + ぎみだ to join directly at the end of the sentence, with 最近 and ちょっと serving as adverbs. All three distractors fling the stem 太り to the sentence-final position—a bare renyoukei stem can't close a sentence on its own, and ぎみだ is torn away from its stem, leaving it stranded. The only valid order is 最近 → ちょっと → 太り → ぎみだ." },
     exampleJapanese: "最近ちょっと太りぎみだ。",
-    exampleMeaningZh: "最近好像有點變胖了。"
+    exampleMeaningZh: "最近好像有點變胖了。",
+    exampleMeaningI18n: { "ja": "このごろ少し太ってきた気がする。", "en": "I feel like I've been putting on a little weight lately." },
   }),
   examQuestion({
     id: "n2-order-kaneru",
@@ -9721,7 +9833,8 @@ export const n2Items: PracticeQuestion[] = [
     explanation: "接尾「Vます語幹＋かねる」（難以…）須「判断し＋かねます」緊接置句尾，「その件は」為主題、「私には」標記主體。三個干擾都把語幹「判断し」甩到句尾——連用形語幹無法單獨收句，且「かねます」被拆離語幹而落空。唯一順序為『その件は→私には→判断し→かねます』。",
     explanationI18n: { "ja": "接尾語「Vます語幹＋かねる」（…しにくい）は「判断し＋かねます」とつながって文末に置かれ、「その件は」が主題、「私には」が主体を示します。三つの誤答はいずれも語幹「判断し」を文末に放り出しており、連用形の語幹だけでは文を締めくくれず、しかも「かねます」が語幹から切り離されて宙に浮きます。正しい順序は『その件は→私には→判断し→かねます』のみです。", "en": "The suffix \"V (masu-stem) + かねる\" (hard to ...) needs 判断し + かねます to join directly at the end of the sentence, with その件は as the topic and 私には marking the agent. All three distractors fling the stem 判断し to the sentence-final position—a bare renyoukei stem can't close a sentence on its own, and かねます is torn away from its stem, leaving it stranded. The only valid order is その件は → 私には → 判断し → かねます." },
     exampleJapanese: "その件は私には判断しかねます。",
-    exampleMeaningZh: "那件事我難以做出判斷。"
+    exampleMeaningZh: "那件事我難以做出判斷。",
+    exampleMeaningI18n: { "ja": "その件については、私には判断するのが難しい。", "en": "I'm afraid that matter is not something I can judge." },
   }),
   examQuestion({
     id: "n2-context-shitagatte-r2a",

--- a/src/domain/exam/items/n3.ts
+++ b/src/domain/exam/items/n3.ts
@@ -777,7 +777,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「都」在此讀「つ」、「合」濁化讀「ごう」，故「都合」＝つごう（情況、方便與否）。「とごう」誤把「都」讀成「と」；「つこう」漏掉「合」的濁音；「とこう」兩處都錯。",
     explanationI18n: { "ja": "「都」はここでは「つ」と読み、「合」は濁って「ごう」と読むので、「都合」＝つごう（状況・都合のよしあし）です。「とごう」は「都」を「と」と読み間違えたもの、「つこう」は「合」の濁音を落としたもの、「とこう」は両方とも誤りです。", "en": "Here 「都」is read 「つ」and 「合」voices to 「ごう」, so 「都合」＝つごう (circumstances; convenience). 「とごう」wrongly reads 「都」as 「と」; 「つこう」drops the voicing on 「合」; 「とこう」gets both wrong." },
     exampleJapanese: "今日はちょっと都合が悪いので、また今度にしてください。",
-    exampleMeaningZh: "今天有點不方便，請改約下次。"
+    exampleMeaningZh: "今天有點不方便，請改約下次。",
+    exampleMeaningI18n: { "ja": "今日は少し予定が合わないので、また次の機会にしてほしい。", "en": "Today doesn't quite work for me, so let's make it another time." },
   }),
   examQuestion({
     id: "n3-kanji-kufuu",
@@ -797,7 +798,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「工」讀短音「く」、「夫」讀「ふ」（不濁化），故「工夫」＝くふう（設法、巧思）。「こうふう」誤把「工」讀成長音「こう」；「くぶう」把「夫」誤濁成「ぶ」；「こうぶう」兩處都錯。",
     explanationI18n: { "ja": "「工」は短音で「く」、「夫」は「ふ」（濁らない）と読むので、「工夫」＝くふう（工夫・くふう）です。「こうふう」は「工」を長音の「こう」と読み間違えたもの、「くぶう」は「夫」を誤って「ぶ」と濁らせたもの、「こうぶう」は両方とも誤りです。", "en": "「工」is read as the short 「く」and 「夫」as 「ふ」(no voicing), so 「工夫」＝くふう (devising a way; ingenuity). 「こうふう」wrongly reads 「工」as the long 「こう」; 「くぶう」wrongly voices 「夫」to 「ぶ」; 「こうぶう」gets both wrong." },
     exampleJapanese: "問題を解決するために、いろいろな工夫をした。",
-    exampleMeaningZh: "為了解決問題，下了各種工夫。"
+    exampleMeaningZh: "為了解決問題，下了各種工夫。",
+    exampleMeaningI18n: { "ja": "問題を解決するために、いろいろとやり方を考えて試した。", "en": "I tried all sorts of creative approaches to solve the problem." },
   }),
   examQuestion({
     id: "n3-kanji-housou",
@@ -817,7 +819,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「放」讀長音「ほう」、「送」讀「そう」，故「放送」＝ほうそう（播送）。「ぼうそう」把「放」誤濁成「ぼう」（會變成「暴走」）；「ほそう」漏掉長音；「ほうぞう」把「送」誤濁成「ぞう」。",
     explanationI18n: { "ja": "「放」は長音で「ほう」、「送」は「そう」と読むので、「放送」＝ほうそう（放送）です。「ぼうそう」は「放」を誤って「ぼう」と濁らせたもの（これでは「暴走」になってしまいます）、「ほそう」は長音を落としたもの、「ほうぞう」は「送」を誤って「ぞう」と濁らせたものです。", "en": "「放」is read as the long 「ほう」and 「送」as 「そう」, so 「放送」＝ほうそう (broadcast). 「ぼうそう」wrongly voices 「放」to 「ぼう」(which would make it 「暴走」); 「ほそう」drops the long vowel; 「ほうぞう」wrongly voices 「送」to 「ぞう」." },
     exampleJapanese: "台風の最新情報がテレビで放送された。",
-    exampleMeaningZh: "颱風的最新資訊在電視上播送了。"
+    exampleMeaningZh: "颱風的最新資訊在電視上播送了。",
+    exampleMeaningI18n: { "ja": "台風の最新情報がテレビで流された。", "en": "The latest typhoon updates were broadcast on TV." },
   }),
   examQuestion({
     id: "n3-kanji-keiken",
@@ -837,7 +840,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「経」讀長音「けい」、「験」讀「けん」，故「経験」＝けいけん（經驗）。「けいげん」把「験」誤濁成「げん」；「けえけん」把長音誤寫成「けえ」；「きけん」音節錯誤（近「危険」）。",
     explanationI18n: { "ja": "「経」は長音で「けい」、「験」は「けん」と読むので、「経験」＝けいけん（経験）です。「けいげん」は「験」を誤って「げん」と濁らせたもの、「けえけん」は長音を「けえ」と書き誤ったもの、「きけん」は音節が違います（「危険」に近くなります）。", "en": "「経」is read as the long 「けい」and 「験」as 「けん」, so 「経験」＝けいけん (experience). 「けいげん」wrongly voices 「験」to 「げん」; 「けえけん」spells the long vowel wrongly as 「けえ」; 「きけん」has the wrong syllables (close to 「危険」)." },
     exampleJapanese: "海外で働いた経験が、今の仕事に役立っている。",
-    exampleMeaningZh: "在海外工作的經驗，對現在的工作很有幫助。"
+    exampleMeaningZh: "在海外工作的經驗，對現在的工作很有幫助。",
+    exampleMeaningI18n: { "ja": "海外で働いたことが、今の仕事に役立っている。", "en": "My experience working overseas is a big help in my current job." },
   }),
   examQuestion({
     id: "n3-kanji-shinsetsu",
@@ -857,7 +861,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「親」讀「しん」、「切」讀「せつ」，故「親切」＝しんせつ（親切）。「じんせつ」把「親」誤濁成「じん」；「しんぜつ」把「切」誤濁成「ぜつ」；「じんぜつ」兩處都錯。",
     explanationI18n: { "ja": "「親」は「しん」、「切」は「せつ」と読むので、「親切」＝しんせつ（親切）です。「じんせつ」は「親」を誤って「じん」と濁らせたもの、「しんぜつ」は「切」を誤って「ぜつ」と濁らせたもの、「じんぜつ」は両方とも誤りです。", "en": "「親」is read 「しん」and 「切」as 「せつ」, so 「親切」＝しんせつ (kind). 「じんせつ」wrongly voices 「親」to 「じん」; 「しんぜつ」wrongly voices 「切」to 「ぜつ」; 「じんぜつ」gets both wrong." },
     exampleJapanese: "道に迷ったとき、親切な人が駅まで案内してくれた。",
-    exampleMeaningZh: "迷路的時候，有位親切的人帶我到車站。"
+    exampleMeaningZh: "迷路的時候，有位親切的人帶我到車站。",
+    exampleMeaningI18n: { "ja": "道に迷ったとき、やさしい人が駅まで案内してくれた。", "en": "When I got lost, a kind person showed me the way to the station." },
   }),
   examQuestion({
     id: "n3-context-sorede",
@@ -1157,7 +1162,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「原」讀「げん」、「因」讀「いん」，故「原因」＝げんいん。「げいいん」是把「ん」音脫落的誤讀；「げんにん」與「現任／原人」等別語混同；「がんいん」是語頭母音的誤讀。",
     explanationI18n: { "ja": "「原」は「げん」、「因」は「いん」と読むので「原因」＝げんいんです。「げいいん」は「ん」の音が抜けた誤読、「げんにん」は「現任・原人」などの別語との混同、「がんいん」は語頭の母音の誤読です。", "en": "「原」is read 「げん」and 「因」is read 「いん」, so 「原因」= げんいん. 「げいいん」drops the 「ん」sound in a misreading; 「げんにん」confuses it with other words like 「現任／原人」; 「がんいん」is a misreading of the initial vowel." },
     exampleJapanese: "事故の原因を調べるため、現場を確認した。",
-    exampleMeaningZh: "為了調查事故的原因，確認了現場。"
+    exampleMeaningZh: "為了調查事故的原因，確認了現場。",
+    exampleMeaningI18n: { "ja": "事故がなぜ起きたのかを調べるために、現場を確認した。", "en": "To investigate the cause of the accident, they examined the scene." },
   }),
   examQuestion({
     id: "n3-kanji-koutsuu",
@@ -1177,7 +1183,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「交」讀長音「こう」、「通」讀「つう」，故「交通」＝こうつう。「こうずう」是把「つ」誤濁成「ず」；「こつう」是長音脫落；「こうとう」是把「通」誤讀成別音（近「高等」）。",
     explanationI18n: { "ja": "「交」は長音「こう」、「通」は「つう」と読むので「交通」＝こうつうです。「こうずう」は「つ」を誤って「ず」と濁らせたもの、「こつう」は長音が抜けたもの、「こうとう」は「通」を別の音（「高等」に近い音）と誤読したものです。", "en": "「交」is read with a long vowel 「こう」and 「通」is read 「つう」, so 「交通」= こうつう. 「こうずう」wrongly voices 「つ」into 「ず」; 「こつう」drops the long vowel; 「こうとう」misreads 「通」as a different sound (close to 「高等」)." },
     exampleJapanese: "雪のため、交通が大きく乱れている。",
-    exampleMeaningZh: "因為下雪，交通大亂。"
+    exampleMeaningZh: "因為下雪，交通大亂。",
+    exampleMeaningI18n: { "ja": "雪のせいで、電車や道路などの交通が大きく乱れている。", "en": "Traffic is badly disrupted because of the snow." },
   }),
   examQuestion({
     id: "n3-kanji-shippai",
@@ -1197,7 +1204,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「失」促音化讀「しっ」、「敗」讀「ぱい」，故「失敗」＝しっぱい。「しつばい」是促音與清濁皆誤；「しはい」是音脫落（近「支配」）；「しっぺい」是「疾病」等別語的讀音。",
     explanationI18n: { "ja": "「失」は促音化して「しっ」、「敗」は「ぱい」と読むので「失敗」＝しっぱいです。「しつばい」は促音と清濁の両方を誤ったもの、「しはい」は音が抜けたもの（「支配」に近い）、「しっぺい」は「疾病」などの別語の読み方です。", "en": "「失」takes the double consonant reading 「しっ」and 「敗」is read 「ぱい」, so 「失敗」= しっぱい. 「しつばい」gets both the double consonant and the voicing wrong; 「しはい」drops a sound (close to 「支配」); 「しっぺい」is the reading of a different word like 「疾病」." },
     exampleJapanese: "一度の失敗であきらめず、もう一度挑戦した。",
-    exampleMeaningZh: "沒有因一次失敗就放棄，再挑戰了一次。"
+    exampleMeaningZh: "沒有因一次失敗就放棄，再挑戰了一次。",
+    exampleMeaningI18n: { "ja": "一度うまくいかなかったくらいであきらめず、もう一度挑戦した。", "en": "Instead of giving up after one failure, I gave it another try." },
   }),
   examQuestion({
     id: "n3-kanji-yakusoku",
@@ -1217,7 +1225,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「約」讀「やく」、「束」讀「そく」，故「約束」＝やくそく。「やくぞく」是把「そ」誤濁成「ぞ」；「よくそく」是語頭母音的誤讀；「やっそく」是把「く」誤促音化。",
     explanationI18n: { "ja": "「約」は「やく」、「束」は「そく」と読むので「約束」＝やくそくです。「やくぞく」は「そ」を誤って「ぞ」と濁らせたもの、「よくそく」は語頭の母音の誤読、「やっそく」は「く」を誤って促音化したものです。", "en": "「約」is read 「やく」and 「束」is read 「そく」, so 「約束」= やくそく. 「やくぞく」wrongly voices 「そ」into 「ぞ」; 「よくそく」misreads the initial vowel; 「やっそく」wrongly turns 「く」into a double consonant." },
     exampleJapanese: "友達との約束を忘れてしまった。",
-    exampleMeaningZh: "把和朋友的約定忘了。"
+    exampleMeaningZh: "把和朋友的約定忘了。",
+    exampleMeaningI18n: { "ja": "友達と交わした約束をすっかり忘れてしまった。", "en": "I forgot about the promise I made with a friend." },
   }),
   examQuestion({
     id: "n3-context-tokorode-meeting",
@@ -1279,7 +1288,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「とうとう」表示經過長時間或過程後最終的結果（此處是最終沒來），≒「ついに」。「すぐに」是「馬上」（無過程）；「だんだん」是「漸漸地」（描述變化過程，不是最終結果）；「もうすぐ」是「快要」（事情尚未發生）。唯「ついに」與「とうとう」同義。",
     explanationI18n: { "ja": "「とうとう」は長い時間や過程を経た末の最終的な結果（ここでは結局来なかったこと）を表し、「ついに」とほぼ同じ意味です。「すぐに」は「間もなく」（過程がない）、「だんだん」は「少しずつ」（変化の過程を表し、最終結果ではない）、「もうすぐ」は「まもなく」（まだ起きていない）です。「とうとう」と同義なのは「ついに」だけです。", "en": "「とうとう」expresses a final outcome after a long time or process (here, ultimately not coming), ≒「ついに」. 「すぐに」means \"right away\" (no process); 「だんだん」means \"gradually\" (describes a process of change, not a final result); 「もうすぐ」means \"soon\" (the thing hasn't happened yet). Only 「ついに」is synonymous with 「とうとう」." },
     exampleJapanese: "三時間も待って、バスはついに来なかった。",
-    exampleMeaningZh: "等了三個小時，巴士到最後還是沒來。"
+    exampleMeaningZh: "等了三個小時，巴士到最後還是沒來。",
+    exampleMeaningI18n: { "ja": "三時間も待ったのに、バスは最後まで来なかった。", "en": "I waited three whole hours, but in the end the bus never came." },
   }),
   examQuestion({
     id: "n3-syn-tashika",
@@ -1301,7 +1311,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "副詞「たしか」表示憑記憶的不確定推測「記得好像…」，與表推測的「おそらく」相近。「きっと」是「一定」（把握度高）；「ぜったいに」是「絕對」（100% 肯定）；「やっぱり」是「果然」（事後印證）。唯「おそらく」與「たしか」同為不確定的推測語氣。",
     explanationI18n: { "ja": "副詞「たしか」は記憶に基づく不確かな推測「たしか…だったと思う」を表し、推測を表す「おそらく」に近い意味です。「きっと」は「必ず」（確信度が高い）、「ぜったいに」は「絶対に」（100％の断定）、「やっぱり」は「思ったとおり」（あとで確認された）です。「たしか」と同じく不確かな推測を表すのは「おそらく」だけです。", "en": "The adverb 「たしか」expresses an uncertain guess based on memory, \"if I recall correctly…,\" close to the conjectural 「おそらく」. 「きっと」means \"surely\" (high certainty); 「ぜったいに」means \"absolutely\" (100% sure); 「やっぱり」means \"as expected\" (confirmed after the fact). Only 「おそらく」, like 「たしか」, carries an uncertain conjectural tone." },
     exampleJapanese: "会議はおそらく三時からだったと思う。",
-    exampleMeaningZh: "我記得會議好像是三點開始。"
+    exampleMeaningZh: "我記得會議好像是三點開始。",
+    exampleMeaningI18n: { "ja": "はっきりではないが、会議は三時からだったと覚えている。", "en": "If I remember correctly, the meeting was supposed to start at three." },
   }),
   examQuestion({
     id: "n3-syn-sassoku",
@@ -1323,7 +1334,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「さっそく」表示「（得到某物或機會後）立刻著手做」，≒「すぐに」。「ゆっくり」是「慢慢地」（相反）；「あとで」是「待會兒」（延後）；「たまに」是「偶爾」（頻率）。唯「すぐに」與「さっそく」同表立即去做。",
     explanationI18n: { "ja": "「さっそく」は「（何かを手に入れたり機会を得たりしたあと）すぐに取りかかる」ことを表し、「すぐに」とほぼ同じ意味です。「ゆっくり」は「のんびり」（反対）、「あとで」は「後で」（先送り）、「たまに」は「ときどき」（頻度）です。「さっそく」と同じくすぐに取りかかる意味を表すのは「すぐに」だけです。", "en": "「さっそく」means \"to set to work immediately (after obtaining something or getting the chance),\" ≒「すぐに」. 「ゆっくり」means \"slowly\" (the opposite); 「あとで」means \"later\" (a delay); 「たまに」means \"occasionally\" (frequency). Only 「すぐに」, like 「さっそく」, expresses doing something right away." },
     exampleJapanese: "新しい辞書を買って、すぐに使ってみた。",
-    exampleMeaningZh: "買了新字典，馬上就用用看。"
+    exampleMeaningZh: "買了新字典，馬上就用用看。",
+    exampleMeaningI18n: { "ja": "新しい辞書を買って、時間をおかずに使ってみた。", "en": "I bought a new dictionary and tried it out right away." },
   }),
   examQuestion({
     id: "n3-syn-jouzu",
@@ -1345,7 +1357,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「上手」表示某事做得好、很在行，≒「得意」（擅長且有自信）。「下手」「苦手」都表示「不擅長」（相反）；「丁寧」是「仔細、有禮」（描述做事態度，不等於擅長）。唯「得意」與「上手」同義。",
     explanationI18n: { "ja": "「上手」はあることをうまくこなし、よく慣れていることを表し、「得意」（うまくて自信がある）とほぼ同じ意味です。「下手」「苦手」はどちらも「うまくない」（反対）を表し、「丁寧」は「ていねいで礼儀正しい」（やり方の態度を表し、うまいこととは限らない）です。「上手」と同義なのは「得意」だけです。", "en": "「上手」means doing something well and being skilled at it, ≒「得意」(good at it and confident). 「下手」and 「苦手」both mean \"not good at\" (the opposite); 「丁寧」means \"careful, polite\" (describes attitude, not skill). Only 「得意」is synonymous with 「上手」." },
     exampleJapanese: "姉は料理が得意で、いつもおいしい。",
-    exampleMeaningZh: "姊姊很會做菜，總是很好吃。"
+    exampleMeaningZh: "姊姊很會做菜，總是很好吃。",
+    exampleMeaningI18n: { "ja": "姉は料理がうまくて、作るものはいつもおいしい。", "en": "My older sister is a great cook—her food is always delicious." },
   }),
   examQuestion({
     id: "n3-syn-kichinto",
@@ -1367,7 +1380,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「きちんと」表示「確實、不馬虎地完成」，口語近義詞是「ちゃんと」。「ときどき」是「有時」（頻率）；「だんだん」是「漸漸」（變化）；「やっと」是「好不容易才」（強調費力達成）。唯「ちゃんと」與「きちんと」同表確實做好。",
     explanationI18n: { "ja": "「きちんと」は「確実に、いいかげんにせず仕上げる」ことを表し、話し言葉での類義語は「ちゃんと」です。「ときどき」は「時々」（頻度）、「だんだん」は「少しずつ」（変化）、「やっと」は「ようやく」（苦労して達成したことを強調）です。「きちんと」と同じく確実にやり遂げる意味を表すのは「ちゃんと」だけです。", "en": "「きちんと」means \"to complete something properly, without cutting corners,\" and its colloquial synonym is 「ちゃんと」. 「ときどき」means \"sometimes\" (frequency); 「だんだん」means \"gradually\" (change); 「やっと」means \"finally, with effort\" (emphasizing a hard-won result). Only 「ちゃんと」, like 「きちんと」, expresses doing something properly." },
     exampleJapanese: "出かける前に、戸締まりをちゃんとしてください。",
-    exampleMeaningZh: "出門前請好好把門窗鎖上。"
+    exampleMeaningZh: "出門前請好好把門窗鎖上。",
+    exampleMeaningI18n: { "ja": "出かける前に、戸締まりをしっかり確認してほしい。", "en": "Please make sure the doors and windows are properly locked before you go out." },
   }),
   examQuestion({
     id: "n3-usage-tsutaeru",
@@ -1389,7 +1403,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「伝える」＝把話語、訊息傳達給人，本句「請向大家轉達會議延期」最自然。把感冒傳染給人用「うつす」；把球傳給隊友用「パスする／渡す」；疾病經由血緣遺傳用「遺伝する」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「伝える」は言葉やメッセージを人に伝達することで、この文の「会議が延期になったことをみんなに伝えてください」が最も自然です。風邪を人にうつすことは「うつす」、ボールを味方に渡すことは「パスする／渡す」、病気が血縁を通じて受け継がれることは「遺伝する」を使います。ほかの三文はいずれも不自然で、正解は最初の文だけです。", "en": "「伝える」= to convey words or a message to someone; here \"please pass on to everyone that the meeting is postponed\" is the most natural. To pass a cold to someone uses 「うつす」; to pass a ball to a teammate uses 「パスする／渡す」; a disease being inherited through bloodline uses 「遺伝する」. The other three pairings don't work; only the first sentence is correct." },
     exampleJapanese: "会議が延期になったと、みんなに伝えてください。",
-    exampleMeaningZh: "請向大家轉達會議延期了。"
+    exampleMeaningZh: "請向大家轉達會議延期了。",
+    exampleMeaningI18n: { "ja": "会議が延期になったことを、みんなに知らせてください。", "en": "Please let everyone know that the meeting has been postponed." },
   }),
   examQuestion({
     id: "n3-usage-tsukareru",
@@ -1411,7 +1426,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「疲れる」＝（人或身體部位）因勞動而感到勞累，本句「走了一整天，腳很累」最自然。電池沒電用「なくなる／切れる」；食物變質用「腐る」；花枯萎用「枯れる」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「疲れる」は（人や体の一部が）働いて疲労を感じることで、この文の「一日中歩いたので、足がとても疲れた」が最も自然です。電池が切れることは「なくなる／切れる」、食べ物が傷むことは「腐る」、花がしおれることは「枯れる」を使います。ほかの三文はいずれも不自然で、正解は最初の文だけです。", "en": "「疲れる」= (a person or body part) feeling worn out from exertion; here \"I walked all day, so my legs are tired\" is the most natural. A dead battery uses 「なくなる／切れる」; food going bad uses 「腐る」; a flower wilting uses 「枯れる」. The other three pairings don't work; only the first sentence is correct." },
     exampleJapanese: "一日中歩いたので、足がとても疲れた。",
-    exampleMeaningZh: "走了一整天，腳非常累。"
+    exampleMeaningZh: "走了一整天，腳非常累。",
+    exampleMeaningI18n: { "ja": "一日中歩いたので、足がくたくたになった。", "en": "I walked all day, so my legs are really tired." },
   }),
   examQuestion({
     id: "n3-usage-tarinai",
@@ -1433,7 +1449,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「足りない」＝數量、程度不夠，本句「人手不夠，所以決定再找一個人」最自然。個子矮用「（背が）低い」；考試不及格用「落ちる」；沒趕上電車用「間に合わない」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「足りない」は数量や程度が不足していることで、この文の「人手が足りないので、もう一人呼ぶことにした」が最も自然です。背が低いことは「（背が）低い」、試験に不合格になることは「落ちる」、電車に乗り遅れることは「間に合わない」を使います。ほかの三文はいずれも不自然で、正解は最初の文だけです。", "en": "「足りない」= a quantity or degree being insufficient; here \"there aren't enough hands, so we decided to call in one more\" is the most natural. Being short in height uses 「（背が）低い」; failing an exam uses 「落ちる」; missing a train uses 「間に合わない」. The other three pairings don't work; only the first sentence is correct." },
     exampleJapanese: "人手が足りないので、もう一人呼ぶことにした。",
-    exampleMeaningZh: "因為人手不夠，所以決定再找一個人。"
+    exampleMeaningZh: "因為人手不夠，所以決定再找一個人。",
+    exampleMeaningI18n: { "ja": "働く人が不足しているので、もう一人呼ぶことにした。", "en": "We're short-handed, so we decided to call in one more person." },
   }),
   examQuestion({
     id: "n3-usage-kuraberu",
@@ -1455,7 +1472,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「比べる」＝把兩者對照看出差別，本句「比較兩家店的價格後再決定」最自然。並排站立用「並ぶ」；收集資料用「集める」；按順序排放用「並べる」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「比べる」は二つを照らし合わせて違いを見きわめることで、この文の「二つの店の値段を比べてから決めた」が最も自然です。横に並んで立つことは「並ぶ」、資料を集めることは「集める」、順番どおりに並べて置くことは「並べる」を使います。ほかの三文はいずれも不自然で、正解は最初の文だけです。", "en": "「比べる」= to set two things side by side to see the difference; here \"after comparing the prices at the two stores, I decided\" is the most natural. Standing in a line uses 「並ぶ」; gathering materials uses 「集める」; arranging things in order uses 「並べる」. The other three pairings don't work; only the first sentence is correct." },
     exampleJapanese: "二つの店の値段を比べてから、買う店を決めた。",
-    exampleMeaningZh: "比較了兩家店的價格後，才決定要買的店。"
+    exampleMeaningZh: "比較了兩家店的價格後，才決定要買的店。",
+    exampleMeaningI18n: { "ja": "二つの店の値段を見比べてから、どちらの店で買うかを決めた。", "en": "I compared the prices at the two stores before deciding where to buy." },
   }),
   examQuestion({
     id: "n3-usage-todoku",
@@ -1477,7 +1495,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「届く」＝（寄送的物品）送達、寄到，本句「昨天訂的書今天就寄到了」最自然。趕上電車用「間に合う」；（人）抵達某處用「着く」（届く 用於物品，不用於人到達）；伸手搆到用「手が届く」（自動詞，不可說「手を届く」）。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「届く」は（送られた物が）着く・送られてくることで、この文の「昨日注文した本が今日もう届いた」が最も自然です。電車に間に合うことは「間に合う」、（人が）どこかに到着することは「着く」（届くは物に使い、人の到着には使いません）、手が届くことは「手が届く」（自動詞なので「手を届く」とは言えません）を使います。ほかの三文はいずれも不自然で、正解は最初の文だけです。", "en": "「届く」= (a shipped item) arriving or being delivered; here \"the book I ordered yesterday arrived today\" is the most natural. Making it for a train uses 「間に合う」; (a person) arriving somewhere uses 「着く」(届く is for objects, not for people arriving); reaching something with your hand uses 「手が届く」(intransitive—you can't say 「手を届く」). The other three pairings don't work; only the first sentence is correct." },
     exampleJapanese: "昨日注文した本が、今日もう届いた。",
-    exampleMeaningZh: "昨天訂的書，今天就已經寄到了。"
+    exampleMeaningZh: "昨天訂的書，今天就已經寄到了。",
+    exampleMeaningI18n: { "ja": "昨日注文した本が、今日もう手元に着いた。", "en": "The book I ordered yesterday already arrived today." },
   }),
   examQuestion({
     id: "n3-vocab-mamoru",
@@ -3642,7 +3661,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=けいざい。「経」音読み けい、「済」音読み ざい，合成為複合詞 けいざい。干擾けいさい＝把濁音 ざ 誤讀成清音 さ（清濁混淆，意義不成立）；げいざい＝首音清音 け 誤讀成濁音 げ（清濁混淆）；けいざいい＝在尾巴多加一個長音 い（長音添加，無此讀法）。語境「経済のニュース」只接受けいざい。",
     explanationI18n: { "ja": "正解＝けいざい。「経」は音読み けい、「済」は音読み ざい で、合わさって複合語 けいざい になります。誤答けいさい＝濁音 ざ を清音 さ と読み違えたもの（清濁の混同で、意味が成り立ちません）。げいざい＝語頭の清音 け を濁音 げ と読み違えたもの（清濁の混同）。けいざいい＝末尾に長音 い を余分に足したもの（長音の付加で、そのような読み方はありません）。文脈「経済のニュース」ではけいざいしか受け入れられません。", "en": "The answer is けいざい. 「経」 has the on'yomi けい and 「済」 has the on'yomi ざい, combining into the compound けいざい. The distractor けいさい misreads the voiced ざ as the voiceless さ (voicing confusion; not a real word here); げいざい misreads the initial voiceless け as the voiced げ (voicing confusion); けいざいい adds an extra long vowel い at the end (no such reading). The context 「経済のニュース」 only accepts けいざい." },
     exampleJapanese: "新聞で日本の経済のニュースを毎朝チェックしている。",
-    exampleMeaningZh: "我每天早上都在新聞上查看日本經濟的新聞。"
+    exampleMeaningZh: "我每天早上都在新聞上查看日本經濟的新聞。",
+    exampleMeaningI18n: { "ja": "毎朝、新聞で日本の経済に関するニュースをチェックしている。", "en": "Every morning I check the news for stories on Japan's economy." },
   }),
   examQuestion({
     id: "n3-kanji-kisoku",
@@ -3662,7 +3682,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=きそく。「規」き＋「則」そく＝きそく。干擾ぎそく＝首音 き 誤濁化成 ぎ（清濁混淆）；きぞく＝把 そく 的 そ 誤讀成濁音 ぞ（清濁混淆，且易與同音的「貴族」混淆）；きょそく＝把 き 誤加拗音變 きょ（拗音混淆，無此讀法）。四個選項皆為平假名且互異，正解唯一。",
     explanationI18n: { "ja": "正解＝きそく。「規」き＋「則」そく＝きそく。誤答ぎそく＝語頭 き を誤って濁らせ ぎ にしたもの（清濁の混同）。きぞく＝そく の そ を濁音 ぞ と読み違えたもの（清濁の混同で、同音の「貴族」とも紛らわしい）。きょそく＝き に拗音を足して きょ にしたもの（拗音の混同で、そのような読み方はありません）。四つの選択肢はいずれも平仮名で互いに異なり、正解は一つだけです。", "en": "The answer is きそく. 「規」 き + 「則」 そく = きそく. The distractor ぎそく wrongly voices the initial き to ぎ (voicing confusion); きぞく misreads the そ in そく as the voiced ぞ (voicing confusion, and is easily confused with the homophone 「貴族」); きょそく wrongly adds a contracted sound, turning き into きょ (yōon confusion; no such reading). All four options are in hiragana and distinct, and there's only one correct answer." },
     exampleJapanese: "この学校には守らなければならない規則がたくさんある。",
-    exampleMeaningZh: "這所學校有許多必須遵守的規則。"
+    exampleMeaningZh: "這所學校有許多必須遵守的規則。",
+    exampleMeaningI18n: { "ja": "この学校には、守らなければならない決まりがたくさんある。", "en": "This school has a lot of rules that must be followed." },
   }),
   examQuestion({
     id: "n3-kanji-kaiketsu",
@@ -3682,7 +3703,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=かいけつ。「解」かい＋「決」けつ＝かいけつ。干擾がいけつ＝首音 か 誤讀成濁音 が（清濁混淆）；かいげつ＝把 けつ 的 け 誤讀成濁音 げ，會偏向「海月」方向，語境不通（清濁混淆）；かいけっつ＝在 け 後多塞一個促音 っ（促音添加，無此讀法）。語境「問題を～した」只接受かいけつ。",
     explanationI18n: { "ja": "正解＝かいけつ。「解」かい＋「決」けつ＝かいけつ。誤答がいけつ＝語頭 か を濁音 が と読み違えたもの（清濁の混同）。かいげつ＝けつ の け を濁音 げ と読み違えたもので「海月」の方向に寄り、文脈に合いません（清濁の混同）。かいけっつ＝け のあとに促音 っ を余分に入れたもの（促音の付加で、そのような読み方はありません）。文脈「問題を～した」ではかいけつしか受け入れられません。", "en": "The answer is かいけつ. 「解」 かい + 「決」 けつ = かいけつ. The distractor がいけつ misreads the initial か as the voiced が (voicing confusion); かいげつ misreads the け in けつ as the voiced げ, leaning toward 「海月」, which doesn't fit the context (voicing confusion); かいけっつ inserts an extra small tsu っ after け (added double consonant; no such reading). The context 「問題を～した」 only accepts かいけつ." },
     exampleJapanese: "その問題はみんなで話し合って解決した。",
-    exampleMeaningZh: "那個問題大家一起討論後解決了。"
+    exampleMeaningZh: "那個問題大家一起討論後解決了。",
+    exampleMeaningI18n: { "ja": "その問題は、みんなで話し合って解決することができた。", "en": "We solved that problem by talking it over together." },
   }),
   examQuestion({
     id: "n3-kanji-reigi",
@@ -3702,7 +3724,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=れいぎ。「礼」れい＋「儀」ぎ＝れいぎ。干擾れいき＝把濁音 ぎ 誤讀成清音 き（清濁混淆，意義不成立）；れえぎ＝把長音 れい 寫成 れえ（長音表記混淆，標準假名為 れい）；れいぎい＝尾巴多加長音 い（長音添加，無此讀法）。語境「年上の人には～を忘れない」只接受れいぎ。",
     explanationI18n: { "ja": "正解＝れいぎ。「礼」れい＋「儀」ぎ＝れいぎ。誤答れいき＝濁音 ぎ を清音 き と読み違えたもの（清濁の混同で、意味が成り立ちません）。れえぎ＝長音 れい を れえ と書いたもの（長音表記の混同で、標準の仮名は れい）。れいぎい＝末尾に長音 い を余分に足したもの（長音の付加で、そのような読み方はありません）。文脈「年上の人には～を忘れない」ではれいぎしか受け入れられません。", "en": "The answer is れいぎ. 「礼」 れい + 「儀」 ぎ = れいぎ. The distractor れいき misreads the voiced ぎ as the voiceless き (voicing confusion; not a real word); れえぎ writes the long vowel れい as れえ (long-vowel spelling confusion; the standard kana is れい); れいぎい adds an extra long vowel い at the end (no such reading). The context 「年上の人には～を忘れない」 only accepts れいぎ." },
     exampleJapanese: "年上の人には礼儀を忘れないようにしている。",
-    exampleMeaningZh: "我留意對長輩不忘禮儀。"
+    exampleMeaningZh: "我留意對長輩不忘禮儀。",
+    exampleMeaningI18n: { "ja": "目上の人に対しては、礼儀を忘れないように心がけている。", "en": "I make a point of never forgetting my manners with people older than me." },
   }),
   examQuestion({
     id: "n3-kanji-inshou",
@@ -3722,7 +3745,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=いんしょう。「印」いん＋「象」しょう＝いんしょう。干擾いんじょう＝把 しょう 的 し 誤讀成濁音 じ（清濁混淆）；いんしょ＝漏掉長音 う 變成 しょ（長音脫落，無此讀法）；いいんしょう＝首音多加一拍變 いい（長音添加，無此讀法）。語境「強い～に残った」只接受いんしょう。",
     explanationI18n: { "ja": "正解＝いんしょう。「印」いん＋「象」しょう＝いんしょう。誤答いんじょう＝しょう の し を濁音 じ と読み違えたもの（清濁の混同）。いんしょ＝長音 う が抜けて しょ になったもの（長音の脱落で、そのような読み方はありません）。いいんしょう＝語頭を一拍余分にして いい にしたもの（長音の付加で、そのような読み方はありません）。文脈「強い～に残った」ではいんしょうしか受け入れられません。", "en": "The answer is いんしょう. 「印」 いん + 「象」 しょう = いんしょう. The distractor いんじょう misreads the し in しょう as the voiced じ (voicing confusion); いんしょ drops the long vowel う, becoming しょ (dropped long vowel; no such reading); いいんしょう adds an extra beat at the start, becoming いい (added long vowel; no such reading). The context 「強い～に残った」 only accepts いんしょう." },
     exampleJapanese: "彼女の明るい笑顔がとても強く印象に残った。",
-    exampleMeaningZh: "她開朗的笑容給我留下了很強的印象。"
+    exampleMeaningZh: "她開朗的笑容給我留下了很強的印象。",
+    exampleMeaningI18n: { "ja": "彼女の明るい笑顔が、とても強く心に残った。", "en": "Her bright smile left a very strong impression on me." },
   }),
   examQuestion({
     id: "n3-kanji-kankou",
@@ -3742,7 +3766,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=かんこう。「観」かん＋「光」こう＝かんこう。干擾かんごう＝把 こう 的 こ 誤讀成濁音 ご（清濁混淆，非「観光」之讀法）；がんこう＝首音 か 誤讀成濁音 が（清濁混淆）；かんこ＝漏掉長音 う 變 こ（長音脫落，無此讀法）。語境「人気のある～の町」只接受かんこう。",
     explanationI18n: { "ja": "正解＝かんこう。「観」かん＋「光」こう＝かんこう。誤答かんごう＝こう の こ を濁音 ご と読み違えたもの（清濁の混同で、「観光」の読みではありません）。がんこう＝語頭 か を濁音 が と読み違えたもの（清濁の混同）。かんこ＝長音 う が抜けて こ になったもの（長音の脱落で、そのような読み方はありません）。文脈「人気のある～の町」ではかんこうしか受け入れられません。", "en": "The answer is かんこう. 「観」 かん + 「光」 こう = かんこう. The distractor かんごう misreads the こ in こう as the voiced ご (voicing confusion; not the reading of 「観光」); がんこう misreads the initial か as the voiced が (voicing confusion); かんこ drops the long vowel う, becoming こ (dropped long vowel; no such reading). The context 「人気のある～の町」 only accepts かんこう." },
     exampleJapanese: "京都は外国人に人気のある観光の町だ。",
-    exampleMeaningZh: "京都是很受外國人歡迎的觀光城市。"
+    exampleMeaningZh: "京都是很受外國人歡迎的觀光城市。",
+    exampleMeaningI18n: { "ja": "京都は、外国人観光客にとても人気のある町だ。", "en": "Kyoto is a sightseeing city that is very popular with visitors from abroad." },
   }),
   examQuestion({
     id: "n3-kanji-suzushii",
@@ -3762,7 +3787,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=すずしい。訓読み すず-しい。干擾すすしい＝把第二拍濁音 ず 誤讀成清音 す（清濁混淆，無此語）；すずじい＝把 し 誤讀成濁音 じ（清濁混淆，無此語）；すづしい＝把 ず 寫成同音近形的 づ（近形假名混淆，現代假名遣標準為 ず）。語境「朝はとても～風」只接受すずしい。",
     explanationI18n: { "ja": "正解＝すずしい。訓読み すず-しい。誤答すすしい＝二拍目の濁音 ず を清音 す と読み違えたもの（清濁の混同で、そのような語はありません）。すずじい＝し を濁音 じ と読み違えたもの（清濁の混同で、そのような語はありません）。すづしい＝ず を、同音で形の近い づ と書いたもの（形の近い仮名の混同で、現代仮名遣いの標準は ず）。文脈「朝はとても～風」ではすずしいしか受け入れられません。", "en": "The answer is すずしい, the kun'yomi すず-しい. The distractor すすしい misreads the second voiced ず as the voiceless す (voicing confusion; not a real word); すずじい misreads the し as the voiced じ (voicing confusion; not a real word); すづしい writes ず as づ, which sounds the same and looks similar (similar-kana confusion; modern kana usage standardizes on ず). The context 「朝はとても～風」 only accepts すずしい." },
     exampleJapanese: "夏でも朝はとても涼しい風がふいて気持ちがいい。",
-    exampleMeaningZh: "即使是夏天，早上也吹著很涼爽的風，感覺很舒服。"
+    exampleMeaningZh: "即使是夏天，早上也吹著很涼爽的風，感覺很舒服。",
+    exampleMeaningI18n: { "ja": "夏でも朝はひんやりした気持ちのいい風が吹いて、心地よい。", "en": "Even in summer, a nice cool breeze blows in the morning and it feels wonderful." },
   }),
   examQuestion({
     id: "n3-kanji-abura",
@@ -3782,7 +3808,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解=あぶら。訓読み あぶら。干擾あふら＝把濁音 ぶ 誤讀成清音 ふ（清濁混淆，無此語）；あぶろ＝把尾音 ら 誤讀成 ろ（近形假名混淆，無此語）；あっぷら＝在 ぶ 前後混入促音變 っぷ（促音添加，無此讀法）。語境「フライパンに～を入れて」只接受あぶら。",
     explanationI18n: { "ja": "正解＝あぶら。訓読み あぶら。誤答あふら＝濁音 ぶ を清音 ふ と読み違えたもの（清濁の混同で、そのような語はありません）。あぶろ＝末尾 ら を ろ と読み違えたもの（形の近い仮名の混同で、そのような語はありません）。あっぷら＝ぶ の前後に促音を混ぜて っぷ にしたもの（促音の付加で、そのような読み方はありません）。文脈「フライパンに～を入れて」ではあぶらしか受け入れられません。", "en": "The answer is あぶら, the kun'yomi あぶら. The distractor あふら misreads the voiced ぶ as the voiceless ふ (voicing confusion; not a real word); あぶろ misreads the final ら as ろ (similar-kana confusion; not a real word); あっぷら mixes in a small tsu around ぶ, turning it into っぷ (added double consonant; no such reading). The context 「フライパンに～を入れて」 only accepts あぶら." },
     exampleJapanese: "フライパンに油を少し入れてから野菜をいためた。",
-    exampleMeaningZh: "在平底鍋裡放了一點油之後再炒蔬菜。"
+    exampleMeaningZh: "在平底鍋裡放了一點油之後再炒蔬菜。",
+    exampleMeaningI18n: { "ja": "フライパンに油を少しひいてから、野菜をいためた。", "en": "I put a little oil in the frying pan before stir-frying the vegetables." },
   }),
   examQuestion({
     id: "n3-grammar-temo",
@@ -4022,7 +4049,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「まねく」＝招く（邀請）。干擾「まめく」把ね誤成め，形近不成詞；「まぬく」把ね誤成ぬ，不成詞；「まねぐ」把く濁化成ぐ，動詞語尾錯誤、不成立。四者皆非「招く」的另一合法讀音，語境只接受まねく。陷阱類型＝近形假名混淆＋清濁誤植。",
     explanationI18n: { "ja": "正解は「まねく」＝招く（誘う・招待する）です。誤答の「まめく」は「ね」を「め」と取り違えたもので、形は似ていますが語になりません。「まぬく」は「ね」を「ぬ」と取り違えたもので、語として成立しません。「まねぐ」は語尾の「く」を濁らせて「ぐ」とした動詞語尾の誤りで、成り立ちません。いずれも「招く」の別の正しい読みではなく、この文脈で受け入れられるのは「まねく」だけです。ひっかけの型は、形の似た仮名の混同と、清濁の取り違えです。", "en": "The answer 「まねく」 = 招く (to invite). The distractor 「まめく」 replaces ね with め—a similar-looking kana that forms no real word; 「まぬく」 replaces ね with ぬ, forming no word; 「まねぐ」 voices the く into ぐ, an incorrect verb ending that doesn't hold up. None of these is another legitimate reading of 「招く」, and the context only accepts まねく. Trap type: confusion between similar-looking kana plus voiced/unvoiced misspelling." },
     exampleJapanese: "今度のパーティーに、友だちを招くつもりです。",
-    exampleMeaningZh: "這次生日，我打算邀請朋友來家裡。"
+    exampleMeaningZh: "這次生日，我打算邀請朋友來家裡。",
+    exampleMeaningI18n: { "ja": "今度のパーティーに、友だちを招待するつもりだ。", "en": "I'm planning to invite my friends to the upcoming party." },
   }),
   examQuestion({
     id: "n3-kanji-yokin",
@@ -4042,7 +4070,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「よきん」＝預金（存款）。干擾「よぎん」把き濁化成ぎ，不成詞；「ようきん」多了長音よう，讀音錯誤；「よっきん」插入促音っ，不成立。四者中只有よきん是「預金」的讀音，其餘皆非另一合法讀音。陷阱類型＝清濁、長音、促音誤植。",
     explanationI18n: { "ja": "正解は「よきん」＝預金です。誤答の「よぎん」は「き」を濁らせて「ぎ」としたもので、語になりません。「ようきん」は長音の「よう」が余分で、読み方が誤っています。「よっきん」は促音「っ」が入り込んでおり、成り立ちません。四つのうち「預金」の読みは「よきん」だけで、ほかはいずれも別の正しい読みではありません。ひっかけの型は、清濁・長音・促音の取り違えです。", "en": "The answer 「よきん」 = 預金 (savings). The distractor 「よぎん」 voices き into ぎ, forming no word; 「ようきん」 adds an extra long vowel よう, giving a wrong reading; 「よっきん」 inserts a geminate っ, which doesn't hold up. Only よきん is the reading of 「預金」; none of the others is a legitimate alternative reading. Trap type: misspelling of voicing, long vowels, and geminate consonants." },
     exampleJapanese: "毎月、給料の一部を銀行の預金に回しています。",
-    exampleMeaningZh: "每個月，我會把薪水的一部分存進銀行存款。"
+    exampleMeaningZh: "每個月，我會把薪水的一部分存進銀行存款。",
+    exampleMeaningI18n: { "ja": "毎月、給料の一部を銀行に預けている。", "en": "Every month I put part of my salary into my bank savings." },
   }),
   examQuestion({
     id: "n3-kanji-teishutsu",
@@ -4062,7 +4091,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「ていしゅつ」＝提出（提交）。干擾「ていしゅっつ」多插促音っ，不成立；「でいしゅつ」把て濁化成で，不成詞；「ていしゅう」把つ誤成長音しゅう，讀音錯誤。皆非「提出」的另一合法讀音，語境只接受ていしゅつ。陷阱類型＝促音、清濁、長音混淆。",
     explanationI18n: { "ja": "正解は「ていしゅつ」＝提出です。誤答の「ていしゅっつ」は促音「っ」が余分に入っており、成り立ちません。「でいしゅつ」は「て」を濁らせて「で」としたもので、語になりません。「ていしゅう」は「つ」を長音の「しゅう」に取り違えたもので、読み方が誤っています。いずれも「提出」の別の正しい読みではなく、この文脈で受け入れられるのは「ていしゅつ」だけです。ひっかけの型は、促音・清濁・長音の混同です。", "en": "The answer 「ていしゅつ」 = 提出 (to submit). The distractor 「ていしゅっつ」 inserts an extra geminate っ and doesn't hold up; 「でいしゅつ」 voices て into で, forming no word; 「ていしゅう」 turns つ into a long vowel しゅう, giving a wrong reading. None is another legitimate reading of 「提出」, and the context only accepts ていしゅつ. Trap type: confusion of geminate consonants, voicing, and long vowels." },
     exampleJapanese: "レポートはあした、先生に提出してください。",
-    exampleMeaningZh: "報告請在明天交給老師。"
+    exampleMeaningZh: "報告請在明天交給老師。",
+    exampleMeaningI18n: { "ja": "レポートは明日、先生に出してください。", "en": "Please hand in your report to the teacher tomorrow." },
   }),
   examQuestion({
     id: "n3-kanji-hyougen",
@@ -4082,7 +4112,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「ひょうげん」＝表現（表達）。干擾「ひょうけん」把げ清音化成け，不成詞；「ひょげん」少了長音、變ひょ，讀音錯誤；「ひゅうげん」把ょ誤成ゅ，拗音錯誤。皆非「表現」的另一合法讀音，只接受ひょうげん。陷阱類型＝清濁、長音、拗音混淆。",
     explanationI18n: { "ja": "正解は「ひょうげん」＝表現です。誤答の「ひょうけん」は「げ」を清音の「け」としたもので、語になりません。「ひょげん」は長音が抜けて「ひょ」になっており、読み方が誤っています。「ひゅうげん」は拗音の「ょ」を「ゅ」と取り違えた誤りです。いずれも「表現」の別の正しい読みではなく、受け入れられるのは「ひょうげん」だけです。ひっかけの型は、清濁・長音・拗音の混同です。", "en": "The answer 「ひょうげん」 = 表現 (to express). The distractor 「ひょうけん」 unvoices げ into け, forming no word; 「ひょげん」 drops the long vowel and becomes ひょ, giving a wrong reading; 「ひゅうげん」 changes ょ into ゅ, a wrong contracted sound. None is another legitimate reading of 「表現」; only ひょうげん is accepted. Trap type: confusion of voicing, long vowels, and contracted sounds." },
     exampleJapanese: "この言葉は、感謝の気持ちを表現するときに使います。",
-    exampleMeaningZh: "這個詞用在表達感謝心情的時候。"
+    exampleMeaningZh: "這個詞用在表達感謝心情的時候。",
+    exampleMeaningI18n: { "ja": "この言葉は、感謝の気持ちを表すときに使います。", "en": "This word is used when expressing feelings of gratitude." },
   }),
   examQuestion({
     id: "n3-kanji-shouhin",
@@ -4102,7 +4133,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「しょうひん」＝商品（商品）。干擾「しょうびん」把ひ濁化成び，不成詞；「しょひん」少了長音しょう，讀音錯誤；「しょうぴん」把ひ半濁化成ぴ，不成立。皆非「商品」的另一合法讀音，語境只接受しょうひん。陷阱類型＝清濁、半濁、長音誤植。",
     explanationI18n: { "ja": "正解は「しょうひん」＝商品です。誤答の「しょうびん」は「ひ」を濁らせて「び」としたもので、語になりません。「しょひん」は長音の「しょう」が抜けており、読み方が誤っています。「しょうぴん」は「ひ」を半濁音の「ぴ」としたもので、成り立ちません。いずれも「商品」の別の正しい読みではなく、この文脈で受け入れられるのは「しょうひん」だけです。ひっかけの型は、清濁・半濁・長音の取り違えです。", "en": "The answer 「しょうひん」 = 商品 (goods). The distractor 「しょうびん」 voices ひ into び, forming no word; 「しょひん」 drops the long vowel しょう, giving a wrong reading; 「しょうぴん」 half-voices ひ into ぴ, which doesn't hold up. None is another legitimate reading of 「商品」, and the context only accepts しょうひん. Trap type: misspelling of voicing, half-voicing, and long vowels." },
     exampleJapanese: "この店では、新しい商品が毎週入ってきます。",
-    exampleMeaningZh: "這家店每週都會進新商品。"
+    exampleMeaningZh: "這家店每週都會進新商品。",
+    exampleMeaningI18n: { "ja": "この店には、毎週新しい商品が入ってきます。", "en": "New products arrive at this store every week." },
   }),
   examQuestion({
     id: "n3-usage-boshuu",
@@ -4124,7 +4156,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句意為「這家店現在正在徵求兼職員工」，對外公開徵求人員，正是「募集」的典型用法。干擾一「拿了傳單放進包包」應改用「拾う／もらう」，撿拾／拿取個別物品不是募集。干擾二「下個月要進新公司」是自己求職入職，應改用「就職する／入る」，主語是被招募的一方而非招募者，方向相反。干擾三「拜託媽媽要點旅費」是向個人索討金錢，應改用「もらう／借りる」，募集是向不特定多數公開徵集，對象與規模不符。陷阱類型為對象/方向混淆與規模誤用。",
     explanationI18n: { "ja": "正解の文は「この店では今、アルバイトのスタッフを募集しています」で、外に向けて公に人を募っており、まさに「募集」の典型的な使い方です。誤答一「チラシを募集してかばんに入れた」は、個々の物を拾ったり受け取ったりする場面なので「拾う／もらう」を使うべきで、募集ではありません。誤答二「新しい会社に募集する」は自分が求職して入る側の話で、「就職する／入る」を使うべきです。主語が募集される側であって募集する側ではなく、方向が逆です。誤答三「母にお願いして旅行のお金を募集してもらった」は個人にお金を求める場面で、「もらう／借りる」を使うべきです。募集は不特定多数に向けて公に募ることで、対象も規模も合いません。ひっかけの型は、対象・方向の混同と規模の誤用です。", "en": "The correct sentence means \"This shop is currently recruiting part-time staff\"—openly soliciting people from the public, which is exactly the typical use of 「募集」. Distractor 1, \"took a flyer being handed out and put it in my bag,\" should use 「拾う／もらう」; picking up or taking an individual item is not recruiting. Distractor 2, \"will join a new company next month,\" is about the speaker seeking employment and joining; it should use 「就職する／入る」, since the subject is the one being recruited rather than the recruiter—the direction is reversed. Distractor 3, \"asked my mother for a bit of travel money,\" is asking an individual for money and should use 「もらう／借りる」; 募集 means openly soliciting from an unspecified large group, so the target and scale don't match. The trap types are confusion of target/direction and misuse of scale." },
     exampleJapanese: "この店では今、アルバイトのスタッフを募集しています。",
-    exampleMeaningZh: "這家店現在正在招募兼職員工。"
+    exampleMeaningZh: "這家店現在正在招募兼職員工。",
+    exampleMeaningI18n: { "ja": "この店では今、アルバイトのスタッフを集めています。", "en": "This store is currently recruiting part-time staff." },
   }),
   examQuestion({
     id: "n3-usage-oboeru",
@@ -4146,7 +4179,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句意為「為了明天的考試，得記住五十個新單字」，把新詞記進腦中，正是「覚える」的典型用法。干擾一「借的書下週前要還」應改用「返す」，歸還物品不是記憶。干擾二「房間太暗就把燈打開」應改用「つける」，開燈不能用「覚える」。干擾三「把約定時間記在手帳上」是寫在紙上而非記在腦中，應改用「書く／メモする」；「覚えておく」是記在腦裡，與寫進手帳矛盾。陷阱類型為「腦中記憶」與「書面記錄／其他動作」的混淆。",
     explanationI18n: { "ja": "正解の文は「明日のテストのために、新しい単語を五十個覚えなければならない」で、新しい語を頭に入れる場面であり、まさに「覚える」の典型的な使い方です。誤答一「冷めたスープを電子レンジで覚えて温かくした」は温める場面なので「温める」を使うべきで、記憶とは関係ありません。誤答二「部屋が暗かったので電気を覚えて明るくした」は「つける」を使うべきで、電気をつけることに「覚える」は使えません。誤答三「約束の時間を手帳に覚えておいた」は紙に書く場面であって頭に入れるのではないので、「書く／メモする」を使うべきです。「覚えておく」は頭に記憶しておくことで、手帳に書くこととは矛盾します。ひっかけの型は、「頭の中の記憶」と「書面への記録・その他の動作」の混同です。", "en": "The correct sentence means \"For tomorrow's test, I have to memorize fifty new words\"—storing new words in the mind, which is exactly the typical use of 「覚える」. Distractor 1, \"have to return the borrowed book by next week,\" should use 「返す」; returning an item is not memorizing. Distractor 2, \"the room was too dark, so I turned on the light,\" should use 「つける」; you can't use 「覚える」 for turning on a light. Distractor 3, \"wrote the appointment time in my planner,\" is writing on paper rather than keeping it in mind and should use 「書く／メモする」; 「覚えておく」 means holding it in your head, which contradicts writing it in a planner. The trap type is confusion between \"mental memory\" and \"written records / other actions.\"" },
     exampleJapanese: "明日のテストのために、新しい単語を五十個覚えなければならない。",
-    exampleMeaningZh: "為了明天的考試，我必須記住五十個新單字。"
+    exampleMeaningZh: "為了明天的考試，我必須記住五十個新單字。",
+    exampleMeaningI18n: { "ja": "明日のテストのために、新しい単語を五十個暗記しなければなりません。", "en": "I have to memorize fifty new words for tomorrow's test." },
   }),
   examQuestion({
     id: "n3-usage-tsuzukeru",
@@ -4168,7 +4202,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句意為「為了健康，每天慢跑三十分鐘，已持續了五年」，不間斷地長期進行同一件事，正是「続ける」的核心用法。干擾一「雨變大趕緊把窗戶關上」應改用「閉める」，關窗是中止開著的狀態，與「持續」相反。干擾二「工作做完了就把電腦電源關掉」應改用「切る」，關電源是停止而非繼續。干擾三「太晚了講到一半就掛電話睡了」應改用「切る／やめる」，中途結束與「続ける」語意完全相反。陷阱類型為以「停止／關閉」類動詞當干擾，用反義鎖死方向。",
     explanationI18n: { "ja": "正解の文は「健康のために、毎日三十分のジョギングを五年間も続けている」で、同じ物事を途切れずに長く行っており、まさに「続ける」の中心的な使い方です。誤答一「雨が強くなったので窓をすぐに続けた」は「閉める」を使うべきで、窓を閉めるのは開いている状態をやめることであり、「続ける」とは逆です。誤答二「仕事が終わったのでパソコンの電源を続けた」は「切る」を使うべきで、電源を切るのは止めることであって続けることではありません。誤答三「授業が終わったので教室の電気を続けて帰った」は「消す」を使うべきで、途中でやめることは「続ける」とは意味が正反対です。ひっかけの型は、「止める・閉じる」類の動詞を誤答に使い、反対の意味で方向を否定するものです。", "en": "The correct sentence means \"For my health, I've jogged thirty minutes every day and have kept it up for five years\"—doing the same thing continuously over a long period, which is the core use of 「続ける」. Distractor 1, \"the rain got heavy so I quickly closed the open window,\" should use 「閉める」; closing a window ends the open state, the opposite of \"continuing.\" Distractor 2, \"finished all my work so I turned off the computer,\" should use 「切る」; turning off the power is stopping, not continuing. Distractor 3, \"it got late so I hung up mid-conversation and went to sleep,\" should use 「切る／やめる」; ending partway is completely opposite in meaning to 「続ける」. The trap type uses \"stop/turn-off\" verbs as distractors, locking in the direction through antonyms." },
     exampleJapanese: "健康のために、毎日三十分のジョギングを五年間も続けている。",
-    exampleMeaningZh: "為了健康，我每天慢跑三十分鐘，已經持續了五年。"
+    exampleMeaningZh: "為了健康，我每天慢跑三十分鐘，已經持續了五年。",
+    exampleMeaningI18n: { "ja": "健康のために、毎日三十分のジョギングを五年間も休まずに行っています。", "en": "For my health, I jog for thirty minutes every day, and I've kept it up for five years now." },
   }),
   examQuestion({
     id: "n3-context-sonotame",
@@ -4250,7 +4285,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「多くなった（變多了）」與「増えた」同義，都表示數量上升，代入後句意完全一致。干擾「少なくなった（變少了）」是反義，方向相反，與「だいぶ増えた」的語境衝突，明確不成立。干擾「古くなった（變舊了）」描述事物老化，與人數多寡無關。干擾「高くなった（變高/變貴了）」描述高度或價格上升，雖同為「上升」概念但對象是高度或價格而非數量，外國人「變貴」不通。陷阱類型：用反義（少なく）鎖死方向，並用「上升」近義（高く）但對象不符製造混淆。",
     explanationI18n: { "ja": "正解の「多くなった」は「増えた」と同義で、どちらも数量が上がることを表し、入れ替えても意味がぴったり合います。誤答「少なくなった」は反対の意味で方向が逆であり、「だいぶ増えた」という文脈と衝突するため、明らかに成り立ちません。誤答「古くなった」は物が古びることを表し、人数の多い少ないとは関係ありません。誤答「高くなった」は高さや値段が上がることを表し、同じ「上昇」の概念でも対象が高さや値段であって数量ではないため、外国人が「高くなる」では意味が通りません。ひっかけの型は、反対語（少なく）で方向を否定しつつ、「上昇」の類語（高く）を対象違いで使い混乱を誘うものです。", "en": "The answer 「多くなった」 (\"has become more numerous\") is synonymous with 「増えた」—both indicate a rise in quantity, and substituting it keeps the sentence meaning identical. The distractor 「少なくなった」 (\"has become fewer\") is the antonym, running in the opposite direction and clashing with the context 「だいぶ増えた」, so it clearly fails. The distractor 「古くなった」 (\"has become old\") describes things aging and has nothing to do with the number of people. The distractor 「高くなった」 (\"has become high / expensive\") describes a rise in height or price; although it's also an \"increase\" concept, its target is height or price rather than quantity, and foreigners \"becoming more expensive\" makes no sense. Trap type: an antonym (少なく) locks the direction, while an \"increase\" near-synonym (高く) with a mismatched target creates confusion." },
     exampleJapanese: "最近、この町に住む外国人がだいぶ多くなった。",
-    exampleMeaningZh: "最近，住在這個鎮上的外國人變多了不少。"
+    exampleMeaningZh: "最近，住在這個鎮上的外國人變多了不少。",
+    exampleMeaningI18n: { "ja": "最近、この町に住む外国人がかなり多くなりました。", "en": "Recently, the number of foreigners living in this town has grown quite a bit." },
   }),
   examQuestion({
     id: "n3-syn-mezurashii",
@@ -4272,7 +4308,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「あまり見ない（不太常見）」與「珍しい」同義，都強調「少見、難得一見」，代入後「外国のあまり見ないお菓子」自然成立。干擾「よく見る（經常看到）」是反義，與「珍しい（罕見）」方向相反，明確不成立。干擾「とても甘い（很甜）」描述味道，雖然搭配的是「お菓子」很自然，但「甜」與「稀奇」語意完全不同，是搭配誘餌。干擾「値段が安い（價格便宜）」描述價格，與「罕見」無關。陷阱類型：用反義（よく見る）鎖方向，並用與「お菓子」搭配自然的味道、價格屬性製造看似通順實則不同義的干擾。",
     explanationI18n: { "ja": "正解の「あまり見ない」は「珍しい」と同義で、どちらも「めったに見かけない・なかなか手に入らない」ことを強調し、入れ替えても「外国のあまり見ないお菓子」と自然に成り立ちます。誤答「よく見る」は反対の意味で、「珍しい」とは方向が逆であり、明らかに成り立ちません。誤答「とても甘い」は味を表し、「お菓子」との組み合わせは自然ですが、「甘い」と「珍しい」は意味がまったく異なる、組み合わせにつられた誘い水です。誤答「値段が安い」は値段を表し、「珍しい」とは関係ありません。ひっかけの型は、反対語（よく見る）で方向を否定しつつ、「お菓子」と自然に結びつく味や値段の属性で、一見通るようで意味の違う誤答を作るものです。", "en": "The answer 「あまり見ない」 (\"not often seen\") is synonymous with 「珍しい」—both stress \"rare, seldom encountered\"—and substituting it gives the natural 「外国のあまり見ないお菓子」. The distractor 「よく見る」 (\"often seen\") is the antonym, opposite in direction to 「珍しい」 (rare), and clearly fails. The distractor 「とても甘い」 (\"very sweet\") describes taste; although it pairs naturally with 「お菓子」, \"sweet\" is completely different in meaning from \"rare\" and is a collocation lure. The distractor 「値段が安い」 (\"cheap in price\") describes price and is unrelated to \"rare.\" Trap type: an antonym (よく見る) locks the direction, while taste and price attributes that pair naturally with 「お菓子」 create distractors that look coherent but aren't actually synonymous." },
     exampleJapanese: "この店では、外国のあまり見ないお菓子が買える。",
-    exampleMeaningZh: "在這家店可以買到外國的不太常見的點心。"
+    exampleMeaningZh: "在這家店可以買到外國的不太常見的點心。",
+    exampleMeaningI18n: { "ja": "この店では、外国のあまり見かけないお菓子が買えます。", "en": "At this store, you can buy foreign sweets that you don't see very often." },
   }),
   examQuestion({
     id: "n3-vocab-akirameru-no-tonaeru",
@@ -4372,7 +4409,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「記録」讀「きろく」（記＝き、録＝ろく）。「ぎろく」誤把記濁化（議録不是常用詞，語境也指紀錄練習，不成立）；「きるく」把録誤讀成る非ろ，是不存在的讀音；「きろう」誤把録讀成ろう，亦非此詞。故只有「きろく」成立。",
     explanationI18n: { "ja": "「記録」は「きろく」（記＝き、録＝ろく）と読みます。「ぎろく」は「記」を誤って濁らせたもので（「議録」は一般的な語ではなく、文脈も練習の記録を指すので成り立ちません）。「きるく」は「録」を「ろ」ではなく「る」と誤読したもので、存在しない読みです。「きろう」は「録」を誤って「ろう」と読んだもので、これもこの語ではありません。したがって成り立つのは「きろく」だけです。", "en": "「記録」 is read 「きろく」 (記 = き, 録 = ろく). 「ぎろく」 wrongly voices 記 (議録 is not a common word, and the context is about recording practice, so it doesn't hold up); 「きるく」 misreads 録 as る instead of ろ, a reading that doesn't exist; 「きろう」 misreads 録 as ろう, also not this word. So only 「きろく」 holds up." },
     exampleJapanese: "彼は毎日の練習を記録している。",
-    exampleMeaningZh: "他每天都把練習的情況記錄下來。"
+    exampleMeaningZh: "他每天都把練習的情況記錄下來。",
+    exampleMeaningI18n: { "ja": "彼は毎日の練習の様子を書きとめています。", "en": "He keeps a record of his practice every day." },
   }),
   examQuestion({
     id: "n3-kanji-kansatsu",
@@ -4392,7 +4430,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「観察」讀「かんさつ」（観＝かん、察＝さつ）。「がんさつ」誤把観濁化（偽札がんさつ＝偽鈔是別詞，孩子觀察昆蟲的語境不成立）；「かんざつ」誤把察濁化，是不存在的讀音；「かんさち」誤把察讀成さち，亦非此詞。故只有「かんさつ」成立。",
     explanationI18n: { "ja": "「観察」は「かんさつ」（観＝かん、察＝さつ）と読みます。「がんさつ」は「観」を誤って濁らせたもので（「贋札」＝偽札は別の語で、子どもが虫を観察する文脈では成り立ちません）。「かんざつ」は「察」を誤って濁らせたもので、存在しない読みです。「かんさち」は「察」を「さち」と誤読したもので、これもこの語ではありません。したがって成り立つのは「かんさつ」だけです。", "en": "「観察」 is read 「かんさつ」 (観 = かん, 察 = さつ). 「がんさつ」 wrongly voices 観 (偽札 = がんさつ, \"counterfeit bill,\" is a different word, and the context of children observing insects doesn't hold up); 「かんざつ」 wrongly voices 察, a reading that doesn't exist; 「かんさち」 misreads 察 as さち, also not this word. So only 「かんさつ」 holds up." },
     exampleJapanese: "子どもたちは虫を観察して絵をかいた。",
-    exampleMeaningZh: "孩子們觀察昆蟲後畫了畫。"
+    exampleMeaningZh: "孩子們觀察昆蟲後畫了畫。",
+    exampleMeaningI18n: { "ja": "子どもたちは虫をじっくり見て、その絵をかきました。", "en": "The children observed insects and then drew pictures of them." },
   }),
   examQuestion({
     id: "n3-kanji-keiei",
@@ -4412,7 +4451,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「経営」讀「けいえい」（経＝けい、営＝えい）。「げいえい」誤把経濁化，是不存在的讀音；「けいえん」誤把営讀成えん（敬遠けいえん是別詞，經營店舖的語境不成立）；「けえい」漏掉い的長音，亦非此詞。故只有「けいえい」成立。",
     explanationI18n: { "ja": "「経営」は「けいえい」（経＝けい、営＝えい）と読みます。「げいえい」は「経」を誤って濁らせたもので、存在しない読みです。「けいえん」は「営」を「えん」と誤読したもので（「敬遠」は別の語で、店を経営する文脈では成り立ちません）。「けえい」は「い」の長音を落としたもので、これもこの語ではありません。したがって成り立つのは「けいえい」だけです。", "en": "「経営」 is read 「けいえい」 (経 = けい, 営 = えい). 「げいえい」 wrongly voices 経, a reading that doesn't exist; 「けいえん」 misreads 営 as えん (敬遠 = けいえん is a different word, and the context of running a shop doesn't hold up); 「けえい」 drops the long vowel い, also not this word. So only 「けいえい」 holds up." },
     exampleJapanese: "父は小さなパン屋を経営している。",
-    exampleMeaningZh: "父親經營著一間小麵包店。"
+    exampleMeaningZh: "父親經營著一間小麵包店。",
+    exampleMeaningI18n: { "ja": "父は小さなパン屋を営んでいます。", "en": "My father runs a small bakery." },
   }),
   examQuestion({
     id: "n3-kanji-yunyuu",
@@ -4432,7 +4472,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「輸入」讀「ゆにゅう」（輸＝ゆ、入＝にゅう）。「ゆうにゅう」在輸後多加長音（牛乳ぎゅうにゅう類的誤推），是不存在的讀音；「ゆにゅ」漏掉入的長音；「しゅにゅう」誤把輸讀成しゅ（收入しゅうにゅう是別詞，從國外進口商品的語境不成立）。故只有「ゆにゅう」成立。",
     explanationI18n: { "ja": "「輸入」は「ゆにゅう」（輸＝ゆ、入＝にゅう）と読みます。「ゆうにゅう」は「輸」のあとに長音を余分に加えたもので（「牛乳＝ぎゅうにゅう」からの類推による誤り）、存在しない読みです。「ゆにゅ」は「入」の長音を落としたものです。「しゅにゅう」は「輸」を「しゅ」と誤読したもので（「収入＝しゅうにゅう」は別の語で、外国から商品を輸入する文脈では成り立ちません）。したがって成り立つのは「ゆにゅう」だけです。", "en": "「輸入」 is read 「ゆにゅう」 (輸 = ゆ, 入 = にゅう). 「ゆうにゅう」 adds an extra long vowel after 輸 (a false analogy to words like 牛乳 = ぎゅうにゅう), a reading that doesn't exist; 「ゆにゅ」 drops the long vowel of 入; 「しゅにゅう」 misreads 輸 as しゅ (収入 = しゅうにゅう is a different word, and the context of importing goods from abroad doesn't hold up). So only 「ゆにゅう」 holds up." },
     exampleJapanese: "この店は外国から果物を輸入している。",
-    exampleMeaningZh: "這家店從國外進口水果。"
+    exampleMeaningZh: "這家店從國外進口水果。",
+    exampleMeaningI18n: { "ja": "この店は、外国から果物を取り寄せて売っています。", "en": "This store imports fruit from overseas." },
   }),
   examQuestion({
     id: "n3-grammar-ppanashi",
@@ -4632,7 +4673,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "経由唸「けいゆ」，表示中途經過某地。「けいゆう」多了長音不對；「げいゆ」把清音け錯讀成濁音げ；「けいよ」把ゆ錯成よ、字音不符，三者皆非此詞讀音。",
     explanationI18n: { "ja": "「経由」は「けいゆ」と読み、途中である場所を通ることを表します。「けいゆう」は余分な長音があり誤りです。「げいゆ」は清音の「け」を濁音の「げ」と読み間違えています。「けいよ」は「ゆ」を「よ」と間違えており字音が合わず、いずれもこの語の読みではありません。", "en": "経由 is read けいゆ, meaning to pass through somewhere along the way. けいゆう has an extra long vowel and is wrong; げいゆ mistakenly reads the voiceless け as the voiced げ; けいよ replaces ゆ with よ, and its sound doesn't match. None of these three is the correct reading." },
     exampleJapanese: "東京へ行くとき、私はいつも大阪を「経由」します。",
-    exampleMeaningZh: "去東京的時候，我總是經由大阪。"
+    exampleMeaningZh: "去東京的時候，我總是經由大阪。",
+    exampleMeaningI18n: { "ja": "東京へ行くとき、私はいつも大阪を通って行きます。", "en": "Whenever I go to Tokyo, I always travel via Osaka." },
   }),
   examQuestion({
     id: "n3-kanji-kakunin",
@@ -4652,7 +4694,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "確認唸「かくにん」，指核對使其無誤。「がくにん」把清音か錯成濁音が；「かくにい」把ん錯成長音い；「かっくにん」多了促音っ，皆非此詞讀音。",
     explanationI18n: { "ja": "「確認」は「かくにん」と読み、照らし合わせて誤りがないようにすることを指します。「がくにん」は清音の「か」を濁音の「が」と間違えています。「かくにい」は「ん」を長音の「い」と間違えています。「かっくにん」は余分な促音「っ」があり、いずれもこの語の読みではありません。", "en": "確認 is read かくにん, meaning to verify something to make sure it's correct. がくにん mistakenly reads the voiceless か as the voiced が; かくにい replaces the ん with a long vowel い; かっくにん adds an extra double consonant っ. None is the correct reading." },
     exampleJapanese: "出かける前に、戸じまりをもう一度「確認」します。",
-    exampleMeaningZh: "出門前，再確認一次門有沒有鎖好。"
+    exampleMeaningZh: "出門前，再確認一次門有沒有鎖好。",
+    exampleMeaningI18n: { "ja": "出かける前に、戸じまりをもう一度確かめます。", "en": "Before leaving the house, I check one more time that the door is locked." },
   }),
   examQuestion({
     id: "n3-grammar-gasuru",
@@ -4714,7 +4757,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「がっかりする」是『感到失落、沮喪』，與『残念に思う（覺得遺憾可惜）』最接近。『安心した（放心）』『緊張した（緊張）』『感動した（感動）』與輸球後的低落心情皆不符。唯『残念に思った』成立。",
     explanationI18n: { "ja": "「がっかりする」は「落胆する・気が沈む」で、「残念に思う（惜しく思う）」が最も近い意味です。「安心した」「緊張した」「感動した」はいずれも負けた後の沈んだ気持ちとは合いません。「残念に思った」だけが成立します。", "en": "がっかりする means \"to feel let down, disappointed,\" which is closest to 残念に思う (to find it regrettable). 安心した (relieved), 緊張した (nervous), and 感動した (moved) all fail to match the low spirits after a loss. Only 残念に思った works." },
     exampleJapanese: "応援していたチームが負けて、残念に思った。",
-    exampleMeaningZh: "支持的隊伍輸了，感到很失落。"
+    exampleMeaningZh: "支持的隊伍輸了，感到很失落。",
+    exampleMeaningI18n: { "ja": "応援していたチームが負けて、残念な気持ちになりました。", "en": "The team I was rooting for lost, and I felt really let down." },
   }),
   examQuestion({
     id: "n3-syn-daitai",
@@ -4736,7 +4780,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「だいたい」表示程度上接近全部、八九成完成，與「ほぼ」同義，「ほぼ終わった」＝幾乎做完。「まったく」「ぜんぜん」均為「完全（不）」之意、後須接否定，與後句肯定的「終わった」搭配不成立；「ちょうど」是「剛好、正好」表精確，與「大致」相反。唯「ほぼ」與「だいたい」同表近乎全部的程度。",
     explanationI18n: { "ja": "「だいたい」は程度として全体に近く、八、九割ほど終わっていることを表し、「ほぼ」と同義で、「ほぼ終わった＝ほとんど終わった」となります。「まったく」「ぜんぜん」はどちらも「完全に（〜ない）」の意味で後に否定を伴うため、後半の肯定の「終わった」とは組み合わせが成立しません。「ちょうど」は「ちょうど・きっかり」で正確さを表し、「だいたい」とは反対です。「ほぼ」だけが「だいたい」と同じくほとんど全体に近い程度を表します。", "en": "だいたい indicates being close to complete, around eighty or ninety percent finished, which is synonymous with ほぼ; ほぼ終わった = almost done. まったく and ぜんぜん both mean \"(not) at all\" and must be followed by a negative, so they don't fit the affirmative 終わった. ちょうど means \"exactly, just right,\" expressing precision, the opposite of \"roughly.\" Only ほぼ, like だいたい, expresses a degree close to complete." },
     exampleJapanese: "今日の宿題はほぼ終わったので、少し休もう。",
-    exampleMeaningZh: "今天的作業幾乎都做完了，休息一下吧。"
+    exampleMeaningZh: "今天的作業幾乎都做完了，休息一下吧。",
+    exampleMeaningI18n: { "ja": "今日の宿題はほとんど終わったので、少し休みましょう。", "en": "I've mostly finished today's homework, so let's take a short break." },
   }),
   examQuestion({
     id: "n3-usage-akeru",
@@ -4758,7 +4803,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解：「梅雨が明ける」是「明ける」的典型搭配，指梅雨季結束、放晴，自動詞用法自然成立。干擾一「電気をつけて明けた」：開燈讓房間變亮應用「明るくなった／明るくした」，「明ける」不指空間變亮，搭配不成立。干擾二「階段を…明けて行った」：上樓梯應用「上がる／上って」，「明ける」與移動無關，語意不通。干擾三「調べて明けた」：解開問題應用「解けた／分かった」，「明ける」不表示問題解決，明顯不對。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「梅雨が明ける」は「明ける」の典型的な組み合わせで、梅雨の季節が終わって晴れることを指し、自動詞の用法として自然に成立します。誤答一の「電気をつけて明けた」は、電気をつけて部屋を明るくする場合「明るくなった／明るくした」を使うべきで、「明ける」は空間が明るくなることを指さず、組み合わせが成立しません。誤答二の「階段を…明けて行った」は、階段を上る場合「上がる／上って」を使うべきで、「明ける」は移動とは無関係で意味が通りません。誤答三の「調べて明けた」は、問題を解く場合「解けた／分かった」を使うべきで、「明ける」は問題の解決を表さず明らかに誤りです。したがって第一文だけが成立します。", "en": "Correct: 梅雨が明ける is the typical collocation of 明ける, meaning the rainy season ends and clears up; this intransitive usage is natural. Distractor 1, 電気をつけて明けた: making a room brighter by turning on the light should use 明るくなった／明るくした; 明ける doesn't mean a space getting brighter, so the collocation fails. Distractor 2, 階段を…明けて行った: going up stairs should use 上がる／上って; 明ける has nothing to do with movement, so it makes no sense. Distractor 3, 調べて明けた: solving a problem should use 解けた／分かった; 明ける doesn't mean resolving a problem, so it's clearly wrong. Thus only the first sentence works." },
     exampleJapanese: "長い梅雨がやっと明けて、青い空が見えるようになった。",
-    exampleMeaningZh: "漫長的梅雨季終於結束，能看見藍天了。"
+    exampleMeaningZh: "漫長的梅雨季終於結束，能看見藍天了。",
+    exampleMeaningI18n: { "ja": "長い梅雨がやっと終わって、青い空が見えるようになりました。", "en": "The long rainy season finally ended, and the blue sky came into view." },
   }),
   examQuestion({
     id: "n3-usage-omoikiru",
@@ -4780,7 +4826,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解：「ずっと迷っていたが、思い切って…話した」前有「迷っていた」鋪墊猶豫，後接果斷行動，正是「思い切って」鼓起勇氣的核心用法。干擾一「思い切って早く寝るのが普通だ」：早睡是日常選擇、非需下決心之事，且「普通だ」與果斷語氣矛盾，不成立。干擾二「思い切って傘を持って行くべきだ」：帶傘是合理的小判斷應用「念のため」，談不上需要鼓起勇氣，搭配不對。干擾三「毎朝…思い切って電車に乗っている」：每天通勤是習慣動作，與下定決心的語意完全不合。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「ずっと迷っていたが、思い切って…話した」は、前に「迷っていた」で迷いを示し、後に思い切った行動が続いており、まさに「思い切って」＝勇気を出すという中心的な用法です。誤答一の「思い切って早く寝るのが普通だ」は、早寝は日常の選択で決心を要することではなく、「普通だ」も思い切った語気と矛盾し成立しません。誤答二の「思い切って傘を持って行くべきだ」は、傘を持つのは妥当な小さな判断で「念のため」を使うべきで、勇気を出すほどのことではなく組み合わせが合いません。誤答三の「毎朝…思い切って電車に乗っている」は、毎日の通勤は習慣的な動作で、決心するという意味とはまったく合いません。したがって第一文だけが成立します。", "en": "Correct: ずっと迷っていたが、思い切って…話した sets up hesitation with 迷っていた before a decisive action, which is exactly the core use of 思い切って — working up one's courage. Distractor 1, 思い切って早く寝るのが普通だ: going to bed early is a routine choice, not something that requires resolve, and 普通だ contradicts the decisive tone, so it doesn't work. Distractor 2, 思い切って傘を持って行くべきだ: bringing an umbrella is a reasonable small judgment that should use 念のため; it hardly requires courage, so the collocation is wrong. Distractor 3, 毎朝…思い切って電車に乗っている: taking the train every morning is a habitual action, completely at odds with the meaning of making up one's mind. Thus only the first sentence works." },
     exampleJapanese: "ずっと迷っていたが、思い切って先生に本当の気持ちを話した。",
-    exampleMeaningZh: "猶豫了很久，最後鼓起勇氣向老師說出了真實的想法。"
+    exampleMeaningZh: "猶豫了很久，最後鼓起勇氣向老師說出了真實的想法。",
+    exampleMeaningI18n: { "ja": "ずっと迷っていましたが、最後は勇気を出して先生に本当の気持ちを話しました。", "en": "After hesitating for a long time, I finally worked up the courage to tell my teacher how I really felt." },
   }),
   examQuestion({
     id: "n3-kanji-teian",
@@ -4800,7 +4847,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "提案唸「ていあん」，指提出方案。「でいあん」把清音て錯成濁音で；「ていえん」把あん錯成えん、會變成別的字音；「ていはん」把あ錯成は，皆非此詞正確讀音。",
     explanationI18n: { "ja": "「提案」は「ていあん」と読み、案を出すことを指します。「でいあん」は清音の「て」を濁音の「で」と間違えています。「ていえん」は「あん」を「えん」と間違え、別の字音になってしまいます。「ていはん」は「あ」を「は」と間違えており、いずれもこの語の正しい読みではありません。", "en": "提案 is read ていあん, meaning to put forward a plan. でいあん mistakenly reads the voiceless て as the voiced で; ていえん changes あん to えん, producing a different sound; ていはん changes あ to は. None is the correct reading of this word." },
     exampleJapanese: "会議で部長が新しい提案をしました。",
-    exampleMeaningZh: "在會議上，部長提出了新的提案。"
+    exampleMeaningZh: "在會議上，部長提出了新的提案。",
+    exampleMeaningI18n: { "ja": "会議で部長が新しい案を出しました。", "en": "At the meeting, the department manager made a new proposal." },
   }),
   examQuestion({
     id: "n3-kanji-hyoumen",
@@ -4820,7 +4868,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "表面唸「ひょうめん」，指物體的外層。「ひょめん」少了長音；「びょうめん」把清音ひ錯成濁音び；「ひょうべん」把め錯成べ，皆非此詞讀音。",
     explanationI18n: { "ja": "「表面」は「ひょうめん」と読み、物体の外側の層を指します。「ひょめん」は長音が抜けています。「びょうめん」は清音の「ひ」を濁音の「び」と間違えています。「ひょうべん」は「め」を「べ」と間違えており、いずれもこの語の読みではありません。", "en": "表面 is read ひょうめん, meaning the outer layer of an object. ひょめん is missing the long vowel; びょうめん mistakenly reads the voiceless ひ as the voiced び; ひょうべん changes め to べ. None is the correct reading." },
     exampleJapanese: "このテーブルは表面がとてもなめらかです。",
-    exampleMeaningZh: "這張桌子的表面非常光滑。"
+    exampleMeaningZh: "這張桌子的表面非常光滑。",
+    exampleMeaningI18n: { "ja": "このテーブルは、表側の面がとてもなめらかです。", "en": "The surface of this table is very smooth." },
   }),
   examQuestion({
     id: "n3-kanji-idou",
@@ -4840,7 +4889,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "移動唸「いどう」，指從一處移到另一處。「いとう」把濁音ど錯成清音と；「いっどう」多了促音っ；「いどお」把う錯寫成お，皆非此詞正確讀音。",
     explanationI18n: { "ja": "「移動」は「いどう」と読み、ある場所から別の場所へ移ることを指します。「いとう」は濁音の「ど」を清音の「と」と間違えています。「いっどう」は余分な促音「っ」があります。「いどお」は「う」を「お」と書き間違えており、いずれもこの語の正しい読みではありません。", "en": "移動 is read いどう, meaning to move from one place to another. いとう mistakenly reads the voiced ど as the voiceless と; いっどう adds an extra double consonant っ; いどお mistakenly writes う as お. None is the correct reading of this word." },
     exampleJapanese: "次の部屋へみんなで移動しましょう。",
-    exampleMeaningZh: "大家一起移動到下一個房間吧。"
+    exampleMeaningZh: "大家一起移動到下一個房間吧。",
+    exampleMeaningI18n: { "ja": "みんなで次の部屋へ移りましょう。", "en": "Let's all move to the next room together." },
   }),
   examQuestion({
     id: "n3-usage-yakunitatsu",
@@ -4862,7 +4912,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「この辞書は…外国語の勉強にとても役に立つ」＝這本字典對學外語很有用，『工具/知識＋に役に立つ』是標準搭配。干擾一「約束の時間に役に立たなかった」想表達『沒趕上時間』，應用「間に合わなかった」，趕時間不用役に立つ。干擾二「景色がよく役に立った」想說『景色看得很清楚』，應用「見えた」，景色不會『派上用場』。干擾三「学校に役に立つことになった」想說『開始上這所學校』，應用「通う」，「役に立つ」不能表示就讀，搭配不成立。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「この辞書は…外国語の勉強にとても役に立つ」は「この辞書は外国語学習にとても役立つ」の意味で、「道具／知識＋に役に立つ」は標準的な組み合わせです。誤答一の「約束の時間に役に立たなかった」は「時間に間に合わなかった」と言いたいもので、「間に合わなかった」を使うべきで、時間に間に合うことに「役に立つ」は使いません。誤答二の「景色がよく役に立った」は「景色がよく見えた」と言いたいもので、「見えた」を使うべきで、景色が「役に立つ」ことはありません。誤答三の「学校に役に立つことになった」は「この学校に通い始める」と言いたいもので、「通う」を使うべきで、「役に立つ」は通学を表せず組み合わせが成立しません。したがって第一文だけが成立します。", "en": "The correct sentence この辞書は…外国語の勉強にとても役に立つ = this dictionary is very useful for studying a foreign language; \"tool/knowledge ＋ に役に立つ\" is the standard collocation. Distractor 1, 約束の時間に役に立たなかった, tries to say \"didn't make it in time,\" which should use 間に合わなかった; being on time doesn't use 役に立つ. Distractor 2, 景色がよく役に立った, tries to say \"could see the scenery clearly,\" which should use 見えた; scenery doesn't \"come in handy.\" Distractor 3, 学校に役に立つことになった, tries to say \"started attending this school,\" which should use 通う; 役に立つ can't mean enrolling, so the collocation fails. Thus only the first sentence works." },
     exampleJapanese: "この辞書は例文が多いので、外国語の勉強にとても役に立つ。",
-    exampleMeaningZh: "這本字典例句很多，對學外語很有幫助。"
+    exampleMeaningZh: "這本字典例句很多，對學外語很有幫助。",
+    exampleMeaningI18n: { "ja": "この辞書は例文が多いので、外国語の勉強にとても助けになります。", "en": "This dictionary has lots of example sentences, so it's very useful for studying foreign languages." },
   }),
   examQuestion({
     id: "n3-usage-heiki",
@@ -4884,7 +4935,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「何を言われても…平気な顔をしている」＝不管別人說什麼都一副無所謂的樣子，『平気な顔』是固定說法，表不受影響。干擾一「難しくて…もう平気だ」想表達『太難我做不到』，方向相反，應用「無理だ／解けない」。干擾二「平気な天気」不成立，天氣好應說「いい天気／穏やかな天気」。干擾三「平気な気持ち」與『見到喜歡的歌手』的喜悅不合，應用「うれしい気持ち」。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「何を言われても…平気な顔をしている」は「何を言われても気にしないようす」で、「平気な顔」は決まった言い方で影響を受けないことを表します。誤答一の「難しくて…もう平気だ」は「難しすぎてもうできない」と言いたいもので方向が反対で、「無理だ／解けない」を使うべきです。誤答二の「平気な天気」は成立せず、天気がよい場合「いい天気／穏やかな天気」と言うべきです。誤答三の「平気な気持ち」は「好きな歌手に会えた」喜びと合わず、「うれしい気持ち」を使うべきです。したがって第一文だけが成立します。", "en": "The correct sentence 何を言われても…平気な顔をしている = keeps an unbothered look no matter what others say; 平気な顔 is a set expression meaning to remain unaffected. Distractor 1, 難しくて…もう平気だ, tries to say \"it's too hard, I can't do it,\" which is the opposite direction and should use 無理だ／解けない. Distractor 2, 平気な天気, doesn't work; good weather should be いい天気／穏やかな天気. Distractor 3, 平気な気持ち, doesn't match the joy of \"meeting a favorite singer\" and should use うれしい気持ち. Thus only the first sentence works." },
     exampleJapanese: "彼は周りの人に何を言われても、いつも平気な顔をしている。",
-    exampleMeaningZh: "不管周圍的人說什麼，他總是一副無所謂的表情。"
+    exampleMeaningZh: "不管周圍的人說什麼，他總是一副無所謂的表情。",
+    exampleMeaningI18n: { "ja": "周りの人に何を言われても、彼はいつも気にしていない顔をしています。", "en": "No matter what the people around him say, he always looks completely unfazed." },
   }),
   examQuestion({
     id: "n3-usage-mettani",
@@ -4906,7 +4958,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「自分のことをめったに話さない」＝幾乎不談自己的事，『めったに＋否定』表平時很少發生，符合無口（沉默）的習慣描述。干擾一寫的是當天忘了錢包這個一次性事件，『幾乎不能買東西』不通，應用「結局／とうとう買い物ができなかった」。干擾二空氣乾淨理應『星星看得清楚』，用『幾乎看不到』與きれい矛盾，應用「よく見えた」。干擾三是某一天大雨整天出不了門的單一情況，不是『偶爾才會』，應用「ほとんど／まったく外に出られなかった」。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「自分のことをめったに話さない」は「ほとんど自分のことを話さない」の意味で、「めったに＋否定」は普段めったに起こらないことを表し、無口（口数が少ない）という習慣の描写に合います。誤答一はその日に財布を忘れたという一度きりの出来事を述べており、「ほとんど買い物ができない」は通らず、「結局／とうとう買い物ができなかった」を使うべきです。誤答二は空気がきれいなら「星がよく見える」はずで、「ほとんど見えない」を使うと「きれい」と矛盾し、「よく見えた」を使うべきです。誤答三はある一日、大雨で一日中外に出られなかったという単発の状況で、「たまにしか」ではなく、「ほとんど／まったく外に出られなかった」を使うべきです。したがって第一文だけが成立します。", "en": "The correct sentence 自分のことをめったに話さない = hardly ever talks about himself; めったに ＋ negative indicates something rarely happens as a rule, matching the description of a quiet (無口) habit. Distractor 1 describes a one-time event of forgetting a wallet that day, so \"hardly able to shop\" doesn't work; it should use 結局／とうとう買い物ができなかった. Distractor 2: with clean air the stars should be clearly visible, so \"hardly visible\" contradicts きれい; it should use よく見えた. Distractor 3 is a single instance of being unable to go out all day because of heavy rain, not something that happens \"only occasionally\"; it should use ほとんど／まったく外に出られなかった. Thus only the first sentence works." },
     exampleJapanese: "兄はとても無口で、自分のことをめったに話さない。",
-    exampleMeaningZh: "哥哥很沉默，幾乎不談自己的事。"
+    exampleMeaningZh: "哥哥很沉默，幾乎不談自己的事。",
+    exampleMeaningI18n: { "ja": "兄はとても無口で、自分のことをほとんど話しません。", "en": "My older brother is very quiet and hardly ever talks about himself." },
   }),
   examQuestion({
     id: "n3-usage-hattatsu",
@@ -4928,7 +4981,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「医療の技術が大きく発達して」＝醫療技術大幅進步，『技術＋発達』是標準搭配，指領域整體的進步。干擾一講身高變化，應用「伸びて」，身高不用発達。干擾二講蓋好新大樓，建築物落成應用「建った」，建物不用発達。干擾三講個人語言能力進步，應用「上達した」，個人技能的精進用上達而非発達。故只有第一句成立。",
     explanationI18n: { "ja": "正解の「医療の技術が大きく発達して」は「医療技術が大きく進歩して」の意味で、「技術＋発達」は標準的な組み合わせで、分野全体の進歩を指します。誤答一は身長の変化を述べており「伸びて」を使うべきで、身長に「発達」は使いません。誤答二は新しいビルが完成したことを述べており、建物ができる場合「建った」を使うべきで、建物に「発達」は使いません。誤答三は個人の語学力の進歩を述べており「上達した」を使うべきで、個人の技能の上達には「発達」ではなく「上達」を使います。したがって第一文だけが成立します。", "en": "The correct sentence 医療の技術が大きく発達して = medical technology has advanced greatly; \"technology ＋ 発達\" is the standard collocation, referring to the overall advancement of a field. Distractor 1 talks about a change in height, which should use 伸びて; height doesn't use 発達. Distractor 2 talks about a new building going up, which should use 建った; buildings don't use 発達. Distractor 3 talks about an individual's language ability improving, which should use 上達した; the honing of a personal skill uses 上達, not 発達. Thus only the first sentence works." },
     exampleJapanese: "近年は医療の技術が大きく発達して、治せる病気が増えた。",
-    exampleMeaningZh: "近年來醫療技術大幅發展，能治好的疾病變多了。"
+    exampleMeaningZh: "近年來醫療技術大幅發展，能治好的疾病變多了。",
+    exampleMeaningI18n: { "ja": "近年は医療の技術が大きく進歩して、治せる病気が増えました。", "en": "In recent years, medical technology has advanced greatly, and more diseases can now be cured." },
   }),
   examQuestion({
     id: "n3-context-soretomo",
@@ -5010,7 +5064,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「少しずつ」與「だんだん」都表示變化一點一點慢慢進行，代入句中自然且同義。「急に」是突然、變化快速，與逐漸相反；「とつぜん」是突如其來的瞬間變化，方向相反；「いつも」是總是、一直，描述頻率而非漸進變化，語意不符。故唯一正解為「少しずつ」。",
     explanationI18n: { "ja": "正解の「少しずつ」も「だんだん」も、変化が少しずつゆっくり進むことを表し、文に入れても自然で同義です。「急に」は突然で変化が速く、次第にとは反対です。「とつぜん」は突如として起こる瞬間的な変化で方向が反対です。「いつも」は「常に・いつも」で頻度を表し、次第に進む変化ではないため意味が合いません。したがって唯一の正解は「少しずつ」です。", "en": "The answer 少しずつ, like だんだん, indicates that a change proceeds bit by bit, slowly; substituted into the sentence it is natural and synonymous. 急に means \"suddenly, rapidly,\" the opposite of gradually; とつぜん means an abrupt, instantaneous change, also the opposite direction; いつも means \"always, all the time,\" describing frequency rather than gradual change, so it doesn't fit. Thus the only answer is 少しずつ." },
     exampleJapanese: "九月になって、朝の空気が少しずつ涼しくなってきた。",
-    exampleMeaningZh: "進入九月後，早晨的空氣一點一點地變涼了。"
+    exampleMeaningZh: "進入九月後，早晨的空氣一點一點地變涼了。",
+    exampleMeaningI18n: { "ja": "九月になって、朝の空気が少しずつ涼しくなってきました。", "en": "Since September began, the morning air has been getting cooler little by little." },
   }),
   examQuestion({
     id: "n3-syn-monku",
@@ -5032,7 +5087,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「不満」與「文句」都指對某事不滿、抱怨的內容，「不満を言う」與「文句を言う」同義且代入自然。「お礼」是道謝，語意相反；「感想」是中性的想法、感受，不含不滿之意；「冗談」是玩笑話，與抱怨無關。客人因等太久而抱怨，只有「不満」成立。",
     explanationI18n: { "ja": "正解の「不満」は「文句」と同じく、あることに満足できない、抗議する内容を指します。「不満を言う」と「文句を言う」は同義で、言い換えても自然です。「お礼」は感謝を伝える言葉で意味が正反対です。「感想」は中立的な考えや感じたことで、不満の意味は含みません。「冗談」はふざけて言う言葉で、抗議とは関係がありません。客が待たされて文句を言っているので、「不満」だけが当てはまります。", "en": "The correct answer 「不満」 and 「文句」 both refer to expressing dissatisfaction or a complaint about something; 「不満を言う」 and 「文句を言う」 mean the same thing and fit naturally here. 「お礼」 means giving thanks, which is the opposite; 「感想」 is a neutral impression or thought that carries no sense of dissatisfaction; 「冗談」 is a joke, unrelated to complaining. Since the customer is complaining about the long wait, only 「不満」 works." },
     exampleJapanese: "料理が出てくるのが遅くて、客が店員に不満を言った。",
-    exampleMeaningZh: "因為餐點上得很慢，客人對店員表達了不滿。"
+    exampleMeaningZh: "因為餐點上得很慢，客人對店員表達了不滿。",
+    exampleMeaningI18n: { "ja": "料理が出てくるのが遅くて、客が店員に不満を伝えました。", "en": "Because the food was slow to arrive, the customer complained to the staff." },
   }),
   examQuestion({
     id: "n3-syn-yatto",
@@ -5054,7 +5110,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「ようやく」與「やっと」都表示經過長時間或努力後終於達成，代入「ようやく山の頂上に着いた」自然同義。「すでに」是已經、早已，雖能接過去式「着いた」，但只陳述既成事實、不含「歷經辛苦才達成」的語感，與「歩三小時終於登頂」的努力色彩不符；「つねに」是總是、經常，描述常態頻率，與一次性登頂矛盾；「たまに」是偶爾，也是頻率副詞，與此處時間情境不符。爬了三小時終於登頂，只有「ようやく」成立。",
     explanationI18n: { "ja": "正解の「ようやく」は「やっと」と同じく、長い時間や努力を経て、ついに達成することを表します。「ようやく山の頂上に着いた」と言い換えても自然で同義です。「すでに」は「もう・とっくに」という意味で、過去形「着いた」に続けられますが、既に起きた事実を述べるだけで「苦労してやっと達成した」という語感は含まず、「三時間歩いてついに登頂した」という努力の色合いに合いません。「つねに」は「いつも・しょっちゅう」で、常に起こる頻度を表し、一回きりの登頂と矛盾します。「たまに」も頻度の副詞で、この場面には合いません。三時間歩いてついに登頂したので、「ようやく」だけが当てはまります。", "en": "The correct answer 「ようやく」 and 「やっと」 both express finally achieving something after a long time or much effort; 「ようやく山の頂上に着いた」 is naturally synonymous. 「すでに」 means already; although it can attach to the past-tense 「着いた」, it merely states an accomplished fact and lacks the nuance of \"achieved only after hardship,\" which clashes with the effort of reaching the summit after a three-hour climb. 「つねに」 means always or constantly, describing habitual frequency, which contradicts a one-time arrival at the summit. 「たまに」 means occasionally, another frequency adverb that doesn't fit the situation here. Since the speaker finally summits after a three-hour climb, only 「ようやく」 works." },
     exampleJapanese: "三時間も歩いて、ようやく山の頂上に着いた。",
-    exampleMeaningZh: "走了整整三個小時，終於到達了山頂。"
+    exampleMeaningZh: "走了整整三個小時，終於到達了山頂。",
+    exampleMeaningI18n: { "ja": "三時間も歩いて、ついに山の頂上に着きました。", "en": "After walking for a full three hours, we finally reached the top of the mountain." },
   }),
   examQuestion({
     id: "n3-syn-hotondo",
@@ -5076,7 +5133,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「だいたい」與「ほとんど」在此都表示「大部分、差不多全部」完成，代入「だいたい終わって、まだ少し残っている」自然同義。「まったく」後須接否定才通（且意為完全沒），與肯定句「終わって」不合；「ちょうど」是剛好、正好，不表程度多寡；「けっして」是絕（不），須與否定呼應，無法表示完成的程度。作業快做完只剩一點，只有「だいたい」成立。",
     explanationI18n: { "ja": "正解の「だいたい」は、ここでは「ほとんど」と同じく「大部分・ほぼ全部」終わっていることを表し、「だいたい終わって、まだ少し残っている」と言い換えても自然で同義です。「まったく」は後ろに否定を伴ってはじめて成立し（意味は「まるで～ない」）、肯定文の「終わって」には合いません。「ちょうど」は「ぴったり・まさに」の意味で、程度の多い少ないは表しません。「けっして」は「決して（～ない）」で否定と呼応する必要があり、完了の程度を表せません。宿題がほぼ終わって少しだけ残っているので、「だいたい」だけが当てはまります。", "en": "The correct answer 「だいたい」 and 「ほとんど」 both mean \"mostly, nearly all\" complete here; 「だいたい終わって、まだ少し残っている」 is naturally synonymous. 「まったく」 requires a following negative to work (and would mean \"not at all\"), which doesn't fit the affirmative 「終わって」. 「ちょうど」 means exactly or just right and doesn't express degree of quantity. 「けっして」 means \"by no means\" and must pair with a negative, so it can't express a degree of completion. Since the homework is nearly done with just a bit left, only 「だいたい」 works." },
     exampleJapanese: "宿題はだいたい終わって、まだ少しだけ残っている。",
-    exampleMeaningZh: "作業大部分都做完了，只剩下一點點還沒寫完。"
+    exampleMeaningZh: "作業大部分都做完了，只剩下一點點還沒寫完。",
+    exampleMeaningI18n: { "ja": "宿題は大部分が終わって、あと少しだけ残っています。", "en": "The homework is mostly done, with just a little bit left to finish." },
   }),
   examQuestion({
     id: "n3-syn-joubu",
@@ -5098,7 +5156,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「強い」與「丈夫」都可形容物品結實、堅固耐用，「丈夫なかばん／強いかばん」都能與「破れない」呼應，代入自然同義，且「強い」屬 N4/N3 常見詞、符合等級。「便利」是方便，描述使用上的好處而非堅固程度；「高価」是價格昂貴，與耐用無關；「派手」是花俏、華麗，描述外觀。包包裝重物也不破，強調的是結實，只有「強い」成立。",
     explanationI18n: { "ja": "正解の「強い」は「丈夫」と同じく、物が頑丈で長持ちする様子を表せます。「丈夫なかばん／強いかばん」はどちらも「破れない」と呼応でき、言い換えても自然で同義です。また「強い」はN4／N3でよく使われる語でレベルにも合います。「便利」は「使いやすい」という利点を表し、頑丈さは表しません。「高価」は値段が高いことで、丈夫さとは関係ありません。「派手」は見た目の華やかさを表します。かばんが重い物を入れても破れず頑丈さを強調しているので、「強い」だけが当てはまります。", "en": "The correct answer 「強い」 and 「丈夫」 can both describe an object as sturdy, solid, and durable; both 「丈夫なかばん」 and 「強いかばん」 pair naturally with 「破れない」, and 「強い」 is a common N4/N3 word appropriate for this level. 「便利」 means convenient, describing a benefit of use rather than sturdiness; 「高価」 means expensive, unrelated to durability; 「派手」 means flashy or showy, describing appearance. Since the point is that the bag won't tear even loaded with heavy things, emphasizing sturdiness, only 「強い」 works." },
     exampleJapanese: "このかばんは強いから、重い本をたくさん入れても破れない。",
-    exampleMeaningZh: "這個包包很結實，所以裝很多重的書也不會破。"
+    exampleMeaningZh: "這個包包很結實，所以裝很多重的書也不會破。",
+    exampleMeaningI18n: { "ja": "このかばんはつくりがしっかりしているので、重い本をたくさん入れても破れません。", "en": "This bag is sturdy, so it won't tear even when packed with lots of heavy books." },
   }),
   examQuestion({
     id: "n3-usage-choushi",
@@ -5120,7 +5179,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「調子」＝身體或機器運作的狀態、情況。正解「体の調子が悪い」＝身體狀況不好，是最典型的搭配，與「病院で診てもらった」語境完全相配。干擾「駅までの調子が分からない」要表達不知道路，應用「道」或「行き方」，「調子」不指路線；「外の調子が寒い」要表達天氣寒冷，應用「天気」，「調子」不形容氣溫；「この本の調子はむずかしい」要表達內容難，應用「内容」，書本本身不用「調子」形容難易。三個干擾接續都通，但搭配明確不對，唯第一句成立。",
     explanationI18n: { "ja": "「調子」は体や機械が動く状態・具合を指します。正解の「体の調子が悪い」は体の状態が悪いという最も典型的な組み合わせで、「病院で診てもらった」という文脈にぴったり合います。誤答の「駅までの調子が分からない」は道が分からないことを言いたい場面で、「道」や「行き方」を使うべきで、「調子」は道筋を指しません。「外の調子が寒い」は天気が寒いことを言いたい場面で「天気」を使うべきで、「調子」は気温を表しません。「この本の調子はむずかしい」は内容が難しいことを言いたい場面で「内容」を使うべきで、本そのものの難易度に「調子」は使いません。三つの誤答は文法的には続きますが組み合わせが明確に不適切で、一文目だけが成立します。", "en": "「調子」 means the condition or state of one's body or a machine's operation. The correct answer 「体の調子が悪い」 (\"feeling unwell\") is the most typical collocation and fits perfectly with 「病院で診てもらった」. The distractor 「駅までの調子が分からない」 tries to say the speaker doesn't know the way, which should use 「道」 or 「行き方」—「調子」 doesn't refer to a route. 「外の調子が寒い」 tries to say the weather is cold, which should use 「天気」—「調子」 doesn't describe temperature. 「この本の調子はむずかしい」 tries to say the content is difficult, which should use 「内容」—a book itself isn't described with 「調子」. All three distractors are grammatically fine but clearly wrong collocations, so only the first sentence works." },
     exampleJapanese: "最近、体の調子が悪いので、病院で診てもらった。",
-    exampleMeaningZh: "最近身體狀況不好，所以去醫院給醫生看了。"
+    exampleMeaningZh: "最近身體狀況不好，所以去醫院給醫生看了。",
+    exampleMeaningI18n: { "ja": "最近、体の具合がよくないので、病院で診てもらいました。", "en": "I haven't been feeling well lately, so I went to the hospital to see a doctor." },
   }),
   examQuestion({
     id: "n3-usage-yoyuu",
@@ -5142,7 +5202,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「余裕」＝時間、金錢或心情上的從容、空閒、餘地。正解「一時間も余裕がある」＝還有一小時的寬裕時間，與「急がなくても大丈夫」相配。干擾「味が余裕になってしまった」要表達味道變濃／變鹹，應用「濃い」或「しょっぱい」，「余裕」不形容味道；「弟より頭一つ分も余裕がある」要表達身高差距，應用「差」，「余裕」不指身高差；「空が明るく余裕になってきた」要表達天空轉晴，應用「晴れて」，「余裕」不形容天氣。三個干擾句語法雖通順，但搭配明確不對，唯第一句成立。",
     explanationI18n: { "ja": "「余裕」は時間・お金・気持ちのゆとりを表します。正解の「一時間も余裕がある」は、まだ一時間のゆとりがあるという意味で、「急がなくても大丈夫」とよく合います。誤答の「味が余裕になってしまった」は味が濃く／しょっぱくなったことを言いたい場面で、「濃い」や「しょっぱい」を使うべきで、「余裕」は味を表しません。「弟より頭一つ分も余裕がある」は身長の差を言いたい場面で「差」を使うべきで、「余裕」は身長差を指しません。「空が明るく余裕になってきた」は空が晴れてきたことを言いたい場面で「晴れて」を使うべきで、「余裕」は天気を表しません。三つの誤答は文法的には通りますが組み合わせが明確に不適切で、一文目だけが成立します。", "en": "「余裕」 means leeway or spare room in time, money, or one's frame of mind. The correct answer 「一時間も余裕がある」 (\"a whole hour to spare\") fits with 「急がなくても大丈夫」. The distractor 「味が余裕になってしまった」 tries to say the flavor became strong or salty, which should use 「濃い」 or 「しょっぱい」—「余裕」 doesn't describe taste. 「弟より頭一つ分も余裕がある」 tries to say there's a height difference, which should use 「差」—「余裕」 doesn't refer to a difference in height. 「空が明るく余裕になってきた」 tries to say the sky is clearing, which should use 「晴れて」—「余裕」 doesn't describe weather. The three distractors are grammatically smooth but clearly wrong collocations, so only the first sentence works." },
     exampleJapanese: "出発まで一時間も余裕があるので、急がなくても大丈夫だ。",
-    exampleMeaningZh: "離出發還有一個小時的寬裕時間，所以不趕也沒關係。"
+    exampleMeaningZh: "離出發還有一個小時的寬裕時間，所以不趕也沒關係。",
+    exampleMeaningI18n: { "ja": "出発までまだ1時間もゆとりがあるので、急がなくても間に合う、という意味。", "en": "There's a whole hour to spare before departure, so there's no need to rush." },
   }),
   examQuestion({
     id: "n3-usage-monotarinai",
@@ -5164,7 +5225,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「物足りない」＝雖然沒有具體缺什麼，但總覺得不夠滿足、美中不足。正解「量が少なくて、少し物足りない」＝分量少而覺得不夠滿足，是最典型的用法。干擾「お金が物足りない」要表達錢數不夠，應用「足りない」，缺具體數量用「足りない」而非「物足りない」；「手が物足りなくて」要表達搆不到，應用「届かなくて」，「物足りない」不指距離不及；「会議に物足りなくて遅刻した」要表達趕不上，應用「間に合わなくて」，「物足りない」不表示來不及。三個干擾接續都通，但搭配明確不對，唯第一句成立。",
     explanationI18n: { "ja": "「物足りない」は、具体的に何かが欠けているわけではないが、どこか満たされない、いま一つだと感じることを表します。正解の「量が少なくて、少し物足りない」は量が少なくて満たされないという最も典型的な使い方です。誤答の「お金が物足りない」はお金が不足していることを言いたい場面で「足りない」を使うべきで、具体的な数量が不足している場合は「物足りない」ではなく「足りない」を使います。「手が物足りなくて」は手が届かないことを言いたい場面で「届かなくて」を使うべきで、「物足りない」は距離が及ばないことを指しません。「会議に物足りなくて遅刻した」は間に合わないことを言いたい場面で「間に合わなくて」を使うべきで、「物足りない」は間に合わないことを表しません。三つの誤答は文法的には続きますが組み合わせが明確に不適切で、一文目だけが成立します。", "en": "「物足りない」 means that, although nothing is concretely lacking, something still feels unsatisfying or falls just short. The correct answer 「量が少なくて、少し物足りない」 (\"not quite enough because the portion is small\") is the most typical usage. The distractor 「お金が物足りない」 tries to say there isn't enough money, which should use 「足りない」—a specific shortfall in quantity takes 「足りない」, not 「物足りない」. 「手が物足りなくて」 tries to say one can't reach, which should use 「届かなくて」—「物足りない」 doesn't refer to falling short in distance. 「会議に物足りなくて遅刻した」 tries to say one couldn't make it in time, which should use 「間に合わなくて」—「物足りない」 doesn't mean being too late. All three distractors are grammatically fine but clearly wrong collocations, so only the first sentence works." },
     exampleJapanese: "この店のランチは量が少なくて、少し物足りない。",
-    exampleMeaningZh: "這家店的午餐分量太少，感覺有點不夠滿足。"
+    exampleMeaningZh: "這家店的午餐分量太少，感覺有點不夠滿足。",
+    exampleMeaningI18n: { "ja": "この店のランチは量が少なくて、なんとなく満足できない感じがする、という意味。", "en": "The lunch portions at this restaurant are small, so it feels a little unsatisfying." },
   }),
   examQuestion({
     id: "n3-usage-afureru",
@@ -5186,7 +5248,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「あふれる」＝液體等裝不下而從容器中溢出（也引申為充滿）。正解「水が洗面台からあふれてしまった」＝水從洗手台溢出，是最典型的用法。干擾「時計があふれて動かなくなった」要表達電池沒電而停，應用「止まって」，「あふれる」不表示停止；「書類が床にあふれて散らばった」要表達被吹落，應用「落ちて」，紙張被風吹掉不是「溢出」；「前にあふれて転んでしまった」要表達身體往前傾倒，應用「のめって」或「倒れて」，「あふれる」不形容人跌倒。三個干擾接續都通，但搭配明確不對，唯第一句成立。",
     explanationI18n: { "ja": "「あふれる」は、水などが入りきらずに容器からこぼれ出ることを表します（「満ちる」の意味に広がることもあります）。正解の「水が洗面台からあふれてしまった」は水が洗面台からこぼれ出るという最も典型的な使い方です。誤答の「時計があふれて動かなくなった」は電池が切れて止まったことを言いたい場面で「止まって」を使うべきで、「あふれる」は止まることを表しません。「書類が床にあふれて散らばった」は風で落とされたことを言いたい場面で「落ちて」を使うべきで、紙が風で落ちるのは「あふれる」ではありません。「前にあふれて転んでしまった」は体が前に傾いて倒れることを言いたい場面で「のめって」や「倒れて」を使うべきで、「あふれる」は人が転ぶ様子を表しません。三つの誤答は文法的には続きますが組み合わせが明確に不適切で、一文目だけが成立します。", "en": "「あふれる」 means a liquid (etc.) spilling over because a container can't hold it (and by extension, being full of something). The correct answer 「水が洗面台からあふれてしまった」 (\"the water overflowed from the sink\") is the most typical usage. The distractor 「時計があふれて動かなくなった」 tries to say a dead battery stopped the clock, which should use 「止まって」—「あふれる」 doesn't mean stopping. 「書類が床にあふれて散らばった」 tries to say papers were blown down, which should use 「落ちて」—papers blown off by wind isn't \"overflowing.\" 「前にあふれて転んでしまった」 tries to say someone pitched forward, which should use 「のめって」 or 「倒れて」—「あふれる」 doesn't describe a person falling. All three distractors are grammatically fine but clearly wrong collocations, so only the first sentence works." },
     exampleJapanese: "水を出しっぱなしにしたので、水が洗面台からあふれてしまった。",
-    exampleMeaningZh: "因為一直開著水沒關，水從洗手台溢出來了。"
+    exampleMeaningZh: "因為一直開著水沒關，水從洗手台溢出來了。",
+    exampleMeaningI18n: { "ja": "水を出したままにしていたので、水が洗面台の外にこぼれ出てしまった、という意味。", "en": "I left the water running, so it overflowed from the sink." },
   }),
   examQuestion({
     id: "n3-context-sokode",
@@ -5268,7 +5331,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「わざと」=有意識、刻意去做，與「故意に」完全同義，句中弟弟是「為了讓我為難」才摔，正是故意。干擾：「偶然」(碰巧、無意間) 與句意「為了讓我為難」相反，母語者不接受；「急に」只表示時間上突然，不含「有意」之意，與「困らせようとして」(企圖) 矛盾；「きっと」是表推測的副詞「一定」，無法描述已發生且帶意圖的動作，語意不成立。只有「故意に」成立。",
     explanationI18n: { "ja": "「わざと」は意識して、意図的に行うことで、「故意に」とまったく同義です。文中では弟が「私を困らせようとして」落としたので、まさに故意です。誤答について、「偶然」（たまたま・意図せず）は文意「困らせようとして」と反対で、母語話者は受け入れません。「急に」は時間的に突然という意味だけで「意図的」の意味は含まず、「困らせようとして」（意図）と矛盾します。「きっと」は推量を表す副詞「きっと」で、すでに起きた意図的な動作を描写できず成立しません。「故意に」だけが成立します。", "en": "「わざと」 means to do something consciously and deliberately, exactly synonymous with 「故意に」; in the sentence, the brother drops the plate \"to give me a hard time,\" which is precisely intentional. Distractors: 「偶然」 (by chance, accidentally) is the opposite of \"to give me a hard time,\" and native speakers wouldn't accept it; 「急に」 only indicates suddenness in time and carries no sense of intent, contradicting 「困らせようとして」 (trying to); 「きっと」 is an adverb of conjecture meaning \"surely,\" which can't describe an already-completed, intentional action. Only 「故意に」 works." },
     exampleJapanese: "弟は私を困らせようとして、故意に皿を落とした。",
-    exampleMeaningZh: "弟弟為了讓我為難，故意把盤子摔了。"
+    exampleMeaningZh: "弟弟為了讓我為難，故意把盤子摔了。",
+    exampleMeaningI18n: { "ja": "弟は私を困らせようとして、故意に皿を落とした、という意味。", "en": "My little brother dropped the plate on purpose to give me a hard time." },
   }),
   examQuestion({
     id: "n3-syn-sorosoro",
@@ -5290,7 +5354,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "句中「そろそろ」表示「再過不久就要發生」，與「まもなく」(不久、即將) 同義，搭配「来るだろう」自然。干擾：「ときどき」是頻率副詞「有時」，與「もう九時だから」這種對單一即將發生事件的判斷不合；「ずっと」表示「一直、長時間」，與「快要來了」的瞬間預期相反；「もう一度」意為「再一次」，但電車尚未來過、談不上再來，語意不成立。只有「まもなく」成立。",
     explanationI18n: { "ja": "文中の「そろそろ」は「もう間もなく起こる」ことを表し、「まもなく」（間もなく・もうすぐ）と同義で、「来るだろう」との組み合わせも自然です。誤答について、「ときどき」は頻度の副詞「時々」で、「もう九時だから」というこれから起こる一つの出来事への判断には合いません。「ずっと」は「長い間・ずっと」を表し、「もうすぐ来る」という瞬間的な予期と反対です。「もう一度」は「もう一回」の意味ですが、電車はまだ来ておらず「もう一度」とは言えず成立しません。「まもなく」だけが成立します。", "en": "Here 「そろそろ」 means \"about to happen before long,\" synonymous with 「まもなく」 (shortly, soon), pairing naturally with 「来るだろう」. Distractors: 「ときどき」 is the frequency adverb \"sometimes,\" which doesn't fit a judgment about a single imminent event like 「もう九時だから」; 「ずっと」 means \"the whole time, for a long time,\" the opposite of the momentary expectation of something arriving soon; 「もう一度」 means \"once more,\" but the train hasn't come yet, so \"again\" makes no sense. Only 「まもなく」 works." },
     exampleJapanese: "もう九時だから、まもなく電車が来るだろう。",
-    exampleMeaningZh: "已經九點了，電車不久就會來了吧。"
+    exampleMeaningZh: "已經九點了，電車不久就會來了吧。",
+    exampleMeaningI18n: { "ja": "もう9時だから、電車はまもなく来るだろう、という意味。", "en": "It's already nine o'clock, so the train should be here any moment now." },
   }),
   examQuestion({
     id: "n3-syn-ainiku",
@@ -5312,7 +5377,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「あいにく」表示「事情不湊巧、令人遺憾地」，與「残念ながら」同義，句中朋友來了自己卻外出正是不巧。干擾：「幸い」(幸好) 是正面的「運氣好」，與「朋友來了我卻不在」這種掃興結果意思相反；「偶然」(碰巧、偶然) 只表事情湊巧發生，不含「遺憾、不合時宜」的負面評價，母語者不會用來表達這種惋惜；「きっと」是表推測的「一定」，不能描述已確定發生的事實。只有「残念ながら」成立。",
     explanationI18n: { "ja": "「あいにく」は「タイミングが悪くて、残念なことに」を表し、「残念ながら」と同義です。文中では友達が来たのに自分は出かけていて、まさに折悪しくです。誤答について、「幸い」（幸いにも）はプラスの「運が良い」ことで、「友達が来たのに自分がいない」という残念な結果とは反対です。「偶然」（たまたま・偶然に）は物事がたまたま起こることを表すだけで、「残念だ・都合が悪い」というマイナスの評価は含まず、母語話者はこの残念さを表すのに使いません。「きっと」は推量の「きっと」で、すでに確定して起きた事実を描写できません。「残念ながら」だけが成立します。", "en": "「あいにく」 means \"as ill luck would have it, regrettably,\" synonymous with 「残念ながら」; in the sentence, the friend comes but the speaker happens to be out—precisely bad timing. Distractors: 「幸い」 (fortunately) is a positive \"lucky,\" the opposite of the disappointing result of \"my friend came but I wasn't there\"; 「偶然」 (by chance, coincidentally) merely notes that something happened to coincide, without the negative evaluation of \"regrettable, ill-timed,\" so native speakers wouldn't use it to express this kind of regret; 「きっと」 is the conjectural \"surely,\" which can't describe a confirmed, already-occurred fact. Only 「残念ながら」 works." },
     exampleJapanese: "友だちが遊びに来たが、残念ながらその日は仕事で出かけていた。",
-    exampleMeaningZh: "朋友來找我玩，但很遺憾那天我因工作外出了。"
+    exampleMeaningZh: "朋友來找我玩，但很遺憾那天我因工作外出了。",
+    exampleMeaningI18n: { "ja": "友だちが遊びに来てくれたが、残念ながらその日は仕事で出かけていた、という意味。", "en": "A friend came over to visit, but unfortunately I was out for work that day." },
   }),
   examQuestion({
     id: "n3-syn-wagamama",
@@ -5334,7 +5400,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "句中「わがまま」描述「只顧自己、不顧別人」的性格，與「自分勝手」(只按自己方便行事、自私) 同義，與「自分の意見ばかり通そうとして」吻合。干擾：「正直」(誠實) 是說話不騙人的正面性格，與「只顧自己」無關，不同義；「素直」(坦率、聽話) 指肯接受他人意見，與句中「只想貫徹己見」正好相反；「おとなしい」(老實、安靜) 形容個性溫順內向，與「強行通過己見」相矛盾。只有「自分勝手」成立。",
     explanationI18n: { "ja": "文中の「わがまま」は「自分のことだけを考え、人を顧みない」性格を表し、「自分勝手」（自分の都合だけで行動する・自己中心的）と同義で、「自分の意見ばかり通そうとして」と合致します。誤答について、「正直」（正直）は嘘をつかないプラスの性格で、「自分のことだけを考える」こととは関係がなく同義ではありません。「素直」（素直・従順）は他人の意見を受け入れることを指し、文中の「自分の意見ばかり通そうとする」とはちょうど反対です。「おとなしい」（おとなしい・静か）は温順で内向的な性格を表し、「自分の意見を無理に通す」ことと矛盾します。「自分勝手」だけが成立します。", "en": "Here 「わがまま」 describes a personality that only considers oneself and disregards others, synonymous with 「自分勝手」 (acting only for one's own convenience, selfish), matching 「自分の意見ばかり通そうとして」. Distractors: 「正直」 (honest) is a positive trait of not lying, unrelated to \"only thinking of oneself,\" so it's not synonymous; 「素直」 (obedient, receptive) means being willing to accept others' opinions, the very opposite of \"only wanting to push through one's own view\"; 「おとなしい」 (docile, quiet) describes a gentle, introverted character, contradicting \"forcing through one's own opinion.\" Only 「自分勝手」 works." },
     exampleJapanese: "彼はいつも自分の意見ばかり通そうとして、本当に自分勝手だ。",
-    exampleMeaningZh: "他總是只想貫徹自己的意見，真的很自私自利。"
+    exampleMeaningZh: "他總是只想貫徹自己的意見，真的很自私自利。",
+    exampleMeaningI18n: { "ja": "彼はいつも自分の意見ばかり通そうとして、本当に自分勝手だ、という意味。", "en": "He always tries to push through his own opinions—he really is selfish." },
   }),
   examQuestion({
     id: "n3-usage-chuumon",
@@ -5356,7 +5423,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「レストランで、私はカレーを注文した」：在餐廳向店家要求咖哩，正是「注文（點餐／訂購）」的標準用法。干擾1「顔を注文した」：早上起床洗臉應用「洗う」，向誰要求「臉」語意完全不通。干擾2「公園で、私は静かに本を注文した」：在公園靜靜地是看書「読む」，並非向店家訂購，搭配「静かに」也不對。干擾3「子どもたちが注文している」：在公園小孩活力地玩耍應用「遊ぶ」，沒有任何訂購對象，語意不成立。",
     explanationI18n: { "ja": "正解の「レストランで、私はカレーを注文した」は、レストランで店にカレーを求めるという、まさに「注文（頼む／取り寄せる）」の標準的な使い方です。誤答1の「顔を注文した」は、朝起きて顔を洗うなら「洗う」を使うべきで、誰かに「顔」を求めるのは意味がまったく通りません。誤答2の「公園で、私は静かに本を注文した」は、公園で静かにするのは本を「読む」ことで、店に注文するのではなく、「静かに」との組み合わせも合いません。誤答3の「子どもたちが注文している」は、公園で子どもが元気にするのは「遊ぶ」ことで、注文する相手もなく成立しません。", "en": "The correct answer 「レストランで、私はカレーを注文した」: requesting curry from the staff at a restaurant is precisely the standard use of 「注文」 (to order/place an order). Distractor 1 「顔を注文した」: washing your face after getting up in the morning should use 「洗う」; requesting a \"face\" from someone makes no sense. Distractor 2 「公園で、私は静かに本を注文した」: quietly in the park you'd be reading a book with 「読む」, not ordering from a shop, and 「静かに」 doesn't collocate either. Distractor 3 「子どもたちが注文している」: children energetically in a park should use 「遊ぶ」 (playing); there's no one to order from, so it doesn't hold." },
     exampleJapanese: "レストランで、私はカレーを注文した。",
-    exampleMeaningZh: "在餐廳，我點了咖哩飯。"
+    exampleMeaningZh: "在餐廳，我點了咖哩飯。",
+    exampleMeaningI18n: { "ja": "レストランで、私はカレーを頼んだ、という意味。", "en": "At the restaurant, I ordered curry." },
   }),
   examQuestion({
     id: "n3-usage-watasu",
@@ -5378,7 +5446,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「同僚に、私は書類を渡した」：把文件交到同事手裡，正是「渡す（交給）」的核心用法，有具體物品與接收對象。干擾1「時間を渡した」：時間不是能交到別人手上的東西，「時間を渡す」語意不通。干擾2「窓を渡した」：天熱應「窓を開ける（開窗）」，把窗戶「交給誰」語意不通。干擾3「単語を渡した」：為考試而記單字應用「覚える」，沒有交付對象，「渡す」不成立。",
     explanationI18n: { "ja": "正解の「同僚に、私は書類を渡した」は、書類を同僚の手に手渡すという、まさに「渡す」の中心的な使い方で、具体的な物と受け取る相手がそろっています。誤答1の「時間を渡した」は、時間は人の手に渡せる物ではなく、「時間を渡す」は意味が通りません。誤答2の「窓を渡した」は、暑いときは「窓を開ける」べきで、窓を「誰かに渡す」のは意味が通りません。誤答3の「単語を渡した」は、試験のために単語を覚えるなら「覚える」を使うべきで、渡す相手もなく「渡す」は成立しません。", "en": "The correct answer 「同僚に、私は書類を渡した」: handing documents into a colleague's hand is precisely the core use of 「渡す」 (to hand over), with a concrete object and a recipient. Distractor 1 「時間を渡した」: time isn't something you can hand to another person, so 「時間を渡す」 makes no sense. Distractor 2 「窓を渡した」: when it's hot you'd say 「窓を開ける」 (open the window); \"handing a window to someone\" makes no sense. Distractor 3 「単語を渡した」: memorizing vocabulary for an exam should use 「覚える」; there's no recipient, so 「渡す」 doesn't hold." },
     exampleJapanese: "同僚に、私は書類を渡した。",
-    exampleMeaningZh: "我把文件交給了同事。"
+    exampleMeaningZh: "我把文件交給了同事。",
+    exampleMeaningI18n: { "ja": "私は同僚に書類を手渡した、という意味。", "en": "I handed the documents to a coworker." },
   }),
   examQuestion({
     id: "n3-usage-makaseru",
@@ -5400,7 +5469,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「この仕事は、後輩に任せることにした」：把工作整件交給後輩負責，正是「任せる（託付）」的典型用法。干擾1「足元に任せて」：黑暗的路上要「注意（気をつける）」腳下，把腳下「託付」給某人語意不成立。干擾2「薬を任せて寝た」：感冒應「薬を飲む（吃藥）」，藥不是交給別人負責的對象。干擾3「次の電車を任せた」：錯過電車後是「次の電車を待つ（等下一班）」，電車不是可以託付給別人負責的事，「任せる」不通。",
     explanationI18n: { "ja": "正解の「この仕事は、後輩に任せることにした」は、仕事をまるごと後輩に責任をもってやってもらうという、まさに「任せる」の典型的な使い方です。誤答1の「足元に任せて」は、暗い道では足元に「気をつける」べきで、足元を誰かに「任せる」のは成立しません。誤答2の「薬を任せて寝た」は、風邪をひいたら「薬を飲む」べきで、薬は他人に責任をもってもらう対象ではありません。誤答3の「次の電車を任せた」は、電車に乗り遅れたら「次の電車を待つ」ことで、電車は他人に任せられる対象ではなく、「任せる」は通りません。", "en": "The correct answer 「この仕事は、後輩に任せることにした」: handing the whole job over to a junior to take charge of is precisely the typical use of 「任せる」 (to entrust). Distractor 1 「足元に任せて」: on a dark road you should 「注意（気をつける）」 to your footing; \"entrusting\" your footing to someone makes no sense. Distractor 2 「薬を任せて寝た」: with a cold you'd 「薬を飲む」 (take medicine); medicine isn't something you leave to someone else to handle. Distractor 3 「次の電車を任せた」: after missing a train you 「次の電車を待つ」 (wait for the next one); a train isn't a matter you can entrust to someone, so 「任せる」 doesn't work." },
     exampleJapanese: "この仕事は、後輩に任せることにした。",
-    exampleMeaningZh: "這份工作，我決定交給後輩去負責。"
+    exampleMeaningZh: "這份工作，我決定交給後輩去負責。",
+    exampleMeaningI18n: { "ja": "この仕事は、後輩に担当してもらうことにした、という意味。", "en": "I decided to leave this job to a junior colleague." },
   }),
   examQuestion({
     id: "n3-usage-awateru",
@@ -5422,7 +5492,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「寝坊して、私は慌てて家を出た」：睡過頭這個突發狀況使人心急、慌張出門，正是「慌てる（驚慌失措）」的用法。干擾1「天気がよくて慌てて散歩した」：天氣好心情應是悠閒，沒有令人慌張的事，前後語意矛盾，宜用「のんびり」。干擾2「おなかがすいて慌てて昼寝した」：肚子餓應「食べる」，餓了去午睡本身不通，也無慌張的理由。干擾3「宿題が終わって慌てて休んだ」：作業做完是輕鬆下來，應「ゆっくり休んだ」，不該慌張。",
     explanationI18n: { "ja": "正解の「寝坊して、私は慌てて家を出た」は、寝坊という突然の出来事に心が急いて慌てて家を出るという、まさに「慌てる」の使い方です。誤答1の「天気がよくて慌てて散歩した」は、天気が良ければ気分はのんびりするはずで、慌てる要因がなく前後が矛盾します。「のんびり」がふさわしいです。誤答2の「おなかがすいて慌てて昼寝した」は、おなかがすいたら「食べる」べきで、空腹で昼寝すること自体が不自然で、慌てる理由もありません。誤答3の「宿題が終わって慌てて休んだ」は、宿題が終わればほっとするので「ゆっくり休んだ」がふさわしく、慌てるべきではありません。", "en": "The correct answer 「寝坊して、私は慌てて家を出た」: oversleeping is a sudden situation that makes one anxious and rush out flustered—precisely the use of 「慌てる」 (to be flustered). Distractor 1 「天気がよくて慌てて散歩した」: good weather should make one relaxed, with nothing to cause panic, so the two halves contradict; 「のんびり」 would be better. Distractor 2 「おなかがすいて慌てて昼寝した」: when hungry you should 「食べる」 (eat); napping because you're hungry makes no sense on its own, and there's no reason to panic. Distractor 3 「宿題が終わって慌てて休んだ」: finishing homework means relaxing, so it should be 「ゆっくり休んだ」—there's no cause for panic." },
     exampleJapanese: "寝坊して、私は慌てて家を出た。",
-    exampleMeaningZh: "睡過頭了，我慌慌張張地出了門。"
+    exampleMeaningZh: "睡過頭了，我慌慌張張地出了門。",
+    exampleMeaningI18n: { "ja": "寝坊してしまい、あせって急いで家を出た、という意味。", "en": "I overslept and rushed out of the house in a panic." },
   }),
   examQuestion({
     id: "n3-context-tokoroga",
@@ -5524,7 +5595,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「だいぶ」表示程度相當大、變化很多，與「かなり」（相當地）語意最接近，代回「熱はかなり下がりました」自然成立。「まったく」後接否定才自然（まったく下がらない），用於肯定的「下がりました」語意變成「完全下降」不通且方向相反，明確不對。「ますます」是「越來越…」表持續加強，但句中是吃藥後退燒的單次結果，語意不合。「わざわざ」是「特地」修飾刻意的動作，無法形容退燒的程度，搭配明確不對。故唯一正解為かなり。",
     explanationI18n: { "ja": "「だいぶ」は程度がかなり大きく、変化が大きいことを表し、「かなり」（かなり）と最も意味が近く、「熱はかなり下がりました」と言い換えても自然に成立します。「まったく」は後ろに否定が続いてはじめて自然で（まったく下がらない）、肯定の「下がりました」に使うと「完全に下がった」という意味になって通らず、方向も反対で明確に不適切です。「ますます」は「ますます…」で持続的に強まることを表しますが、文中は薬を飲んで熱が下がった一回きりの結果で意味が合いません。「わざわざ」は「わざわざ」で意図的な動作を修飾し、熱の下がる程度を表せず、組み合わせが明確に不適切です。したがって唯一の正解は「かなり」です。", "en": "「だいぶ」 indicates a considerable degree or a large change, closest in meaning to 「かなり」 (considerably); substituting back, 「熱はかなり下がりました」 works naturally. 「まったく」 is natural only before a negative (まったく下がらない); with the affirmative 「下がりました」 it would mean \"dropped completely\" and reverses the direction, so it's clearly wrong. 「ますます」 means \"more and more,\" indicating continued intensification, but the sentence describes a single result of the fever going down after taking medicine, so it doesn't fit. 「わざわざ」 means \"going out of one's way\" and modifies a deliberate action; it can't describe the degree of a fever dropping, so the collocation is clearly wrong. Thus the only correct answer is 「かなり」." },
     exampleJapanese: "薬を飲んだので、熱はかなり下がりました。",
-    exampleMeaningZh: "因為吃了藥，燒退了不少。"
+    exampleMeaningZh: "因為吃了藥，燒退了不少。",
+    exampleMeaningI18n: { "ja": "薬を飲んだので、熱はかなり下がった、という意味。", "en": "Since I took the medicine, my fever has gone down considerably." },
   }),
   examQuestion({
     id: "n3-syn-soudansuru",
@@ -5546,7 +5618,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「相談する」是就煩惱或選擇找對方商量、徵求意見，與「意見を聞いた」（聽取意見）語意最接近，代回「先生に意見を聞いた」自然成立。「文句を言った」是抱怨、發牢騷，帶負面情緒，與商量求建議方向相反，明確不對。「命令した」是命令、下指示，學生對老師也不符上下關係，語意不合。「謝った」是道歉，與就出路徵詢意見毫無關係。故唯一正解為意見を聞いた。",
     explanationI18n: { "ja": "「相談する」は悩みや選択について相手に話して意見を求めることで、「意見を聞いた」（意見を聞く）と最も意味が近く、「先生に意見を聞いた」と言い換えても自然に成立します。「文句を言った」は不満を言う・愚痴をこぼすことで、マイナスの感情を帯び、相談して助言を求めることとは方向が反対で明確に不適切です。「命令した」は命令する・指示を出すことで、生徒が先生に対しては上下関係にも合わず意味が合いません。「謝った」は謝ることで、進路について意見を求めることとはまったく関係がありません。したがって唯一の正解は「意見を聞いた」です。", "en": "「相談する」 means to discuss a worry or choice with someone and seek their opinion, closest in meaning to 「意見を聞いた」 (asked for their opinion); substituting back, 「先生に意見を聞いた」 works naturally. 「文句を言った」 means to complain or grumble, carrying negative emotion, the opposite direction of consulting for advice, so it's clearly wrong. 「命令した」 means to order or command, which also doesn't fit the student-to-teacher hierarchy, so it doesn't work. 「謝った」 means to apologize, entirely unrelated to seeking advice about one's path. Thus the only correct answer is 「意見を聞いた」." },
     exampleJapanese: "進路のことで、先生に意見を聞いた。",
-    exampleMeaningZh: "關於將來的出路，我向老師徵詢了意見。"
+    exampleMeaningZh: "關於將來的出路，我向老師徵詢了意見。",
+    exampleMeaningI18n: { "ja": "進路のことについて、先生に意見を聞いた、という意味。", "en": "I asked my teacher for advice about my future path." },
   }),
   examQuestion({
     id: "n3-syn-tochuude",
@@ -5568,7 +5641,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「途中で」指還沒抵達目的地、正在前往的那段過程，與「行く間に」（去的過程中）語意最接近，代回「駅へ向かう間に友達に会った」表達同樣的「在路上」之意。「着いた後で」是抵達之後，時間點在到達車站以後，與「還在路上」相反，明確不對。「出かける前に」是出門之前，動作尚未開始，也不是中途，語意不合。「帰るかわりに」是「不回去而改做別的」，與在去程路上的情境完全不符。故唯一正解為行く間に。",
     explanationI18n: { "ja": "「途中で」は、まだ目的地に着いておらず、そこへ向かっている最中を表し、「行く間に」（行く過程の中で）と最も意味が近い。代入すると「駅へ向かう間に友達に会った」となり、同じく「道の途中で」という意味になる。「着いた後で」は到着したあとで、時点が駅に着いてからになり、「まだ向かっている最中」とは逆で明らかに合わない。「出かける前に」は家を出る前で、動作がまだ始まっておらず、途中でもないため意味が合わない。「帰るかわりに」は「帰らずに別のことをする」という意味で、向かう途中の場面とはまったく合わない。よって唯一の正解は「行く間に」。", "en": "「途中で」 refers to the stretch of a journey when you haven't yet arrived and are still on your way, which is closest to 「行く間に」 (during the trip there). Substituting it back gives 「駅へ向かう間に友達に会った」, expressing the same \"on the road\" idea. 「着いた後で」 means after arriving, a point in time once you've reached the station—the opposite of \"still on the way,\" so clearly wrong. 「出かける前に」 means before setting out, when the action hasn't even started, which isn't \"partway\" either and doesn't fit. 「帰るかわりに」 means \"instead of going home, doing something else,\" which doesn't match the scene of being on the outbound trip at all. So the only correct answer is 行く間に." },
     exampleJapanese: "駅へ向かう途中で、友達に会った。",
-    exampleMeaningZh: "在前往車站的路上，遇到了朋友。"
+    exampleMeaningZh: "在前往車站的路上，遇到了朋友。",
+    exampleMeaningI18n: { "ja": "駅へ向かっている間に、友達に会った、という意味。", "en": "On the way to the station, I ran into a friend." },
   }),
   examQuestion({
     id: "n3-usage-enki",
@@ -5590,7 +5664,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「運動会が台風で来週の土曜日に延期になった」＝把預定的活動改到別的日子，正是「延期」的用法。第二句「同分後再延長比賽時間」應用「延長」（延長同一場的時間），不是把日子挪到改天；第三句「睡過頭，到公司遲到」應用「遅刻」，「延期」不能用在個人晚到；第四句「因為太貴而不買那件外套」應用「やめた／諦めた」（放棄購買），與把日期往後挪無關。唯第一句成立。",
     explanationI18n: { "ja": "正解の文「運動会が台風で来週の土曜日に延期になった」は、予定していた行事を別の日にずらすことで、まさに「延期」の使い方。二つめの「同点のあと試合の時間をのばしてもう一度戦った」は、同じ試合の時間をのばす「延長」を使うべきで、日を別の日にずらすわけではない。三つめの「寝坊して会社に遅く着いた」は「遅刻」を使うべきで、個人が遅れて着くのに「延期」は使えない。四つめの「高いのでその上着を買わない」は「やめた／諦めた」（買うのをやめる）を使うべきで、日をずらすこととは関係がない。よって成り立つのは一つめの文だけ。", "en": "The correct sentence, 「運動会が台風で来週の土曜日に延期になった」 = moving a scheduled event to a different day, which is exactly how 「延期」 is used. The second sentence, \"extend the match after a tie,\" should use 「延長」 (lengthening the time of the same match), not moving a date to another day. The third sentence, \"overslept and was late to the company,\" should use 「遅刻」; 「延期」 cannot describe an individual arriving late. The fourth sentence, \"decided not to buy the jacket because it was too expensive,\" should use 「やめた／諦めた」 (giving up the purchase) and has nothing to do with pushing a date back. Only the first sentence works." },
     exampleJapanese: "台風が近づいているため、運動会は来週の土曜日に延期になった。",
-    exampleMeaningZh: "因為颱風接近，運動會延期到下週六了。"
+    exampleMeaningZh: "因為颱風接近，運動會延期到下週六了。",
+    exampleMeaningI18n: { "ja": "台風が近づいているため、運動会の日程が来週の土曜日に延ばされた、という意味。", "en": "Because a typhoon is approaching, the sports day has been postponed to next Saturday." },
   }),
   examQuestion({
     id: "n3-usage-chirakaru",
@@ -5612,7 +5687,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「玩具散落滿屋」＝東西到處放著、亂糟糟，正是「散らかる」的用法。第二句「鞋子沾到泥巴」應用「汚れる」（變髒），不是東西散落；第三句「椅子腳斷掉」應用「壊れる」（壞掉、斷掉），不能用「散らかる」；第四句「早上電車人很多」應用「込む／混む」（擁擠），與物品凌亂無關。唯第一句成立。",
     explanationI18n: { "ja": "正解の文「おもちゃが部屋中に散らばっている」は、物があちこちに置かれてごちゃごちゃした状態で、まさに「散らかる」の使い方。二つめの「靴が泥で汚れた」は「汚れる」（汚くなる）を使うべきで、物が散らばるわけではない。三つめの「いすの足が折れた」は「壊れる」（壊れる・折れる）を使うべきで、「散らかる」は使えない。四つめの「朝の電車は人が多い」は「込む／混む」（混雑する）を使うべきで、物が乱雑なこととは関係がない。よって成り立つのは一つめの文だけ。", "en": "The correct sentence, \"toys scattered all over the room\" = things left lying around in a mess, which is exactly how 「散らかる」 is used. The second sentence, \"the shoes got muddy,\" should use 「汚れる」 (to get dirty), not things being scattered. The third sentence, \"the chair leg broke off,\" should use 「壊れる」 (to break); you can't use 「散らかる」 here. The fourth sentence, \"the morning train is crowded,\" should use 「込む／混む」 (to be crowded) and has nothing to do with objects being in disarray. Only the first sentence works." },
     exampleJapanese: "子どもが遊んだあとで、部屋中におもちゃが散らかっている。",
-    exampleMeaningZh: "小孩玩過之後，整個房間裡玩具散落一地。"
+    exampleMeaningZh: "小孩玩過之後，整個房間裡玩具散落一地。",
+    exampleMeaningI18n: { "ja": "子どもが遊んだあと、部屋じゅうにおもちゃがばらばらに広がっている、という意味。", "en": "After the kids finished playing, toys were scattered all over the room." },
   }),
   examQuestion({
     id: "n3-usage-kurou",
@@ -5634,7 +5710,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解句「母親獨力辛苦地把三個孩子養大」＝費盡力氣、歷經難處，正是「苦労」的用法。第二句「擔心明天能不能考過」應用「心配」（擔心），不是付出辛勞；第三句「大聲說話給其他客人添麻煩」應用「迷惑（をかけた）」（給人添麻煩），不能用「苦労をかけた」；第四句「我從小很不擅長游泳」應用「苦手」（不擅長），與費盡力氣的辛勞無關。唯第一句成立。",
     explanationI18n: { "ja": "正解の文「母が一人で苦労して三人の子を育てた」は、力を尽くし、大変な思いを重ねることで、まさに「苦労」の使い方。二つめの「明日受かるか気にしている」は「心配」（心配する）を使うべきで、苦労を重ねているわけではない。三つめの「大声で話してほかの客に迷惑をかけた」は「迷惑（をかけた）」（迷惑をかける）を使うべきで、「苦労をかけた」とは言えない。四つめの「子どものころから泳ぐのがとても下手だ」は「苦手」（得意でない）を使うべきで、力を尽くす大変さとは関係がない。よって成り立つのは一つめの文だけ。", "en": "The correct sentence, \"my mother raised her three children alone through hardship\" = going to great effort and enduring difficulty, which is exactly how 「苦労」 is used. The second sentence, \"worrying about whether I'll pass tomorrow's exam,\" should use 「心配」 (to worry), not putting in hard effort. The third sentence, \"talking loudly and bothering the other customers,\" should use 「迷惑（をかけた）」 (to cause trouble for others); you can't say 「苦労をかけた」. The fourth sentence, \"I've been bad at swimming since childhood,\" should use 「苦手」 (not good at) and has nothing to do with the hardship of great effort. Only the first sentence works." },
     exampleJapanese: "母は女手一つで、苦労して私たち三人を育ててくれた。",
-    exampleMeaningZh: "母親獨自一人，辛苦地把我們三個養大。"
+    exampleMeaningZh: "母親獨自一人，辛苦地把我們三個養大。",
+    exampleMeaningI18n: { "ja": "母は女手一つで、大変な思いをしながら私たち三人を育ててくれた、という意味。", "en": "My mother raised the three of us all on her own, through a great deal of hardship." },
   }),
   examQuestion({
     id: "n3-context-soreni",
@@ -5756,7 +5833,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「やり方」與「方法」都指做某件事的手段、步驟，「解く方法」與「解くやり方」同義且代入自然。「理由」是原因，回答的是「為什麼」而非「怎麼做」，語意不符；「結果」是事情完成後的結局，方向相反；「場所」是地點，與手段無關。學生不知道「怎麼解題」，只有「やり方」成立。",
     explanationI18n: { "ja": "正解の「やり方」も「方法」も、あることをするための手段や手順を指し、「解く方法」と「解くやり方」は同じ意味で自然に入れ替えられる。「理由」は原因で、「なぜ」に答えるものであって「どうやって」ではないため意味が合わない。「結果」は物事が終わったあとの結末で、方向が逆。「場所」は地点で、手段とは関係がない。学生は「どうやって解くか」がわからないのだから、成り立つのは「やり方」だけ。", "en": "The correct answer 「やり方」 and 「方法」 both refer to the means or steps for doing something; 「解く方法」 and 「解くやり方」 are synonymous and substitute in naturally. 「理由」 is a reason—it answers \"why\" rather than \"how,\" so it doesn't match; 「結果」 is the outcome after something is done, which points the opposite way; 「場所」 is a place, unrelated to means. The student doesn't know \"how to solve the problem,\" so only 「やり方」 works." },
     exampleJapanese: "この問題を解くやり方がわからず、先生に聞いた。",
-    exampleMeaningZh: "因為不知道解這道題的做法，所以去問了老師。"
+    exampleMeaningZh: "因為不知道解這道題的做法，所以去問了老師。",
+    exampleMeaningI18n: { "ja": "この問題の解き方がわからなくて、先生に聞いた、という意味。", "en": "I didn't know how to solve this problem, so I asked my teacher." },
   }),
   examQuestion({
     id: "n3-syn-fuan",
@@ -5778,7 +5856,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「心配」與「不安」都表示對未確定之事感到擔憂、心裡不踏實，題幹已點明「悪い点ではないかと」（擔心考差），「ずっと心配だった」與「ずっと不安だった」同義且代入自然。「安心」是放心、心裡踏實，與不安相反；「退屈」是無聊，描述的是沒事做的心情，與擔心結果的忐忑無關；「満足」是滿意、已得到滿足，與結果未定時的不安不符。怕考差等結果的心情只有「心配」成立。",
     explanationI18n: { "ja": "正解の「心配」も「不安」も、まだ確定していないことに対して気がかりで、落ち着かない気持ちを表す。問題文にも「悪い点ではないかと」（悪い点を気にして）と示されており、「ずっと心配だった」と「ずっと不安だった」は同じ意味で自然に入れ替えられる。「安心」は安らかで落ち着いた気持ちで、不安とは逆。「退屈」はつまらないことで、することがない気持ちを表し、結果を気にする落ち着かなさとは関係がない。「満足」は満ち足りた気持ちで、結果がまだ出ていないときの不安とは合わない。悪い点を恐れて結果を待つ気持ちに合うのは「心配」だけ。", "en": "The correct answer 「心配」 and 「不安」 both express worry and uneasiness about something undecided; the prompt already notes 「悪い点ではないかと」 (worried about doing poorly), and 「ずっと心配だった」 and 「ずっと不安だった」 are synonymous and substitute in naturally. 「安心」 is being relieved and at ease, the opposite of anxious; 「退屈」 is boredom, describing having nothing to do, unrelated to the unease of worrying about results; 「満足」 is satisfaction, which doesn't fit the anxiety of an undecided outcome. For the feeling of dreading a poor result while waiting, only 「心配」 works." },
     exampleJapanese: "試験の結果が出るまで、悪い点ではないかと私はずっと心配だった。",
-    exampleMeaningZh: "在考試結果公布之前，我一直擔心會不會考差。"
+    exampleMeaningZh: "在考試結果公布之前，我一直擔心會不會考差。",
+    exampleMeaningI18n: { "ja": "試験の結果が出るまで、悪い点だったのではないかとずっと心配だった、という意味。", "en": "Until the exam results came out, I kept worrying that I might have done badly." },
   }),
   examQuestion({
     id: "n3-syn-damaru",
@@ -5800,7 +5879,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「何も言わないで」與「黙って」都表示什麼都不說、保持沉默的狀態，「ただ黙っていた」與「ただ何も言わないでいた」同義且代入自然。「大声で笑って」是大聲笑出來，與沉默相反；「急いで出て」是匆忙離開，描述動作而非不出聲；「次々と質問して」是不斷發問，正好是一直在說話，與沉默相反。被問意見卻不回應，只有「何も言わないで」成立。",
     explanationI18n: { "ja": "正解の「何も言わないで」も「黙って」も、何も言わずに沈黙している状態を表し、「ただ黙っていた」と「ただ何も言わないでいた」は同じ意味で自然に入れ替えられる。「大声で笑って」は大声で笑い出すことで、沈黙とは逆。「急いで出て」は急いで出て行くことで、動作を表しており黙っていることではない。「次々と質問して」は次々に質問することで、むしろずっと話している状態であり、沈黙とは逆。意見を聞かれても答えないのだから、成り立つのは「何も言わないで」だけ。", "en": "The correct answer 「何も言わないで」 and 「黙って」 both mean saying nothing and staying silent; 「ただ黙っていた」 and 「ただ何も言わないでいた」 are synonymous and substitute in naturally. 「大声で笑って」 is bursting out laughing, the opposite of silence; 「急いで出て」 is hurrying out, describing an action rather than staying quiet; 「次々と質問して」 is asking question after question, which is talking constantly—the opposite of silence. When asked for an opinion but giving no response, only 「何も言わないで」 works." },
     exampleJapanese: "みんなに意見を聞かれても、彼はただ何も言わないでいた。",
-    exampleMeaningZh: "即使大家問他的意見，他也只是什麼都不說。"
+    exampleMeaningZh: "即使大家問他的意見，他也只是什麼都不說。",
+    exampleMeaningI18n: { "ja": "みんなに意見を聞かれても、彼はただ何も言わずにいた、という意味。", "en": "Even when everyone asked for his opinion, he just stayed silent." },
   }),
   examQuestion({
     id: "n3-usage-waku",
@@ -5822,7 +5902,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「湧く」表示興趣、感情、勇氣等自然地從心中冒出，與『興味が湧く』為固定搭配，「興味が湧いてきた」最自然。干擾一「水を湧いて飲んでいる」助詞與自他不對，水是被燒開的對象，應用「沸かして」(他動)或「お湯を沸かす」，「湧く」用於泉水自然冒出而非把水煮開。干擾二「ベンチで湧いて休んだ」語意不通，在長椅上休息是「座って／休んで」，「湧く」不能描述人坐下休息。干擾三「夜おそくまで湧いていた」應為「起きていた」(熬夜)，「湧く」無法表示人醒著或熬夜的狀態。四句都含「湧く」，只有第一句（興趣自然湧出）成立。",
     explanationI18n: { "ja": "正解の「湧く」は、興味・感情・勇気などが心から自然に生じることを表し、「興味が湧く」は決まった言い方で、「興味が湧いてきた」が最も自然。誤答の一つ「水を湧いて飲んでいる」は助詞や自他が合っておらず、水は沸かされる対象なので「沸かして」（他動詞）や「お湯を沸かす」を使うべきで、「湧く」は泉が自然に湧き出るのに使い、水を沸かすことには使わない。誤答の二つめ「ベンチで湧いて休んだ」は意味が通らず、ベンチで休むのは「座って／休んで」で、「湧く」は人が座って休む様子を表せない。誤答の三つめ「夜おそくまで湧いていた」は「起きていた」（夜ふかしする）とすべきで、「湧く」は人が起きている・夜ふかしする状態を表せない。四つとも「湧く」を含むが、成り立つのは一つめ（興味が自然に湧く）だけ。", "en": "The correct answer 「湧く」 expresses interest, feelings, courage, and the like naturally welling up from within; 「興味が湧く」 is a fixed collocation, and 「興味が湧いてきた」 is most natural. Distractor one, 「水を湧いて飲んでいる」, has the wrong particle and transitivity—water is the thing being boiled, so it should use 「沸かして」 (transitive) or 「お湯を沸かす」; 「湧く」 is for spring water rising on its own, not for boiling water. Distractor two, 「ベンチで湧いて休んだ」, makes no sense—resting on a bench is 「座って／休んで」, and 「湧く」 can't describe a person sitting down to rest. Distractor three, 「夜おそくまで湧いていた」, should be 「起きていた」 (staying up); 「湧く」 can't express a person being awake or staying up. All four contain 「湧く」, but only the first (interest naturally welling up) works." },
     exampleJapanese: "恐竜の化石を見て、古代の生き物への興味が「湧いて」きた。",
-    exampleMeaningZh: "看到恐龍的化石，對古代的生物湧起了興趣。"
+    exampleMeaningZh: "看到恐龍的化石，對古代的生物湧起了興趣。",
+    exampleMeaningI18n: { "ja": "恐竜の化石を見て、古代の生き物への興味がわき起こってきた、という意味。", "en": "Seeing the dinosaur fossils, I felt an interest in ancient creatures welling up inside me." },
   }),
   examQuestion({
     id: "n3-usage-usui",
@@ -5844,7 +5925,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「味が薄い」形容味道淡、不濃，為地道搭配，與後句『再加點豆子（讓味道更濃）』邏輯一致。干擾一「荷物が薄いので一人では持てなかった」語意矛盾，行李拿不動是因為「重い」(重)，與「薄い」(薄)無關。干擾二「薄い一日」不成立，形容一天累或忙應用「疲れた／忙しい」，「薄い」不修飾日子。干擾三「走るのが薄い」不通，跑得快應用「速い」，「薄い」與速度無關。四句都含「薄い」，只有第一句（味道淡）符合其詞義與搭配。",
     explanationI18n: { "ja": "正解の「味が薄い」は、味がうすくてこくがないことを表す自然な言い方で、後の文「もう少し豆を足してほしい（味を濃くしたい）」と論理が合う。誤答の一つ「荷物が薄いので一人では持てなかった」は意味が矛盾しており、荷物が持てないのは「重い」（重い）からであって「薄い」（うすい）こととは関係がない。誤答の二つめ「薄い一日」は成り立たず、一日が疲れた・忙しいなら「疲れた／忙しい」を使うべきで、「薄い」は日を修飾しない。誤答の三つめ「走るのが薄い」は通じず、走るのが速いなら「速い」を使うべきで、「薄い」は速さとは関係がない。四つとも「薄い」を含むが、その語義と組み合わせに合うのは一つめ（味がうすい）だけ。", "en": "The correct answer 「味が薄い」 describes a weak, non-rich flavor—an idiomatic collocation—and is logically consistent with the following clause \"add more beans (to make it richer).\" Distractor one, 「荷物が薄いので一人では持てなかった」, is self-contradictory: not being able to carry luggage is because it's 「重い」 (heavy), which has nothing to do with 「薄い」 (thin). Distractor two, 「薄い一日」, doesn't work—describing a tiring or busy day should use 「疲れた／忙しい」; 「薄い」 doesn't modify a day. Distractor three, 「走るのが薄い」, makes no sense—being fast at running should use 「速い」; 「薄い」 has nothing to do with speed. All four contain 「薄い」, but only the first (weak flavor) fits its meaning and collocation." },
     exampleJapanese: "このコーヒーは味が薄いので、もう少し豆を足してほしい。",
-    exampleMeaningZh: "這杯咖啡味道太淡，希望再多加一點咖啡豆。"
+    exampleMeaningZh: "這杯咖啡味道太淡，希望再多加一點咖啡豆。",
+    exampleMeaningI18n: { "ja": "このコーヒーは味が濃くないので、もう少し豆を足してほしい、という意味。", "en": "This coffee tastes too weak—I'd like a few more beans added." },
   }),
   examQuestion({
     id: "n3-usage-komu",
@@ -5866,7 +5948,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「込む」作複合動詞後項，『考え込む』表示深陷思考、陷入沉默地沉思，與『被問難題後抱著手臂沉默』的情境完全吻合。干擾「出す」作後項是『開始～』，『考え出す』意為『開始思考』，但情境是面對難題說不出話、深陷其中，不是『開始想』，方向相反。干擾「合う」作後項表互相，『考え合う』需多人一起商量，但這裡只有他一個人在沉默，主體不符。干擾「過ぎる」作後項表『過度』，『考え過ぎる』指想太多、鑽牛角尖，與『沉默地陷入思考』語意不同，且無法呈現『被問當下沉默』的瞬間樣態。只有「込む」成立。",
     explanationI18n: { "ja": "正解の「込む」は複合動詞の後ろにつき、「考え込む」で深く考えにふける、黙って物思いにふけることを表し、「難しい質問をされて腕を組んで黙り込む」という場面と完全に合う。誤答の「出す」は後ろについて「～し始める」の意味で、「考え出す」は「考え始める」だが、場面は難題を前に言葉が出ず深く入り込んでいるところであって「考え始める」ではなく、方向が逆。誤答の「合う」は後ろについて互いにする意味を表し、「考え合う」は複数人で相談する必要があるが、ここは彼一人が黙っているので主体が合わない。誤答の「過ぎる」は後ろについて「～しすぎる」を表し、「考え過ぎる」は考えすぎる・思いつめることで、「黙って考えにふける」とは意味が違い、「聞かれたその場で黙る」瞬間の様子も表せない。成り立つのは「込む」だけ。", "en": "The correct answer 「込む」 as the second element of a compound verb, 「考え込む」, means to sink deep into thought—silently absorbed in thinking—which perfectly matches the scene of \"folding one's arms in silence after being asked a hard question.\" The distractor 「出す」 as the second element means \"to begin to—\"; 「考え出す」 means \"to start thinking,\" but the scene is being at a loss and sunk deep in a hard question, not \"starting to think\"—the opposite direction. The distractor 「合う」 as the second element expresses mutuality; 「考え合う」 requires several people discussing together, but here only he alone is silent, so the subject doesn't match. The distractor 「過ぎる」 as the second element means \"excessively\"; 「考え過ぎる」 means overthinking or splitting hairs, which differs in meaning from \"silently sinking into thought\" and can't capture the momentary state of \"falling silent at the moment of being asked.\" Only 「込む」 works." },
     exampleJapanese: "難しい質問をされて、彼は腕を組んで考え込んでしまった。",
-    exampleMeaningZh: "被問到很難的問題，他抱著手臂陷入了沉思。"
+    exampleMeaningZh: "被問到很難的問題，他抱著手臂陷入了沉思。",
+    exampleMeaningI18n: { "ja": "難しい質問をされて、彼は腕を組んで深く考えてしまった、という意味。", "en": "Asked a difficult question, he folded his arms and sank deep into thought." },
   }),
   examQuestion({
     id: "n3-context-tatoeba-x",
@@ -6008,7 +6091,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「素直に」在此指不加掩飾、照著真心說出來，最接近「正直に（坦白、誠實地）」。「我慢して」是忍耐，與「說出」方向相反；「適当に」是隨便敷衍，語意不符；「必死に」是拼命地，強調程度而非坦率，皆不成立，故唯一正解為「正直に」。",
     explanationI18n: { "ja": "「素直に」はここでは飾らずに本心のまま口に出すことを指し、「正直に（正直に・誠実に）」に最も近い。「我慢して」は我慢することで、「口に出す」とは逆の方向。「適当に」はいい加減にごまかすことで意味が合わない。「必死に」は必死になることで、程度を強調するのであって素直さではない。いずれも成り立たず、よって唯一の正解は「正直に」。", "en": "Here 「素直に」 means saying something as it truly is, without concealment, which is closest to 「正直に（frankly, honestly）」. 「我慢して」 is enduring, the opposite direction from \"speaking out\"; 「適当に」 is doing something carelessly or half-heartedly, which doesn't match; 「必死に」 is desperately, stressing intensity rather than frankness—none of these work, so the only correct answer is 「正直に」." },
     exampleJapanese: "あの子の前だと、好きという気持ちを正直に言えなくて、わざと冷たい態度を取ってしまう。",
-    exampleMeaningZh: "在那個女孩面前，總是沒辦法坦白說出喜歡的心情，反而故意擺出冷淡的態度。"
+    exampleMeaningZh: "在那個女孩面前，總是沒辦法坦白說出喜歡的心情，反而故意擺出冷淡的態度。",
+    exampleMeaningI18n: { "ja": "あの子の前では、好きだという気持ちを正直に言えなくて、わざと冷たい態度を取ってしまう、という意味。", "en": "In front of that girl, I can never say honestly that I like her—instead I end up deliberately acting cold." },
   }),
   examQuestion({
     id: "n3-grammar-wakenihaikanai",
@@ -6090,7 +6174,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「とともに」在此表「隨著前項的推移，後項也同步變化」，與「につれて」(隨著…而漸漸)語意最接近，「練習を重ねるにつれて」表隨著反覆練習而逐漸進步。「かわりに」是代替、「きっかけに」是以…為契機(一次性觸發)、「にもかかわらず」是逆接，皆與「同步漸變」不符，故僅一個正解。",
     explanationI18n: { "ja": "ここでの「とともに」は「前の事柄が進むにつれて、後ろの事柄も同時に変化する」ことを表し、「につれて」（…するにつれてだんだん）と意味が最も近い。「練習を重ねるにつれて」は、練習を重ねるにつれて少しずつ上達していくことを表す。「かわりに」は代わりに、「きっかけに」は…をきっかけに（一度きりの契機）、「にもかかわらず」は逆接で、いずれも「同時に少しずつ変化する」という意味に合わないため、正解は一つだけ。", "en": "Here 「とともに」 means \"as the first clause progresses, the second clause changes in step with it,\" which is closest to 「につれて」 (gradually, as ~ proceeds). 「練習を重ねるにつれて」 means you improve steadily as you practice repeatedly. 「かわりに」 means \"instead of,\" 「きっかけに」 means \"triggered by ~\" (a one-time trigger), and 「にもかかわらず」 is concessive (\"despite\") — none fit \"changing gradually in step,\" so there is only one correct answer." },
     exampleJapanese: "彼女に近づきたくて練習を重ねるにつれて、わたしの指先は少しずつ自由になっていった。",
-    exampleMeaningZh: "隨著為了靠近她而不斷累積練習，我的指尖一點一點變得自由了。"
+    exampleMeaningZh: "隨著為了靠近她而不斷累積練習，我的指尖一點一點變得自由了。",
+    exampleMeaningI18n: { "ja": "彼女に近づきたくて練習を重ねるにつれて、私の指先は少しずつ自由に動くようになっていった、という意味。", "en": "As I kept piling up practice in hopes of getting closer to her, my fingertips little by little began to move freely." },
   }),
   examQuestion({
     id: "n3-syn-nichigainai",
@@ -6112,7 +6197,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「に違いない」表說話者有把握的強烈推斷，與「に決まっている」(必定如此)語意最接近。「かもしれない」是不確定的或許、「わけがない」是斷然否定(不可能)、「おそれがある」是擔心會發生壞事，方向皆不同，僅一個成立。",
     explanationI18n: { "ja": "「に違いない」は話し手が確信をもって行う強い推量を表し、「に決まっている」（きっとそうだ）と意味が最も近い。「かもしれない」は不確かな「もしかしたら」、「わけがない」はきっぱりとした否定（あり得ない）、「おそれがある」は悪いことが起こりそうで心配だ、という意味で、いずれも方向が異なり、成立するのは一つだけ。", "en": "「に違いない」 expresses a strong, confident inference by the speaker, which is closest to 「に決まっている」 (it's bound to be so). 「かもしれない」 is an uncertain \"maybe,\" 「わけがない」 is a flat denial (\"no way it could be\"), and 「おそれがある」 means \"there's a risk that something bad will happen\" — all point in different directions, so only one works." },
     exampleJapanese: "あんなに舞台で輝く彼女は、誰よりも努力してきたに決まっている。",
-    exampleMeaningZh: "能在舞台上那樣耀眼的她，背後一定比誰都更努力過。"
+    exampleMeaningZh: "能在舞台上那樣耀眼的她，背後一定比誰都更努力過。",
+    exampleMeaningI18n: { "ja": "あんなに舞台で輝いている彼女は、きっと誰よりも努力してきたはずだ、という意味。", "en": "For her to shine like that on stage, she must have worked harder than anyone." },
   }),
   examQuestion({
     id: "n3-vocab-saichuu",
@@ -6194,7 +6280,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「思いっきり」是「毫無保留、卯足全力地做某動作」的副詞，修飾的是有意志、可放開去做的動作，如「声を張り上げる（放聲喊）」。第二句要表「正好九時」應用「ちょうど」；第三句把「思いっきり」放進「〜かどうかわからない」的不確定判斷裡並不成立，且「重い」是非意志的性質，要表程度應用「かなり／相当」；第四句「還不太習慣」是程度不足，方向與「盡情、全力」相反，應用「あまり〜ない」。故只有第一句成立。",
     explanationI18n: { "ja": "「思いっきり」は「少しも遠慮せず、力の限り何かの動作をする」という副詞で、修飾するのは意志的で思いきりできる動作、たとえば「声を張り上げる」など。二つ目の文は「ちょうど九時」を表すなら「ちょうど」を使うべき。三つ目の文は「思いっきり」を「〜かどうかわからない」という不確かな判断の中に入れると成立せず、「重い」は非意志的な性質なので、程度を表すなら「かなり／相当」を使うべき。四つ目の文の「まだあまり慣れていない」は程度の不足で、「思う存分、力の限り」とは方向が逆であり、「あまり〜ない」を使うべき。したがって成立するのは一つ目の文だけ。", "en": "「思いっきり」 is an adverb meaning \"to do some action holding nothing back, with all one's might,\" modifying a volitional action you can throw yourself into, like 「声を張り上げる (to raise one's voice)」. The second sentence, meaning \"exactly nine o'clock,\" should use 「ちょうど」. The third sentence puts 「思いっきり」 inside the uncertain judgment 「〜かどうかわからない」, which doesn't work, and 「重い」 is a non-volitional quality — to express degree you'd use 「かなり／相当」. The fourth sentence, \"not yet very used to it,\" is insufficiency, the opposite direction from \"to one's heart's content, all-out,\" and should use 「あまり〜ない」. So only the first sentence works." },
     exampleJapanese: "頂上に着いた仲間たちは、空に向かって思いっきり声を張り上げた。",
-    exampleMeaningZh: "抵達山頂的夥伴們，朝著天空盡情地放聲呼喊。"
+    exampleMeaningZh: "抵達山頂的夥伴們，朝著天空盡情地放聲呼喊。",
+    exampleMeaningI18n: { "ja": "頂上に着いた仲間たちは、空に向かって力いっぱい大きな声を上げた、という意味。", "en": "Having reached the summit, the friends shouted toward the sky with all their might." },
   }),
   examQuestion({
     id: "n3-usage-omoni",
@@ -6216,7 +6303,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「主に」表「在多數情況／多數比重上以某事為主」，修飾「占大部分的對象或內容」，如「主に〜の練習に時間を使う（時間主要花在某練習）」。第二句要表「總有一天」應用「いつか」搭配，「主に」無法修飾「たどり着ける」這種單一結果；第三句句中已有「一番の力」表唯一最大，要強調是最大推力應用「何よりも」，「主に」與「一番（唯一）」語意衝突；第四句「準時趕上」是時間點而非比重，應用「ちゃんと／きちんと」。故只有第一句成立。",
     explanationI18n: { "ja": "「主に」は「多くの場合／多くの割合で、ある事柄を中心にする」ことを表し、「大部分を占める対象や内容」を修飾する。たとえば「主に〜の練習に時間を使う（時間を主にある練習に使う）」など。二つ目の文は「いつか」を表すなら「いつか」と組み合わせるべきで、「主に」は「たどり着ける」という単一の結果を修飾できない。三つ目の文はすでに「一番の力」で唯一・最大を表しており、最大の後押しだと強調するなら「何よりも」を使うべきで、「主に」は「一番（唯一）」と意味が衝突する。四つ目の文の「時間どおりに間に合う」は時間の一点であって割合ではなく、「ちゃんと／きちんと」を使うべき。したがって成立するのは一つ目の文だけ。", "en": "「主に」 means \"chiefly / for the most part, with something as the main focus,\" modifying \"the object or content that makes up the largest share,\" as in 「主に〜の練習に時間を使う (spend time mainly on a certain practice)」. The second sentence, meaning \"someday,\" should pair with 「いつか」; 「主に」 can't modify a single outcome like 「たどり着ける」. The third sentence already has 「一番の力」 marking the single greatest thing — to stress it's the biggest driving force you'd use 「何よりも」, and 「主に」 clashes with 「一番 (the single greatest)」. The fourth sentence, \"making it on time,\" is a point in time rather than a proportion, and should use 「ちゃんと／きちんと」. So only the first sentence works." },
     exampleJapanese: "本番までの一か月は、主に声を合わせる練習に時間を使うつもりだ。",
-    exampleMeaningZh: "到正式演出前的這一個月，打算把時間主要花在合聲（對拍合唱）的練習上。"
+    exampleMeaningZh: "到正式演出前的這一個月，打算把時間主要花在合聲（對拍合唱）的練習上。",
+    exampleMeaningI18n: { "ja": "本番までの1か月は、時間の大部分を声を合わせる練習に使うつもりだ、という意味。", "en": "In the month before the real performance, I plan to spend my time mainly on practice for getting our voices in sync." },
   }),
   examQuestion({
     id: "n3-vocab-totanni",
@@ -6438,7 +6526,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「ずるい」指用不正當手段佔便宜、不公平,與「ひきょう(卑怯)」最接近——兩者都帶有「靠不光明正大的手段佔便宜」的負面評價,日常會話中責怪別人「ずるい」也常以「卑怯だ」替換。「すなお(坦率)」「ゆうかん(勇敢)」「けんきょ(謙虛)」皆為正面性格,與責怪不公平的語感相反,代回語境母語者不會接受,故唯一正解為ひきょう。",
     explanationI18n: { "ja": "「ずるい」は不正な手段で得をする、公平でないことを指し、「ひきょう（卑怯）」に最も近い。両者とも「正々堂々でない手段で得をする」というマイナスの評価を含み、日常会話で人を責めて「ずるい」と言うときも、しばしば「卑怯だ」に言い換えられる。「すなお（素直）」「ゆうかん（勇敢）」「けんきょ（謙虚）」はいずれもプラスの性格で、不公平を責める語感と逆であり、当てはめると母語話者は受け入れないため、唯一の正解は「ひきょう」。", "en": "「ずるい」 means to gain an unfair advantage through improper means, unfairness — closest to 「ひきょう(卑怯)」: both carry the negative judgment of \"gaining an advantage by underhanded means,\" and in everyday conversation blaming someone as 「ずるい」 is often swapped for 「卑怯だ」. 「すなお (honest)」, 「ゆうかん (brave)」, and 「けんきょ (humble)」 are all positive traits, opposite to the sense of blaming unfairness, and native speakers wouldn't accept them substituted into the context, so the only correct answer is ひきょう." },
     exampleJapanese: "あの子だけ先生にこっそり答えを教えてもらうなんて、本当にひきょうだ。",
-    exampleMeaningZh: "只有那個女孩偷偷被老師告知答案,真是太卑鄙了。"
+    exampleMeaningZh: "只有那個女孩偷偷被老師告知答案,真是太卑鄙了。",
+    exampleMeaningI18n: { "ja": "あの子だけが先生にこっそり答えを教えてもらうなんて、本当にひきょうだ、という意味。", "en": "Only that girl got secretly told the answers by the teacher—that's so unfair." },
   }),
   examQuestion({
     id: "n3-kanji-tokeru",
@@ -6458,7 +6547,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「溶ける」讀作「とける」,表示固體化開、融化或情感、隔閡消融。干擾項:「どける」是濁音化,實為「退ける(どける)」的讀法,語意為挪開,在此句不成立;「とおける」加了長音,並非實際存在的讀法;「とっける」混入促音,亦非正確讀音。只有「とける」符合句中「冷たさが溶ける(冰冷感融化)」的語境。",
     explanationI18n: { "ja": "「溶ける」は「とける」と読み、固体がとけること、または感情やわだかまりが解けることを表す。ほかの選択肢について。「どける」は濁音化していて、実際は「退ける（どける）」の読みであり、意味は「どかす」で、この文では成立しない。「とおける」は長音を加えていて、実在する読みではない。「とっける」は促音が混じっていて、これも正しい読みではない。文中の「冷たさが溶ける」という文脈に合うのは「とける」だけ。", "en": "「溶ける」 is read 「とける」, meaning a solid dissolving/melting, or feelings and barriers melting away. Distractors: 「どける」 with voicing is actually the reading of 「退ける(どける)」, meaning to move aside, which doesn't work here; 「とおける」 adds a long vowel and is not an actual reading; 「とっける」 inserts a geminate consonant and is also not a correct reading. Only 「とける」 fits the context of 「冷たさが溶ける (the coldness melting)」 in the sentence." },
     exampleJapanese: "君に触れられると、心の奥の冷たさまで「溶ける」気がして怖い。",
-    exampleMeaningZh: "被你碰觸時,連內心深處的冰冷都彷彿要融化,讓我害怕。"
+    exampleMeaningZh: "被你碰觸時,連內心深處的冰冷都彷彿要融化,讓我害怕。",
+    exampleMeaningI18n: { "ja": "君に触れられると、心の奥の冷たささえとけていく気がして怖い、という意味。", "en": "When you touch me, it feels as if even the coldness deep in my heart is about to melt, and that scares me." },
   }),
   examQuestion({
     id: "n3-kanji-mayoi",
@@ -6478,7 +6568,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "動詞「迷う」的名詞形(連用形)為「まよい」。干擾項「まよえ」尾音誤作え段;「まよひ」是歷史假名遣的舊寫法、現代不讀此音;「まいよ」把よ・い兩拍前後對調,皆非此處讀音,故唯一正解為「まよい」。",
     explanationI18n: { "ja": "動詞「迷う」の名詞形（連用形）は「まよい」。ほかの選択肢について。「まよえ」は末尾がえ段になっている誤り。「まよひ」は歴史的仮名遣いの古い書き方で、現代ではこう読まない。「まいよ」は「よ・い」の二拍を前後で入れかえたもので、いずれもここでの読みではないため、唯一の正解は「まよい」。", "en": "The noun form (continuative form) of the verb 「迷う」 is 「まよい」. The distractor 「まよえ」 wrongly ends in the え-row; 「まよひ」 is the old historical kana spelling and isn't read this way in modern Japanese; 「まいよ」 swaps the order of the よ and い morae — none of these is the reading here, so the only correct answer is 「まよい」." },
     exampleJapanese: "改札の前で足を止めたまま、行くべきか戻るべきかという迷いを、彼女はまだ手放せずにいた。",
-    exampleMeaningZh: "在剪票口前停下腳步,該前行還是折返的那份迷惘,她始終放不下。"
+    exampleMeaningZh: "在剪票口前停下腳步,該前行還是折返的那份迷惘,她始終放不下。",
+    exampleMeaningI18n: { "ja": "改札の前で足を止めたまま、進むべきか戻るべきかという心の揺れを、彼女はまだ手放せずにいた。", "en": "Stopped in her tracks in front of the ticket gate, she still couldn't let go of the hesitation over whether to go on or turn back." },
   }),
   examQuestion({
     id: "n3-vocab-sentaku",
@@ -6598,7 +6689,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「輝く」読作「かがやく」，意為閃耀、發光。干擾項「かがやか」非動詞終止形（且非該字讀音）；「ががやく」首音濁化錯誤；「かかやく」第二音未濁化，母語者都不會接受，故唯一正解為「かがやく」。",
     explanationI18n: { "ja": "「輝く」は「かがやく」と読み、きらめく・光を放つという意味です。誤答「かがやか」は動詞の終止形ではなく（そもそもこの字の読みでもありません）、「ががやく」は語頭が濁ってしまう誤り、「かかやく」は二拍目が濁らない誤りで、いずれもネイティブには受け入れられません。したがって正解は「かがやく」のみです。", "en": "「輝く」is read「かがやく」, meaning to shine or sparkle. The distractor「かがやか」is not the dictionary form of the verb (and isn't a valid reading of the word); 「ががやく」wrongly voices the first syllable; 「かかやく」leaves the second syllable unvoiced, which no native speaker would accept. The only correct answer is therefore「かがやく」." },
     exampleJapanese: "君がくれた小さな星が、今も胸の奥で輝くのだろう。",
-    exampleMeaningZh: "你送我的那顆小小的星，如今或許仍在我心底深處閃耀著吧。"
+    exampleMeaningZh: "你送我的那顆小小的星，如今或許仍在我心底深處閃耀著吧。",
+    exampleMeaningI18n: { "ja": "君がくれた小さな星が、今も胸の奥で光り続けているのだろう。", "en": "That little star you gave me is probably still shining deep in my heart even now." },
   }),
   examQuestion({
     id: "n3-kanji-eien",
@@ -6618,7 +6710,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「永遠」読作「えいえん」，意為永恆。干擾項「えいおん」「えいねん」均為「遠」字的錯誤讀音；「えんえん」首字讀音錯誤（且易與「延々」混淆），在此語境母語者都不會接受，故唯一正解為「えいえん」。",
     explanationI18n: { "ja": "「永遠」は「えいえん」と読み、永遠という意味です。誤答「えいおん」「えいねん」はどちらも「遠」の誤った読み、「えんえん」は最初の字の読みが誤り（しかも「延々」と混同しやすい）で、この文脈ではネイティブには受け入れられません。したがって正解は「えいえん」のみです。", "en": "「永遠」is read「えいえん」, meaning eternity. The distractors「えいおん」and「えいねん」are both incorrect readings of the character 「遠」; 「えんえん」misreads the first character (and is easily confused with 「延々」). In this context no native speaker would accept them, so the only correct answer is「えいえん」." },
     exampleJapanese: "流れ星のように消えても、この願いだけは永遠でありたい。",
-    exampleMeaningZh: "即使像流星般消逝，唯有這份心願，但願能成為永遠。"
+    exampleMeaningZh: "即使像流星般消逝，唯有這份心願，但願能成為永遠。",
+    exampleMeaningI18n: { "ja": "流れ星のように消えてしまっても、この願いだけはいつまでも変わらずにあってほしい。", "en": "Even if it vanishes like a shooting star, I want this one wish to last forever." },
   }),
   examQuestion({
     id: "n3-vocab-yozora",
@@ -6778,7 +6871,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「叫ぶ」讀作「さけぶ」,意為呼喊、吶喊。「さげぶ」是清濁錯誤的混淆;「さげる(下げる)」意為放下/降低,語境不成立;「さがす(探す)」意為尋找,與「向暗處吶喊」的語境不符。故唯一正解為「さけぶ」。",
     explanationI18n: { "ja": "「叫ぶ」は「さけぶ」と読み、叫ぶ・大声を出すという意味です。「さげぶ」は清濁を取り違えた混同、「さげる（下げる）」は下ろす／下げるという意味で文脈に合わず、「さがす（探す）」は探すという意味で「暗闇に向かって叫ぶ」という文脈に合いません。したがって正解は「さけぶ」のみです。", "en": "「叫ぶ」is read「さけぶ」, meaning to shout or cry out. 「さげぶ」is a voicing error; 「さげる(下げる)」means to lower / put down, which doesn't fit the context; 「さがす(探す)」means to search, which doesn't match \"crying out into the darkness.\" The only correct answer is therefore「さけぶ」." },
     exampleJapanese: "涙をこらえ、暗闇に向かって叫ぶその声が、仲間を守る力になる。",
-    exampleMeaningZh: "在黑暗中強忍淚水發出的那道吶喊,化作了守護同伴的力量。"
+    exampleMeaningZh: "在黑暗中強忍淚水發出的那道吶喊,化作了守護同伴的力量。",
+    exampleMeaningI18n: { "ja": "暗闇に向かって涙をこらえながら上げた大声が、仲間を守る力になる。", "en": "That cry, shouted into the darkness while holding back tears, became the strength to protect their companions." },
   }),
   examQuestion({
     id: "n3-kanji-tatakau",
@@ -6798,7 +6892,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「戦う」讀作「たたかう」,意為戰鬥、奮戰。「たたがう」是清濁錯誤;「たかかう」與「たてかう」皆為音節順序或近形的混淆,均非實際讀音。故唯一正解為「たたかう」。",
     explanationI18n: { "ja": "「戦う」は「たたかう」と読み、戦う・奮闘するという意味です。「たたがう」は清濁の誤り、「たかかう」と「たてかう」はどちらも音節の順序や字形の近さによる混同で、いずれも実際の読みではありません。したがって正解は「たたかう」のみです。", "en": "「戦う」is read「たたかう」, meaning to fight or battle. 「たたがう」is a voicing error; 「たかかう」and「たてかう」are confusions of syllable order or similar-looking forms, and none is an actual reading. The only correct answer is therefore「たたかう」." },
     exampleJapanese: "守りたいものがあるから、私は逃げずに最後まで戦うと心に決めた。",
-    exampleMeaningZh: "因為有想守護的事物,我下定決心不逃避、奮戰到最後。"
+    exampleMeaningZh: "因為有想守護的事物,我下定決心不逃避、奮戰到最後。",
+    exampleMeaningI18n: { "ja": "守りたいものがあるから、逃げずに最後まで立ち向かうと心に決めた。", "en": "Because I have something I want to protect, I've resolved not to run away and to fight until the very end." },
   }),
   examQuestion({
     id: "n3-vocab-tsunagu",
@@ -6838,7 +6933,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「転ぶ」讀作「ころぶ」,意為跌倒、摔倒,與句中「何度~ことがあっても、立ち上がって」(即使一再~也爬起來)的語境吻合;「こころぶ」多一拍、「こらぶ」「こおぶ」皆非該字讀音,在此語境下都不成立。",
     explanationI18n: { "ja": "「転ぶ」は「ころぶ」と読み、転ぶ・倒れるという意味で、文中の「何度～ことがあっても、立ち上がって」（何度～しても立ち上がって）という文脈に合います。「こころぶ」は一拍多く、「こらぶ」「こおぶ」はどちらもこの字の読みではなく、この文脈ではいずれも成り立ちません。したがって正解は「ころぶ」のみです。", "en": "「転ぶ」is read「ころぶ」, meaning to fall or tumble down, matching「何度~ことがあっても、立ち上がって」(getting up no matter how many times you ~). 「こころぶ」has an extra mora; 「こらぶ」and「こおぶ」are not readings of this character, and none works in this context. The only correct answer is「ころぶ」." },
     exampleJapanese: "何度転ぶことがあっても、泥だらけの膝で立ち上がって、夢へ走り続ける。",
-    exampleMeaningZh: "無論摔倒幾次,都用沾滿泥的膝蓋站起來,繼續朝夢想奔跑。"
+    exampleMeaningZh: "無論摔倒幾次,都用沾滿泥的膝蓋站起來,繼續朝夢想奔跑。",
+    exampleMeaningI18n: { "ja": "何度倒れても、泥だらけの膝で立ち上がり、夢に向かって走り続ける。", "en": "No matter how many times I fall, I get up on mud-covered knees and keep running toward my dream." },
   }),
   examQuestion({
     id: "n3-kanji-inoru",
@@ -6858,7 +6954,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「祈る」讀作「いのる」,意為祈禱、祈求。干擾項:「いなる」「いのろ」「いおる」均非此字讀音,在此語境(為遠方之人祈求幸福)皆不成立,只有「いのる」正確。",
     explanationI18n: { "ja": "「祈る」は「いのる」と読み、祈る・祈願するという意味です。誤答の「いなる」「いのろ」「いおる」はいずれもこの字の読みではなく、この文脈（遠くの人の幸せを祈る）では成り立ちません。正しいのは「いのる」だけです。", "en": "「祈る」is read「いのる」, meaning to pray or wish for. The distractors「いなる」「いのろ」「いおる」are not readings of this character and none works in this context (praying for the happiness of someone far away). Only「いのる」is correct." },
     exampleJapanese: "地平線にひとつだけ光る星を見上げて、遠く離れた人の幸せを祈る夜だった。",
-    exampleMeaningZh: "仰望地平線上唯一閃爍的那顆星,這是為遠方的人祈求幸福的夜晚。"
+    exampleMeaningZh: "仰望地平線上唯一閃爍的那顆星,這是為遠方的人祈求幸福的夜晚。",
+    exampleMeaningI18n: { "ja": "地平線にひとつだけ光る星を見上げて、遠く離れた人の幸せを願う夜だった。", "en": "Looking up at the single star shining on the horizon, it was a night for praying for the happiness of someone far away." },
   }),
   examQuestion({
     id: "n3-vocab-kousaten",
@@ -6920,7 +7017,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "句意為「就算跌倒擦傷、就算___，也不停下朝夢想奔跑的腳步」。前後並列的都是負面挫折（轉んで膝をすりむく），需填同屬狼狽窘境的詞，「遅刻」（遲到）最自然。「出席」（出席）、「完成」（完成）、「成功」（成功）都是正面或中性事件，與「跌倒擦傷」並列不成立，且與「仍不放棄」的轉折邏輯矛盾，故唯一正解為遅刻。",
     explanationI18n: { "ja": "文意は「転んで膝をすりむいても、___しても、夢に向かって走る足を止めない」です。前後に並んでいるのはどれもマイナスの挫折（転んで膝をすりむく）で、同じく不格好で困った状況を表す語を入れる必要があり、「遅刻」が最も自然です。「出席」「完成」「成功」はどれも前向きか中立の出来事で、「転んで膝をすりむく」と並べても成り立たず、「それでもあきらめない」という逆接の論理とも矛盾します。したがって正解は「遅刻」のみです。", "en": "The sentence means \"even if I fall and scrape myself, even if I ___, I won't stop my feet running toward my dream.\" The items listed on either side are all negative setbacks (転んで膝をすりむく), so the blank needs a word that also belongs to the realm of clumsy mishaps, and「遅刻」(being late) is the most natural. 「出席」(attendance), 「完成」(completion), and「成功」(success) are all positive or neutral events that don't belong alongside \"falling and scraping oneself,\" and they contradict the \"still won't give up\" turn of logic. The only correct answer is therefore「遅刻」." },
     exampleJapanese: "また遅刻してしまい、教室まで全力で走った。",
-    exampleMeaningZh: "又遲到了，於是用盡全力跑到教室。"
+    exampleMeaningZh: "又遲到了，於是用盡全力跑到教室。",
+    exampleMeaningI18n: { "ja": "また遅れてしまい、全力で教室まで走った。", "en": "Late again, so I ran to the classroom as fast as I could." },
   }),
   examQuestion({
     id: "n3-vocab-kabe",
@@ -6960,7 +7058,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「映る」訓讀為「うつる」，意為映照、倒映，此處指晨光映在濕潤的路面上，為自動詞。干擾項「くつる」「うする」「おつる」皆非實際存在的讀音，屬近形與母音替換的造假讀，於詞中皆不成立。故唯一正解為「うつる」。",
     explanationI18n: { "ja": "「映る」は訓読みで「うつる」と読み、映る・映し出されるという意味で、ここでは朝の光が濡れた路面に映る様子を指し、自動詞です。誤答「くつる」「うする」「おつる」はいずれも実在しない読みで、字形の近さや母音の入れ替えによる作られた読みであり、語中では成り立ちません。したがって正解は「うつる」のみです。", "en": "「映る」has the kun reading「うつる」, meaning to be reflected or mirrored; here it refers to the morning light reflecting off the wet road, and it's an intransitive verb. The distractors「くつる」「うする」「おつる」are none of them real readings — they are fabricated readings based on similar shapes or vowel swaps, and none works in the word. The only correct answer is therefore「うつる」." },
     exampleJapanese: "信号が青に変わる瞬間、濡れたアスファルトに朝の光が映るのを見て、胸が少しだけ高鳴った。",
-    exampleMeaningZh: "號誌轉綠的那一瞬間，看見晨光映照在濕潤的柏油路面上，心頭微微悸動了一下。"
+    exampleMeaningZh: "號誌轉綠的那一瞬間，看見晨光映照在濕潤的柏油路面上，心頭微微悸動了一下。",
+    exampleMeaningI18n: { "ja": "信号が青に変わった瞬間、濡れたアスファルトに朝の光が照り返しているのが見えて、胸が少しだけ高鳴った。", "en": "The moment the light turned green, I saw the morning light reflected on the wet asphalt, and my heart skipped a little." },
   }),
   examQuestion({
     id: "n3-kanji-noboru",
@@ -6980,7 +7079,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「昇る」讀作「のぼる」,指太陽升起或往上攀升;在「朝日が昇る」這個語境中只有「のぼる」成立。四個選項都保留「の〜る/う」近形外觀:「のぽる」把濁音「ぼ」誤成半濁音「ぽ」;「のぼう」把結尾「る」誤讀成「う」;「のばる」把「ぼ」母音誤讀成「ば」。三者皆非「昇る」的正確讀音,故唯一正解為「のぼる」。",
     explanationI18n: { "ja": "「昇る」は「のぼる」と読み、太陽が昇る・上へ上がるという意味で、「朝日が昇る」というこの文脈では「のぼる」だけが成り立ちます。四つの選択肢はいずれも「の〜る/う」という似た見た目を残しています。「のぽる」は濁音の「ぼ」を半濁音の「ぽ」と誤り、「のぼう」は語尾の「る」を「う」と誤読し、「のばる」は「ぼ」の母音を「ば」と誤読しています。三つとも「昇る」の正しい読みではありません。したがって正解は「のぼる」のみです。", "en": "「昇る」is read「のぼる」, referring to the sun rising or climbing upward; in the context「朝日が昇る」only「のぼる」works. All four options keep the similar「の〜る/う」shape: 「のぽる」mistakes the voiced「ぼ」for the semi-voiced「ぽ」; 「のぼう」misreads the final「る」as「う」; 「のばる」misreads the vowel of「ぼ」as「ば」. None of these three is a correct reading of「昇る」, so the only correct answer is「のぼる」." },
     exampleJapanese: "大人になる季節へ続く長い階段の向こうで、まっすぐな朝日がゆっくり昇るのを、私は嘘をつかない心のままに見つめていた。",
-    exampleMeaningZh: "在通往大人世界的漫長階梯彼端,我以不說謊的純粹之心,凝望著筆直的朝陽緩緩升起。"
+    exampleMeaningZh: "在通往大人世界的漫長階梯彼端,我以不說謊的純粹之心,凝望著筆直的朝陽緩緩升起。",
+    exampleMeaningI18n: { "ja": "大人になる季節へと続く長い階段の向こうで、まっすぐな朝日がゆっくり上がっていくのを、嘘のない素直な心のままに見つめていた。", "en": "Beyond the long staircase leading to the season of growing up, I watched with an honest, unlying heart as the morning sun slowly rose straight into the sky." },
   }),
   examQuestion({
     id: "n3-vocab-jishin",
@@ -7020,7 +7120,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「騒ぐ」讀作「さわぐ」,意為吵鬧、起鬨。語境是放聲喧鬧地度過自己的夜晚,動詞需要濁音的辭書形「さわぐ」。「さわく」缺了結尾的濁音、「ざわぐ」開頭多了濁音、「さばぐ」中間假名錯成「ば」,三者皆非此字的正確讀音,故唯一正解為「さわぐ」。",
     explanationI18n: { "ja": "「騒ぐ」は「さわぐ」と読み、騒ぐ・はしゃぐという意味です。文脈は思いきり騒いで自分の夜を過ごすことで、動詞は濁音の辞書形「さわぐ」が必要です。「さわく」は語尾の濁音が欠け、「ざわぐ」は語頭に濁音が余分で、「さばぐ」は中の仮名が「ば」に誤っており、三つともこの字の正しい読みではありません。したがって正解は「さわぐ」のみです。", "en": "「騒ぐ」is read「さわぐ」, meaning to make noise or whoop it up. The context is spending your own night in boisterous fun, so the verb needs the voiced dictionary form「さわぐ」. 「さわく」lacks the final voicing, 「ざわぐ」adds voicing at the start, and 「さばぐ」has the middle kana wrong as「ば」— none of these is the correct reading of the character, so the only correct answer is「さわぐ」." },
     exampleJapanese: "誰かと比べる声なんていらない、胸に応援歌を抱いて思いきり騒ぐ夜が、いちばん自分らしい。",
-    exampleMeaningZh: "不需要拿來和別人比較的聲音,把應援歌抱在胸口、盡情喧鬧的夜晚,最像自己。"
+    exampleMeaningZh: "不需要拿來和別人比較的聲音,把應援歌抱在胸口、盡情喧鬧的夜晚,最像自己。",
+    exampleMeaningI18n: { "ja": "誰かと比べる声なんていらない。応援歌を胸に抱いて思いきりはしゃぐ夜が、いちばん自分らしい。", "en": "I don't need voices that compare me to others—a night spent making noise to my heart's content, with a cheer song held close to my chest, is when I feel most like myself." },
   }),
   examQuestion({
     id: "n3-vocab-mikata",
@@ -7100,7 +7201,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「影」訓讀為「かげ」,指影子。正午太陽在正上方時,影子最短,呼應高掛中天的烈日意象。干擾項「がけ」「かべ」「かさ」皆非「影」的讀音,且在此語境中(腳邊變短的東西)語意不成立,故唯一正解為「かげ」。",
     explanationI18n: { "ja": "「影」の訓読みは「かげ」で、影を表します。太陽が真上にあるときに影がいちばん短くなり、中天にかかる強い日差しのイメージと合致します。ほかの「がけ」「かべ」「かさ」はいずれも「影」の読みではなく、しかもこの文脈(足もとで短くなるもの)では意味も通らないため、正解は「かげ」だけです。", "en": "「影」has the kun-reading「かげ」, meaning \"shadow.\" When the sun is directly overhead at noon, shadows are at their shortest, matching the image of the blazing sun high in the sky. The distractors「がけ」「かべ」「かさ」are none of them readings of「影」, and none makes sense in this context (the thing beside your feet growing shorter), so「かげ」is the only correct answer." },
     exampleJapanese: "真上の太陽が照りつけて、足もとの影がいちばん短くなった。",
-    exampleMeaningZh: "正上方的太陽火辣辣地照下來,腳邊的影子變得最短了。"
+    exampleMeaningZh: "正上方的太陽火辣辣地照下來,腳邊的影子變得最短了。",
+    exampleMeaningI18n: { "ja": "太陽が真上から強く照りつけて、足もとにできる影がいちばん短くなった。", "en": "With the sun blazing directly overhead, the shadow at my feet became its shortest." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-001",
@@ -7122,7 +7224,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「違反」（違＝背離、反＝相反）。「偉反」把違誤成同音(い)的偉（偉大）；「異反」把違誤成同音(い)的異（不同）；「違判」把反誤成同音(はん)的判（判斷）。三者皆讀いはん但非正確寫法。",
     explanationI18n: { "ja": "正解は「違反」(違＝そむく、反＝さからう)。「偉反」は「違」を同音(い)の「偉」(偉大)に取りちがえたもの、「異反」は「違」を同音(い)の「異」(異なる)に取りちがえたもの、「違判」は「反」を同音(はん)の「判」(判断)に取りちがえたものです。いずれも「いはん」と読めますが正しい表記ではありません。", "en": "The correct answer is「違反」(違 = to deviate, 反 = to go against). 「偉反」mistakes 違 for the homophone (い) 偉 (great); 「異反」mistakes 違 for the homophone (い) 異 (different); 「違判」mistakes 反 for the homophone (はん) 判 (to judge). All three read いはん but are the wrong spelling." },
     exampleJapanese: "スピードの違反で警察に止められた。",
-    exampleMeaningZh: "因為超速違規被警察攔了下來。"
+    exampleMeaningZh: "因為超速違規被警察攔了下來。",
+    exampleMeaningI18n: { "ja": "スピードの出しすぎで、警察に止められた。", "en": "I was stopped by the police for speeding." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-002",
@@ -7144,7 +7247,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「提出」（提＝拿出、出＝交出）。「堤出」把提誤成形近且同音(てい)的堤（堤防）；「程出」把提誤成同音(てい)的程（程度）；「抵出」把提誤成同音(てい)的抵（抵抗）。",
     explanationI18n: { "ja": "正解は「提出」(提＝差し出す、出＝出す)。「堤出」は「提」を形が似て同音(てい)の「堤」(堤防)に取りちがえたもの、「程出」は「提」を同音(てい)の「程」(程度)に取りちがえたもの、「抵出」は「提」を同音(てい)の「抵」(抵抗)に取りちがえたものです。", "en": "The correct answer is「提出」(提 = to hold out, 出 = to put forth). 「堤出」mistakes 提 for the similar-looking homophone (てい) 堤 (embankment); 「程出」mistakes 提 for the homophone (てい) 程 (degree); 「抵出」mistakes 提 for the homophone (てい) 抵 (to resist)." },
     exampleJapanese: "レポートを来週までに提出してください。",
-    exampleMeaningZh: "請在下週之前提交報告。"
+    exampleMeaningZh: "請在下週之前提交報告。",
+    exampleMeaningI18n: { "ja": "レポートは来週までに出してください。", "en": "Please submit the report by next week." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-003",
@@ -7166,7 +7270,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「経験」（経＝經歷、験＝體驗）。「経検」把験誤成同音(けん)的検（檢查）；「径験」把経誤成形近且同音(けい)的径（小徑）；「軽験」把経誤成同音(けい)的軽（輕）。",
     explanationI18n: { "ja": "正解は「経験」(経＝経る、験＝ためす)。「経検」は「験」を同音(けん)の「検」(検査)に取りちがえたもの、「径験」は「経」を形が似て同音(けい)の「径」(小道)に取りちがえたもの、「軽験」は「経」を同音(けい)の「軽」(軽い)に取りちがえたものです。", "en": "The correct answer is「経験」(経 = to go through, 験 = to test/undergo). 「経検」mistakes 験 for the homophone (けん) 検 (to inspect); 「径験」mistakes 経 for the similar-looking homophone (けい) 径 (a path); 「軽験」mistakes 経 for the homophone (けい) 軽 (light)." },
     exampleJapanese: "海外で働いた経験がとても役に立った。",
-    exampleMeaningZh: "在國外工作的經驗非常有幫助。"
+    exampleMeaningZh: "在國外工作的經驗非常有幫助。",
+    exampleMeaningI18n: { "ja": "海外で働いたことがとても役に立った。", "en": "My experience working abroad was very useful." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-004",
@@ -7188,7 +7293,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「賛成」（賛＝贊同、成＝成立）。「賛盛」把成誤成同音(せい)的盛（興盛）；「賛性」把成誤成同音(せい)的性（性質）；「参成」把賛誤成同音(さん)的参（参加）。三者皆讀さんせい但非正確寫法。",
     explanationI18n: { "ja": "正解は「賛成」(賛＝同意する、成＝成り立つ)。「賛盛」は「成」を同音(せい)の「盛」(盛ん)に取りちがえたもの、「賛性」は「成」を同音(せい)の「性」(性質)に取りちがえたもの、「参成」は「賛」を同音(さん)の「参」(参加)に取りちがえたものです。いずれも「さんせい」と読めますが正しい表記ではありません。", "en": "The correct answer is「賛成」(賛 = to endorse, 成 = to establish). 「賛盛」mistakes 成 for the homophone (せい) 盛 (flourishing); 「賛性」mistakes 成 for the homophone (せい) 性 (nature); 「参成」mistakes 賛 for the homophone (さん) 参 (to take part). All three read さんせい but are the wrong spelling." },
     exampleJapanese: "私はその意見に賛成です。",
-    exampleMeaningZh: "我贊成那個意見。"
+    exampleMeaningZh: "我贊成那個意見。",
+    exampleMeaningI18n: { "ja": "私はその意見に同意します。", "en": "I agree with that opinion." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-005",
@@ -7210,7 +7316,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「案内」（案＝引導、内＝裡面）。「安内」把案誤成同音(あん)的安（安全）；「按内」把案誤成形近且同音(あん)的按（按壓）；「暗内」把案誤成同音(あん)的暗（黑暗）。",
     explanationI18n: { "ja": "正解は「案内」(案＝導く、内＝うち)。「安内」は「案」を同音(あん)の「安」(安全)に取りちがえたもの、「按内」は「案」を形が似て同音(あん)の「按」(押す)に取りちがえたもの、「暗内」は「案」を同音(あん)の「暗」(暗い)に取りちがえたものです。", "en": "The correct answer is「案内」(案 = to guide, 内 = inside). 「安内」mistakes 案 for the homophone (あん) 安 (safe); 「按内」mistakes 案 for the similar-looking homophone (あん) 按 (to press); 「暗内」mistakes 案 for the homophone (あん) 暗 (dark)." },
     exampleJapanese: "駅員さんが出口まで案内してくれた。",
-    exampleMeaningZh: "站務員帶我到了出口。"
+    exampleMeaningZh: "站務員帶我到了出口。",
+    exampleMeaningI18n: { "ja": "駅員さんが出口まで連れて行ってくれた。", "en": "The station attendant guided me to the exit." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-006",
@@ -7232,7 +7339,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「解決」（解＝化解、決＝定下）。「回決」把解誤成同音(かい)的回（回轉）；「改決」把解誤成同音(かい)的改（更改）；「解結」把決誤成同音(けつ)的結（結束）。",
     explanationI18n: { "ja": "正解は「解決」(解＝解きほぐす、決＝定める)。「回決」は「解」を同音(かい)の「回」(回る)に取りちがえたもの、「改決」は「解」を同音(かい)の「改」(改める)に取りちがえたもの、「解結」は「決」を同音(けつ)の「結」(結ぶ)に取りちがえたものです。", "en": "The correct answer is「解決」(解 = to unravel, 決 = to settle). 「回決」mistakes 解 for the homophone (かい) 回 (to turn); 「改決」mistakes 解 for the homophone (かい) 改 (to change); 「解結」mistakes 決 for the homophone (けつ) 結 (to conclude)." },
     exampleJapanese: "話し合いで問題が無事に解決した。",
-    exampleMeaningZh: "透過商談，問題順利解決了。"
+    exampleMeaningZh: "透過商談，問題順利解決了。",
+    exampleMeaningI18n: { "ja": "話し合いで、問題は無事に片づいた。", "en": "Through discussion, the problem was resolved without trouble." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-007",
@@ -7254,7 +7362,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「努力」（努＝盡力、力＝力量）。「怒力」把努誤成形近且同音(ど)的怒（憤怒）；「弩力」把努誤成形近且同音(ど)的弩（弩弓）；「度力」把努誤成同音(ど)的度（程度）。",
     explanationI18n: { "ja": "正解は「努力」(努＝つとめる、力＝力)。「怒力」は「努」を形が似て同音(ど)の「怒」(怒り)に取りちがえたもの、「弩力」は「努」を形が似て同音(ど)の「弩」(いしゆみ)に取りちがえたもの、「度力」は「努」を同音(ど)の「度」(程度)に取りちがえたものです。", "en": "The correct answer is「努力」(努 = to exert oneself, 力 = strength). 「怒力」mistakes 努 for the similar-looking homophone (ど) 怒 (anger); 「弩力」mistakes 努 for the similar-looking homophone (ど) 弩 (crossbow); 「度力」mistakes 努 for the homophone (ど) 度 (degree)." },
     exampleJapanese: "彼は合格のために毎日努力している。",
-    exampleMeaningZh: "他為了考上，每天都在努力。"
+    exampleMeaningZh: "他為了考上，每天都在努力。",
+    exampleMeaningI18n: { "ja": "彼は合格するために毎日がんばっている。", "en": "He works hard every day in order to pass the exam." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-008",
@@ -7276,7 +7385,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「比較」（比＝相比、較＝較量）。「批較」把比誤成同音(ひ)的批（批評）；「比格」把較誤成同音(かく)的格（格子）；「比確」把較誤成同音(かく)的確（確認）。三者皆讀ひかく但非正確寫法。",
     explanationI18n: { "ja": "正解は「比較」(比＝くらべる、較＝くらべる)。「批較」は「比」を同音(ひ)の「批」(批評)に取りちがえたもの、「比格」は「較」を同音(かく)の「格」(格子)に取りちがえたもの、「比確」は「較」を同音(かく)の「確」(確認)に取りちがえたものです。いずれも「ひかく」と読めますが正しい表記ではありません。", "en": "The correct answer is「比較」(比 = to compare, 較 = to weigh against). 「批較」mistakes 比 for the homophone (ひ) 批 (to criticize); 「比格」mistakes 較 for the homophone (かく) 格 (grid); 「比確」mistakes 較 for the homophone (かく) 確 (to confirm). All three read ひかく but are the wrong spelling." },
     exampleJapanese: "二つの店の値段を比較して決めた。",
-    exampleMeaningZh: "比較了兩家店的價格後才決定。"
+    exampleMeaningZh: "比較了兩家店的價格後才決定。",
+    exampleMeaningI18n: { "ja": "二つの店の値段を比べてから決めた。", "en": "I compared the prices at the two shops before deciding." },
   }),
   examQuestion({
     id: "n3-kanji-hyoki-009",
@@ -7298,7 +7408,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「訪問」（訪＝探訪、問＝探問）。「訪門」把問誤成形近且同音(もん)的門（門）；「防問」把訪誤成同音(ほう)的防（防止）；「訪紋」把問誤成同音(もん)的紋（花紋）。",
     explanationI18n: { "ja": "正解は「訪問」(訪＝おとずれる、問＝たずねる)。「訪門」は「問」を形が似て同音(もん)の「門」(門)に取りちがえたもの、「防問」は「訪」を同音(ほう)の「防」(防ぐ)に取りちがえたもの、「訪紋」は「問」を同音(もん)の「紋」(模様)に取りちがえたものです。", "en": "The correct answer is「訪問」(訪 = to visit, 問 = to inquire). 「訪門」mistakes 問 for the similar-looking homophone (もん) 門 (gate); 「防問」mistakes 訪 for the homophone (ほう) 防 (to prevent); 「訪紋」mistakes 問 for the homophone (もん) 紋 (pattern)." },
     exampleJapanese: "お世話になった先生のお宅を訪問した。",
-    exampleMeaningZh: "拜訪了一直以來照顧我的老師家。"
+    exampleMeaningZh: "拜訪了一直以來照顧我的老師家。",
+    exampleMeaningI18n: { "ja": "お世話になった先生のお宅にうかがった。", "en": "I visited the home of the teacher who has looked after me." },
   }),
   examQuestion({
     id: "n3-order-bahodo",
@@ -7398,7 +7509,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "懐＝なつ(訓讀)，讀「なつかしい」。「かいかしい」誤用音讀かい；「なつがしい」「なづかしい」都多了不該有的濁音。",
     explanationI18n: { "ja": "「懐」は「なつ」(訓読み)で、「なつかしい」と読みます。「かいかしい」は音読みの「かい」を誤って当てたもの、「なつがしい」「なづかしい」はどちらも本来ないはずの濁音が入っています。", "en": "懐 has the kun-reading なつ, so the word reads「なつかしい」. 「かいかしい」wrongly uses the on-reading かい; 「なつがしい」and「なづかしい」both add a voiced sound (dakuten) that shouldn't be there." },
     exampleJapanese: "古いアルバムを開くと、懐かしい気持ちになった。",
-    exampleMeaningZh: "翻開舊相簿，湧上一股懷念。"
+    exampleMeaningZh: "翻開舊相簿，湧上一股懷念。",
+    exampleMeaningI18n: { "ja": "古いアルバムを開くと、昔を思い出してしみじみとした気持ちになった。", "en": "Opening the old photo album, a wave of nostalgia washed over me." },
   }),
   examQuestion({
     id: "n3-vocab-eien",
@@ -7480,7 +7592,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「物語」＝有情節的故事，≒「話」。「噂」是傳聞；「命令」是命令；「質問」是提問，皆非「故事」之意。",
     explanationI18n: { "ja": "「物語」は筋のあるストーリーで、「話」≒とほぼ同じ意味です。「噂」はうわさ、「命令」は命令、「質問」は問いかけで、いずれも「物語」の意味ではありません。", "en": "「物語」means a story with a plot, roughly equal to「話」. 「噂」is a rumor; 「命令」is a command; 「質問」is a question — none means \"story.\"" },
     exampleJapanese: "この小説は、一人の少女が成長していく話だ。",
-    exampleMeaningZh: "這本小說是描寫一個少女成長的故事。"
+    exampleMeaningZh: "這本小說是描寫一個少女成長的故事。",
+    exampleMeaningI18n: { "ja": "この小説は、一人の少女が成長していく姿を描いた作品だ。", "en": "This novel is the story of a young girl growing up." },
   }),
   examQuestion({
     id: "n3-hyoki-kankei",
@@ -7502,7 +7615,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「関係」（関＝關連、係＝牽連）。「観係」把関誤成同音(かん)的観（觀看）；「関系」把係誤成形近的系；「間係」把関誤成同音(かん)的間（中間）。三者皆讀かんけい但非正確寫法。",
     explanationI18n: { "ja": "正解は「関係」(関＝かかわる、係＝かかわる)。「観係」は「関」を同音(かん)の「観」(観る)に取りちがえたもの、「関系」は「係」を形が似た「系」に取りちがえたもの、「間係」は「関」を同音(かん)の「間」(あいだ)に取りちがえたものです。いずれも「かんけい」と読めますが正しい表記ではありません。", "en": "The correct answer is「関係」(関 = connection, 係 = to involve). 「観係」mistakes 関 for the homophone (かん) 観 (to observe); 「関系」mistakes 係 for the similar-looking 系; 「間係」mistakes 関 for the homophone (かん) 間 (between). All three read かんけい but are the wrong spelling." },
     exampleJapanese: "二人の関係は仕事だけのつきあいだ。",
-    exampleMeaningZh: "兩人之間只是工作上的往來關係。"
+    exampleMeaningZh: "兩人之間只是工作上的往來關係。",
+    exampleMeaningI18n: { "ja": "二人のあいだは、仕事だけのつきあいだ。", "en": "The relationship between the two of them is strictly professional." },
   }),
   examQuestion({
     id: "n3-hyoki-kitai",
@@ -7524,7 +7638,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「期待」（期＝盼望的時機、待＝等待）。「期対」把待誤成同音(たい)的対（相對）；「機待」把期誤成同音(き)的機（機器）；「季待」把期誤成同音(き)的季（季節）。三者皆讀きたい但非正確寫法。",
     explanationI18n: { "ja": "正解は「期待」(期＝待ち望む時機、待＝待つ)。「期対」は「待」を同音(たい)の「対」(相対)に取りちがえたもの、「機待」は「期」を同音(き)の「機」(機械)に取りちがえたもの、「季待」は「期」を同音(き)の「季」(季節)に取りちがえたものです。いずれも「きたい」と読めますが正しい表記ではありません。", "en": "The correct answer is「期待」(期 = the hoped-for time, 待 = to wait). 「期対」mistakes 待 for the homophone (たい) 対 (opposite); 「機待」mistakes 期 for the homophone (き) 機 (machine); 「季待」mistakes 期 for the homophone (き) 季 (season). All three read きたい but are the wrong spelling." },
     exampleJapanese: "新人選手の活躍を大いに期待している。",
-    exampleMeaningZh: "非常指望新人選手能大顯身手。"
+    exampleMeaningZh: "非常指望新人選手能大顯身手。",
+    exampleMeaningI18n: { "ja": "新人選手の活躍を大いに楽しみにしている。", "en": "Everyone has high hopes that the rookie player will shine." },
   }),
   examQuestion({
     id: "n3-hyoki-shoutai",
@@ -7546,7 +7661,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「招待」（招＝招呼、待＝接待）。「招対」把待誤成同音(たい)的対（相對）；「紹待」把招誤成同音(しょう)的紹（介紹）；「招体」把待誤成同音(たい)的体（身體）。三者皆讀しょうたい但非正確寫法。",
     explanationI18n: { "ja": "正解は「招待」(招＝招く、待＝もてなす)。「招対」は「待」を同音(たい)の「対」(相対)に取りちがえたもの、「紹待」は「招」を同音(しょう)の「紹」(紹介)に取りちがえたもの、「招体」は「待」を同音(たい)の「体」(からだ)に取りちがえたものです。いずれも「しょうたい」と読めますが正しい表記ではありません。", "en": "The correct answer is「招待」(招 = to beckon, 待 = to receive/host). 「招対」mistakes 待 for the homophone (たい) 対 (opposite); 「紹待」mistakes 招 for the homophone (しょう) 紹 (to introduce); 「招体」mistakes 待 for the homophone (たい) 体 (body). All three read しょうたい but are the wrong spelling." },
     exampleJapanese: "友人の結婚式に招待された。",
-    exampleMeaningZh: "受邀參加朋友的婚禮。"
+    exampleMeaningZh: "受邀參加朋友的婚禮。",
+    exampleMeaningI18n: { "ja": "友人の結婚式に招かれた。", "en": "I was invited to a friend's wedding." },
   }),
   examQuestion({
     id: "n3-hyoki-keizai",
@@ -7568,7 +7684,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「経済」（経＝經營、済＝接濟）。「経財」把済誤成同音(ざい)的財（財產）；「径済」把経誤成同音(けい)的径（路徑）；「経剤」把済誤成同音(ざい)的剤（藥劑）。三者皆讀けいざい但非正確寫法。",
     explanationI18n: { "ja": "正解は「経済」(経＝いとなむ、済＝すくう)。「経財」は「済」を同音(ざい)の「財」(財産)に取りちがえたもの、「径済」は「経」を同音(けい)の「径」(小道)に取りちがえたもの、「経剤」は「済」を同音(ざい)の「剤」(薬剤)に取りちがえたものです。いずれも「けいざい」と読めますが正しい表記ではありません。", "en": "The correct answer is「経済」(経 = to manage, 済 = to relieve/settle). 「経財」mistakes 済 for the homophone (ざい) 財 (wealth); 「径済」mistakes 経 for the homophone (けい) 径 (a path); 「経剤」mistakes 済 for the homophone (ざい) 剤 (medicinal preparation). All three read けいざい but are the wrong spelling." },
     exampleJapanese: "この国の経済はゆっくり回復してきた。",
-    exampleMeaningZh: "這個國家的經濟正慢慢復甦。"
+    exampleMeaningZh: "這個國家的經濟正慢慢復甦。",
+    exampleMeaningI18n: { "ja": "この国の景気は、ゆっくりと回復してきた。", "en": "This country's economy has been slowly recovering." },
   }),
   examQuestion({
     id: "n3-hyoki-seikou",
@@ -7590,7 +7707,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「成功」（成＝達成、功＝功效）。「成効」把功誤成同音(こう)的効（效果）；「性功」把成誤成同音(せい)的性（性質）；「成工」把功誤成同音(こう)的工（工程）。三者皆讀せいこう但非正確寫法。",
     explanationI18n: { "ja": "正解は「成功」(成＝なしとげる、功＝てがら・効き目)。「成効」は「功」を同音(こう)の「効」(効果)に取りちがえたもの、「性功」は「成」を同音(せい)の「性」(性質)に取りちがえたもの、「成工」は「功」を同音(こう)の「工」(工事)に取りちがえたものです。いずれも「せいこう」と読めますが正しい表記ではありません。", "en": "The correct answer is「成功」(成 = to accomplish, 功 = achievement). 「成効」mistakes 功 for the homophone (こう) 効 (effect); 「性功」mistakes 成 for the homophone (せい) 性 (nature); 「成工」mistakes 功 for the homophone (こう) 工 (construction). All three read せいこう but are the wrong spelling." },
     exampleJapanese: "何度も実験して、ついに成功した。",
-    exampleMeaningZh: "做了好幾次實驗，終於成功了。"
+    exampleMeaningZh: "做了好幾次實驗，終於成功了。",
+    exampleMeaningI18n: { "ja": "何度も実験を重ねて、ついにうまくいった。", "en": "After many experiments, it finally succeeded." },
   }),
   examQuestion({
     id: "n3-hyoki-kenkou",
@@ -7612,7 +7730,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「健康」（健＝強健、康＝安康）。「建康」把健誤成同音(けん)的建（建造）；「健効」把康誤成同音(こう)的効（效果）；「険康」把健誤成同音(けん)的険（危險）。三者皆讀けんこう但非正確寫法。",
     explanationI18n: { "ja": "正解は「健康」(健＝すこやか、康＝やすらか)。「建康」は「健」を同音(けん)の「建」(建てる)に取りちがえたもの、「健効」は「康」を同音(こう)の「効」(効果)に取りちがえたもの、「険康」は「健」を同音(けん)の「険」(危険)に取りちがえたものです。いずれも「けんこう」と読めますが正しい表記ではありません。", "en": "The correct answer is「健康」(健 = robust, 康 = well/at ease). 「建康」mistakes 健 for the homophone (けん) 建 (to build); 「健効」mistakes 康 for the homophone (こう) 効 (effect); 「険康」mistakes 健 for the homophone (けん) 険 (dangerous). All three read けんこう but are the wrong spelling." },
     exampleJapanese: "毎朝歩いて健康に気をつけている。",
-    exampleMeaningZh: "每天早上走路，注意保持健康。"
+    exampleMeaningZh: "每天早上走路，注意保持健康。",
+    exampleMeaningI18n: { "ja": "毎朝歩いて、体の調子に気をつけている。", "en": "I walk every morning to take care of my health." },
   }),
   examQuestion({
     id: "n3-hyoki-zouka",
@@ -7634,7 +7753,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「増加」（増＝增多、加＝添加）。「像加」把増誤成同音(ぞう)的像（影像）；「増価」把加誤成同音(か)的価（價格）；「造加」把増誤成同音(ぞう)的造（製造）。三者皆讀ぞうか但非正確寫法。",
     explanationI18n: { "ja": "正解は「増加」（増＝ふえる、加＝くわえる）です。「像加」は「増」を同音（ぞう）の「像」（映像）に取り違えたもの、「増価」は「加」を同音（か）の「価」（価格）に取り違えたもの、「造加」は「増」を同音（ぞう）の「造」（製造）に取り違えたものです。いずれも「ぞうか」と読めますが正しい表記ではありません。", "en": "The answer is 「増加」 (増 = increase, 加 = add). 「像加」 mistakes 増 for its homophone (ぞう) 像 (image); 「増価」 mistakes 加 for its homophone (か) 価 (price); 「造加」 mistakes 増 for its homophone (ぞう) 造 (to make). All three read ぞうか but are not the correct spelling." },
     exampleJapanese: "この町の人口は年々増加している。",
-    exampleMeaningZh: "這個城鎮的人口逐年增加。"
+    exampleMeaningZh: "這個城鎮的人口逐年增加。",
+    exampleMeaningI18n: { "ja": "この町の人口は、年々増えている。", "en": "The population of this town is increasing year by year." },
   }),
   examQuestion({
     id: "n3-hyoki-shippai",
@@ -7656,7 +7776,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "正解「失敗」（失＝失去、敗＝敗北）。「矢敗」把失誤成形近的矢（箭）；「失敵」把敗誤成形近的敵（敵人）；「室敗」把失誤成同音(しつ)的室（房間）。三者讀音或字形相近但非正確寫法。",
     explanationI18n: { "ja": "正解は「失敗」（失＝うしなう、敗＝やぶれる）です。「矢敗」は「失」を字形の似た「矢」（や）に取り違えたもの、「失敵」は「敗」を字形の似た「敵」（てき）に取り違えたもの、「室敗」は「失」を同音（しつ）の「室」（部屋）に取り違えたものです。いずれも読みや字形が近いだけで正しい表記ではありません。", "en": "The answer is 「失敗」 (失 = to lose, 敗 = defeat). 「矢敗」 mistakes 失 for the similar-looking 矢 (arrow); 「失敵」 mistakes 敗 for the similar-looking 敵 (enemy); 「室敗」 mistakes 失 for its homophone (しつ) 室 (room). All three are close in sound or shape but are not the correct spelling." },
     exampleJapanese: "準備が足りなくて、発表は失敗だった。",
-    exampleMeaningZh: "準備不夠，發表搞砸了。"
+    exampleMeaningZh: "準備不夠，發表搞砸了。",
+    exampleMeaningI18n: { "ja": "準備が足りず、発表はうまくいかなかった。", "en": "I wasn't well prepared, so the presentation was a failure." },
   }),
   examQuestion({
     id: "n3-order-tabini",
@@ -7678,7 +7799,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "錨點「Vるたびに」（每當…）前接受詞「その写真を」成「その写真を見るたびに」；述部「泣いて＋しまう」固定相連置句尾。「その写真を泣いて」格關係不成立（「泣く」不以「写真」為對象）；句尾留「見るたびに」則接續詞無主句、句子無法收束；「しまう泣いて」顛倒了補助動詞。唯一順序為『その写真を→見るたびに→泣いて→しまう』。",
     explanationI18n: { "ja": "軸となる「Vるたびに」（…するたびに）の前に目的語「その写真を」を置いて「その写真を見るたびに」となり、述部の「泣いて＋しまう」は固定した形でつながって文末に来ます。「その写真を泣いて」は格関係が成り立ちません（「泣く」は「写真」を対象に取らないため）。文末に「見るたびに」が残ると、接続の言葉に主となる文が続かず、文が終わりません。「しまう泣いて」は補助動詞の順序が逆です。成り立つ順序は『その写真を→見るたびに→泣いて→しまう』だけです。", "en": "The anchor 「Vるたびに」 (every time...) takes the object 「その写真を」 before it, forming 「その写真を見るたびに」; the predicate 「泣いて」 + 「しまう」 is fixed together at the end of the sentence. 「その写真を泣いて」 breaks the case relationship (「泣く」 does not take 「写真」 as its object); leaving 「見るたびに」 at the end strands a subordinate clause with no main clause, so the sentence cannot conclude; 「しまう泣いて」 reverses the auxiliary verb. The only valid order is その写真を → 見るたびに → 泣いて → しまう." },
     exampleJapanese: "その写真を見るたびに泣いてしまう。",
-    exampleMeaningZh: "每次看到那張照片就會哭出來。"
+    exampleMeaningZh: "每次看到那張照片就會哭出來。",
+    exampleMeaningI18n: { "ja": "その写真を目にするたびに、つい泣いてしまう。", "en": "Every time I see that photo, I end up crying." },
   }),
   examQuestion({
     id: "n3-order-nagara",
@@ -7700,7 +7822,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "錨點「V₁ますstemながら」（一邊…）前接受詞「音楽を」成「音楽を聞きながら」；述部「歩いて＋いた」固定相連。「音楽を歩いて」格關係不成立（「を」找不到可支配它的他動詞，「歩く」不以音楽為對象）；句尾留「聞きながら」則接續詞無主句；「いた歩いて」顛倒了補助動詞。唯一順序為『音楽を→聞きながら→歩いて→いた』。",
     explanationI18n: { "ja": "軸となる「V₁ますstemながら」（…しながら）の前に目的語「音楽を」を置いて「音楽を聞きながら」となり、述部の「歩いて＋いた」は固定した形でつながります。「音楽を歩いて」は格関係が成り立ちません（「を」を受け取れる他動詞がなく、「歩く」は音楽を対象に取らないため）。文末に「聞きながら」が残ると、接続の言葉に主となる文が続きません。「いた歩いて」は補助動詞の順序が逆です。成り立つ順序は『音楽を→聞きながら→歩いて→いた』だけです。", "en": "The anchor 「V₁ますstemながら」 (while...) takes the object 「音楽を」 before it, forming 「音楽を聞きながら」; the predicate 「歩いて」 + 「いた」 is fixed together. 「音楽を歩いて」 breaks the case relationship (the 「を」 has no transitive verb to govern it, and 「歩く」 does not take music as its object); leaving 「聞きながら」 at the end strands a subordinate clause with no main clause; 「いた歩いて」 reverses the auxiliary verb. The only valid order is 音楽を → 聞きながら → 歩いて → いた." },
     exampleJapanese: "音楽を聞きながら歩いていた。",
-    exampleMeaningZh: "一邊聽著音樂一邊走路。"
+    exampleMeaningZh: "一邊聽著音樂一邊走路。",
+    exampleMeaningI18n: { "ja": "音楽を耳にしながら、歩いていた。", "en": "I was walking while listening to music." },
   }),
   examQuestion({
     id: "n3-order-younaru",
@@ -7722,7 +7845,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "錨點「Vる＋ように＋なる」表「變得會…／開始…」，「泳げる→ように→なった」須依序固定相連置句尾，「練習して」為前項て形子句。句尾留「ように」則必須再接「なる」、句子無法收束；「なったように」更顛倒了固定結尾；「ように」不可領頭、且「泳げるなった」缺「に」不成立。唯一順序為『練習して→泳げる→ように→なった』。",
     explanationI18n: { "ja": "軸となる「Vる＋ように＋なる」は「…できるようになる／…し始める」を表し、「泳げる→ように→なった」の順で固定してつながり、文末に来ます。「練習して」は前に置くて形の従属節です。文末に「ように」が残ると、そのあとに「なる」を続けなければならず、文が終わりません。「なったように」はさらに固定した文末の順序を逆にしています。また「ように」は文頭に立てず、「泳げるなった」は「に」が抜けて成り立ちません。成り立つ順序は『練習して→泳げる→ように→なった』だけです。", "en": "The anchor 「Vる + ように + なる」 means 'to become able to... / to start...', so 「泳げる → ように → なった」 must stay fixed in that order at the end of the sentence, with 「練習して」 as the leading te-form clause. Leaving 「ように」 at the end requires 「なる」 to follow, so the sentence cannot conclude; 「なったように」 also reverses the fixed ending; 「ように」 cannot lead, and 「泳げるなった」 is invalid without 「に」. The only valid order is 練習して → 泳げる → ように → なった." },
     exampleJapanese: "練習して泳げるようになった。",
-    exampleMeaningZh: "練習之後變得會游泳了。"
+    exampleMeaningZh: "練習之後變得會游泳了。",
+    exampleMeaningI18n: { "ja": "練習を重ねて、泳げるようになった。", "en": "After practicing, I became able to swim." },
   }),
   examQuestion({
     id: "n3-order-tekuru",
@@ -7744,7 +7868,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「だんだん（漸漸）＋寒く（形容詞連用）＋なって（變化）＋きた（てくる、向現在推移）」須依此序相連成「寒くなってきた」。「なって寒く」顛倒了變化對象與動詞；「きたなって」顛倒了補助動詞；其餘排法均拆散了「寒く→なって→きた」的固定鏈。唯一順序為『だんだん→寒く→なって→きた』。",
     explanationI18n: { "ja": "「だんだん（少しずつ）＋寒く（形容詞の連用形）＋なって（変化）＋きた（てくる、現在へ向かう推移）」はこの順でつながって「寒くなってきた」となります。「なって寒く」は変化の対象と動詞が逆です。「きたなって」は補助動詞の順序が逆です。その他の並べ方も「寒く→なって→きた」の固定した連なりを崩しています。成り立つ順序は『だんだん→寒く→なって→きた』だけです。", "en": "「だんだん (gradually) + 寒く (adjective adverbial form) + なって (change) + きた (てくる, shift toward the present)」 must connect in this order to form 「寒くなってきた」. 「なって寒く」 reverses the target of the change and the verb; 「きたなって」 reverses the auxiliary verb; the other arrangements all break up the fixed chain 「寒く → なって → きた」. The only valid order is だんだん → 寒く → なって → きた." },
     exampleJapanese: "だんだん寒くなってきた。",
-    exampleMeaningZh: "天氣漸漸變冷了。"
+    exampleMeaningZh: "天氣漸漸變冷了。",
+    exampleMeaningI18n: { "ja": "少しずつ寒さが増してきた。", "en": "It has gradually been getting colder." },
   }),
   examQuestion({
     id: "n3-order-bayokatta",
@@ -7766,7 +7891,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "「もっと早く（副詞）＋家を（離脫起點）＋出れば（假定形）＋よかった（後悔）」。錨點「〜ばよかった」須假定形緊接「よかった」置句尾；「家を」標記離開的起點、須緊接「出れば」。三個干擾都把「よかった」插到「出れば」之前、顛倒了固定結尾，且句尾留下假定形「出れば」使句子無法收束。唯一順序為『もっと早く→家を→出れば→よかった』。",
     explanationI18n: { "ja": "「もっと早く（副詞）＋家を（出発点）＋出れば（仮定形）＋よかった（後悔）」という並びです。軸となる「〜ばよかった」では、仮定形のすぐあとに「よかった」を置いて文末とします。「家を」は出発点を示し、「出れば」のすぐ前に置きます。三つの誤答はいずれも「よかった」を「出れば」の前に割り込ませ、固定した文末の順序を逆にしており、また文末に仮定形の「出れば」が残ると文が終わりません。成り立つ順序は『もっと早く→家を→出れば→よかった』だけです。", "en": "「もっと早く (adverb) + 家を (point of departure) + 出れば (conditional form) + よかった (regret)」. The anchor 「〜ばよかった」 requires the conditional form to directly precede 「よかった」 at the end of the sentence; 「家を」 marks the starting point of leaving and must directly precede 「出れば」. All three distractors insert 「よかった」 before 「出れば」, reversing the fixed ending, and leaving the conditional 「出れば」 at the end prevents the sentence from concluding. The only valid order is もっと早く → 家を → 出れば → よかった." },
     exampleJapanese: "もっと早く家を出ればよかった。",
-    exampleMeaningZh: "當初要是早點出門就好了。"
+    exampleMeaningZh: "當初要是早點出門就好了。",
+    exampleMeaningI18n: { "ja": "もっと早く家を出ておけばよかった。", "en": "I should have left the house earlier." },
   }),
   examQuestion({
     id: "n3-order-temo",
@@ -7788,7 +7914,8 @@ export const n3Items: PracticeQuestion[] = [
     explanation: "呼應句型「いくら〜ても」須「いくら」領頭、「練習しても」緊隨；述部「上手に＋ならない」固定相連置句尾。「練習してもいくら」拆散了「いくら〜ても」的呼應（「いくら」後沒有「ても」）；其餘兩個把讓步子句「練習しても」甩到句尾，使句子停在接續詞上而無法收束。唯一順序為『いくら→練習しても→上手に→ならない』。",
     explanationI18n: { "ja": "呼応する文型「いくら〜ても」では「いくら」を文頭に置き、「練習しても」がそのすぐあとに続きます。述部の「上手に＋ならない」は固定した形でつながって文末に来ます。「練習してもいくら」は「いくら〜ても」の呼応を崩しています（「いくら」のあとに「ても」がないため）。ほかの二つは譲歩の節「練習しても」を文末に回してしまい、接続の言葉で文が止まって終わりません。成り立つ順序は『いくら→練習しても→上手に→ならない』だけです。", "en": "The correlative pattern 「いくら〜ても」 requires 「いくら」 to lead and 「練習しても」 to immediately follow; the predicate 「上手に」 + 「ならない」 is fixed together at the end. 「練習してもいくら」 breaks the 「いくら〜ても」 correlation (there is no 「ても」 after 「いくら」); the other two push the concessive clause 「練習しても」 to the end, leaving the sentence stopped on a subordinate clause with no conclusion. The only valid order is いくら → 練習しても → 上手に → ならない." },
     exampleJapanese: "いくら練習しても上手にならない。",
-    exampleMeaningZh: "再怎麼練習也不會變厲害。"
+    exampleMeaningZh: "再怎麼練習也不會變厲害。",
+    exampleMeaningI18n: { "ja": "どんなに練習しても、なかなか上達しない。", "en": "No matter how much I practice, I don't get any better." },
   }),
   examQuestion({
     id: "n3-vocab-ukkari-r2a",

--- a/src/domain/exam/items/n4.ts
+++ b/src/domain/exam/items/n4.ts
@@ -100,7 +100,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「経」讀長音「けい」、「済」濁化讀「ざい」，故「経済」＝けいざい。「けいさい」沒把「済」讀濁音；「きょうざい」誤把「経」讀「きょう」；「けえざい」把長音誤寫成「けえ」。",
     explanationI18n: { "ja": "「経」は長音で「けい」、「済」は濁って「ざい」と読むので、「経済」＝けいざい です。「けいさい」は「済」を濁らせていません。「きょうざい」は「経」を「きょう」と読み間違えています。「けえざい」は長音を「けえ」と誤って表記しています。", "en": "「経」takes the long vowel「けい」and「済」becomes voiced as「ざい」, so「経済」＝けいざい.「けいさい」fails to voice「済」;「きょうざい」mistakenly reads「経」as「きょう」;「けえざい」wrongly writes the long vowel as「けえ」." },
     exampleJapanese: "毎朝、新聞で経済のニュースを読みます。",
-    exampleMeaningZh: "每天早上看報紙的經濟新聞。"
+    exampleMeaningZh: "每天早上看報紙的經濟新聞。",
+    exampleMeaningI18n: { "ja": "毎朝、新聞で経済のニュースを読みます。", "en": "Every morning I read the economics news in the newspaper." },
   }),
   examQuestion({
     id: "n4-grammar-kanou-ryouri",
@@ -380,7 +381,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「説」讀「せつ」、「明」讀長音「めい」，故「説明」＝せつめい。「せつめえ」把長音「めい」誤寫成「めえ」；「せきめい」把「説（せつ）」誤讀成「せき」；「ぜつめい」把語頭「せ」誤濁成「ぜ」（近「絶命」）。唯「せつめい」正確。",
     explanationI18n: { "ja": "「説」は「せつ」、「明」は長音で「めい」と読むので、「説明」＝せつめい です。「せつめえ」は長音「めい」を「めえ」と誤って表記しています。「せきめい」は「説（せつ）」を「せき」と読み間違えています。「ぜつめい」は語頭の「せ」を誤って濁らせています（「絶命」に近い音）。正しいのは「せつめい」だけです。", "en": "「説」reads「せつ」and「明」takes the long vowel「めい」, so「説明」＝せつめい.「せつめえ」wrongly writes the long vowel「めい」as「めえ」;「せきめい」misreads「説（せつ）」as「せき」;「ぜつめい」wrongly voices the initial「せ」to「ぜ」(close to「絶命」). Only「せつめい」is correct." },
     exampleJapanese: "先生が使い方をていねいに説明してくれた。",
-    exampleMeaningZh: "老師仔細地說明了使用方法。"
+    exampleMeaningZh: "老師仔細地說明了使用方法。",
+    exampleMeaningI18n: { "ja": "先生が使い方を丁寧に説明してくれました。", "en": "The teacher carefully explained how to use it for me." },
   }),
   examQuestion({
     id: "n4-kanji-riyou",
@@ -400,7 +402,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「利」讀「り」、「用」讀「よう」，故「利用」＝りよう（三拍：り・よ・う）。「りょう」把「りよ」誤拼成拗音一拍「りょ」（少一拍，近「量／料」）；「りゆう」把「用（よう）」誤讀成「ゆう」（近「理由」）；「りようう」多加一個「う」。唯「りよう」正確。",
     explanationI18n: { "ja": "「利」は「り」、「用」は「よう」と読むので、「利用」＝りよう（り・よ・うの三拍）です。「りょう」は「りよ」を拗音一拍の「りょ」と誤り、一拍足りません（「量／料」に近い音）。「りゆう」は「用（よう）」を「ゆう」と読み間違えています（「理由」に近い音）。「りようう」は「う」を一つ余計に付けています。正しいのは「りよう」だけです。", "en": "「利」reads「り」and「用」reads「よう」, so「利用」＝りよう (three morae: り・よ・う).「りょう」collapses「りよ」into the single contracted mora「りょ」(one mora short, close to「量／料」);「りゆう」misreads「用（よう）」as「ゆう」(close to「理由」);「りようう」adds an extra「う」. Only「りよう」is correct." },
     exampleJapanese: "図書館はだれでも無料で利用できます。",
-    exampleMeaningZh: "圖書館任何人都可以免費使用。"
+    exampleMeaningZh: "圖書館任何人都可以免費使用。",
+    exampleMeaningI18n: { "ja": "図書館は誰でも無料で利用できます。", "en": "Anyone can use the library for free." },
   }),
   examQuestion({
     id: "n4-kanji-seiji",
@@ -420,7 +423,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「政」讀長音「せい」、「治」在此濁化讀「じ」，故「政治」＝せいじ。「せいち」沒把「治」讀濁音（清音「ち」）；「せえじ」把長音「せい」誤寫成「せえ」；「しょうじ」把「政（せい）」誤讀成「しょう」。唯「せいじ」正確。",
     explanationI18n: { "ja": "「政」は長音で「せい」、「治」はここでは濁って「じ」と読むので、「政治」＝せいじ です。「せいち」は「治」を濁らせず清音の「ち」で読んでいます。「せえじ」は長音「せい」を「せえ」と誤って表記しています。「しょうじ」は「政（せい）」を「しょう」と読み間違えています。正しいのは「せいじ」だけです。", "en": "「政」takes the long vowel「せい」and「治」is voiced here to「じ」, so「政治」＝せいじ. In「せいち」the「治」stays unvoiced (「ち」instead of「じ」);「せえじ」spells the long vowel「せい」wrongly as「せえ」;「しょうじ」misreads「政（せい）」as「しょう」. Only「せいじ」is correct." },
     exampleJapanese: "若い人ももっと政治に関心を持ったほうがいい。",
-    exampleMeaningZh: "年輕人也最好多關心政治。"
+    exampleMeaningZh: "年輕人也最好多關心政治。",
+    exampleMeaningI18n: { "ja": "若い人ももっと政治に関心を持ったほうがいいです。", "en": "Young people should take more of an interest in politics, too." },
   }),
   examQuestion({
     id: "n4-kanji-yotei",
@@ -440,7 +444,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「予」讀短音「よ」、「定」讀長音「てい」，故「予定」＝よてい。「ようてい」把「予（よ）」誤讀成長音「よう」；「よてえ」把長音「てい」誤寫成「てえ」；「よでい」把「定（てい）」誤濁成「でい」。唯「よてい」正確。",
     explanationI18n: { "ja": "「予」は短音で「よ」、「定」は長音で「てい」と読むので、「予定」＝よてい です。「ようてい」は「予（よ）」を長音の「よう」と読み間違えています。「よてえ」は長音「てい」を「てえ」と誤って表記しています。「よでい」は「定（てい）」を誤って濁らせて「でい」としています。正しいのは「よてい」だけです。", "en": "「予」is the short「よ」and「定」is the long「てい」, so「予定」＝よてい.「ようてい」misreads「予（よ）」as the long「よう」;「よてえ」spells the long vowel「てい」wrongly as「てえ」;「よでい」wrongly voices「定（てい）」to「でい」. Only「よてい」is correct." },
     exampleJapanese: "来月の旅行の予定はもう決まりました。",
-    exampleMeaningZh: "下個月旅行的行程已經定下來了。"
+    exampleMeaningZh: "下個月旅行的行程已經定下來了。",
+    exampleMeaningI18n: { "ja": "来月の旅行の予定はもう決まりました。", "en": "The plans for next month's trip have already been settled." },
   }),
   examQuestion({
     id: "n4-grammar-tara-jouken",
@@ -642,7 +647,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「届く」是自動詞，指物品送達、寄到，本句「訂的書寄到家」即此，與「家に〜」（抵達某處）搭配成立。「集めました」是「收集」，及物且方向相反；「配りました」是「分發」，指把東西發給多人，非『寄到我家』；「送りました」是「寄出」，站在寄件方的角度，與『書終於到我這裡』的收件視角不符。表物品送達唯「届きました」成立。",
     explanationI18n: { "ja": "「届く」は自動詞で、物が送り届けられる、送られてくることを指します。この文の「注文した本が家に届く」がまさにこれで、「家に〜」（ある場所に到着する）と結びついて成立します。「集めました」は「集める」で、他動詞であり方向も逆です。「配りました」は「配る」で、物を大勢に配り渡すことを指し、『私の家に届く』ではありません。「送りました」は「送る」で、送り手の視点に立つため、『本がやっと私のところに届く』という受け手の視点と合いません。物が送り届けられることを表せるのは「届きました」だけです。", "en": "「届く」is an intransitive verb meaning an item arrives or is delivered; here, \"the book I ordered arrived at home\" is exactly that, pairing with「家に〜」(arriving at a place).「集めました」means \"collect,\" transitive and in the opposite direction;「配りました」means \"distribute,\" handing things out to many people, not \"delivered to my home\";「送りました」means \"send off,\" from the sender's viewpoint, which doesn't match the receiver's perspective of \"the book finally reached me.\" To express an item arriving, only「届きました」works." },
     exampleJapanese: "先週注文した本が、今朝やっと家に届きました。",
-    exampleMeaningZh: "上週訂的書，今天早上終於寄到家了。"
+    exampleMeaningZh: "上週訂的書，今天早上終於寄到家了。",
+    exampleMeaningI18n: { "ja": "先週注文した本が、今朝ようやく家に着きました。", "en": "The book I ordered last week finally arrived at my house this morning." },
   }),
   examQuestion({
     id: "n4-vocab-komu-densha",
@@ -742,7 +748,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「旅」讀拗音「りょ」（一拍）、「行」讀長音「こう」，故「旅行」＝りょこう。「りょうこう」把「旅（りょ）」誤讀成長音「りょう」；「りょこ」漏掉「行」的長音尾「う」（少一拍）；「りこう」把拗音「りょ」誤讀成直音「り」（近「利口」）。唯「りょこう」正確。",
     explanationI18n: { "ja": "「旅」は拗音「りょ」（一拍）、「行」は長音「こう」と読むので、「旅行」＝りょこうです。「りょうこう」は「旅（りょ）」を長音「りょう」と読み間違えています。「りょこ」は「行」の長音の尾「う」を抜かしています（一拍足りません）。「りこう」は拗音「りょ」を直音「り」と読み間違えています（「利口」に近い）。正しいのは「りょこう」だけです。", "en": "「旅」is the contracted「りょ」(one beat) and「行」is the long「こう」, so「旅行」＝りょこう.「りょうこう」misreads「旅（りょ）」as the long「りょう」;「りょこ」drops the long-vowel tail「う」of「行」(one beat short);「りこう」misreads the contracted「りょ」as the plain「り」(close to「利口」). Only「りょこう」is correct." },
     exampleJapanese: "夏休みに家族で沖縄へ旅行に行きます。",
-    exampleMeaningZh: "暑假要和家人去沖繩旅行。"
+    exampleMeaningZh: "暑假要和家人去沖繩旅行。",
+    exampleMeaningI18n: { "ja": "夏休みに家族で沖縄へ旅行に行きます。", "en": "I'm going on a trip to Okinawa with my family over summer vacation." },
   }),
   examQuestion({
     id: "n4-kanji-undou",
@@ -762,7 +769,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「運」讀「うん」、「動」濁化讀長音「どう」，故「運動」＝うんどう。「うんとう」沒把「動」讀濁音（清音「とう」）；「うんど」漏掉「動」的長音尾「う」（少一拍）；「うどう」漏掉「運（うん）」的撥音「ん」。唯「うんどう」正確。",
     explanationI18n: { "ja": "「運」は「うん」、「動」は濁って長音「どう」と読むので、「運動」＝うんどうです。「うんとう」は「動」を濁らずに（清音「とう」で）読んでいます。「うんど」は「動」の長音の尾「う」を抜かしています（一拍足りません）。「うどう」は「運（うん）」の撥音「ん」を抜かしています。正しいのは「うんどう」だけです。", "en": "「運」is「うん」and「動」is voiced to the long「どう」, so「運動」＝うんどう.「うんとう」leaves「動」unvoiced (「とう」);「うんど」drops the long-vowel tail「う」of「動」(one beat short);「うどう」drops the「ん」(the moraic nasal) of「運（うん）」. Only「うんどう」is correct." },
     exampleJapanese: "健康のために、毎朝公園で軽い運動をしています。",
-    exampleMeaningZh: "為了健康，每天早上在公園做點輕度運動。"
+    exampleMeaningZh: "為了健康，每天早上在公園做點輕度運動。",
+    exampleMeaningI18n: { "ja": "健康のために、毎朝公園で軽い運動をしています。", "en": "For my health, I do some light exercise in the park every morning." },
   }),
   examQuestion({
     id: "n4-kanji-aji",
@@ -782,7 +790,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「味」單獨作名詞用訓讀「あじ」，本句指食物的味道。「あぢ」是把「じ」誤寫成現代假名遣已不用的「ぢ」；「み」是「味」的音讀，多用於「意味（いみ）／興味（きょうみ）」等詞，單獨指食物滋味要用訓讀「あじ」；「あい」與「味」的讀音無關。指食物味道唯「あじ」正確。",
     explanationI18n: { "ja": "「味」は単独で名詞として使うとき訓読みの「あじ」で、この文は食べ物の味を指します。「あぢ」は「じ」を現代仮名遣いでは使わない「ぢ」と書き間違えたものです。「み」は「味」の音読みで、「意味（いみ）／興味（きょうみ）」などの語に多く使われ、単独で食べ物の味を指すには訓読みの「あじ」を使います。「あい」は「味」の読みとは関係がありません。食べ物の味を指すには「あじ」だけが正しいです。", "en": "Used alone as a noun,「味」takes the kun-reading「あじ」; here it means the taste of food.「あぢ」wrongly spells「じ」as「ぢ」, which modern kana usage no longer uses;「み」is the on-reading of「味」, used mostly in words like「意味（いみ）／興味（きょうみ）」, whereas the taste of food alone takes the kun-reading「あじ」;「あい」has nothing to do with the reading of「味」. For the taste of food, only「あじ」is correct." },
     exampleJapanese: "このスープはすこしうすいので、もう少し味をつけましょう。",
-    exampleMeaningZh: "這道湯有點淡，再多調點味道吧。"
+    exampleMeaningZh: "這道湯有點淡，再多調點味道吧。",
+    exampleMeaningI18n: { "ja": "このスープは少し薄いので、もう少し味をつけましょう。", "en": "This soup is a little bland, so let's season it a bit more." },
   }),
   examQuestion({
     id: "n4-kanji-kazoku",
@@ -802,7 +811,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「家」讀「か」、「族」濁化讀「ぞく」，故「家族」＝かぞく。「かそく」沒把「族」讀濁音（清音「そく」，近「加速」）；「けぞく」把「家（か）」誤讀成「け」；「かずく」把「ぞ」誤讀成「ず」。唯「かぞく」正確。",
     explanationI18n: { "ja": "「家」は「か」、「族」は濁って「ぞく」と読むので、「家族」＝かぞくです。「かそく」は「族」を濁らずに（清音「そく」で、「加速」に近い）読んでいます。「けぞく」は「家（か）」を「け」と読み間違えています。「かずく」は「ぞ」を「ず」と読み間違えています。正しいのは「かぞく」だけです。", "en": "「家」is「か」and「族」is voiced to「ぞく」, so「家族」＝かぞく.「かそく」leaves「族」unvoiced (「そく」, close to「加速」);「けぞく」misreads「家（か）」as「け」;「かずく」misreads「ぞ」as「ず」. Only「かぞく」is correct." },
     exampleJapanese: "日曜日は家族といっしょに公園でお弁当を食べました。",
-    exampleMeaningZh: "星期天和家人一起在公園吃便當。"
+    exampleMeaningZh: "星期天和家人一起在公園吃便當。",
+    exampleMeaningI18n: { "ja": "日曜日は家族と一緒に公園でお弁当を食べました。", "en": "On Sunday I ate a boxed lunch in the park with my family." },
   }),
   examQuestion({
     id: "n4-syn-yatto",
@@ -824,7 +834,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「やっと」表示經過時間或辛苦之後總算達成，≒「ようやく」。「すぐに」是「馬上」（沒有過程）；「もうすぐ」是「快要」（事情還沒發生）；「ときどき」是「有時」（頻率）。唯「ようやく」與「やっと」同表歷經辛苦後終於達成。",
     explanationI18n: { "ja": "「やっと」は時間や苦労を経てようやく達成することを表し、「ようやく」に近い意味です。「すぐに」は「すぐに」（過程がない）です。「もうすぐ」は「もうすぐ」（物事はまだ起きていない）です。「ときどき」は「ときどき」（頻度）です。苦労を経てようやく達成することを「やっと」と同じく表せるのは「ようやく」だけです。", "en": "「やっと」means that after time or hardship, something is finally achieved, ≒「ようやく」. 「すぐに」means \"right away\" (with no process involved); 「もうすぐ」means \"soon\" (the event hasn't happened yet); 「ときどき」means \"sometimes\" (frequency). Only 「ようやく」, like 「やっと」, expresses finally achieving something after going through hardship." },
     exampleJapanese: "三十分も歩いて、ようやく駅に着いた。",
-    exampleMeaningZh: "走了三十分鐘，終於到了車站。"
+    exampleMeaningZh: "走了三十分鐘，終於到了車站。",
+    exampleMeaningI18n: { "ja": "三十分も歩いて、やっと駅に着きました。", "en": "After walking for a whole thirty minutes, I finally reached the station." },
   }),
   examQuestion({
     id: "n4-syn-tabun",
@@ -846,7 +857,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「たぶん」表示把握度中等的推測「大概」，≒「おそらく」。「ぜったいに」是「絕對」（100% 肯定）；「やっぱり」是「果然」（事後印證）；「もちろん」是「當然」（理所當然、無疑問）。唯「おそらく」與「たぶん」同為不確定的推測語氣。",
     explanationI18n: { "ja": "「たぶん」は確信度が中程度の推測「たぶん」を表し、「おそらく」に近い意味です。「ぜったいに」は「絶対に」（100%の確信）です。「やっぱり」は「やっぱり」（あとで裏づけられた）です。「もちろん」は「もちろん」（当然、疑いがない）です。不確かな推測のニュアンスを「たぶん」と同じく表せるのは「おそらく」だけです。", "en": "「たぶん」expresses a guess with moderate confidence, \"probably,\" ≒「おそらく」. 「ぜったいに」means \"absolutely\" (100% certain); 「やっぱり」means \"as expected\" (confirmed after the fact); 「もちろん」means \"of course\" (self-evident, beyond doubt). Only 「おそらく」, like 「たぶん」, conveys an uncertain, tentative guess." },
     exampleJapanese: "彼はおそらくもう家に帰ったでしょう。",
-    exampleMeaningZh: "他大概已經回家了吧。"
+    exampleMeaningZh: "他大概已經回家了吧。",
+    exampleMeaningI18n: { "ja": "彼はたぶんもう家に帰ったのでしょう。", "en": "He has probably gone home already." },
   }),
   examQuestion({
     id: "n4-syn-yuumei",
@@ -868,7 +880,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「有名」表示廣為人知，≒「よく知られている」。「新しくできた」是「新建成的」（描述新舊）；「とても静かな」是「很安靜的」（描述氛圍）；「少し珍しい」是「有點稀奇的」（描述稀有度）。三者都不等於「為人所知」，唯「よく知られている」與「有名」同義。",
     explanationI18n: { "ja": "「有名」は広く知られていることを表し、「よく知られている」に近い意味です。「新しくできた」は「新しくできた」（新旧を述べる）です。「とても静かな」は「とても静かな」（雰囲気を述べる）です。「少し珍しい」は「少し珍しい」（珍しさを述べる）です。三つとも「知られている」とは等しくなく、「有名」と同義なのは「よく知られている」だけです。", "en": "「有名」means widely known, ≒「よく知られている」. 「新しくできた」means \"newly built\" (describing age); 「とても静かな」means \"very quiet\" (describing atmosphere); 「少し珍しい」means \"a bit unusual\" (describing rarity). None of these mean \"known by many people\"; only 「よく知られている」is synonymous with 「有名」." },
     exampleJapanese: "この町は古いお寺でよく知られています。",
-    exampleMeaningZh: "這個城鎮以古老的寺廟聞名。"
+    exampleMeaningZh: "這個城鎮以古老的寺廟聞名。",
+    exampleMeaningI18n: { "ja": "この町は古いお寺で有名です。", "en": "This town is famous for its old temple." },
   }),
   examQuestion({
     id: "n4-syn-hajimeni",
@@ -890,7 +903,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「はじめに」表示順序上的「最先、一開始」，≒「さいしょに」。「さいごに」是「最後」（順序相反）；「すぐに」是「馬上」（強調沒有間隔的時間，不是順序的開頭）；「たまに」是「偶爾」（頻率）。唯「さいしょに」與「はじめに」同表順序的開頭。",
     explanationI18n: { "ja": "「はじめに」は順序のうえで「いちばん先に、最初に」を表し、「さいしょに」に近い意味です。「さいごに」は「最後に」（順序が逆）です。「すぐに」は「すぐに」（間を置かない時間を強調するもので、順序の始まりではありません）です。「たまに」は「たまに」（頻度）です。順序の始まりを「はじめに」と同じく表せるのは「さいしょに」だけです。", "en": "「はじめに」indicates \"first, at the very start\" in a sequence, ≒「さいしょに」. 「さいごに」means \"lastly\" (the opposite order); 「すぐに」means \"right away\" (stressing no time gap, not the start of a sequence); 「たまに」means \"occasionally\" (frequency). Only 「さいしょに」, like 「はじめに」, marks the beginning of a sequence." },
     exampleJapanese: "りょうりを作るとき、さいしょに野菜を洗います。",
-    exampleMeaningZh: "做菜的時候，一開始先洗菜。"
+    exampleMeaningZh: "做菜的時候，一開始先洗菜。",
+    exampleMeaningI18n: { "ja": "料理を作るとき、はじめに野菜を洗います。", "en": "When cooking, you start by washing the vegetables." },
   }),
   examQuestion({
     id: "n4-usage-naoru",
@@ -912,7 +926,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「治る」是自動詞，指生病、受傷恢復健康，本句「吃藥休息後感冒痊癒」最自然。修理壞掉的東西用「直す」（直してくれた）；開電燈用「つける」；向人問路用「聞く／たずねる」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「治る」は自動詞で、病気やけがが健康を取り戻すことを指し、この文の「薬を飲んで休んだら風邪が治った」が最も自然です。壊れた物を修理するには「直す」（直してくれた）を使います。電気をつけるには「つける」を使います。人に道を尋ねるには「聞く／たずねる」を使います。三つの文は組み合わせが通らず、一つ目の文だけが成立します。", "en": "「治る」is an intransitive verb meaning that an illness or injury recovers, so \"after taking medicine and resting, the cold got better\" is the most natural. To repair something broken you use 「直す」(直してくれた); to turn on a light you use 「つける」; to ask someone for directions you use 「聞く／たずねる」. The other three combinations don't work; only the first sentence is valid." },
     exampleJapanese: "薬を飲んで休んだら、風邪がすっかり治った。",
-    exampleMeaningZh: "吃了藥休息之後，感冒就完全好了。"
+    exampleMeaningZh: "吃了藥休息之後，感冒就完全好了。",
+    exampleMeaningI18n: { "ja": "薬を飲んで休んだら、風邪がすっかりよくなりました。", "en": "After I took some medicine and rested, my cold got completely better." },
   }),
   examQuestion({
     id: "n4-usage-sodateru",
@@ -934,7 +949,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「育てる」指花心力使人或動植物成長，本句「在院子裡種菜是爸爸的樂趣」最自然。把舊大樓改建用「建て直す」；整理房間用「片付ける」；把行李搬上樓用「運ぶ」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「育てる」は手をかけて人や動植物を成長させることを指し、この文の「庭で野菜を育てるのが父の楽しみだ」が最も自然です。古いビルを建て替えるには「建て直す」を使います。部屋を片づけるには「片付ける」を使います。荷物を二階へ運ぶには「運ぶ」を使います。三つの文は組み合わせが通らず、一つ目の文だけが成立します。", "en": "「育てる」means to put in effort so that a person, animal, or plant grows, so \"growing vegetables in the garden is my father's pleasure\" is the most natural. To rebuild an old building you use 「建て直す」; to tidy a room you use 「片付ける」; to carry luggage upstairs you use 「運ぶ」. The other three combinations don't work; only the first sentence is valid." },
     exampleJapanese: "庭で野菜を育てるのが、父の楽しみだ。",
-    exampleMeaningZh: "在院子裡種菜是爸爸的樂趣。"
+    exampleMeaningZh: "在院子裡種菜是爸爸的樂趣。",
+    exampleMeaningI18n: { "ja": "庭で野菜を育てるのが父の楽しみです。", "en": "Growing vegetables in the garden is my father's favorite pastime." },
   }),
   examQuestion({
     id: "n4-usage-kimeru",
@@ -956,7 +972,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「決める」＝做出選擇、把事情定下來，本句「大家商量後決定旅行的日子」最自然。開電燈用「つける」；和朋友碰面用「会う」；把行李搬上樓用「運ぶ」。三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「決める」＝選択をして物事を定めることで、この文の「みんなで相談して旅行に行く日を決めた」が最も自然です。電気をつけるには「つける」を使います。友達と会うには「会う」を使います。荷物を二階へ運ぶには「運ぶ」を使います。三つの文は組み合わせが通らず、一つ目の文だけが成立します。", "en": "「決める」means to make a choice and finalize something, so \"after discussing it, we decided on the trip date\" is the most natural. To turn on a light you use 「つける」; to meet a friend you use 「会う」; to carry luggage upstairs you use 「運ぶ」. The other three combinations don't work; only the first sentence is valid." },
     exampleJapanese: "みんなで相談して、旅行に行く日を決めた。",
-    exampleMeaningZh: "大家商量後，決定了去旅行的日子。"
+    exampleMeaningZh: "大家商量後，決定了去旅行的日子。",
+    exampleMeaningI18n: { "ja": "みんなで相談して、旅行に行く日を決めました。", "en": "After talking it over together, we decided on the date for the trip." },
   }),
   examQuestion({
     id: "n4-usage-nigiyaka",
@@ -978,7 +995,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「にぎやか」形容人多、有活力而熱鬧，本句「祭典的夜晚，街上很熱鬧」最自然。形容湯的味道要用「味が濃い／薄い」；車子停著的狀態不會用「熱鬧」形容；圖書館應是「静か（安靜）」才好睡，「にぎやかでよく眠れる」自相矛盾。三句皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「にぎやか」は人が多く活気があってにぎわう様子を表し、この文の「お祭りの夜、町はとてもにぎやかだった」が最も自然です。スープの味を表すには「味が濃い／薄い」を使います。車が止まっている状態を「にぎやか」とは言いません。図書館は「静か」なほうがよく眠れるはずで、「にぎやかでよく眠れる」は自己矛盾です。三つの文は通らず、一つ目の文だけが成立します。", "en": "「にぎやか」describes a lively, energetic scene with many people, so \"on the festival night, the town was lively\" is the most natural. To describe the taste of soup you use 「味が濃い／薄い」; the state of parked cars isn't described as \"lively\"; a library should be 「静か」(quiet) to sleep well, so 「にぎやかでよく眠れる」contradicts itself. The other three don't work; only the first sentence is valid." },
     exampleJapanese: "お祭りの夜、町はとてもにぎやかだった。",
-    exampleMeaningZh: "祭典的夜晚，街上非常熱鬧。"
+    exampleMeaningZh: "祭典的夜晚，街上非常熱鬧。",
+    exampleMeaningI18n: { "ja": "お祭りの夜、町はとてもにぎやかでした。", "en": "On the night of the festival, the town was very lively." },
   }),
   examQuestion({
     id: "n4-context-dakara",
@@ -1000,7 +1018,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "前句「很熱」是原因，後句「泳池很多人」是結果，用表因果的「だから」（所以）。「しかし」是逆接「但是」（很熱與人多不是相反）；「それとも」是「或者」（選擇）；「ところで」是「對了」（轉換話題）。表因果唯「だから」成立。",
     explanationI18n: { "ja": "前の文「とても暑い」が原因、後の文「プールに人が多い」が結果なので、因果を表す「だから」を使います。「しかし」は逆接の「しかし」（暑いことと人が多いことは反対ではありません）です。「それとも」は「それとも」（選択）です。「ところで」は「ところで」（話題の転換）です。因果を表せるのは「だから」だけです。", "en": "The first sentence \"it was hot\" is the cause and the second \"the pool was crowded\" is the result, so use the cause-effect 「だから」(so). 「しかし」is the adversative \"but\" (hot weather and a crowd aren't opposites); 「それとも」means \"or\" (a choice); 「ところで」means \"by the way\" (changing the topic). For cause and effect, only 「だから」works." },
     exampleJapanese: "今日は朝からとても暑かった。だから、プールはたくさんの人でこんでいた。",
-    exampleMeaningZh: "今天從早上就很熱。所以游泳池擠滿了人。"
+    exampleMeaningZh: "今天從早上就很熱。所以游泳池擠滿了人。",
+    exampleMeaningI18n: { "ja": "今日は朝からとても暑かった。そのため、プールはたくさんの人で混んでいました。", "en": "It was very hot from early this morning. That's why the pool was packed with people." },
   }),
   examQuestion({
     id: "n4-context-demo",
@@ -1022,7 +1041,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "前句「吃藥早睡」讓人期待會好轉，後句卻是「沒退燒」，前後相反，用逆接的「でも」（可是）。「だから」「それで」都是因果（會變成「所以沒退燒」，邏輯矛盾）；「そして」是並列「然後」，無法表達轉折。表逆接唯「でも」成立。",
     explanationI18n: { "ja": "前の文「薬を飲んで早く寝た」はよくなることを期待させますが、後の文は「熱が下がらなかった」で前後が反対なので、逆接の「でも」を使います。「だから」「それで」はどちらも因果で（「だから熱が下がらなかった」となり論理が矛盾します）。「そして」は並列の「そして」で、転換を表せません。逆接を表せるのは「でも」だけです。", "en": "The first sentence \"took medicine and slept early\" makes you expect improvement, but the second is \"the fever didn't go down,\" so the two contrast, calling for the adversative 「でも」(but). 「だから」and 「それで」are both causal (they'd turn it into \"so the fever didn't go down,\" which is a logical contradiction); 「そして」is the additive \"and then,\" which can't express a turn. For contrast, only 「でも」works." },
     exampleJapanese: "薬を飲んで早く寝た。でも、次の朝も熱は下がらなかった。",
-    exampleMeaningZh: "吃了藥早早睡了。可是隔天早上燒還是沒退。"
+    exampleMeaningZh: "吃了藥早早睡了。可是隔天早上燒還是沒退。",
+    exampleMeaningI18n: { "ja": "薬を飲んで早く寝ました。しかし、次の朝も熱は下がりませんでした。", "en": "I took medicine and went to bed early. But the next morning my fever still hadn't gone down." },
   }),
   examQuestion({
     id: "n4-context-sonoato",
@@ -1044,7 +1064,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "前句「碰面」與後句「去看電影」是依時間先後發生的兩件事，用表時間順序的「その後」（之後）。「だから」是因果（「所以去看電影」不自然）；「しかし」是逆接（前後不相反）；「それとも」是選擇。表時間先後唯「その後」成立。",
     explanationI18n: { "ja": "前の「会った」と後の「映画を見に行った」は時間の流れに沿って続けて起こった二つの出来事なので、時間の順序を表す「その後」を使います。「だから」は因果関係（「だから映画を見に行った」は不自然）、「しかし」は逆接（前後は反対の内容ではない）、「それとも」は選択を表します。時間の前後関係を表せるのは「その後」だけです。", "en": "The first sentence \"met up\" and the second \"went to see a movie\" are two events occurring in time order, so use the time-sequence 「その後」(after that). 「だから」is causal (\"so we went to see a movie\" is unnatural); 「しかし」is adversative (the two don't contrast); 「それとも」is a choice. For time sequence, only 「その後」works." },
     exampleJapanese: "私は十時に駅で友だちに会った。その後、いっしょに映画を見に行った。",
-    exampleMeaningZh: "我十點在車站和朋友碰面。之後一起去看了電影。"
+    exampleMeaningZh: "我十點在車站和朋友碰面。之後一起去看了電影。",
+    exampleMeaningI18n: { "ja": "私は十時に駅で友だちに会いました。それから、一緒に映画を見に行きました。", "en": "I met my friend at the station at ten. After that, we went to see a movie together." },
   }),
   examQuestion({
     id: "n4-context-mata",
@@ -1066,7 +1087,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "前句「好吃」與後句「便宜」都是優點、同方向，後句再追加一項，用表並列追加的「また」（另外、還有）。「でも」是逆接（好吃與便宜不相反）；「だから」是因果（「所以便宜」不通）；「それとも」是選擇。表同方向追加唯「また」成立。",
     explanationI18n: { "ja": "前の「おいしい」と後の「安い」はどちらも長所で、同じ方向の内容にもう一つ付け加えているので、並列・追加を表す「また」を使います。「でも」は逆接（おいしいことと安いことは反対ではない）、「だから」は因果関係（「だから安い」は不自然）、「それとも」は選択を表します。同じ方向の内容を付け加えられるのは「また」だけです。", "en": "The first sentence \"tasty\" and the second \"cheap\" are both merits pointing the same way, and the second adds another one, so use the additive 「また」(also, in addition). 「でも」is adversative (tasty and cheap aren't opposites); 「だから」is causal (\"so it's cheap\" doesn't work); 「それとも」is a choice. For adding a point in the same direction, only 「また」works." },
     exampleJapanese: "この店の料理はとてもおいしい。また、ねだんも安い。",
-    exampleMeaningZh: "這家店的菜很好吃。另外價錢也便宜。"
+    exampleMeaningZh: "這家店的菜很好吃。另外價錢也便宜。",
+    exampleMeaningI18n: { "ja": "この店の料理はとてもおいしい。それに、値段も安いです。", "en": "The food at this restaurant is delicious. What's more, the prices are low, too." },
   }),
   examQuestion({
     id: "n4-grammar-hazu-renshu",
@@ -1726,7 +1748,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「うんてん」：運=うん、転=てん，無濁音、無促音。干擾「うんでん」把第二字濁化成「でん」（清濁陷阱），不存在此讀法。「うってん」多插促音「っ」（促音陷阱），讀法不成立。「うんてい」把「てん」誤聽成「てい」（近形/撥音與長音混淆），不是此詞讀音。四選只有一個成立。",
     explanationI18n: { "ja": "正解は「うんてん」。運＝うん、転＝てん で、濁音も促音もありません。誤答の「うんでん」は二文字目を濁って「でん」にしたもの（清濁の落とし穴）で、この読み方は存在しません。「うってん」は促音「っ」を余分に入れたもの（促音の落とし穴）で、読み方として成立しません。「うんてい」は「てん」を「てい」と聞き違えたもの（形の近い撥音と長音の混同）で、この語の読みではありません。四つのうち成立するのは一つだけです。", "en": "The answer 「うんてん」: 運=うん, 転=てん, with no voiced sound and no double consonant. The distractor 「うんでん」 voices the second character into 「でん」 (voiced/unvoiced trap); this reading doesn't exist. 「うってん」 inserts an extra double consonant 「っ」 (sokuon trap), which is not a valid reading. 「うんてい」 mishears 「てん」 as 「てい」 (confusion between the moraic nasal and a long vowel), which is not this word's reading. Only one of the four works." },
     exampleJapanese: "兄は毎朝、車を運転して会社へ行きます。",
-    exampleMeaningZh: "哥哥每天早上開車去公司。"
+    exampleMeaningZh: "哥哥每天早上開車去公司。",
+    exampleMeaningI18n: { "ja": "兄は毎朝、車を運転して会社へ行きます。", "en": "My older brother drives to work every morning." },
   }),
   examQuestion({
     id: "n4-kanji-shinsetsu",
@@ -1746,7 +1769,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「しんせつ」：親=しん、切=せつ。干擾「しんぜつ」把「せつ」濁化（清濁陷阱），無此讀法。「じんせつ」把首音「しん」誤作「じん」（雖然親有じん的音讀，但「親切」固定讀しん；此處給的是錯誤組合，並非另一個合法讀音的整詞），語感不成立。「しんせい」把「せつ」改成「せい」（促音脫落＋長音混淆，近形假名陷阱），不是此詞讀音。只有一個成立。",
     explanationI18n: { "ja": "正解は「しんせつ」。親＝しん、切＝せつ です。誤答の「しんぜつ」は「せつ」を濁ったもの（清濁の落とし穴）で、この読み方はありません。「じんせつ」は頭の音「しん」を「じん」としたもので（親には「じん」の音読みもありますが、「親切」は「しん」と読むのが決まりで、ここでは誤った組み合わせを示しており、別の正しい読みの語というわけではありません）、語感として成立しません。「しんせい」は「せつ」を「せい」に変えたもの（促音の脱落＋長音の混同、形の近い仮名の落とし穴）で、この語の読みではありません。成立するのは一つだけです。", "en": "The answer 「しんせつ」: 親=しん, 切=せつ. The distractor 「しんぜつ」 voices 「せつ」 (voiced/unvoiced trap); no such reading exists. 「じんせつ」 misreads the first sound 「しん」 as 「じん」 (although 親 does have the on'yomi じん, 「親切」 is fixed as しん here; this is an incorrect combination, not another valid reading of the whole word), so it doesn't feel right. 「しんせい」 changes 「せつ」 into 「せい」 (dropped double consonant plus long-vowel confusion, a similar-kana trap) and is not this word's reading. Only one works." },
     exampleJapanese: "道に迷ったとき、駅員さんがとても親切でした。",
-    exampleMeaningZh: "迷路的時候，站務員非常親切。"
+    exampleMeaningZh: "迷路的時候，站務員非常親切。",
+    exampleMeaningI18n: { "ja": "道に迷ったとき、駅員さんがとても親切でした。", "en": "When I got lost, the station attendant was very kind." },
   }),
   examQuestion({
     id: "n4-kanji-bunka",
@@ -1766,7 +1790,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「ぶんか」：文=ぶん、化=か。干擾「ぶんが」把「か」濁化成「が」（清濁陷阱），無此讀法。「ぷんか」把首音「ぶ」誤作半濁「ぷ」（近形假名陷阱），不成立。「ぼんか」把「ぶん」誤作「ぼん」（母音混淆），不是此詞讀音。只有一個成立。",
     explanationI18n: { "ja": "正解は「ぶんか」。文＝ぶん、化＝か です。誤答の「ぶんが」は「か」を濁って「が」にしたもの（清濁の落とし穴）で、この読み方はありません。「ぷんか」は頭の音「ぶ」を半濁音の「ぷ」としたもの（形の近い仮名の落とし穴）で、成立しません。「ぼんか」は「ぶん」を「ぼん」としたもの（母音の混同）で、この語の読みではありません。成立するのは一つだけです。", "en": "The answer 「ぶんか」: 文=ぶん, 化=か. The distractor 「ぶんが」 voices 「か」 into 「が」 (voiced/unvoiced trap); no such reading exists. 「ぷんか」 misreads the first sound 「ぶ」 as the semi-voiced 「ぷ」 (similar-kana trap) and doesn't work. 「ぼんか」 misreads 「ぶん」 as 「ぼん」 (vowel confusion) and is not this word's reading. Only one works." },
     exampleJapanese: "日本の文化について、もっと勉強したいです。",
-    exampleMeaningZh: "我想更深入學習日本的文化。"
+    exampleMeaningZh: "我想更深入學習日本的文化。",
+    exampleMeaningI18n: { "ja": "日本の文化について、もっと勉強したいです。", "en": "I want to learn more about Japanese culture." },
   }),
   examQuestion({
     id: "n4-kanji-ryori",
@@ -1786,7 +1811,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「りょうり」：料=りょう（含長音）、理=り。干擾「りょり」漏掉長音「う」（長音脫落陷阱），讀法不成立。「りゅうり」把拗音「りょ」誤作「りゅう」（近形拗音陷阱），不是此詞讀音。「りょうりょ」把第二字「り」誤作拗音「りょ」（多餘拗音），不成立。只有一個成立。",
     explanationI18n: { "ja": "正解は「りょうり」。料＝りょう（長音を含む）、理＝り です。誤答の「りょり」は長音「う」を落としたもの（長音脱落の落とし穴）で、読み方として成立しません。「りゅうり」は拗音「りょ」を「りゅう」と間違えたもの（形の近い拗音の落とし穴）で、この語の読みではありません。「りょうりょ」は二文字目の「り」を拗音の「りょ」にしたもの（余分な拗音）で、成立しません。成立するのは一つだけです。", "en": "The answer 「りょうり」: 料=りょう (with a long vowel), 理=り. The distractor 「りょり」 drops the long vowel 「う」 (dropped-long-vowel trap), so the reading fails. 「りゅうり」 misreads the contracted sound 「りょ」 as 「りゅう」 (similar contracted-sound trap) and is not this word's reading. 「りょうりょ」 misreads the second character 「り」 as the contracted sound 「りょ」 (an extra contracted sound) and doesn't work. Only one works." },
     exampleJapanese: "母が作る料理は、世界で一番おいしいです。",
-    exampleMeaningZh: "媽媽做的菜，是世界上最好吃的。"
+    exampleMeaningZh: "媽媽做的菜，是世界上最好吃的。",
+    exampleMeaningI18n: { "ja": "母が作る料理は、世界で一番おいしいです。", "en": "My mother's cooking is the most delicious in the world." },
   }),
   examQuestion({
     id: "n4-kanji-sewa",
@@ -1806,7 +1832,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「せわ」：世=せ、話=わ（世＝せ、話＝わ，皆為音讀）。干擾「せいわ」多加長音「い」（長音陷阱），讀法不成立。「ぜわ」把首音「せ」濁化（清濁陷阱），無此讀法。「せば」把「わ」誤作「ば」（近形假名わ／ば混淆），不是此詞讀音。只有一個成立。",
     explanationI18n: { "ja": "正解は「せわ」。世＝せ、話＝わ（世＝せ、話＝わ で、どちらも音読み）です。誤答の「せいわ」は長音「い」を余分に加えたもの（長音の落とし穴）で、読み方として成立しません。「ぜわ」は頭の音「せ」を濁ったもの（清濁の落とし穴）で、この読み方はありません。「せば」は「わ」を「ば」としたもの（形の近い仮名 わ／ば の混同）で、この語の読みではありません。成立するのは一つだけです。", "en": "The answer 「せわ」: 世=せ, 話=わ (世=せ, 話=わ, both on'yomi). The distractor 「せいわ」 adds an extra long vowel 「い」 (long-vowel trap), so the reading fails. 「ぜわ」 voices the first sound 「せ」 (voiced/unvoiced trap); no such reading exists. 「せば」 misreads 「わ」 as 「ば」 (similar-kana わ/ば confusion) and is not this word's reading. Only one works." },
     exampleJapanese: "毎日、犬の世話をするのは私の仕事です。",
-    exampleMeaningZh: "每天照顧狗是我的工作。"
+    exampleMeaningZh: "每天照顧狗是我的工作。",
+    exampleMeaningI18n: { "ja": "毎日、犬の世話をするのは私の仕事です。", "en": "Taking care of the dog every day is my job." },
   }),
   examQuestion({
     id: "n4-kanji-chizu",
@@ -1826,7 +1853,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「ちず」：地=ち、図=ず。干擾「ちす」把「ず」清音化成「す」（清濁陷阱），讀法不成立。「じず」把首音「ち」濁化成「じ」（清濁陷阱），無此讀法。「ちづ」用近形假名「づ」取代「ず」（同音近形假名陷阱，標準寫法為ず），不是此詞正確假名。只有一個成立。",
     explanationI18n: { "ja": "正解は「ちず」。地＝ち、図＝ず です。誤答の「ちす」は「ず」を清音の「す」にしたもの（清濁の落とし穴）で、読み方として成立しません。「じず」は頭の音「ち」を濁って「じ」にしたもの（清濁の落とし穴）で、この読み方はありません。「ちづ」は形の近い仮名「づ」で「ず」を置き換えたもの（同じ音で形の近い仮名の落とし穴。標準の表記は「ず」）で、この語の正しい仮名ではありません。成立するのは一つだけです。", "en": "The answer 「ちず」: 地=ち, 図=ず. The distractor 「ちす」 unvoices 「ず」 into 「す」 (voiced/unvoiced trap), so the reading fails. 「じず」 voices the first sound 「ち」 into 「じ」 (voiced/unvoiced trap); no such reading exists. 「ちづ」 replaces 「ず」 with the similar kana 「づ」 (a homophone similar-kana trap; the standard spelling is ず) and is not this word's correct kana. Only one works." },
     exampleJapanese: "知らない町では、地図を見ながら歩きます。",
-    exampleMeaningZh: "在不熟悉的城鎮，會邊看地圖邊走。"
+    exampleMeaningZh: "在不熟悉的城鎮，會邊看地圖邊走。",
+    exampleMeaningI18n: { "ja": "知らない町では、地図を見ながら歩きます。", "en": "In an unfamiliar town, I walk around while looking at a map." },
   }),
   examQuestion({
     id: "n4-kanji-kuukou",
@@ -1846,7 +1874,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「くうこう」：空=くう（長音）、港=こう（長音）。干擾「くこう」漏掉第一個長音「う」（長音脫落陷阱），讀法不成立。「くうごう」把「こう」濁化成「ごう」（清濁陷阱），無此讀法。「くうこ」漏掉第二個長音（長音脫落），不是此詞讀音。只有一個成立。",
     explanationI18n: { "ja": "正解は「くうこう」。空＝くう（長音）、港＝こう（長音）です。誤答の「くこう」は一つ目の長音「う」を落としたもの（長音脱落の落とし穴）で、読み方として成立しません。「くうごう」は「こう」を濁って「ごう」にしたもの（清濁の落とし穴）で、この読み方はありません。「くうこ」は二つ目の長音を落としたもの（長音の脱落）で、この語の読みではありません。成立するのは一つだけです。", "en": "The answer 「くうこう」: 空=くう (long vowel), 港=こう (long vowel). The distractor 「くこう」 drops the first long vowel 「う」 (dropped-long-vowel trap), so the reading fails. 「くうごう」 voices 「こう」 into 「ごう」 (voiced/unvoiced trap); no such reading exists. 「くうこ」 drops the second long vowel (dropped long vowel) and is not this word's reading. Only one works." },
     exampleJapanese: "飛行機が遅れて、空港で三時間も待ちました。",
-    exampleMeaningZh: "飛機誤點，在機場等了三個小時之久。"
+    exampleMeaningZh: "飛機誤點，在機場等了三個小時之久。",
+    exampleMeaningI18n: { "ja": "飛行機が遅れて、空港で三時間も待ちました。", "en": "The plane was delayed, so I waited at the airport for a whole three hours." },
   }),
   examQuestion({
     id: "n4-kanji-koujou",
@@ -1866,7 +1895,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「こうじょう」：工=こう（長音）、場=じょう（拗音＋長音）。干擾「こうじょ」漏掉第二字長音「う」（長音脫落陷阱），讀法不成立。「こじょう」漏掉第一個長音（長音脫落），不成立。「こうしょう」把「じょう」清音化成「しょう」（清濁陷阱），不是此詞讀音。只有一個成立。",
     explanationI18n: { "ja": "正解は「こうじょう」。工＝こう（長音）、場＝じょう（拗音＋長音）です。誤答の「こうじょ」は二文字目の長音「う」を落としたもの（長音脱落の落とし穴）で、読み方として成立しません。「こじょう」は一つ目の長音を落としたもの（長音の脱落）で、成立しません。「こうしょう」は「じょう」を清音の「しょう」にしたもの（清濁の落とし穴）で、この語の読みではありません。成立するのは一つだけです。", "en": "The answer 「こうじょう」: 工=こう (long vowel), 場=じょう (contracted sound plus long vowel). The distractor 「こうじょ」 drops the long vowel 「う」 of the second character (dropped-long-vowel trap), so the reading fails. 「こじょう」 drops the first long vowel (dropped long vowel) and doesn't work. 「こうしょう」 unvoices 「じょう」 into 「しょう」 (voiced/unvoiced trap) and is not this word's reading. Only one works." },
     exampleJapanese: "父はあの大きな工場で長く働いています。",
-    exampleMeaningZh: "爸爸在那家大工廠工作很久了。"
+    exampleMeaningZh: "爸爸在那家大工廠工作很久了。",
+    exampleMeaningI18n: { "ja": "父はあの大きな工場で長く働いています。", "en": "My father has been working at that big factory for a long time." },
   }),
   examQuestion({
     id: "n4-grammar-temoii-shashin",
@@ -2146,7 +2176,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「銀」讀濁音「ぎん」、「行」讀長音「こう」，故「銀行」＝ぎんこう。「きんこう」把語頭「銀（ぎん）」誤讀成清音「きん」（近「均衡／近郊」）；「ぎんごう」把「行（こう）」誤濁成「ごう」；「ぎんこ」漏掉「行」的長音尾「う」（少一拍，近「銀庫」）。唯「ぎんこう」正確。",
     explanationI18n: { "ja": "「銀」は濁音で「ぎん」、「行」は長音で「こう」と読むので、「銀行」＝ぎんこう です。「きんこう」は語頭の「銀（ぎん）」を清音の「きん」と読み誤ったもの（「均衡／近郊」に近い）。「ぎんごう」は「行（こう）」を濁らせて「ごう」と誤ったもの。「ぎんこ」は「行」の長音の尾「う」を落としたもの（一拍足りず「銀庫」に近い）。正しいのは「ぎんこう」だけです。", "en": "銀 is read with the voiced sound ぎん and 行 with the long vowel こう, so 銀行 = ぎんこう. きんこう misreads the initial 銀 (ぎん) as the unvoiced きん (close to 均衡 \"balance\" / 近郊 \"suburbs\"). ぎんごう wrongly voices 行 (こう) into ごう. ぎんこ drops the long-vowel ending う of 行 (one mora short, close to 銀庫 \"silver vault\"). Only ぎんこう is correct." },
     exampleJapanese: "お金をおろすために、駅前の銀行へ行きました。",
-    exampleMeaningZh: "為了領錢，去了車站前的銀行。"
+    exampleMeaningZh: "為了領錢，去了車站前的銀行。",
+    exampleMeaningI18n: { "ja": "お金を引き出すために、駅前の銀行へ行きました。", "en": "I went to the bank in front of the station to withdraw some money." },
   }),
   examQuestion({
     id: "n4-kanji-shitsumon",
@@ -2166,7 +2197,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「質」讀「しつ」、「問」讀「もん」，故「質問」＝しつもん。「しっもん」把「しつ」誤加促音成「しっ」（多拍、且促音後不接ま行）；「じつもん」把語頭「し」誤濁成「じ」（近「実問」）；「しつぼん」把「問（もん）」誤濁成「ぼん」。唯「しつもん」正確。",
     explanationI18n: { "ja": "「質」は「しつ」、「問」は「もん」と読むので、「質問」＝しつもん です。「しっもん」は「しつ」に誤って促音を加えて「しっ」としたもの（拍が多く、しかも促音のあとにマ行は続きません）。「じつもん」は語頭の「し」を誤って濁らせて「じ」としたもの（「実問」に近い）。「しつぼん」は「問（もん）」を誤って濁らせて「ぼん」としたもの。正しいのは「しつもん」だけです。", "en": "質 is read しつ and 問 もん, so 質問 = しつもん. しっもん wrongly adds a geminate consonant, turning しつ into しっ (an extra mora, and a geminate can't precede the ま-row). じつもん wrongly voices the initial し into じ (close to 実問). しつぼん wrongly voices 問 (もん) into ぼん. Only しつもん is correct." },
     exampleJapanese: "わからないことがあったら、いつでも質問してください。",
-    exampleMeaningZh: "有不懂的地方，請隨時提問。"
+    exampleMeaningZh: "有不懂的地方，請隨時提問。",
+    exampleMeaningI18n: { "ja": "わからないことがあったら、いつでも聞いてください。", "en": "If there's anything you don't understand, feel free to ask at any time." },
   }),
   examQuestion({
     id: "n4-kanji-shippai",
@@ -2186,7 +2218,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「失敗」＝しっぱい：「失」接「敗」時音便為促音「しっ」，「敗」讀半濁音「ぱい」。干擾排除：「しつばい」未起促音、且「ぱ」誤作濁音「ば」；「しっぱつ」末尾誤作「つ」（與「出発＝しゅっぱつ」混淆）；「しゅっぱい」誤把「し」拗音化成「しゅ」。唯「しっぱい」正確。",
     explanationI18n: { "ja": "「失敗」＝しっぱい：「失」は「敗」に続くとき音便で促音「しっ」となり、「敗」は半濁音で「ぱい」と読みます。誤答の見分け方：「しつばい」は促音になっておらず、「ぱ」を誤って濁音「ば」にしています。「しっぱつ」は末尾を誤って「つ」にしたもの（「出発＝しゅっぱつ」との混同）。「しゅっぱい」は「し」を誤って拗音化して「しゅ」にしたもの。正しいのは「しっぱい」だけです。", "en": "失敗 = しっぱい: when 失 attaches to 敗, sound change produces the geminate しっ, and 敗 is read with the half-voiced ぱい. Ruling out the distractors: しつばい has no geminate and mistakes ぱ for the voiced ば; しっぱつ wrongly ends in つ (confusion with 出発 = しゅっぱつ); しゅっぱい wrongly palatalizes し into しゅ. Only しっぱい is correct." },
     exampleJapanese: "一度失敗しても、もう一度やってみればいい。",
-    exampleMeaningZh: "就算失敗一次，再試一次就好。"
+    exampleMeaningZh: "就算失敗一次，再試一次就好。",
+    exampleMeaningI18n: { "ja": "一度うまくいかなくても、もう一度挑戦すればいい。", "en": "Even if you fail once, you can just try again." },
   }),
   examQuestion({
     id: "n4-kanji-sanpo",
@@ -2206,7 +2239,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「散」讀撥音「さん」、「歩」在此讀半濁音「ぽ」，故「散歩」＝さんぽ。「さんぼ」把半濁音「ぽ」誤讀成濁音「ぼ」；「さんほ」把半濁音「ぽ」誤讀成清音「ほ」；「さんぽう」多加長音尾「う」（多一拍，近「三方」）。唯「さんぽ」正確。",
     explanationI18n: { "ja": "「散」は撥音で「さん」、「歩」はここでは半濁音で「ぽ」と読むので、「散歩」＝さんぽ です。「さんぼ」は半濁音「ぽ」を誤って濁音「ぼ」と読んだもの。「さんほ」は半濁音「ぽ」を誤って清音「ほ」と読んだもの。「さんぽう」は長音の尾「う」を余分に加えたもの（一拍多く「三方」に近い）。正しいのは「さんぽ」だけです。", "en": "散 is read with the nasal さん and 歩 here with the half-voiced ぽ, so 散歩 = さんぽ. さんぼ misreads the half-voiced ぽ as the voiced ぼ. さんほ misreads the half-voiced ぽ as the unvoiced ほ. さんぽう adds an extra long-vowel ending う (one mora too many, close to 三方). Only さんぽ is correct." },
     exampleJapanese: "天気がいい日は、犬といっしょに公園を散歩します。",
-    exampleMeaningZh: "天氣好的日子，會和狗一起在公園散步。"
+    exampleMeaningZh: "天氣好的日子，會和狗一起在公園散步。",
+    exampleMeaningI18n: { "ja": "天気のいい日は、犬といっしょに公園を散歩します。", "en": "On nice days, I take a walk in the park with my dog." },
   }),
   examQuestion({
     id: "n4-kanji-atsumeru",
@@ -2226,7 +2260,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「集める」是他動詞，訓讀「あつめる」，本句「外国の切手を集める」是弟弟主動『把郵票收集起來』。「あつまる」是自動詞「集まる」的讀音（東西自己聚集），與本句用「を」的他動詞語意不合；「あづめる」「あづまる」把「つ」誤寫成現代假名遣已不用的濁音「づ」。唯「あつめる」正確。",
     explanationI18n: { "ja": "「集める」は他動詞で、訓読みは「あつめる」。この文の「外国の切手を集める」は弟が自ら『切手を集める』ことです。「あつまる」は自動詞「集まる」の読み（物がひとりでに寄り集まる）で、「を」を使う他動詞のこの文とは意味が合いません。「あづめる」「あづまる」は「つ」を、現代仮名遣いでは使わない濁音「づ」と誤って書いたものです。正しいのは「あつめる」だけです。", "en": "集める is a transitive verb with the kun reading あつめる; in this sentence 外国の切手を集める means the brother actively gathers the stamps. あつまる is the reading of the intransitive 集まる (things gathering on their own), which doesn't fit the transitive verb marked with を here. あづめる and あづまる wrongly write つ as づ, a voiced form no longer used in modern kana orthography. Only あつめる is correct." },
     exampleJapanese: "弟は小さいころから、外国の切手を集めるのが好きだ。",
-    exampleMeaningZh: "弟弟從小就喜歡收集外國的郵票。"
+    exampleMeaningZh: "弟弟從小就喜歡收集外國的郵票。",
+    exampleMeaningI18n: { "ja": "弟は子どものころから、外国の切手集めが好きです。", "en": "My younger brother has loved collecting foreign stamps since he was little." },
   }),
   examQuestion({
     id: "n4-grammar-node",
@@ -2328,7 +2363,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「足りる」是自動詞『足夠』。正解『千円あれば〜足りる』表示一千日圓足以買便當。其餘為誤用：『レジで千円を足りた』應用『払った（付）』；『友だちにお金を足りた』應用『貸した／借りた』；『名前を足りてください』應用『書いて（寫）』。",
     explanationI18n: { "ja": "「足りる」は自動詞で『十分である』の意味です。正解の『千円あれば〜足りる』は千円あればお弁当を買うのに十分だという意味です。他は誤用で、『レジで千円を足りた』は『払った』を使うべき、『友だちにお金を足りた』は『貸した／借りた』を使うべき、『名前を足りてください』は『書いて』を使うべきです。", "en": "足りる is an intransitive verb meaning \"to be enough.\" The answer 千円あれば〜足りる means a thousand yen is enough to buy a lunch. The others are misuses: 「レジで千円を足りた」 should use 払った (\"paid\"); 「友だちにお金を足りた」 should use 貸した／借りた (\"lent / borrowed\"); 「名前を足りてください」 should use 書いて (\"write\")." },
     exampleJapanese: "千円あれば、お弁当を買うのに足りる。",
-    exampleMeaningZh: "只要有一千日圓，買便當就夠了。"
+    exampleMeaningZh: "只要有一千日圓，買便當就夠了。",
+    exampleMeaningI18n: { "ja": "千円あれば、お弁当を買うのに十分です。", "en": "A thousand yen is enough to buy a boxed lunch." },
   }),
   examQuestion({
     id: "n4-usage-niru",
@@ -2350,7 +2386,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「似る」是『相像』。正解『顔がお母さんに似ている』表示長得像媽媽。其餘誤用：『駅で友だちに似ている』應用『会う（遇見）』；『窓の外を似てください』應用『見て（看）』；『壁の色を白に似た』應用『した／塗った（漆成）』。",
     explanationI18n: { "ja": "「似る」は『似ている』の意味です。正解の『顔がお母さんに似ている』はお母さんに似ているという意味です。他は誤用で、『駅で友だちに似ている』は『会う』を使うべき、『窓の外を似てください』は『見て』を使うべき、『壁の色を白に似た』は『した／塗った』を使うべきです。", "en": "似る means \"to resemble.\" The answer 顔がお母さんに似ている means he looks like his mother. The others are misuses: 「駅で友だちに似ている」 should use 会う (\"meet\"); 「窓の外を似てください」 should use 見て (\"look\"); 「壁の色を白に似た」 should use した／塗った (\"painted\")." },
     exampleJapanese: "あの子は顔がお母さんによく似ている。",
-    exampleMeaningZh: "那孩子的長相和媽媽很像。"
+    exampleMeaningZh: "那孩子的長相和媽媽很像。",
+    exampleMeaningI18n: { "ja": "あの子の顔はお母さんとそっくりです。", "en": "That child looks a lot like their mother." },
   }),
   examQuestion({
     id: "n4-usage-maniau",
@@ -2372,7 +2409,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「間に合う」是『趕得上』。正解表示趕上了九點的電車。其餘誤用：『九時の電車を間に合った』應用『に乗った（搭上）』；『駅で友だちと間に合った』應用『会った（碰面）』；『宿題を明日までに間に合った』應用『終わらせた／出した（完成／交出）』。",
     explanationI18n: { "ja": "「間に合う」は『間に合う』の意味です。正解は九時の電車に間に合ったことを表します。他は誤用で、『九時の電車を間に合った』は『に乗った』を使うべき、『駅で友だちと間に合った』は『会った』を使うべき、『宿題を明日までに間に合った』は『終わらせた／出した』を使うべきです。", "en": "間に合う means \"to make it in time.\" The answer means catching the nine o'clock train. The others are misuses: 「九時の電車を間に合った」 should use に乗った (\"boarded\"); 「駅で友だちと間に合った」 should use 会った (\"met\"); 「宿題を明日までに間に合った」 should use 終わらせた／出した (\"finished / handed in\")." },
     exampleJapanese: "急いで走ったので、九時の電車に間に合った。",
-    exampleMeaningZh: "因為趕緊跑了，所以趕上了九點的電車。"
+    exampleMeaningZh: "因為趕緊跑了，所以趕上了九點的電車。",
+    exampleMeaningI18n: { "ja": "急いで走ったおかげで、九時の電車に乗り遅れませんでした。", "en": "I ran as fast as I could, so I made the nine o'clock train." },
   }),
   examQuestion({
     id: "n4-usage-taoreru",
@@ -2394,7 +2432,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「倒れる」是『倒下』。正解表示庭院的樹被強風吹倒。其餘誤用：『葉が倒れて』應用『落ちて（掉落）』；『コップの水が倒れて』應用『こぼれて（灑出）』；『電気が倒れて』應用『消えて（熄掉）』。",
     explanationI18n: { "ja": "「倒れる」は『倒れる』の意味です。正解は庭の木が強い風で倒れたことを表します。他は誤用で、『葉が倒れて』は『落ちて』を使うべき、『コップの水が倒れて』は『こぼれて』を使うべき、『電気が倒れて』は『消えて』を使うべきです。", "en": "倒れる means \"to fall over.\" The answer means the garden tree was blown down by the strong wind. The others are misuses: 「葉が倒れて」 should use 落ちて (\"fell\"); 「コップの水が倒れて」 should use こぼれて (\"spilled\"); 「電気が倒れて」 should use 消えて (\"went out\")." },
     exampleJapanese: "強い風で、庭の木が倒れてしまった。",
-    exampleMeaningZh: "因為強風，院子裡的樹倒了。"
+    exampleMeaningZh: "因為強風，院子裡的樹倒了。",
+    exampleMeaningI18n: { "ja": "風が強かったせいで、庭の木が倒れてしまいました。", "en": "The strong wind knocked over the tree in the yard." },
   }),
   examQuestion({
     id: "n4-syn-daitai",
@@ -2416,7 +2455,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「だいたい」此處＝『大部分、差不多』，與「ほとんど（幾乎全部）」最接近。『何度も（好幾次）』是次數、『さっき（剛才）』是時間、『ゆっくり（慢慢地）』是方式，三者都能接『読みました』但與『讀了大部分』語意不同。故唯「ほとんど」。",
     explanationI18n: { "ja": "ここでの「だいたい」は『大部分、ほぼ』の意味で、「ほとんど（ほぼ全部）」に最も近いです。「何度も（何度も）」は回数、「さっき（さっき）」は時間、「ゆっくり（ゆっくり）」は方法で、三つとも『読みました』には続けられますが『大部分読んだ』とは意味が違います。よって正解は「ほとんど」だけです。", "en": "Here だいたい means \"most of it, more or less,\" closest to ほとんど (\"almost all\"). 何度も (\"many times\") is frequency, さっき (\"just now\") is time, and ゆっくり (\"slowly\") is manner; all three can attach to 読みました but differ in meaning from \"read most of it.\" So only ほとんど works." },
     exampleJapanese: "この本はほとんど読みました。",
-    exampleMeaningZh: "這本書我幾乎讀完了。"
+    exampleMeaningZh: "這本書我幾乎讀完了。",
+    exampleMeaningI18n: { "ja": "この本はほぼ読み終わりました。", "en": "I've read most of this book." },
   }),
   examQuestion({
     id: "n4-syn-dandan",
@@ -2438,7 +2478,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「少しずつ」表示「一點一點地、緩慢地」，與「だんだん（漸漸地推移）」最接近，代回句子描述天氣緩慢轉暖通順。陷阱：「急に」「突然」皆表「突然、一下子」，與「漸進」方向相反，雖接續成立但語意明確矛盾；「やっと」表「終於、好不容易」，強調結果終於到來，不含「逐步推移」之意，與本句強調過程的語境不合。三個干擾皆為「語意方向不對」型。",
     explanationI18n: { "ja": "正解の「少しずつ」は『少しずつ、ゆっくりと』を表し、「だんだん（だんだんと移り変わる）」に最も近く、文に戻すと天気がゆっくり暖かくなる様子を自然に表します。引っかけ：「急に」「突然」はどちらも『急に、いきなり』を表し、『しだいに』とは方向が反対で、接続は成立しても意味は明らかに矛盾します。「やっと」は『やっと、ようやく』を表し、結果がついに訪れたことを強調するもので、『段階的な推移』の意味は含まず、過程を強調するこの文の文脈に合いません。三つの誤答はいずれも『意味の方向が違う』型です。", "en": "The answer 少しずつ means \"bit by bit, slowly,\" closest to だんだん (\"gradually shifting\"); substituted back, it naturally describes the weather slowly warming up. Traps: 急に and 突然 both mean \"suddenly, all at once,\" the opposite of \"gradual\"; though they connect grammatically, they clearly contradict the meaning. やっと means \"finally, at last,\" stressing that a result has finally arrived, without the sense of \"step-by-step progression,\" and doesn't fit a sentence emphasizing the process. All three distractors are of the \"wrong direction of meaning\" type." },
     exampleJapanese: "三月になって、少しずつ暖かくなってきました。",
-    exampleMeaningZh: "到了三月，天氣一點一點地變暖了。"
+    exampleMeaningZh: "到了三月，天氣一點一點地變暖了。",
+    exampleMeaningI18n: { "ja": "三月になって、次第に暖かくなってきました。", "en": "Now that it's March, it's gradually getting warmer." },
   }),
   examQuestion({
     id: "n4-syn-shikaru",
@@ -2460,7 +2501,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「おこられました（被生氣／被罵）」與「しかられました（被責罵）」意思最接近，皆指因犯錯而受到責備，代回句意通順。陷阱：「ほめられました（被稱讚）」與責罵語意完全相反，「うそをついたので」的前因鎖死了不可能是稱讚；「わらわれました（被嘲笑）」「たすけられました（被幫助）」雖接續成立，但與「因說謊而受責」的語境不符，皆非「斥責」之意。三干擾屬「反義／不同動作」型。",
     explanationI18n: { "ja": "正解の「おこられました（怒られる／叱られる）」は「しかられました（叱られる）」に最も意味が近く、どちらも過ちを犯して咎められることを指し、文に戻しても意味が通ります。引っかけ：「ほめられました（ほめられる）」は叱ることと正反対の意味で、「うそをついたので」という前提がほめられる可能性を固く否定します。「わらわれました（笑われる）」「たすけられました（助けられる）」は接続は成立しますが、「うそをついて咎められる」という文脈に合わず、いずれも『叱る』の意味ではありません。三つの誤答は『反対語／別の動作』型です。", "en": "The correct answer 「おこられました」(got told off / got scolded) is closest in meaning to 「しかられました」(was scolded); both refer to being reprimanded for doing something wrong, and substituting it back reads naturally. Trap: 「ほめられました」(was praised) is the exact opposite of being scolded, and the cause 「うそをついたので」rules out praise entirely. 「わらわれました」(was laughed at) and 「たすけられました」(was helped) connect grammatically but don't fit a context of being scolded for lying, so neither means \"reprimand.\" All three distractors are of the antonym / different-action type." },
     exampleJapanese: "うそをついたので、母におこられました。",
-    exampleMeaningZh: "因為說了謊，被媽媽生氣地罵了。"
+    exampleMeaningZh: "因為說了謊，被媽媽生氣地罵了。",
+    exampleMeaningI18n: { "ja": "うそをついたので、母に怒られました。", "en": "I told a lie, so my mother scolded me angrily." },
   }),
   examQuestion({
     id: "n4-context-sorede",
@@ -2660,7 +2702,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「おや」是「親（父母）」當名詞時的訓讀。干擾「あや」是近形假名替換、不是「親」的讀音；「おお」與「おか」都只是形近的假名拼湊，並非「親」的合法讀法。",
     explanationI18n: { "ja": "正解の「おや」は、名詞としての「親（父母）」の訓読みです。「あや」は形の似たかなに置き換えただけで、「親」の読みではありません。「おお」と「おか」はどちらも形の似たかなを寄せ集めただけで、「親」の正しい読み方ではありません。", "en": "The correct answer 「おや」is the kun'yomi of 「親」(parents) used as a noun. The distractor 「あや」is a similar-looking kana substitution, not a reading of 「親」; 「おお」and 「おか」are both just visually similar kana strings and are not valid readings of 「親」." },
     exampleJapanese: "私の「親」は今、田舎に住んでいます。",
-    exampleMeaningZh: "我的父母現在住在鄉下。"
+    exampleMeaningZh: "我的父母現在住在鄉下。",
+    exampleMeaningI18n: { "ja": "私の両親は今、田舎に住んでいます。", "en": "My parents live in the countryside now." },
   }),
   examQuestion({
     id: "n4-grammar-oirikudasai",
@@ -2742,7 +2785,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「沸かす」是他動詞，專指把水（湯）加熱到沸騰。正解『やかんでお湯を沸かした』表示為了泡茶用水壺把水燒開，搭配對象是「お湯」，完全正確。其餘三句都把不能「沸かす」的對象硬接上去而誤用：『部屋を沸かした』要讓房間變涼／通風應用『涼しくした／換気した』，房間不能用「沸かす」；『野菜をフライパンで沸かして』用平底鍋炒菜應用『炒めた（炒）』，蔬菜不是水不能「沸かす」；『手を沸かす』暖手應用『温める（取暖、暖和）』，身體部位不能用「沸かす」。只有針對「水／湯」的第一句成立。",
     explanationI18n: { "ja": "「沸かす」は他動詞で、水（湯）を沸騰するまで熱することを指します。正解の「やかんでお湯を沸かした」は、お茶を入れるためにやかんで水を沸かすという意味で、対象が「お湯」でぴったり正しい使い方です。ほかの三文は、いずれも「沸かす」ことができない対象に無理に付けて誤用しています。「部屋を沸かした」は、部屋を涼しくしたり換気したりするなら「涼しくした／換気した」を使うべきで、部屋に「沸かす」は使えません。「野菜をフライパンで沸かして」は、フライパンで炒めるなら「炒めた」を使うべきで、野菜は水ではないので「沸かす」ことはできません。「手を沸かす」は、手を温めるなら「温める」を使うべきで、体の部位に「沸かす」は使えません。「水／湯」を対象にした最初の文だけが成り立ちます。", "en": "「沸かす」is a transitive verb specifically for heating water (hot water) to boiling. The correct answer 『やかんでお湯を沸かした』means boiling water in a kettle to make tea, taking 「お湯」as its object — completely correct. The other three all force objects that can't be 「沸かす」into misuse: 『部屋を沸かした』— to cool or ventilate a room you'd use 『涼しくした／換気した』; a room can't be 「沸かす」. 『野菜をフライパンで沸かして』— to stir-fry vegetables in a frying pan you'd use 『炒めた』; vegetables aren't water and can't be 「沸かす」. 『手を沸かす』— to warm your hands you'd use 『温める』; body parts can't be 「沸かす」. Only the first sentence, applied to \"water / hot water,\" works." },
     exampleJapanese: "お茶を入れるために、やかんでお湯を沸かした。",
-    exampleMeaningZh: "為了泡茶，用水壺把水燒開了。"
+    exampleMeaningZh: "為了泡茶，用水壺把水燒開了。",
+    exampleMeaningI18n: { "ja": "お茶を入れるために、やかんで水を沸騰させました。", "en": "I boiled water in the kettle to make tea." },
   }),
   examQuestion({
     id: "n4-usage-norikaeru",
@@ -2764,7 +2808,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「乗り換える」是『中途下車改搭另一種交通工具』。正解『東京駅でJRから地下鉄に乗り換えて』用「AからBに乗り換える」標準搭配。其餘誤用：『電車を乗り換えて待った』搭配不通；『いすに座って少し乗り換えた』應用『休んだ』；『新しい服に乗り換えて出かけた』換衣服應用『着替えて』。唯第一句成立。",
     explanationI18n: { "ja": "「乗り換える」は「途中で乗り物を降りて別の乗り物に換える」ことです。正解の「東京駅でJRから地下鉄に乗り換えて」は「AからBに乗り換える」という標準的な組み合わせを使っています。ほかは誤用です。「電車を乗り換えて待った」は組み合わせが通りません。「いすに座って少し乗り換えた」は「休んだ」を使うべきです。「新しい服に乗り換えて出かけた」は服を換えるなら「着替えて」を使うべきです。最初の文だけが成り立ちます。", "en": "「乗り換える」means 'getting off midway and switching to a different form of transport.' The correct answer 『東京駅でJRから地下鉄に乗り換えて』uses the standard 「AからBに乗り換える」collocation. The others are misuses: 『電車を乗り換えて待った』is an ungrammatical collocation; 『いすに座って少し乗り換えた』should use 『休んだ』; 『新しい服に乗り換えて出かけた』— changing clothes should use 『着替えて』. Only the first sentence works." },
     exampleJapanese: "東京駅でJRから地下鉄に乗り換えて、会社へ行く。",
-    exampleMeaningZh: "在東京站從JR換搭地下鐵，再去公司。"
+    exampleMeaningZh: "在東京站從JR換搭地下鐵，再去公司。",
+    exampleMeaningI18n: { "ja": "東京駅でJRを降りて地下鉄に乗り、会社へ向かいます。", "en": "I transfer from the JR line to the subway at Tokyo Station and then go on to work." },
   }),
   examQuestion({
     id: "n4-usage-suteru",
@@ -2786,7 +2831,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「捨てる」是『把不要的東西扔掉』。正解『古いざっしは、まとめて捨てた』把不再看的舊雜誌整批丟掉，正確。其餘誤用：『大切な写真をアルバムに捨てておいた』珍惜的東西應用『しまっておいた』；『友だちにペンを一本捨ててもらって、じゅぎょうで使った』請人丟掉卻又拿來用、前後矛盾，應為『貸してもらって』；『本をたなに捨ててください』放回架上應用『戻して』。唯第一句成立。",
     explanationI18n: { "ja": "「捨てる」は「いらない物を投げ捨てる」ことです。正解の「古いざっしは、まとめて捨てた」は、もう読まない古い雑誌をまとめて捨てるという意味で正しいです。ほかは誤用です。「大切な写真をアルバムに捨てておいた」は大切な物なら「しまっておいた」を使うべきです。「友だちにペンを一本捨ててもらって、じゅぎょうで使った」は、捨ててもらったのにまた使うという前後の矛盾があり、「貸してもらって」とすべきです。「本をたなに捨ててください」は棚に戻すなら「戻して」を使うべきです。最初の文だけが成り立ちます。", "en": "「捨てる」means 'to throw away unwanted things.' The correct answer 『古いざっしは、まとめて捨てた』— throwing out old magazines you no longer read all at once — is correct. The others are misuses: 『大切な写真をアルバムに捨てておいた』— for something you treasure you'd use 『しまっておいた』; 『友だちにペンを一本捨ててもらって、じゅぎょうで使った』— having someone throw away a pen but then using it is self-contradictory; it should be 『貸してもらって』; 『本をたなに捨ててください』— putting a book back on the shelf should use 『戻して』. Only the first sentence works." },
     exampleJapanese: "読まなくなった古いざっしは、まとめて捨てた。",
-    exampleMeaningZh: "已經不看的舊雜誌，整批丟掉了。"
+    exampleMeaningZh: "已經不看的舊雜誌，整批丟掉了。",
+    exampleMeaningI18n: { "ja": "読まなくなった古い雑誌を、まとめて処分しました。", "en": "I threw out all the old magazines I no longer read." },
   }),
   examQuestion({
     id: "n4-context-shikashi",
@@ -2846,7 +2892,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「きゅうこう」是「急行（快車）」的標準音讀。干擾「きゅこう」少了「きゅう」的長音；「きゅうごう」把「こう」錯讀成濁音「ごう」；「ぎゅうこう」把「きゅう」錯讀成「ぎゅう」。三者都不是「急行」的合法讀音。",
     explanationI18n: { "ja": "正解の「きゅうこう」は「急行（快車）」の標準的な音読みです。「きゅこう」は「きゅう」の長音が抜けています。「きゅうごう」は「こう」を誤って濁音の「ごう」で読んでいます。「ぎゅうこう」は「きゅう」を誤って「ぎゅう」で読んでいます。三つとも「急行」の正しい読み方ではありません。", "en": "The correct answer 「きゅうこう」is the standard on'yomi of 「急行」(express train). The distractor 「きゅこう」is missing the long vowel in 「きゅう」; 「きゅうごう」wrongly voices 「こう」into 「ごう」; 「ぎゅうこう」wrongly reads 「きゅう」as 「ぎゅう」. None of the three is a valid reading of 「急行」." },
     exampleJapanese: "駅に着いたら、ちょうど急行が来ました。",
-    exampleMeaningZh: "到了車站，剛好快車進站了。"
+    exampleMeaningZh: "到了車站，剛好快車進站了。",
+    exampleMeaningI18n: { "ja": "駅に着いたら、ちょうど急行電車が入ってきました。", "en": "When I got to the station, the express train was just pulling in." },
   }),
   examQuestion({
     id: "n4-kanji-majime",
@@ -2866,7 +2913,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「まじめ」是「真面目」的固定讀音（熟字訓）。干擾「まじめい」多加了「い」的長音；「まめじ」把「じ」「め」順序顛倒；「ましめ」把濁音「じ」錯讀成清音「し」。三者皆非「真面目」的讀法。",
     explanationI18n: { "ja": "正解の「まじめ」は「真面目」の決まった読み方（熟字訓）です。「まじめい」は「い」という長音を余分に加えています。「まめじ」は「じ」と「め」の順序を逆にしています。「ましめ」は濁音の「じ」を誤って清音の「し」で読んでいます。三つとも「真面目」の読み方ではありません。", "en": "The correct answer 「まじめ」 is the fixed reading of 「真面目」 (a special kanji reading, jukujikun). The distractor 「まじめい」 adds an extra long vowel 「い」; 「まめじ」 swaps the order of 「じ」 and 「め」; and 「ましめ」 misreads the voiced 「じ」 as the unvoiced 「し」. None of the three are valid readings of 「真面目」." },
     exampleJapanese: "彼はとても真面目な学生です。",
-    exampleMeaningZh: "他是個非常認真的學生。"
+    exampleMeaningZh: "他是個非常認真的學生。",
+    exampleMeaningI18n: { "ja": "彼はとてもまじめな学生です。", "en": "He is a very serious, hardworking student." },
   }),
   examQuestion({
     id: "n4-kanji-toshi",
@@ -2886,7 +2934,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「とし」是「都市」的音讀。干擾「とうし」在「と」後多加了長音；「とじ」把「し」錯讀成濁音「じ」；「どし」把「と」錯讀成濁音「ど」。三者都不是「都市」的合法讀音。",
     explanationI18n: { "ja": "正解の「とし」は「都市」の音読みです。「とうし」は「と」のあとに長音を余分に加えています。「とじ」は「し」を誤って濁音の「じ」で読んでいます。「どし」は「と」を誤って濁音の「ど」で読んでいます。三つとも「都市」の正しい読み方ではありません。", "en": "The correct answer 「とし」 is the on'yomi of 「都市」. The distractor 「とうし」 adds a long vowel after 「と」; 「とじ」 misreads 「し」 as the voiced 「じ」; and 「どし」 misreads 「と」 as the voiced 「ど」. None of the three are legitimate readings of 「都市」." },
     exampleJapanese: "大きな都市には人がたくさん集まります。",
-    exampleMeaningZh: "大都市裡聚集了很多人。"
+    exampleMeaningZh: "大都市裡聚集了很多人。",
+    exampleMeaningI18n: { "ja": "大きな都市には人がたくさん集まります。", "en": "Lots of people gather in big cities." },
   }),
   examQuestion({
     id: "n4-kanji-keikaku",
@@ -2906,7 +2955,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「けいかく」是「計画」的音讀。干擾「けいがく」把「か」錯讀成濁音「が」；「けかく」少了「けい」的長音；「けいかぐ」把「く」錯讀成濁音「ぐ」。三者皆非「計画」的讀法。",
     explanationI18n: { "ja": "正解の「けいかく」は「計画」の音読みです。「けいがく」は「か」を誤って濁音の「が」で読んでいます。「けかく」は「けい」の長音が抜けています。「けいかぐ」は「く」を誤って濁音の「ぐ」で読んでいます。三つとも「計画」の読み方ではありません。", "en": "The correct answer 「けいかく」 is the on'yomi of 「計画」. The distractor 「けいがく」 misreads 「か」 as the voiced 「が」; 「けかく」 drops the long vowel in 「けい」; and 「けいかぐ」 misreads 「く」 as the voiced 「ぐ」. None of the three are readings of 「計画」." },
     exampleJapanese: "夏休みの計画をみんなで考えました。",
-    exampleMeaningZh: "大家一起想了暑假的計畫。"
+    exampleMeaningZh: "大家一起想了暑假的計畫。",
+    exampleMeaningI18n: { "ja": "夏休みの計画をみんなで考えました。", "en": "We all thought up plans for summer vacation together." },
   }),
   examQuestion({
     id: "n4-syn-mousugu",
@@ -2928,7 +2978,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「もうすぐ来ます」表示「很快就要來了」，與「まもなく（不久、即將）来ます」意思最接近，兩者都表示時間上即將發生。「ときどき」是「有時、偶爾」，表頻率，代入「ときどき来ます」變成「有時會來」，語意完全不同且不成立。「ゆっくり」是「慢慢地」，描述動作速度，與「即將」的時間語意相反，「ゆっくり来ます」指慢慢來，不對。「やっぱり」是「果然」，表語氣判斷，無法表達「快要」的時間語意，代入不自然。故唯一正解為「まもなく」。",
     explanationI18n: { "ja": "「もうすぐ来ます」は「まもなく来る」という意味で、「まもなく（不久、即將）来ます」と最も意味が近く、どちらも時間的に間もなく起こることを表します。「ときどき」は「有時、偶爾」で頻度を表し、「ときどき来ます」に置き換えると「時々来る」となって意味がまったく異なり、成り立ちません。「ゆっくり」は「慢慢地」で動作の速さを表し、「間もなく」という時間の意味とは逆で、「ゆっくり来ます」はゆっくり来るという意味になり合いません。「やっぱり」は「果然」で語気や判断を表し、「間もなく」という時間の意味は表せず、置き換えると不自然です。したがって唯一の正解は「まもなく」です。", "en": "「もうすぐ来ます」 means \"will come very soon,\" which is closest in meaning to 「まもなく（shortly, imminently）来ます」; both indicate something about to happen in time. 「ときどき」 means \"sometimes, occasionally\" and expresses frequency—plugging it in gives 「ときどき来ます」 (\"comes sometimes\"), a completely different meaning that doesn't fit. 「ゆっくり」 means \"slowly\" and describes the pace of an action, the opposite of the \"imminent\" time sense; 「ゆっくり来ます」 means \"comes slowly,\" which is wrong. 「やっぱり」 means \"as expected\" and conveys the speaker's judgment, so it cannot express the time sense of \"soon\" and sounds unnatural when substituted. Thus the only correct answer is 「まもなく」." },
     exampleJapanese: "電車はまもなく来ます。",
-    exampleMeaningZh: "電車即將到站。"
+    exampleMeaningZh: "電車即將到站。",
+    exampleMeaningI18n: { "ja": "電車はもう少しで到着します。", "en": "The train will arrive any moment now." },
   }),
   examQuestion({
     id: "n4-syn-tokidoki",
@@ -2950,7 +3001,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「ときどき映画を見ます」表示「偶爾看電影」，與「たまに（偶爾）映画を見ます」意思最接近，兩者都表示低頻率。「いつも」是「總是、每次」，表高頻率，與「偶爾」語意明確相反，「いつも見ます」變成總是看，不對。「すぐに」是「立刻、馬上」，表時間先後而非頻率，「すぐに映画を見ます」指馬上看，語意不同。「そろそろ」是「差不多該…了」，表時機，代入「そろそろ映画を見ます」語意不自然且非頻率詞。故唯一正解為「たまに」。",
     explanationI18n: { "ja": "「ときどき映画を見ます」は「たまに映画を見る」という意味で、「たまに（偶爾）映画を見ます」と最も意味が近く、どちらも頻度が低いことを表します。「いつも」は「總是、每次」で高い頻度を表し、「偶爾」とは明確に意味が逆で、「いつも見ます」だと毎回見ることになり合いません。「すぐに」は「立刻、馬上」で時間の前後を表し頻度ではなく、「すぐに映画を見ます」はすぐ見るという意味になり異なります。「そろそろ」は「差不多該…了」で時機を表し、「そろそろ映画を見ます」に置き換えると不自然で、頻度を表す語でもありません。したがって唯一の正解は「たまに」です。", "en": "「ときどき映画を見ます」 means \"watch movies occasionally,\" which is closest to 「たまに（occasionally）映画を見ます」; both indicate low frequency. 「いつも」 means \"always, every time\" and expresses high frequency, clearly the opposite of \"occasionally\"—「いつも見ます」 becomes \"always watch,\" which is wrong. 「すぐに」 means \"immediately, right away\" and expresses timing/sequence rather than frequency; 「すぐに映画を見ます」 means \"watch right away,\" a different meaning. 「そろそろ」 means \"it's about time to…\" and expresses timing; substituting it gives an unnatural 「そろそろ映画を見ます」 and it is not a frequency word. Thus the only correct answer is 「たまに」." },
     exampleJapanese: "わたしはたまに映画を見ます。",
-    exampleMeaningZh: "我偶爾看電影。"
+    exampleMeaningZh: "我偶爾看電影。",
+    exampleMeaningI18n: { "ja": "わたしは時々映画を見ます。", "en": "I watch movies once in a while." },
   }),
   examQuestion({
     id: "n4-vocab-nureru",
@@ -3070,7 +3122,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「牛」濁音拗長音讀「ぎゅう」、「乳」讀「にゅう」，故「牛乳」＝ぎゅうにゅう。「きゅうにゅう」把「牛」誤讀成清音「きゅう」；「ぎゅうにゅ」漏了「乳」的長音；「ぎゅにゅう」漏了「牛」的長音。三個讀法都不被母語者接受，唯「ぎゅうにゅう」成立。",
     explanationI18n: { "ja": "「牛」は濁音の拗長音で「ぎゅう」、「乳」は「にゅう」と読むので、「牛乳」＝ぎゅうにゅうです。「きゅうにゅう」は「牛」を清音の「きゅう」と読み間違えたもの。「ぎゅうにゅ」は「乳」の長音が抜けています。「ぎゅにゅう」は「牛」の長音が抜けています。この三つはいずれも母語話者には受け入れられず、正しいのは「ぎゅうにゅう」だけです。", "en": "「牛」 reads as 「ぎゅう」 (voiced, with a contracted long vowel) and 「乳」 reads as 「にゅう」, so 「牛乳」＝ぎゅうにゅう. 「きゅうにゅう」 misreads 「牛」 as the unvoiced 「きゅう」; 「ぎゅうにゅ」 drops the long vowel of 「乳」; and 「ぎゅにゅう」 drops the long vowel of 「牛」. None of these three readings would be accepted by native speakers—only 「ぎゅうにゅう」 is valid." },
     exampleJapanese: "毎朝、コップ一杯の牛乳を飲みます。",
-    exampleMeaningZh: "每天早上喝一杯牛奶。"
+    exampleMeaningZh: "每天早上喝一杯牛奶。",
+    exampleMeaningI18n: { "ja": "毎朝、コップ一杯の牛乳を飲みます。", "en": "I drink a glass of milk every morning." },
   }),
   examQuestion({
     id: "n4-kanji-daidokoro",
@@ -3090,7 +3143,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「台所」是慣用讀法＝だいどころ（「台」だい、「所」連濁讀「どころ」）。「たいどころ」把「台」誤讀成清音「たい」；「だいところ」漏掉「所」的連濁；「だいどごろ」把濁音放錯位置。三者都不成立，唯「だいどころ」正確。",
     explanationI18n: { "ja": "「台所」は慣用的な読み方で＝だいどころです（「台」だい、「所」は連濁して「どころ」）。「たいどころ」は「台」を清音の「たい」と読み間違えたもの。「だいところ」は「所」の連濁が抜けています。「だいどごろ」は濁音の位置を間違えています。この三つはいずれも成り立たず、正しいのは「だいどころ」だけです。", "en": "「台所」 has the customary reading だいどころ (「台」 as だい, 「所」 with sequential voicing read as 「どころ」). 「たいどころ」 misreads 「台」 as the unvoiced 「たい」; 「だいところ」 omits the sequential voicing of 「所」; and 「だいどごろ」 puts the voicing in the wrong place. None of these three are valid—only 「だいどころ」 is correct." },
     exampleJapanese: "母は台所で晩ご飯を作っています。",
-    exampleMeaningZh: "媽媽正在廚房做晚飯。"
+    exampleMeaningZh: "媽媽正在廚房做晚飯。",
+    exampleMeaningI18n: { "ja": "母は台所で晩ご飯を作っています。", "en": "Mom is making dinner in the kitchen." },
   }),
   examQuestion({
     id: "n4-kanji-shinamono",
@@ -3110,7 +3164,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「品物」用訓讀＝しなもの（「品」しな、「物」もの）。「ひんもの」把「品」誤讀成音讀「ひん」；「しなぶつ」把「物」誤讀成音讀「ぶつ」，訓音混搭不成立；「しなもん」是口語訛音，不是正規讀音。唯「しなもの」正確。",
     explanationI18n: { "ja": "「品物」は訓読みで＝しなものです（「品」しな、「物」もの）。「ひんもの」は「品」を音読みの「ひん」と読み間違えたもの。「しなぶつ」は「物」を音読みの「ぶつ」と読んでいて、訓読みと音読みが混ざり成り立ちません。「しなもん」は口語の訛った音で、正規の読み方ではありません。正しいのは「しなもの」だけです。", "en": "「品物」 uses the kun'yomi reading しなもの (「品」 as しな, 「物」 as もの). 「ひんもの」 misreads 「品」 as the on'yomi 「ひん」; 「しなぶつ」 misreads 「物」 as the on'yomi 「ぶつ」, mixing kun and on readings, which isn't valid; and 「しなもん」 is a colloquial slurred pronunciation, not the standard reading. Only 「しなもの」 is correct." },
     exampleJapanese: "この店は品物がたくさんあって、選ぶのが楽しいです。",
-    exampleMeaningZh: "這家店東西很多，挑選起來很開心。"
+    exampleMeaningZh: "這家店東西很多，挑選起來很開心。",
+    exampleMeaningI18n: { "ja": "この店は品物がたくさんあって、選ぶのが楽しいです。", "en": "This store carries so many goods that picking things out is fun." },
   }),
   examQuestion({
     id: "n4-kanji-yuubinkyoku",
@@ -3130,7 +3185,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「郵便局」＝ゆうびんきょく（郵ゆう、便びん、局きょく）。「ゆうべんきょく」把「便」誤讀成「べん」；「ゆうびんきょう」漏了「局」末尾的「く」；「ゆびんきょく」漏了「郵」的長音。三者都不成立，唯「ゆうびんきょく」正確。",
     explanationI18n: { "ja": "「郵便局」＝ゆうびんきょくです（郵ゆう、便びん、局きょく）。「ゆうべんきょく」は「便」を「べん」と読み間違えたもの。「ゆうびんきょう」は「局」の末尾の「く」が抜けています。「ゆびんきょく」は「郵」の長音が抜けています。この三つはいずれも成り立たず、正しいのは「ゆうびんきょく」だけです。", "en": "「郵便局」＝ゆうびんきょく (郵 as ゆう, 便 as びん, 局 as きょく). 「ゆうべんきょく」 misreads 「便」 as 「べん」; 「ゆうびんきょう」 drops the final 「く」 of 「局」; and 「ゆびんきょく」 drops the long vowel of 「郵」. None of these three are valid—only 「ゆうびんきょく」 is correct." },
     exampleJapanese: "手紙を出しに郵便局へ行きます。",
-    exampleMeaningZh: "去郵局寄信。"
+    exampleMeaningZh: "去郵局寄信。",
+    exampleMeaningI18n: { "ja": "手紙を出しに郵便局へ行きます。", "en": "I'm going to the post office to mail a letter." },
   }),
   examQuestion({
     id: "n4-kanji-fuben",
@@ -3150,7 +3206,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「不便」＝ふべん（不ふ、便べん）。「ぶべん」把「不」誤讀成濁音「ぶ」；「ふへん」把「便」讀成清音，會變成另一個詞「不変（不變）」，與「離車站遠所以不方便」的語境不合；「ふうべん」多了不存在的長音。唯「ふべん」正確。",
     explanationI18n: { "ja": "「不便」＝ふべんです（不ふ、便べん）。「ぶべん」は「不」を濁音の「ぶ」と読み間違えたもの。「ふへん」は「便」を清音で読むと別の言葉「不変」になってしまい、「駅から遠くて不便だ」という文脈に合いません。「ふうべん」は存在しない長音が入っています。正しいのは「ふべん」だけです。", "en": "「不便」＝ふべん (不 as ふ, 便 as べん). 「ぶべん」 misreads 「不」 as the voiced 「ぶ」; 「ふへん」 reads 「便」 as unvoiced, which would become a different word 「不変（unchanging）」, not fitting the context of \"far from the station, so inconvenient\"; and 「ふうべん」 adds a long vowel that isn't there. Only 「ふべん」 is correct." },
     exampleJapanese: "駅から遠いので、この町は少し不便です。",
-    exampleMeaningZh: "離車站很遠，所以這個小鎮有點不方便。"
+    exampleMeaningZh: "離車站很遠，所以這個小鎮有點不方便。",
+    exampleMeaningI18n: { "ja": "駅から遠いので、この町は少し不便です。", "en": "It's far from the station, so this town is a bit inconvenient." },
   }),
   examQuestion({
     id: "n4-kanji-kokusai",
@@ -3170,7 +3227,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「国際」＝こくさい（国こく、際さい）。「こうさい」會變成另一個詞「交際（交往）」，與「國際會議」的語境不合；「ごくさい」把「国」誤讀成濁音「ごく」；「こくざい」把「際」誤讀成濁音「ざい」。唯「こくさい」正確。",
     explanationI18n: { "ja": "「国際」＝こくさいです（国こく、際さい）。「こうさい」だと別の言葉「交際」になってしまい、「国際会議」という文脈に合いません。「ごくさい」は「国」を濁音の「ごく」と読み間違えたもの。「こくざい」は「際」を濁音の「ざい」と読み間違えたものです。正しいのは「こくさい」だけです。", "en": "「国際」＝こくさい (国 as こく, 際 as さい). 「こうさい」 would become a different word 「交際（socializing）」, which doesn't fit the context of an \"international conference\"; 「ごくさい」 misreads 「国」 as the voiced 「ごく」; and 「こくざい」 misreads 「際」 as the voiced 「ざい」. Only 「こくさい」 is correct." },
     exampleJapanese: "来月、大きな国際会議が開かれます。",
-    exampleMeaningZh: "下個月將舉辦一場大型國際會議。"
+    exampleMeaningZh: "下個月將舉辦一場大型國際會議。",
+    exampleMeaningI18n: { "ja": "来月、大きな国際会議が開かれます。", "en": "A large international conference will be held next month." },
   }),
   examQuestion({
     id: "n4-grammar-tekara",
@@ -3192,7 +3250,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「てから」：「動詞て形＋から」表示『做完前項、接著做後項』的先後順序，「手を洗ってから、ごはんを食べましょう」＝先洗手再吃飯，與勸誘語境完全吻合，成立。干擾「てまで」：「～てまで」表『甚至不惜～到那種地步』，「手を洗ってまでごはんを食べる」＝連手都洗了也要吃飯，語意誇張怪異，與單純先後不符，不成立。干擾「ている間」：「洗っている間」＝『正在洗的期間』，表同時進行，但句意是『洗完之後才吃』而非『邊洗邊吃』，方向不對。干擾「たまま」：「洗ったまま」＝『維持洗了的狀態（沒擦乾／放著不管）』，與『洗完接著吃飯』的先後語意不合，且帶有放置不理的語感，不成立。",
     explanationI18n: { "ja": "正解「てから」：「動詞て形＋から」は『前のことを終えてから、次のことをする』という前後関係を表します。「手を洗ってから、ごはんを食べましょう」＝先に手を洗ってから食べる、で勧誘の文脈にぴったり合い、成立します。誤答「てまで」：「～てまで」は『～するほどまでして』の意で、「手を洗ってまでごはんを食べる」＝手を洗ってまで食べる、となり意味が大げさで不自然。単なる前後関係には合わず成立しません。誤答「ている間」：「洗っている間」＝『洗っている最中』で同時進行を表しますが、文意は『洗い終わってから食べる』であって『洗いながら食べる』ではないため方向が違います。誤答「たまま」：「洗ったまま」＝『洗った状態のまま（拭かず・放っておく）』で、『洗ってから食べる』という前後の意味に合わず、放置のニュアンスも出るため成立しません。", "en": "The correct answer 「てから」: 「verb te-form ＋ から」 indicates the sequence of \"finishing the first action, then doing the next.\" 「手を洗ってから、ごはんを食べましょう」 means \"wash your hands first, then eat,\" which fits the invitational context perfectly and is valid. The distractor 「てまで」: 「～てまで」 means \"even going so far as to～,\" and 「手を洗ってまでごはんを食べる」 means \"eating even to the extent of washing one's hands\"—an exaggerated, odd meaning that doesn't match a simple sequence, so it's invalid. The distractor 「ている間」: 「洗っている間」 means \"during the time of washing,\" indicating simultaneous actions, but the sentence means \"eat after finishing washing,\" not \"eat while washing,\" so the direction is wrong. The distractor 「たまま」: 「洗ったまま」 means \"leaving it in a washed state (not dried off / left as is),\" which doesn't fit the sequential sense of \"finish washing and then eat\" and carries a nuance of leaving something unattended, so it's invalid." },
     exampleJapanese: "石けんで手をよく洗ってから、ごはんを食べましょう。",
-    exampleMeaningZh: "用肥皂把手洗乾淨之後，再來吃飯吧。"
+    exampleMeaningZh: "用肥皂把手洗乾淨之後，再來吃飯吧。",
+    exampleMeaningI18n: { "ja": "石けんで手をよく洗ったあとで、ごはんを食べましょう。", "en": "Let's wash our hands well with soap before eating." },
   }),
   examQuestion({
     id: "n4-grammar-kotogadekiru",
@@ -3214,7 +3273,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「ことができます」：「動詞辭書形＋ことができる」表示能力或可能，「カードで払うことができます」＝可以用卡付款，與『げんきんがなくても（即使沒現金也）』描述客觀可能性的語境一致，成立。干擾「ことにします」：「～ことにする」是說話者『自己決定要做』，但本句說明的是店家提供的付款選項（客觀可能），不是個人臨時決定，語意不合。干擾「ことになります」：「～ことになる」表『（非自己意志地）決定／規定為～』，「払うことになります」＝變成（規定）要付，但句意是『能用卡付』這個可能性，而非『被決定要付』，方向錯誤。干擾「ことがあります」：「（辭書形）＋ことがある」表『有時會發生』的頻率，「払うことがあります」＝有時會（用卡）付，與『沒現金也能付』的可能語意不符，不成立。",
     explanationI18n: { "ja": "正解「ことができます」：「動詞辞書形＋ことができる」は能力や可能性を表します。「カードで払うことができます」＝カードで払える、で『げんきんがなくても（現金がなくても）』という客観的な可能性を述べる文脈と一致し、成立します。誤答「ことにします」：「～ことにする」は話し手が『自分で決める』意ですが、この文は店側が用意している支払い方法（客観的な可能性）の説明であって個人の決定ではないため合いません。誤答「ことになります」：「～ことになる」は『（自分の意志ではなく）決まる・規定される』意で、「払うことになります」＝払うことに決まる、となりますが、文意は『カードで払える』という可能性であって『払うと決められる』ではないため方向が違います。誤答「ことがあります」：「（辞書形）＋ことがある」は『時々～する』という頻度を表し、「払うことがあります」＝時々（カードで）払う、となり『現金がなくても払える』という可能の意味に合わず成立しません。", "en": "The correct answer 「ことができます」: 「verb dictionary form ＋ ことができる」 indicates ability or possibility. 「カードで払うことができます」 means \"you can pay by card,\" consistent with the context of 「げんきんがなくても（even without cash）」 describing an objective possibility, so it's valid. The distractor 「ことにします」: 「～ことにする」 means the speaker \"decides on their own to do something,\" but this sentence describes a payment option the shop provides (an objective possibility), not a personal spur-of-the-moment decision, so it doesn't fit. The distractor 「ことになります」: 「～ことになる」 means \"it is decided/ruled (not by one's own will) that～.\" 「払うことになります」 means \"it becomes (a rule) that you pay,\" but the sentence is about the possibility of \"being able to pay by card,\" not \"being made to pay,\" so the direction is wrong. The distractor 「ことがあります」: 「(dictionary form) ＋ ことがある」 indicates the frequency of \"sometimes happening.\" 「払うことがあります」 means \"sometimes pay (by card),\" which doesn't match the possibility sense of \"can pay even without cash,\" so it's invalid." },
     exampleJapanese: "この店では、げんきんがなくてもカードではらうことができます。",
-    exampleMeaningZh: "在這家店，即使沒有現金，用信用卡也能付款。"
+    exampleMeaningZh: "在這家店，即使沒有現金，用信用卡也能付款。",
+    exampleMeaningI18n: { "ja": "この店では、現金がなくてもカードで払えます。", "en": "At this store, you can pay by card even if you don't have cash." },
   }),
   examQuestion({
     id: "n4-grammar-tehoshii",
@@ -3236,7 +3296,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「来てほしい」：「動詞て形＋ほしい」表示『希望別人做某事』，動作者用「に」標記，「友だちに（…）来てほしい」＝希望朋友來（接我），與『わたしは友だちに』的句構及拜託語境完全吻合，成立。干擾「来たい」：「たい」表第一人稱自己的願望，但本句主語『わたし』希望的是『朋友來』，而且對象已用「友だちに」標記，說自己想來（接自己）語意矛盾，不成立。干擾「来たがる」：「たがる」描述第三人稱外顯的願望，主語須是想來的人（友だちが）；此處主語是『わたしは』、且為說話者的期望而非觀察朋友的樣子，人稱與句構都不合。干擾「来よう」：意向形「来よう」表說話者自己『要來吧／我來吧』的意志，但來車站接人的是朋友不是說話者，與「友だちに」的對象標記及拜託語意都不符，不成立。",
     explanationI18n: { "ja": "正解「来てほしい」：「動詞て形＋ほしい」は『他人に～してほしい』という願望を表し、動作をする人は「に」で示します。「友だちに（…）来てほしい」＝友だちに来てほしい、で『わたしは友だちに』という文構造と依頼の文脈にぴったり合い、成立します。誤答「来たい」：「たい」は一人称である自分の願望を表しますが、この文の主語『わたし』が望んでいるのは『友だちが来ること』であり、しかも対象はすでに「友だちに」で示されています。自分が来たい（自分を迎えに）というのは意味が矛盾し成立しません。誤答「来たがる」：「たがる」は第三者の外に現れた願望を表し、主語は来たがっている人（友だちが）でなければなりません。ここは主語が『わたしは』で、しかも話し手の望みであって友だちの様子の観察ではないため、人称も文構造も合いません。誤答「来よう」：意向形の「来よう」は話し手自身の『来よう・私が行こう』という意志を表しますが、駅へ迎えに来るのは友だちで話し手ではなく、「友だちに」という対象の表示にも依頼の意味にも合わず成立しません。", "en": "The correct answer 「来てほしい」: 「verb te-form ＋ ほしい」 expresses \"wanting someone else to do something,\" with the actor marked by 「に」. 「友だちに（…）来てほしい」 means \"I want my friend to come (pick me up),\" which fits the sentence structure 「わたしは友だちに」 and the request context perfectly, so it's valid. The distractor 「来たい」: 「たい」 expresses the first-person speaker's own desire, but the subject 「わたし」 wants \"the friend to come,\" and the target is already marked with 「友だちに」, so saying you yourself want to come (to pick yourself up) is contradictory and invalid. The distractor 「来たがる」: 「たがる」 describes a third person's outwardly shown desire, and the subject must be the person who wants to come (友だちが); here the subject is 「わたしは」 and it's the speaker's wish rather than an observation of the friend's demeanor, so both the person and structure don't fit. The distractor 「来よう」: the volitional 「来よう」 expresses the speaker's own will \"let me come / I'll come,\" but it's the friend, not the speaker, who comes to the station to pick someone up, so it doesn't fit the target marking 「友だちに」 or the request meaning, and is invalid." },
     exampleJapanese: "雨がふってきたので、わたしは友だちに駅まで車でむかえに来てほしい。",
-    exampleMeaningZh: "因為下起雨了，我希望朋友開車到車站來接我。"
+    exampleMeaningZh: "因為下起雨了，我希望朋友開車到車站來接我。",
+    exampleMeaningI18n: { "ja": "雨が降ってきたので、友だちに車で駅まで迎えに来てもらいたい、という意味です。", "en": "Since it started raining, I want my friend to come pick me up at the station by car." },
   }),
   examQuestion({
     id: "n4-usage-naosu",
@@ -3258,7 +3319,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「直す」是他動詞，指把壞掉或錯誤的東西修好、改正。正解『こわれた自転車を、店の人に直してもらった』把壞掉的腳踏車請店家修好，「こわれた」與「直す」搭配完全正確。其餘三句都把不能「直す」的對象硬接上去而誤用：『ベンチに座って少し直した』休息應用『休んだ』，疲勞不是壞掉的東西不能「直す」；『冷たい水で直して飲んだ』把熱咖啡弄涼應用『冷ました（弄涼）』，咖啡溫度不是故障不能「直す」；『本を来週までに直すつもりだ』借的書要還回去應用『返す（歸還）』，借來的書沒壞也不需要「直す」。唯第一句成立。",
     explanationI18n: { "ja": "「直す」は他動詞で、壊れたものや間違ったものを修理する・正す意味です。正解『こわれた自転車を、店の人に直してもらった』は壊れた自転車を店に修理してもらう文で、「こわれた」と「直す」の組み合わせが完全に正しいです。ほかの三文は「直す」の対象にならないものを無理につないだ誤用です。『ベンチに座って少し直した』は休むことを言いたいので『休んだ』が正しく、疲れは壊れたものではないので「直す」は使えません。『冷たい水で直して飲んだ』は熱いコーヒーを冷ますことなので『冷ました』が正しく、コーヒーの温度は故障ではないので「直す」は使えません。『本を来週までに直すつもりだ』は借りた本を返すことなので『返す』が正しく、借りた本は壊れておらず「直す」必要もありません。成り立つのは一つ目だけです。", "en": "「直す」 is a transitive verb meaning to repair or correct something broken or wrong. The correct answer 「こわれた自転車を、店の人に直してもらった」 has the shop fix a broken bicycle, and 「こわれた」 pairs perfectly with 「直す」. The other three sentences all misuse it by forcing 「直す」 onto objects that can't be 「直す」: 「ベンチに座って少し直した」 should use 「休んだ」 for resting—tiredness isn't a broken thing, so it can't be 「直す」; 「冷たい水で直して飲んだ」 should use 「冷ました（cooled down）」 for making hot coffee cool—coffee temperature isn't a malfunction, so it can't be 「直す」; 「本を来週までに直すつもりだ」 should use 「返す（return）」 for a borrowed book—a borrowed book isn't broken and doesn't need 「直す」. Only the first sentence is valid." },
     exampleJapanese: "こわれた自転車を、店の人に直してもらった。",
-    exampleMeaningZh: "把壞掉的腳踏車請店裡的人修好了。"
+    exampleMeaningZh: "把壞掉的腳踏車請店裡的人修好了。",
+    exampleMeaningI18n: { "ja": "壊れた自転車を、お店の人に修理してもらった、という意味です。", "en": "I had the shop staff fix my broken bicycle." },
   }),
   examQuestion({
     id: "n4-usage-enryo",
@@ -3280,7 +3342,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「遠慮」指顧慮場合或他人而克制、不做某事，或客氣地謝絕。正解『病院の中では、けいたい電話は遠慮してください』請人在醫院內克制不打手機，「遠慮してください」是標準用法，完全正確。其餘三句都誤用：『まだ遠慮しています』要表達還不確定應用『迷っています／わかりません』，對天氣不存在「客氣」的對象；『先生に遠慮して教えてもらった』請教老師應用『質問して（請教）』，向老師求教與「克制不打擾」方向相反、前後矛盾；『まどを遠慮して開けた』開窗只是動作，應直接說『開けた』，開窗不是需要克制的事。唯第一句成立。",
     explanationI18n: { "ja": "「遠慮」は場や他人に気を使って控える・しないでおく、または丁寧に辞退する意味です。正解『病院の中では、けいたい電話は遠慮してください』は病院内で携帯電話を控えるよう頼む文で、「遠慮してください」は標準的な使い方で完全に正しいです。ほかの三文はいずれも誤用です。『まだ遠慮しています』はまだ決まらないことを言いたいので『迷っています／わかりません』が正しく、天気に気を使う相手は存在しません。『先生に遠慮して教えてもらった』は先生に尋ねることなので『質問して』が正しく、先生に教えを乞うのは『控えて邪魔しない』とは逆で前後が矛盾します。『まどを遠慮して開けた』は窓を開ける単なる動作なので『開けた』とそのまま言えばよく、窓を開けることは控えるべきことではありません。成り立つのは一つ目だけです。", "en": "「遠慮」means to hold back or refrain from doing something out of regard for the situation or for other people, or to politely decline. The correct answer, 『病院の中では、けいたい電話は遠慮してください』, asks people to refrain from using their phones inside the hospital; 「遠慮してください」is the standard usage here and is perfectly natural. The other three all misuse the word. 『まだ遠慮しています』should be 『迷っています／わかりません』to convey uncertainty—there is no person to \"be considerate\" toward when it comes to the weather. 『先生に遠慮して教えてもらった』should use 『質問して』(to ask), since seeking a teacher's help is the opposite of \"holding back so as not to bother them,\" making the sentence self-contradictory. 『まどを遠慮して開けた』is simply the action of opening a window, which should just be 『開けた』—opening a window is not something you need to hold back from. Only the first sentence works." },
     exampleJapanese: "病院の中では、けいたい電話は遠慮してください。",
-    exampleMeaningZh: "在醫院裡，請克制不要使用手機。"
+    exampleMeaningZh: "在醫院裡，請克制不要使用手機。",
+    exampleMeaningI18n: { "ja": "病院の中では、携帯電話の使用を控えてください、という意味です。", "en": "Please refrain from using cell phones inside the hospital." },
   }),
   examQuestion({
     id: "n4-usage-fukuzatsu",
@@ -3302,7 +3365,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「複雑」是『繁雜、錯綜』。正解『ゲームのルールは複雑で、一回読んだだけでは分からなかった』＝規則複雜、看一次看不懂。其餘誤用：『天気が複雑で気持ちがいい』應為『いい』；『スープは複雑で、とても甘い』味道不用複雑形容，應為『甘くて』；『道はまっすぐで複雑だから』まっすぐ與複雑矛盾。唯第一句成立。",
     explanationI18n: { "ja": "「複雑」は『込み入っている・入り組んでいる』意です。正解『ゲームのルールは複雑で、一回読んだだけでは分からなかった』＝ルールが複雑で一回では分からない、です。ほかは誤用です。『天気が複雑で気持ちがいい』は『いい』が正しく、『スープは複雑で、とても甘い』は味を複雑では表さないので『甘くて』が正しく、『道はまっすぐで複雑だから』はまっすぐと複雑が矛盾します。成り立つのは一つ目だけです。", "en": "「複雑」means complicated or intricate. The correct answer, 『ゲームのルールは複雑で、一回読んだだけでは分からなかった』, means the rules are complicated and can't be understood in one read. The others misuse it: 『天気が複雑で気持ちがいい』should be 『いい』; 『スープは複雑で、とても甘い』can't use 複雑 to describe flavor and should be 『甘くて』; 『道はまっすぐで複雑だから』is contradictory because まっすぐ and 複雑 clash. Only the first sentence works." },
     exampleJapanese: "このゲームのルールは複雑で、一回読んだだけでは分からなかった。",
-    exampleMeaningZh: "這個遊戲的規則很繁雜，只看一遍還看不懂。"
+    exampleMeaningZh: "這個遊戲的規則很繁雜，只看一遍還看不懂。",
+    exampleMeaningI18n: { "ja": "このゲームのルールは入り組んでいて、一度読んだだけでは理解できなかった、という意味です。", "en": "The rules of this game are complicated; I couldn't understand them after reading them just once." },
   }),
   examQuestion({
     id: "n4-context-sorekara",
@@ -3364,7 +3428,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「払う」是把錢交出去＝支付，與「お金を出す」（拿出/付錢）在此語境意思最接近，故正解為「出して」。「借りて」是向別人借（錢還沒付出，方向相反），不成立。「数えて」是數數目，不是付出，語意不對。「もらって」是收下／得到（錢進來），與「付出」方向相反，不成立。",
     explanationI18n: { "ja": "「払う」はお金を渡す＝支払うことで、この文脈では「お金を出す」（出す・払う）と意味が最も近いので、正解は「出して」です。「借りて」は人からお金を借りることで（まだ払っておらず方向が逆）、成立しません。「数えて」は数を数えることで、支払いではないので意味が合いません。「もらって」は受け取る・もらうこと（お金が入ってくる）で、『払う』とは方向が逆のため成立しません。", "en": "「払う」means to hand over money—that is, to pay—so it is closest in meaning to 「お金を出す」(to put out / pay money) in this context, making 「出して」the correct answer. 「借りて」means to borrow (from someone; the money hasn't been paid out yet—the opposite direction) and doesn't work. 「数えて」means to count, not to pay, so the meaning is wrong. 「もらって」means to receive or get (money coming in), the opposite direction of paying, so it doesn't work." },
     exampleJapanese: "レストランで、わたしが みんなの 分を 出しておきました。",
-    exampleMeaningZh: "在餐廳，我先幫大家把那一份錢付了。"
+    exampleMeaningZh: "在餐廳，我先幫大家把那一份錢付了。",
+    exampleMeaningI18n: { "ja": "レストランで、みんなの分のお金を私が先に支払っておいた、という意味です。", "en": "At the restaurant, I went ahead and paid for everyone's share." },
   }),
   examQuestion({
     id: "n4-syn-kanashii",
@@ -3386,7 +3451,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「悲しい」是因為傷心的事而心痛，與「つらい」（難受、痛苦）在此語境意思最接近，故正解「つらい」。「うれしい」是高興（反義），狗死了卻高興，矛盾，不成立。「たのしい」是快樂、開心，與悲傷相反，語意不對。「やさしい」是溫柔／親切，是形容人的性格，不是心情，不成立。",
     explanationI18n: { "ja": "「悲しい」は悲しいことがあって心が痛むことで、この文脈では「つらい」（つらい・苦しい）と意味が最も近いため、正解は「つらい」です。「うれしい」は喜ぶ意味（反対）で、犬が死んで喜ぶのは矛盾し成立しません。「たのしい」は楽しい・愉快なことで、悲しみとは反対で意味が合いません。「やさしい」は優しい・親切なことで、人の性格を表す言葉であって気持ちではないため成立しません。", "en": "「悲しい」means heartache caused by a sorrowful event, closest in meaning here to 「つらい」(painful, hard to bear), so 「つらい」is correct. 「うれしい」means glad (the opposite)—being glad your dog died is contradictory, so it doesn't work. 「たのしい」means fun or happy, the opposite of sad, so the meaning is wrong. 「やさしい」means gentle or kind and describes a person's character, not a mood, so it doesn't work." },
     exampleJapanese: "犬が 死んで、わたしは とても つらい 気もちです。",
-    exampleMeaningZh: "狗死了，我的心情非常難受。"
+    exampleMeaningZh: "狗死了，我的心情非常難受。",
+    exampleMeaningI18n: { "ja": "犬が死んでしまって、とても悲しい気持ちでいる、という意味です。", "en": "My dog died, and I feel terribly sad." },
   }),
   examQuestion({
     id: "n4-syn-taisetsu",
@@ -3408,7 +3474,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「大切」表示重要、珍貴，≒「大事」（だいじ），兩者皆可形容『家族との時間』。「便利」是『方便』（描述好不好用）；「簡単」是『簡單』（描述難易度）；「自由」是『自由』（描述不受拘束）。三者皆為な形容詞、接續通，但與『比什麼都重要』語意不同。唯「大事」與「大切」同義。",
     explanationI18n: { "ja": "「大切」は重要でかけがえがないことを表し、≒「大事」（だいじ）で、どちらも『家族との時間』を形容できます。「便利」は『便利』（使い勝手のよさ）、「簡単」は『簡単』（難易度）、「自由」は『自由』（束縛されないこと）です。三つともな形容詞で接続は通りますが、『何より重要だ』という意味とは異なります。「大切」と同義なのは「大事」だけです。", "en": "「大切」means important or precious, ≒「大事」(だいじ); both can describe 『家族との時間』. 「便利」means 'convenient' (how useful something is); 「簡単」means 'easy' (level of difficulty); 「自由」means 'free' (unrestricted). All three are na-adjectives that connect grammatically, but their meanings differ from 'more important than anything.' Only 「大事」is synonymous with 「大切」." },
     exampleJapanese: "家族と すごす 時間は、私に とって 何より 大事です。",
-    exampleMeaningZh: "和家人相處的時間，對我來說比什麼都重要。"
+    exampleMeaningZh: "和家人相處的時間，對我來說比什麼都重要。",
+    exampleMeaningI18n: { "ja": "家族と過ごす時間は、私にとって何よりも重要だ、という意味です。", "en": "Time spent with my family matters more to me than anything else." },
   }),
   examQuestion({
     id: "n4-syn-odoroita",
@@ -3430,7 +3497,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「驚く」表示因意外而吃驚，「驚いた」≒「びっくりした」，本句被突然叫名字而嚇到。「がっかりした」是『失望』（事情不如預期）；「ほっとした」是『鬆了一口氣』（放心）；「わくわくした」是『興奮期待』（雀躍）。三者皆為情緒動詞、接續通，但情緒方向各不相同。唯「びっくりした」與「驚いた」同表受到驚嚇。",
     explanationI18n: { "ja": "「驚く」は思いがけないことにびっくりすることで、「驚いた」≒「びっくりした」、この文は急に名前を呼ばれて驚いています。「がっかりした」は『失望した』（思い通りにいかない）、「ほっとした」は『安心した』、「わくわくした」は『期待して興奮した』意です。三つとも感情の動詞で接続は通りますが、感情の向きがそれぞれ違います。「驚いた」と同じく驚きを表すのは「びっくりした」だけです。", "en": "「驚く」means to be startled by something unexpected, so 「驚いた」≒「びっくりした」; in this sentence you're startled by being suddenly called by name. 「がっかりした」means 'disappointed' (things didn't go as expected); 「ほっとした」means 'relieved' (put at ease); 「わくわくした」means 'excited with anticipation' (thrilled). All three are emotion verbs that connect grammatically, but each points to a different feeling. Only 「びっくりした」matches 「驚いた」in expressing being startled." },
     exampleJapanese: "とつぜん 後ろから 名前を 呼ばれて、とても びっくりした。",
-    exampleMeaningZh: "突然被後面叫了名字，嚇了一大跳。"
+    exampleMeaningZh: "突然被後面叫了名字，嚇了一大跳。",
+    exampleMeaningI18n: { "ja": "急に後ろから名前を呼ばれて、とても驚いた、という意味です。", "en": "Someone suddenly called my name from behind, and I was really startled." },
   }),
   examQuestion({
     id: "n4-syn-zenbu",
@@ -3452,7 +3520,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「全部」表示一個不剩的整體，≒「すべて」，本句『把菜全吃光』兩者皆通。「半分」是『一半』；「少し」是『一點點』；「一部」是『一部分』。三者皆表分量、接續通，但都只是部分而非整體，與『全吃光』矛盾。唯「すべて」與「全部」同表整體無一遺漏。",
     explanationI18n: { "ja": "「全部」は一つも残さない全体を表し、≒「すべて」で、この文『料理を全部食べた』はどちらも通ります。「半分」は『半分』、「少し」は『少しだけ』、「一部」は『一部分』です。三つとも量を表し接続は通りますが、いずれも部分であって全体ではなく、『全部食べた』とは矛盾します。「全部」と同じく一つも残らない全体を表すのは「すべて」だけです。", "en": "「全部」means the whole thing with nothing left, ≒「すべて」; both fit this sentence about 'eating all the food.' 「半分」means 'half'; 「少し」means 'a little'; 「一部」means 'a part.' All three express an amount and connect grammatically, but they are only portions rather than the whole, contradicting 'ate it all up.' Only 「すべて」matches 「全部」in expressing the whole with nothing left out." },
     exampleJapanese: "お皿に のった 料理を すべて 食べました。",
-    exampleMeaningZh: "把盤子上的菜全都吃光了。"
+    exampleMeaningZh: "把盤子上的菜全都吃光了。",
+    exampleMeaningI18n: { "ja": "お皿にのった料理を残さず食べた、という意味です。", "en": "I ate everything on the plate." },
   }),
   examQuestion({
     id: "n4-usage-okiru",
@@ -3474,7 +3543,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「この道で大きい事故が起きました」中，「事故が起きる」是「起きる」標準的自動詞用法，表示事件發生，母語者自然接受。其餘三句雖都用自動詞「が」接續，但「起きる」不能搭配這些主語：「荷物が起きる」應改用「落ちる」（東西掉下來）；「コップの水が起きる」應改用「こぼれる」（水灑出來）；「本がひとりでに起きる」應改用「倒れる／落ちる」，書本不會「起きる（醒來／發生）」。三個干擾的主語都與「起きる」的語意不符，唯一正解成立。",
     explanationI18n: { "ja": "正解「この道で大きい事故が起きました」では、「事故が起きる」が「起きる」の標準的な自動詞の使い方で、出来事の発生を表し、母語話者に自然に受け入れられます。ほかの三文はどれも自動詞の「が」で接続してはいますが、「起きる」はこれらの主語とは組み合わせられません。「荷物が起きる」は『落ちる』（物が落ちる）に、「コップの水が起きる」は『こぼれる』（水がこぼれる）に、「本がひとりでに起きる」は『倒れる／落ちる』に直すべきで、本が「起きる（目を覚ます／発生する）」ことはありません。三つの誤答の主語はいずれも「起きる」の意味に合わず、正解は一つだけです。", "en": "In the correct answer 「この道で大きい事故が起きました」, 「事故が起きる」is the standard intransitive usage of 「起きる」, meaning an event occurs, and native speakers accept it naturally. The other three all use the intransitive 「が」connection, but 「起きる」can't take these subjects: 「荷物が起きる」should be 「落ちる」(things fall down); 「コップの水が起きる」should be 「こぼれる」(water spills); 「本がひとりでに起きる」should be 「倒れる／落ちる」, since a book can't 「起きる」(wake up / occur). All three distractor subjects clash with the meaning of 「起きる」, so only the correct answer works." },
     exampleJapanese: "昨日の夜、この道で大きい事故が起きました。",
-    exampleMeaningZh: "昨晚在這條路上發生了很大的事故。"
+    exampleMeaningZh: "昨晚在這條路上發生了很大的事故。",
+    exampleMeaningI18n: { "ja": "昨日の夜、この道で大きな事故が発生した、という意味です。", "en": "A big accident happened on this road last night." },
   }),
   examQuestion({
     id: "n4-usage-yawarakai",
@@ -3496,7 +3566,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「このパンは焼きたてで、とてもやわらかい」中，「やわらかい」描述剛烤好麵包的鬆軟觸感，是該形容詞最典型的用法，母語者自然接受。干擾1「外はとてもやわらかい」不成立，風強天氣應用「寒い／涼しい」等，「やわらかい」不形容天氣。干擾2「答えがやわらかい」錯誤，答案難求應用「分からない／難しい」，「やわらかい」不形容問題答案。干擾3「ちょっとやわらかい」不通，距離稍遠應用「遠い」，「やわらかい」不形容距離。三個干擾的描述對象都與「やわらかい」的觸感語意不符，唯一正解成立。",
     explanationI18n: { "ja": "正解「このパンは焼きたてで、とてもやわらかい」では、「やわらかい」が焼きたてのパンのふんわりした手触りを表しており、この形容詞の最も典型的な使い方で、母語話者に自然に受け入れられます。誤答1「外はとてもやわらかい」は成立せず、風が強い天気には『寒い／涼しい』などを使うべきで、「やわらかい」は天気を表しません。誤答2「答えがやわらかい」は誤りで、答えが求めにくいことには『分からない／難しい』を使うべきで、「やわらかい」は問題の答えを表しません。誤答3「ちょっとやわらかい」は通らず、距離が少し遠いことには『遠い』を使うべきで、「やわらかい」は距離を表しません。三つの誤答の対象はいずれも「やわらかい」の手触りの意味に合わず、正解は一つだけです。", "en": "In the correct answer 「このパンは焼きたてで、とてもやわらかい」, 「やわらかい」describes the soft, fluffy texture of freshly baked bread—the most typical use of this adjective—and native speakers accept it naturally. Distractor 1, 「外はとてもやわらかい」, doesn't work; strong wind should be described with 「寒い／涼しい」etc., as 「やわらかい」doesn't describe weather. Distractor 2, 「答えがやわらかい」, is wrong; a hard-to-find answer should use 「分からない／難しい」, as 「やわらかい」doesn't describe an answer to a problem. Distractor 3, 「ちょっとやわらかい」, doesn't work; a somewhat far distance should use 「遠い」, as 「やわらかい」doesn't describe distance. All three distractors' subjects clash with the tactile meaning of 「やわらかい」, so only the correct answer works." },
     exampleJapanese: "このパンは焼きたてで、とてもやわらかいです。",
-    exampleMeaningZh: "這個麵包剛烤好，非常柔軟。"
+    exampleMeaningZh: "這個麵包剛烤好，非常柔軟。",
+    exampleMeaningI18n: { "ja": "このパンは焼きたてで、ふんわりとやわらかい、という意味です。", "en": "This bread is freshly baked and very soft." },
   }),
   examQuestion({
     id: "n4-syn-rusu",
@@ -3518,7 +3589,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「留守」指人外出、不在家，因此「いなかった（不在）」意思最接近，成立。「寝ていた（在睡覺）」表示人在家但睡著，與不在家矛盾，不成立。「怒っていた（在生氣）」是情緒，與是否在家無關，不成立。「忙しかった（很忙）」可能人在家卻沒空，並非不在家之意，不成立。三個干擾都明確不等於「不在家」，故唯一正解為「いなかった」。",
     explanationI18n: { "ja": "「留守」は人が外出していて家にいないことなので、「いなかった（いない）」が意味的に最も近く、成立します。「寝ていた（寝ていた）」は家にはいるが眠っていることで、家にいないことと矛盾し成立しません。「怒っていた（怒っていた）」は感情で、家にいるかどうかとは無関係のため成立しません。「忙しかった（忙しかった）」は家にいても手が空かないことがあり、家にいないという意味ではありません。三つの誤答はいずれも「家にいない」とは明確に一致しないため、正解は「いなかった」だけです。", "en": "「留守」means a person is out and not at home, so 「いなかった」(wasn't there) is closest in meaning and works. 「寝ていた」(was sleeping) means the person is home but asleep, which contradicts being out, so it doesn't work. 「怒っていた」(was angry) is an emotion unrelated to whether someone is home, so it doesn't work. 「忙しかった」(was busy) could mean the person is home but has no time—it doesn't mean being out—so it doesn't work. All three distractors clearly do not equal 'not at home,' so the only correct answer is 「いなかった」." },
     exampleJapanese: "母に電話したが、ちょうどいなかった。",
-    exampleMeaningZh: "打電話給媽媽，但她剛好不在。"
+    exampleMeaningZh: "打電話給媽媽，但她剛好不在。",
+    exampleMeaningI18n: { "ja": "母に電話をかけたが、ちょうど外出中だった、という意味です。", "en": "I called my mother, but she happened to be out." },
   }),
   examQuestion({
     id: "n4-syn-mezurashii",
@@ -3540,7 +3612,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「珍しい」指很少發生、不常見，代入「降ることはあまりない（不太會下）」自然同義，故為正解。「とても多い（非常多）」是相反方向，不成立。「もうすぐ来る（快要來）」講的是時間將至，與稀有與否無關，不成立。「毎年続く（每年持續）」表示常態反覆出現，與罕見矛盾，不成立。三個干擾語意都與「罕見」明確不同，唯一正解為「あまりない」。",
     explanationI18n: { "ja": "「珍しい」はめったに起こらない・よく見られないことで、「降ることはあまりない（あまり降らない）」に置き換えると自然に同義になるため、正解です。「とても多い（とても多い）」は反対の方向で成立しません。「もうすぐ来る（もうすぐ来る）」は時が近いことを言い、まれかどうかとは無関係のため成立しません。「毎年続く（毎年続く）」は常に繰り返し起こることを表し、まれであることと矛盾します。三つの誤答はいずれも「珍しい」とは明確に意味が異なるため、正解は「あまりない」だけです。", "en": "「珍しい」means something that rarely happens and is uncommon, and substituting 「降ることはあまりない」(doesn't really fall much) is naturally synonymous, so it's correct. 「とても多い」(very frequent) is the opposite direction and doesn't work. 「もうすぐ来る」(coming soon) is about timing being near, unrelated to rarity, so it doesn't work. 「毎年続く」(continues every year) means a regular recurring event, which contradicts rarity, so it doesn't work. All three distractors clearly differ in meaning from 'rare,' so the only correct answer is 「あまりない」." },
     exampleJapanese: "この町でこんな大雪が降ることはあまりない。",
-    exampleMeaningZh: "在這個城鎮下這麼大的雪是不太會發生的。"
+    exampleMeaningZh: "在這個城鎮下這麼大的雪是不太會發生的。",
+    exampleMeaningI18n: { "ja": "この町でこれほどの大雪が降ることは、めったにない、という意味です。", "en": "Snow this heavy hardly ever falls in this town." },
   }),
   examQuestion({
     id: "n4-syn-tsutomeru",
@@ -3562,7 +3635,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「会社に勤めている」指在公司上班、受雇工作，與「大きな会社で働いている（在大公司工作）」意思最接近且代入自然，成立。「大きな会社に住んでいる（住在大公司）」是住在某處，公司不是住處，語意不通；「大きな会社に通っている（往返大公司）」只表示定期前往、走動於該處，並不等於『受雇任職』，可能是去上課、洽公，語意偏移；「大きな会社で遊んでいる（在大公司玩）」與工作相反，不成立。把整片語放入選項後，唯一等義的是「大きな会社で働いている」。",
     explanationI18n: { "ja": "「会社に勤めている」は会社に雇われて働いていることで、「大きな会社で働いている（大きな会社で働いている）」と意味が最も近く、置き換えても自然なため成立します。「大きな会社に住んでいる（大きな会社に住んでいる）」はどこかに住むことで、会社は住まいではないため意味が通りません。「大きな会社に通っている（大きな会社に通っている）」は定期的にそこへ通う・出入りすることを表すだけで、『雇われて勤める』ことと同じではなく、通学や用事で行く場合もあり意味がずれます。「大きな会社で遊んでいる（大きな会社で遊んでいる）」は働くこととは逆で成立しません。句全体を選択肢に入れてみると、同義になるのは「大きな会社で働いている」だけです。", "en": "「会社に勤めている」means to work at and be employed by a company, closest in meaning to 「大きな会社で働いている」(works at a big company) and a natural substitution, so it works. 「大きな会社に住んでいる」(lives at a big company) means residing somewhere, but a company isn't a residence, so the meaning is off. 「大きな会社に通っている」(commutes to a big company) only means regularly going to and moving about the place; it doesn't equal being employed there—one could be attending classes or handling business—so the meaning shifts. 「大きな会社で遊んでいる」(plays at a big company) is the opposite of working, so it doesn't work. Substituting each whole phrase into the options, the only equivalent one is 「大きな会社で働いている」." },
     exampleJapanese: "兄は大きな会社で働いている。",
-    exampleMeaningZh: "哥哥在一家大公司工作。"
+    exampleMeaningZh: "哥哥在一家大公司工作。",
+    exampleMeaningI18n: { "ja": "兄は大きな会社で仕事をしている、という意味です。", "en": "My older brother works at a big company." },
   }),
   examQuestion({
     id: "n4-usage-seikatsu",
@@ -3584,7 +3658,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「一人で住みはじめたころは、生活がとても大変でした」中，「生活」指每天的食衣住行起居，獨自居住時的起居很辛苦，母語者自然接受。干擾1「ばんごはんの生活を三つ買いました」不成立，在超市買的應是「品物（東西、商品）」，「生活」不能用「三つ」計數購買。干擾2「この映画は生活がおもしろくて」錯誤，電影吸引人的應是「話（劇情）／内容」，「生活」不形容電影本身。干擾3「母が作ってくれた生活は、おいしかった」搭配不合，媽媽做的、好吃的應是「料理（菜）」，「生活」不能吃。三個干擾的對象都與「生活」語意不符，唯一正解成立。",
     explanationI18n: { "ja": "正解「一人で住みはじめたころは、生活がとても大変でした」では、「生活」が毎日の衣食住・暮らしを指し、独り暮らしの暮らしが大変であることを表しており、母語話者に自然に受け入れられます。誤答1「ばんごはんの生活を三つ買いました」は成立せず、スーパーで買うのは『品物（もの・商品）』で、「生活」は「三つ」と数えて買うことはできません。誤答2「この映画は生活がおもしろくて」は誤りで、映画の面白さは『話（ストーリー）／内容』にあり、「生活」は映画そのものを表しません。誤答3「母が作ってくれた生活は、おいしかった」は組み合わせが合わず、母が作った・おいしいのは『料理』であって、「生活」は食べられません。三つの誤答の対象はいずれも「生活」の意味に合わず、正解は一つだけです。", "en": "In the correct answer 「一人で住みはじめたころは、生活がとても大変でした」, 「生活」means daily living—food, clothing, and shelter—and living alone made everyday life hard; native speakers accept it naturally. Distractor 1, 「ばんごはんの生活を三つ買いました」, doesn't work; what you buy at the supermarket should be 「品物」(goods, items), and 「生活」can't be counted and bought with 「三つ」. Distractor 2, 「この映画は生活がおもしろくて」, is wrong; what makes a movie engaging should be 「話（劇情）／内容」, as 「生活」doesn't describe the movie itself. Distractor 3, 「母が作ってくれた生活は、おいしかった」, is mismatched; what your mother made and was delicious should be 「料理」(a dish), as you can't eat 「生活」. All three distractors' targets clash with the meaning of 「生活」, so only the correct answer works." },
     exampleJapanese: "一人で住みはじめたころは、生活がとても大変でした。",
-    exampleMeaningZh: "剛開始一個人住的時候，過日子非常辛苦。"
+    exampleMeaningZh: "剛開始一個人住的時候，過日子非常辛苦。",
+    exampleMeaningI18n: { "ja": "一人暮らしを始めたばかりのころは、毎日の暮らしがとても大変だった、という意味です。", "en": "When I first started living on my own, everyday life was really hard." },
   }),
   examQuestion({
     id: "n4-usage-itai",
@@ -3606,7 +3681,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「昨日から歯がとても痛いので、これから歯医者に行きます」中，「痛い」描述身體上的疼痛感，牙齒痛去看牙醫，母語者自然接受。天氣句「外はとても痛いです」不成立，下雪寒冷應用「寒い」，「痛い」不形容天氣。咖哩句「とうがらしが多くて、すごく痛い」錯誤，辣椒多應用「辛い」，「痛い」不形容味道。考試句「テストの問題が分からなくて、とても痛かった」搭配不合，題目難應用「難しい」，「痛い」不形容題目難度。三個干擾的描述對象都與「痛い」的身體疼痛語意不符，唯一正解成立。",
     explanationI18n: { "ja": "正解「昨日から歯がとても痛いので、これから歯医者に行きます」では、「痛い」が体の痛みを表しており、歯が痛くて歯医者に行くという場面に自然に合い、母語話者も違和感なく受け入れます。天気の文「外はとても痛いです」は成立せず、雪が降って寒いときは「寒い」を使うべきで、「痛い」は天気を表しません。カレーの文「とうがらしが多くて、すごく痛い」も誤りで、とうがらしが多いときは「辛い」を使うべきで、「痛い」は味を表しません。テストの文「テストの問題が分からなくて、とても痛かった」も組み合わせが不適切で、問題が難しいときは「難しい」を使うべきで、「痛い」は問題の難しさを表しません。三つの誤答はいずれも「痛い」が表す体の痛みという意味と合わず、正解のみが成立します。", "en": "In the correct answer 「昨日から歯がとても痛いので、これから歯医者に行きます」, 「痛い」describes physical pain in the body—a toothache prompting a dentist visit—and native speakers accept it naturally. The weather sentence 「外はとても痛いです」doesn't work; cold snowy weather should use 「寒い」, as 「痛い」doesn't describe weather. The curry sentence 「とうがらしが多くて、すごく痛い」is wrong; lots of chili should use 「辛い」, as 「痛い」doesn't describe flavor. The test sentence 「テストの問題が分からなくて、とても痛かった」is mismatched; a hard question should use 「難しい」, as 「痛い」doesn't describe how hard a question is. All three distractors' targets clash with the bodily-pain meaning of 「痛い」, so only the correct answer works." },
     exampleJapanese: "昨日から歯がとても痛いので、これから歯医者に行きます。",
-    exampleMeaningZh: "從昨天開始牙齒就很痛，所以現在要去看牙醫。"
+    exampleMeaningZh: "從昨天開始牙齒就很痛，所以現在要去看牙醫。",
+    exampleMeaningI18n: { "ja": "昨日から歯がひどく痛むので、これから歯医者に行く、という意味です。", "en": "My tooth has been hurting badly since yesterday, so I'm off to the dentist now." },
   }),
   examQuestion({
     id: "n4-context-tokorode",
@@ -3746,7 +3822,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「せかい」是「世界」的正確讀音，意為世界。「せいかい」誤把「せ」拉成長音；「せっかい」誤加促音；「せがい」把清音「か」誤讀成濁音「が」。三者都不是「世界」的合法讀音，只有「せかい」成立。",
     explanationI18n: { "ja": "正解「せかい」は「世界」の正しい読みで、世界を意味します。「せいかい」は「せ」を誤って長音にしています。「せっかい」は誤って促音を加えています。「せがい」は清音の「か」を誤って濁音「が」で読んでいます。いずれも「世界」の正しい読みではなく、「せかい」だけが成立します。", "en": "The answer「せかい」is the correct reading of「世界」, meaning \"world.\" 「せいかい」wrongly lengthens「せ」into a long vowel;「せっかい」wrongly inserts a small tsu (double consonant);「せがい」wrongly voices the plain「か」into「が」. None of these three is a valid reading of「世界」; only「せかい」is correct." },
     exampleJapanese: "わたしは世界のいろいろな国へ行ってみたいです。",
-    exampleMeaningZh: "我想去世界上各個不同的國家看看。"
+    exampleMeaningZh: "我想去世界上各個不同的國家看看。",
+    exampleMeaningI18n: { "ja": "世界のいろいろな国を訪れてみたい、という意味です。", "en": "I'd like to visit all kinds of different countries around the world." },
   }),
   examQuestion({
     id: "n4-kanji-kenkyuu",
@@ -3766,7 +3843,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「けんきゅう」是「研究」的正確讀音，意為研究。「けんきょう」把「きゅう」誤讀成「きょう」；「げんきゅう」把開頭清音「け」誤讀成濁音「げ」；「けんきゅ」漏掉長音「う」。三者都不是「研究」的合法讀音，只有「けんきゅう」成立。",
     explanationI18n: { "ja": "正解「けんきゅう」は「研究」の正しい読みで、研究を意味します。「けんきょう」は「きゅう」を誤って「きょう」と読んでいます。「げんきゅう」は語頭の清音「け」を誤って濁音「げ」と読んでいます。「けんきゅ」は長音の「う」が抜けています。いずれも「研究」の正しい読みではなく、「けんきゅう」だけが成立します。", "en": "The answer「けんきゅう」is the correct reading of「研究」, meaning \"research.\" 「けんきょう」misreads「きゅう」as「きょう」;「げんきゅう」misreads the initial plain「け」as the voiced「げ」;「けんきゅ」drops the long vowel「う」. None of these three is a valid reading of「研究」; only「けんきゅう」is correct." },
     exampleJapanese: "兄は大学で日本語の研究をしています。",
-    exampleMeaningZh: "哥哥在大學做日語的研究。"
+    exampleMeaningZh: "哥哥在大學做日語的研究。",
+    exampleMeaningI18n: { "ja": "兄は大学で日本語について研究している、という意味です。", "en": "My older brother does research on the Japanese language at a university." },
   }),
   examQuestion({
     id: "n4-syn-heiki",
@@ -3788,7 +3866,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「平気」表示「不要緊、沒事、不在意」，與「だいじょうぶ（沒問題、不要緊）」意思最接近，故為正解。「ふべん（不方便）」是對機能的不便評價，與受傷無大礙的語境不符；「ねむい（想睡）」描述睡意，與傷口無關；「ふしぎ（不可思議）」表示奇怪、神奇，無法形容「不在意傷」的態度。三者代回句中母語者皆不會接受，故唯一正解為「だいじょうぶ」。",
     explanationI18n: { "ja": "「平気」は「大丈夫だ、気にしない」という意味で、「だいじょうぶ（問題ない、心配ない）」ともっとも意味が近いので、これが正解です。「ふべん（不便）」は機能上の不便さを評価する語で、けがが大したことないという文脈に合いません。「ねむい（眠い）」は眠気を表し、傷とは関係ありません。「ふしぎ（不思議）」は変だ・不思議だという意味で、「傷を気にしない」態度は表せません。三つとも文に戻すと母語話者は受け入れないので、唯一の正解は「だいじょうぶ」です。", "en": "「平気」means \"it's nothing, I'm fine, unbothered,\" which is closest to「だいじょうぶ（no problem, all right）」, so it is the answer. 「ふべん（inconvenient）」is an evaluation of functional inconvenience and doesn't fit a context about a harmless injury;「ねむい（sleepy）」describes drowsiness and has nothing to do with the wound;「ふしぎ（strange, mysterious）」means odd or wondrous and can't describe an unconcerned attitude toward an injury. Substituted back into the sentence, none of the three would be accepted by a native speaker, so the only answer is「だいじょうぶ」." },
     exampleJapanese: "足を少し切ったが、彼はだいじょうぶだと言った。",
-    exampleMeaningZh: "他腳被割破了一點，卻說自己沒事。"
+    exampleMeaningZh: "他腳被割破了一點，卻說自己沒事。",
+    exampleMeaningI18n: { "ja": "足を少し切ったのに、彼は何ともないと言った、という意味です。", "en": "He cut his foot slightly, but he said he was fine." },
   }),
   examQuestion({
     id: "n4-syn-sorosoro",
@@ -3810,7 +3889,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「そろそろ」表示「差不多到了某事將發生的時間」，與「もうすぐ（快要、就快）」在「時間將至、就快發生」這個語意上最接近，故為正解。「ときどき（有時、偶爾）」表示頻率，無法表達「快來了」的時機；「なるべく（盡量）」表程度與努力，方向不對；「せっかく（難得、特意）」帶有珍惜機會的語感，代回句中不通。三者皆明確不同義，唯一正解為「もうすぐ」。",
     explanationI18n: { "ja": "「そろそろ」は「ある事が起こる時間が近づいてきた」ことを表し、「もうすぐ（じきに、まもなく）」と「時間が迫っていてもうすぐ起こる」という意味でもっとも近いので、これが正解です。「ときどき（時々）」は頻度を表し、「もうすぐ来る」という時機は表せません。「なるべく（できるだけ）」は程度や努力を表し、方向が違います。「せっかく（わざわざ・貴重な）」は機会を大切にする語感があり、文に戻すと通りません。三つとも明らかに意味が異なり、唯一の正解は「もうすぐ」です。", "en": "「そろそろ」means \"the time for something to happen is just about here,\" which is closest to「もうすぐ（soon, before long）」in the sense of a moment approaching and something about to happen, so it is the answer. 「ときどき（sometimes, occasionally）」expresses frequency and can't convey \"about to come\";「なるべく（as much as possible）」expresses degree and effort, so the direction is wrong;「せっかく（with effort, specially）」carries a sense of treasuring an opportunity and doesn't fit when substituted back. All three clearly differ in meaning, so the only answer is「もうすぐ」." },
     exampleJapanese: "もう九時だから、もうすぐ電車が来ます。",
-    exampleMeaningZh: "已經九點了，電車快來了。"
+    exampleMeaningZh: "已經九點了，電車快來了。",
+    exampleMeaningI18n: { "ja": "もう九時なので、まもなく電車が来る、という意味です。", "en": "It's already nine o'clock, so the train will be here any minute." },
   }),
   examQuestion({
     id: "n4-syn-dekirudake",
@@ -3832,7 +3912,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「できるだけ」表示「在能力範圍內盡量」，與「なるべく（盡量、盡可能）」幾乎同義，故為正解。「だんだん（漸漸）」表示變化的過程，與「盡量早睡」的指示不符；「やっと（終於、好不容易）」表示經過努力才達成，代回句中變成「終於早睡」語意不通；「ずいぶん（相當、非常）」表程度高，無法替換「盡量」。三者代回皆不成立，唯一正解為「なるべく」。",
     explanationI18n: { "ja": "「できるだけ」は「能力の範囲で可能な限り」という意味で、「なるべく（できるだけ、可能な限り）」とほぼ同義なので、これが正解です。「だんだん（次第に）」は変化の過程を表し、「できるだけ早く寝る」という指示に合いません。「やっと（ようやく、なんとか）」は努力の末に達成する意味で、文に戻すと「やっと早く寝る」となり意味が通りません。「ずいぶん（かなり、非常に）」は程度の高さを表し、「できるだけ」とは置き換えられません。三つとも戻すと成立せず、唯一の正解は「なるべく」です。", "en": "「できるだけ」means \"as much as possible within one's ability,\" which is nearly synonymous with「なるべく（as much as possible, as far as one can）」, so it is the answer. 「だんだん（gradually）」expresses a process of change and doesn't fit the instruction to go to bed as early as possible;「やっと（finally, at last）」expresses something achieved after effort, so substituting it gives \"finally going to bed early,\" which makes no sense;「ずいぶん（quite, very）」expresses a high degree and can't replace \"as much as possible.\" None of the three works when substituted back, so the only answer is「なるべく」." },
     exampleJapanese: "明日は試験だから、なるべく早く寝てください。",
-    exampleMeaningZh: "明天要考試，所以請盡量早點睡。"
+    exampleMeaningZh: "明天要考試，所以請盡量早點睡。",
+    exampleMeaningI18n: { "ja": "明日は試験なので、可能なかぎり早く寝てください、という意味です。", "en": "You have an exam tomorrow, so please go to bed as early as you can." },
   }),
   examQuestion({
     id: "n4-syn-tsugoku",
@@ -3854,7 +3935,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「すごく」是口語的程度副詞，表示「非常」，與「とても（非常、很）」意思最接近，故為正解。「あまり」後接否定才表示「不太～」，配「おいしいです」肯定句不成立；「ちっとも」同樣須搭配否定（ちっとも～ない），代回肯定句不通；「わざと（故意）」表示動作的意圖，無法修飾「おいしい」。三者代回皆明確不成立，唯一正解為「とても」。",
     explanationI18n: { "ja": "「すごく」は口語的な程度の副詞で「非常に」を表し、「とても（非常に、とても）」ともっとも意味が近いので、これが正解です。「あまり」は後に否定を伴って初めて「あまり〜ない」という意味になり、肯定の「おいしいです」とは成立しません。「ちっとも」も同様に否定と呼応する必要があり（ちっとも〜ない）、肯定文に戻すと通りません。「わざと（故意に）」は動作の意図を表し、「おいしい」を修飾できません。三つとも戻すと明らかに成立せず、唯一の正解は「とても」です。", "en": "「すごく」is a colloquial adverb of degree meaning \"very,\" which is closest to「とても（very, quite）」, so it is the answer. 「あまり」only means \"not very…\" when followed by a negative, so it doesn't work with the affirmative「おいしいです」;「ちっとも」likewise must pair with a negative (ちっとも～ない) and doesn't work in an affirmative sentence;「わざと（on purpose）」expresses intent behind an action and can't modify「おいしい」. All three clearly fail when substituted back, so the only answer is「とても」." },
     exampleJapanese: "このケーキはとてもおいしいです。",
-    exampleMeaningZh: "這個蛋糕非常好吃。"
+    exampleMeaningZh: "這個蛋糕非常好吃。",
+    exampleMeaningI18n: { "ja": "このケーキは非常においしい、という意味です。", "en": "This cake is really delicious." },
   }),
   examQuestion({
     id: "n4-usage-kayou",
@@ -3876,7 +3958,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「妹は毎日バスで学校に通っています」：「通う」は学校や会社などへ定期的に行き来する意味で、毎日学校へ行く場面に最も自然。干渉①「この道をまっすぐ通うと」：道を通り抜ける意味なので「通る（とおる）」が正しく、「通う」では不自然。干渉②「窓を開けて風を通いました」：空気を通す場面で、ここは「風を通しました（通す）」が適切、「通う」は使えない。干渉③「一度だけ外国へ通うつもり」：旅行で一度行くだけなのに、定期的な往復を表す「通う」を使うのは不自然で、「行く」が正しい。",
     explanationI18n: { "ja": "正解「妹は毎日バスで学校に通っています」：「通う」は学校や会社などへ定期的に行き来する意味で、毎日学校へ行く場面に最も自然です。干渉①「この道をまっすぐ通うと」：道を通り抜ける意味なので「通る（とおる）」が正しく、「通う」では不自然です。干渉②「窓を開けて風を通いました」：空気を通す場面で、ここは「風を通しました（通す）」が適切で、「通う」は使えません。干渉③「一度だけ外国へ通うつもり」：旅行で一度行くだけなのに、定期的な往復を表す「通う」を使うのは不自然で、「行く」が正しいです。", "en": "The answer is「妹は毎日バスで学校に通っています」:「通う」means going back and forth regularly to a place like a school or company, so it fits the scene of going to school every day most naturally. Distractor 1,「この道をまっすぐ通うと」: this means passing through a road, so「通る（とおる）」is correct, and「通う」is unnatural. Distractor 2,「窓を開けて風を通いました」: this is about letting air through, where「風を通しました（通す）」is right and「通う」can't be used. Distractor 3,「一度だけ外国へ通うつもり」: this is going abroad just once for a trip, so using「通う」, which expresses regular back-and-forth, is unnatural, and「行く」is correct." },
     exampleJapanese: "妹は毎日バスで学校に通っています。",
-    exampleMeaningZh: "妹妹每天搭巴士去學校上學。"
+    exampleMeaningZh: "妹妹每天搭巴士去學校上學。",
+    exampleMeaningI18n: { "ja": "妹は毎日バスで学校に通学している、という意味です。", "en": "My younger sister goes to school by bus every day." },
   }),
   examQuestion({
     id: "n4-usage-nigai",
@@ -3898,7 +3981,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「このコーヒーは砂糖を入れないと苦くて飲めません」：砂糖なしのコーヒーの味は「苦い」で、味の表現として正しい。干渉①「レモンはとても苦いので、口の中がすっぱく」：レモンの味は「すっぱい」であり、後半とも矛盾するため「苦い」は不自然。干渉②「塩が多くて、ちょっと苦い」：塩が多い味は「しょっぱい（塩辛い）」であって「苦い」ではない。干渉③「砂糖が多くて、とても苦い」：砂糖が多ければ味は「甘い（あまい）」になるはずで、「苦い」とは正反対で合わない。",
     explanationI18n: { "ja": "正解「このコーヒーは砂糖を入れないと苦くて飲めません」：砂糖なしのコーヒーの味は「苦い」で、味の表現として正しいです。干渉①「レモンはとても苦いので、口の中がすっぱく」：レモンの味は「すっぱい」であり、後半とも矛盾するため「苦い」は不自然です。干渉②「塩が多くて、ちょっと苦い」：塩が多い味は「しょっぱい（塩辛い）」であって「苦い」ではありません。干渉③「砂糖が多くて、とても苦い」：砂糖が多ければ味は「甘い（あまい）」になるはずで、「苦い」とは正反対で合いません。", "en": "The answer is「このコーヒーは砂糖を入れないと苦くて飲めません」: the taste of coffee without sugar is「苦い」, which is correct as a taste expression. Distractor 1,「レモンはとても苦いので、口の中がすっぱく」: the taste of lemon is「すっぱい（sour）」, and since it also contradicts the second half, 「苦い」is unnatural. Distractor 2,「塩が多くて、ちょっと苦い」: a taste with too much salt is「しょっぱい（塩辛い, salty）」, not「苦い」. Distractor 3,「砂糖が多くて、とても苦い」: too much sugar should make the taste「甘い（あまい, sweet）」, which is the exact opposite of「苦い」and doesn't fit." },
     exampleJapanese: "このコーヒーは砂糖を入れないと苦くて飲めません。",
-    exampleMeaningZh: "這杯咖啡不加糖的話太苦了，喝不下去。"
+    exampleMeaningZh: "這杯咖啡不加糖的話太苦了，喝不下去。",
+    exampleMeaningI18n: { "ja": "このコーヒーは砂糖を入れないと苦すぎて飲めない、という意味です。", "en": "This coffee is too bitter to drink unless I add sugar." },
   }),
   examQuestion({
     id: "n4-usage-wakareru",
@@ -3920,7 +4004,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「駅で友だちと別れて、一人で家に帰りました」：人と離れて去る場面で「別れる」が正しい。干渉①「ケーキを四つに別れて」：物をいくつかに分割する意味なので「分ける（わける）」が正しく、「別れる」は不自然。干渉②「絵が急に別れて落ちました」：壁から外れる意味で「外れる（はずれる）」が適切、「別れる」は使えない。干渉③「いらない紙と別れてください」：種類ごとに区別して仕分ける意味で「分ける」が正しく、「別れる」では合わない。",
     explanationI18n: { "ja": "正解「駅で友だちと別れて、一人で家に帰りました」：人と離れて去る場面で「別れる」が正しいです。干渉①「ケーキを四つに別れて」：物をいくつかに分割する意味なので「分ける（わける）」が正しく、「別れる」は不自然です。干渉②「絵が急に別れて落ちました」：壁から外れる意味で「外れる（はずれる）」が適切で、「別れる」は使えません。干渉③「いらない紙と別れてください」：種類ごとに区別して仕分ける意味で「分ける」が正しく、「別れる」では合いません。", "en": "The answer is「駅で友だちと別れて、一人で家に帰りました」:「別れる」is correct for a scene of parting from a person and going off. Distractor 1,「ケーキを四つに別れて」: this means dividing an object into several pieces, so「分ける（わける）」is correct and「別れる」is unnatural. Distractor 2,「絵が急に別れて落ちました」: this is about coming off the wall, where「外れる（はずれる）」is right and「別れる」can't be used. Distractor 3,「いらない紙と別れてください」: this means sorting things into categories, where「分ける」is correct, and「別れる」doesn't fit." },
     exampleJapanese: "駅で友だちと別れて、一人で家に帰りました。",
-    exampleMeaningZh: "在車站和朋友道別後，一個人回家了。"
+    exampleMeaningZh: "在車站和朋友道別後，一個人回家了。",
+    exampleMeaningI18n: { "ja": "駅で友だちと別れのあいさつをして、一人で家に帰った、という意味です。", "en": "I said goodbye to my friend at the station and went home alone." },
   }),
   examQuestion({
     id: "n4-context-sonotame",
@@ -4020,7 +4105,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「仕事」用訓讀，「仕」讀「し」、「事」連濁讀「ごと」，故「仕事」＝しごと。「しこと」沒把「事」連濁（清音「こと」）；「じごと」把語頭「し」誤濁成「じ」；「しごど」把詞尾「と」誤濁成「ど」。唯「しごと」正確。",
     explanationI18n: { "ja": "「仕事」は訓読みで、「仕」を「し」、「事」を連濁して「ごと」と読むので、「仕事」＝しごとです。「しこと」は「事」を連濁させていません（清音の「こと」）。「じごと」は語頭の「し」を誤って濁らせて「じ」にしています。「しごど」は語尾の「と」を誤って濁らせて「ど」にしています。正しいのは「しごと」だけです。", "en": "「仕事」uses kun readings:「仕」is read「し」and「事」undergoes rendaku to「ごと」, so「仕事」＝しごと. 「しこと」fails to voice「事」(plain「こと」);「じごと」wrongly voices the initial「し」into「じ」;「しごど」wrongly voices the final「と」into「ど」. Only「しごと」is correct." },
     exampleJapanese: "兄は毎日朝早くから夜おそくまで仕事をしています。",
-    exampleMeaningZh: "哥哥每天從一大早工作到深夜。"
+    exampleMeaningZh: "哥哥每天從一大早工作到深夜。",
+    exampleMeaningI18n: { "ja": "兄は毎日、朝早くから夜遅くまで働いている、という意味です。", "en": "My older brother works from early in the morning until late at night every day." },
   }),
   examQuestion({
     id: "n4-kanji-tenki",
@@ -4040,7 +4126,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「天」讀「てん」、「気」讀「き」，故「天気」＝てんき。「でんき」把語頭「て」誤濁成「で」（變成另一個詞「電気」的讀音）；「てんぎ」把詞尾「き」誤濁成「ぎ」；「てき」漏掉「天（てん）」的撥音「ん」。唯「てんき」正確。",
     explanationI18n: { "ja": "「天」を「てん」、「気」を「き」と読むので、「天気」＝てんきです。「でんき」は語頭の「て」を誤って濁らせて「で」にしています（別の語「電気」の読みになってしまいます）。「てんぎ」は語尾の「き」を誤って濁らせて「ぎ」にしています。「てき」は「天（てん）」の撥音「ん」が抜けています。正しいのは「てんき」だけです。", "en": "「天」is read「てん」and「気」is read「き」, so「天気」＝てんき. 「でんき」wrongly voices the initial「て」into「で」(making it the reading of a different word,「電気」);「てんぎ」wrongly voices the final「き」into「ぎ」;「てき」drops the moraic nasal「ん」of「天（てん）」. Only「てんき」is correct." },
     exampleJapanese: "明日はいい天気になるそうなので、海へ行こうと思います。",
-    exampleMeaningZh: "聽說明天會是好天氣，所以打算去海邊。"
+    exampleMeaningZh: "聽說明天會是好天氣，所以打算去海邊。",
+    exampleMeaningI18n: { "ja": "明日は晴れるらしいので、海へ行くつもりだ、という意味です。", "en": "I hear the weather will be nice tomorrow, so I'm planning to go to the beach." },
   }),
   examQuestion({
     id: "n4-kanji-genki",
@@ -4060,7 +4147,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「元」濁化讀「げん」、「気」讀「き」，故「元気」＝げんき。「けんき」沒把語頭讀濁音（清音「け」）；「げんぎ」把詞尾「き」誤濁成「ぎ」；「げき」漏掉「元（げん）」的撥音「ん」。唯「げんき」正確。",
     explanationI18n: { "ja": "「元」は濁って「げん」、「気」は「き」と読むので、「元気」＝げんきです。「けんき」は語頭を濁らせていません（清音の「け」）。「げんぎ」は語尾の「き」を誤って濁らせて「ぎ」にしています。「げき」は「元（げん）」の撥音「ん」が抜けています。正しいのは「げんき」だけです。", "en": "「元」is voiced and read「げん」and「気」is read「き」, so「元気」＝げんき. 「けんき」fails to voice the initial (plain「け」);「げんぎ」wrongly voices the final「き」into「ぎ」;「げき」drops the moraic nasal「ん」of「元（げん）」. Only「げんき」is correct." },
     exampleJapanese: "ひさしぶりに会った祖母は、思ったよりずっと元気でした。",
-    exampleMeaningZh: "好久不見的奶奶，比想像中還要有精神得多。"
+    exampleMeaningZh: "好久不見的奶奶，比想像中還要有精神得多。",
+    exampleMeaningI18n: { "ja": "久しぶりに会った祖母は、思っていたよりずっと元気だった、という意味です。", "en": "My grandmother, whom I hadn't seen in a long time, was far more energetic than I had expected." },
   }),
   examQuestion({
     id: "n4-syn-shuppatsu",
@@ -4082,7 +4170,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「出発する」指離開某地動身前往他處。正解「出る」（離開、出發）在此語境＝公車從站前離開動身，意思最接近，成立。「止まる」（停下、停止）與動身相反，公車不會在出發時間「停住」，方向錯，不成立。「着く」（抵達）是到達目的地，與出發完全相反，不成立。「待つ」（等待）是停留不動等候，與離開動身矛盾，不成立。只有「出る」可替換。",
     explanationI18n: { "ja": "「出発する」はある場所を離れて他の場所へ向かうことを指します。正解「出る」（離れる、出発する）はこの文脈ではバスが駅前を離れて動き出す意味になり、もっとも意味が近く成立します。「止まる」（停止する）は動き出すのとは反対で、バスが出発時刻に「止まる」ことはなく、方向が違うので成立しません。「着く」（到着する）は目的地に着くことで、出発とは正反対なので成立しません。「待つ」（待つ）はとどまって待つことで、離れて出発するのと矛盾するので成立しません。置き換えられるのは「出る」だけです。", "en": "「出発する」means to leave a place and head off elsewhere. The answer「出る」(to leave, depart) here means the bus leaves and sets off from in front of the station, closest in meaning, so it works. 「止まる」(to stop, halt) is the opposite of setting off; a bus wouldn't \"stop\" at its departure time, so the direction is wrong and it doesn't work. 「着く」(to arrive) means reaching a destination, the exact opposite of departing, so it doesn't work. 「待つ」(to wait) means staying put and waiting, which contradicts leaving and setting off, so it doesn't work. Only「出る」can substitute." },
     exampleJapanese: "バスは朝の七時に駅前を出る予定です。",
-    exampleMeaningZh: "公車預定早上七點從車站前出發。"
+    exampleMeaningZh: "公車預定早上七點從車站前出發。",
+    exampleMeaningI18n: { "ja": "バスは朝七時に駅前を発つ予定だ、という意味です。", "en": "The bus is scheduled to leave from in front of the station at seven in the morning." },
   }),
   examQuestion({
     id: "n4-syn-dame",
@@ -4104,7 +4193,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「だめ」在此表示「不可以、不被允許」。正解「いけない」（不行、不可以）與之同義，「吸ってはいけない」＝「吸ってはだめ」，成立。「いい」（好、可以）表示允許，意思正好相反，不成立。「うれしい」（高興）是情緒，與許可與否無關，搭配也不對，不成立。「ほしい」（想要）表示欲望，與「禁止」毫無關係，不成立。只有「いけない」可替換。",
     explanationI18n: { "ja": "「だめ」はここでは「してはいけない、許されない」ことを表します。正解「いけない」（いけない、してはならない）は同義で、「吸ってはいけない」＝「吸ってはだめ」となり成立します。「いい」（よい、してよい）は許可を表し、意味が正反対なので成立しません。「うれしい」（うれしい）は感情で、許可の有無とは関係なく、組み合わせも合わないので成立しません。「ほしい」（ほしい）は欲求を表し、「禁止」とはまったく関係がないので成立しません。置き換えられるのは「いけない」だけです。", "en": "「だめ」here means \"not allowed, prohibited.\" The answer「いけない」(no good, not allowed) is synonymous:「吸ってはいけない」＝「吸ってはだめ」, so it works. 「いい」(good, okay) expresses permission, the exact opposite, so it doesn't work. 「うれしい」(happy) is an emotion, unrelated to whether something is permitted, and the pairing is off, so it doesn't work. 「ほしい」(to want) expresses desire, with no connection to prohibition, so it doesn't work. Only「いけない」can substitute." },
     exampleJapanese: "ここでたばこを吸ってはいけないですよ。",
-    exampleMeaningZh: "在這裡抽菸是不可以的喔。"
+    exampleMeaningZh: "在這裡抽菸是不可以的喔。",
+    exampleMeaningI18n: { "ja": "ここでたばこを吸うのは禁止されている、という意味です。", "en": "You're not allowed to smoke here, you know." },
   }),
   examQuestion({
     id: "n4-usage-okureru",
@@ -4126,7 +4216,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解：「遅れる」指比預定／應到的時間晚，「会社に三十分遅れる（遲到三十分鐘）」是最自然的用法，符合電車停駛導致晚到的語境。干擾1「天気がいいので…遅れています」天氣好和「遲到」沒有因果關係，且「とても遅れています」缺主語語意空洞，不成立。干擾2「宿題がやさしかったので、すぐに遅れました」作業簡單應該是「すぐに終わった（很快寫完）」，與「遅れる（變晚）」語意相反，明顯不對。干擾3「この料理はおいしいので、いつも遅れています」料理好吃與遲到沒有因果，「遅れる」也不能形容料理，語意不通。唯第一句成立。",
     explanationI18n: { "ja": "正解:「遅れる」は予定や本来着くべき時刻より遅くなることを表し、「会社に三十分遅れる」が最も自然な使い方で、電車が止まって遅くなったという状況に合います。誤答1「天気がいいので…遅れています」は天気の良さと「遅れる」に因果関係がなく、しかも「とても遅れています」は主語がなく意味が空っぽで成り立ちません。誤答2「宿題がやさしかったので、すぐに遅れました」は宿題が簡単なら「すぐに終わった」となるはずで、「遅れる(遅くなる)」とは反対の意味になり、明らかに誤りです。誤答3「この料理はおいしいので、いつも遅れています」は料理のおいしさと遅刻に因果関係がなく、「遅れる」で料理を表すこともできず、意味が通りません。よって第一文のみが成立します。", "en": "Correct answer: 「遅れる」 means to be later than the scheduled or expected time. 「会社に三十分遅れる」 (to be thirty minutes late to work) is the most natural usage and fits the context of the train stopping and causing a late arrival. Distractor 1, 「天気がいいので…遅れています」, has no cause-and-effect link between good weather and being late, and 「とても遅れています」 lacks a subject and is semantically empty, so it doesn't work. Distractor 2, 「宿題がやさしかったので、すぐに遅れました」, should be 「すぐに終わった」 (finished quickly) if the homework was easy — this is the opposite of 「遅れる」 (to become late), so it is clearly wrong. Distractor 3, 「この料理はおいしいので、いつも遅れています」, has no causal link between tasty food and being late, and 「遅れる」 can't describe food, so it makes no sense. Only the first sentence works." },
     exampleJapanese: "電車が止まったので、会社に三十分も遅れてしまいました。",
-    exampleMeaningZh: "因為電車停駛了，我上班遲到了足足三十分鐘。"
+    exampleMeaningZh: "因為電車停駛了，我上班遲到了足足三十分鐘。",
+    exampleMeaningI18n: { "ja": "電車が止まってしまったせいで、会社に三十分も遅刻してしまいました。", "en": "The train stopped running, so I ended up a full thirty minutes late for work." },
   }),
   examQuestion({
     id: "n4-usage-mamoru",
@@ -4148,7 +4239,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解：「守る」常與「ルール・約束・時間」搭配，表示遵守，「交通のルールを守る（遵守交通規則）」是標準用法，與騎自行車的語境完全相符。選項「バスでルールを守りました」雖然「ルールを守る」搭配對，但「駅まで遠いので、バスで（因為到車站遠所以搭公車）」與「守る」毫無因果與語意連結，整句不成立。選項「写真を守っています」照片應該用「撮る（拍）」，「守る」用在照片上搭配不對，語意不成立。選項「まどを守ってください」窗戶應該用「閉める（關）」來禦寒，「窓を守る」搭配與語意都不對。",
     explanationI18n: { "ja": "正解:「守る」は「ルール・約束・時間」などと結びついて「きちんと従う」ことを表し、「交通のルールを守る」は標準的な使い方で、自転車に乗る場面にぴったり合います。選択肢「バスでルールを守りました」は「ルールを守る」という組み合わせ自体は正しいものの、「駅まで遠いので、バスで」と「守る」には因果も意味のつながりもなく、文全体が成り立ちません。選択肢「写真を守っています」は写真には「撮る」を使うべきで、「守る」を写真に使うのは組み合わせが不適切で意味が通りません。選択肢「まどを守ってください」は寒さを防ぐには窓を「閉める」を使うべきで、「窓を守る」は組み合わせも意味も正しくありません。", "en": "Correct answer: 「守る」 commonly pairs with 「ルール・約束・時間」 to mean to obey or keep. 「交通のルールを守る」 (to follow traffic rules) is the standard usage and matches the cycling context perfectly. In 「バスでルールを守りました」, although 「ルールを守る」 is a correct collocation, 「駅まで遠いので、バスで」 (taking the bus because the station is far) has no causal or semantic link to 「守る」, so the whole sentence fails. In 「写真を守っています」, a photo should take 「撮る」 (to take), so 「守る」 doesn't collocate with photos and makes no sense. In 「まどを守ってください」, a window should take 「閉める」 (to close) to keep out the cold — 「窓を守る」 is wrong in both collocation and meaning." },
     exampleJapanese: "自転車に乗るときは、交通のルールをしっかり守りましょう。",
-    exampleMeaningZh: "騎自行車的時候，要好好遵守交通規則。"
+    exampleMeaningZh: "騎自行車的時候，要好好遵守交通規則。",
+    exampleMeaningI18n: { "ja": "自転車に乗るときは、交通ルールにきちんと従いましょう。", "en": "When you ride a bicycle, be sure to follow the traffic rules." },
   }),
   examQuestion({
     id: "n4-usage-hieru",
@@ -4170,7 +4262,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解：「冷える」指溫度自然下降變涼／變冷，「夜は体が冷える（夜裡身體會冷）」是典型用法，與提醒帶外套的情境吻合。「頭がよく冷えません」要表達題目難，應說「分からない／頭が働かない」，「頭が冷える」並非此語意，搭配不對。「足がだんだん冷えてきました」每天跑步腿應是「強くなる（變強）」，且跑步反而會發熱，與「冷える（變冷）」語意相反，不成立。「気持ちが冷えています」開始新工作通常是緊張或期待，「気持ちが冷える」用在這裡語意不通、不自然。",
     explanationI18n: { "ja": "正解:「冷える」は温度が自然に下がって涼しく・冷たくなることを表し、「夜は体が冷える」は典型的な使い方で、上着を持って行くよう促す場面に合います。「頭がよく冷えません」は問題が難しいことを言いたいなら「分からない/頭が働かない」と言うべきで、「頭が冷える」はその意味ではなく組み合わせが不適切です。「足がだんだん冷えてきました」は毎日走れば脚は「強くなる」はずで、しかも走ると逆に熱くなるので、「冷える(冷たくなる)」とは反対の意味になり成り立ちません。「気持ちが冷えています」は新しい仕事を始めれば普通は緊張や期待を感じるもので、「気持ちが冷える」をここで使うのは意味が通らず不自然です。", "en": "Correct answer: 「冷える」 means the temperature naturally drops and something gets cool or cold. 「夜は体が冷える」 (the body gets cold at night) is a typical usage and fits the reminder to bring a jacket. In 「頭がよく冷えません」, to say a problem is hard you'd say 「分からない／頭が働かない」 — 「頭が冷える」 doesn't carry that meaning, so it doesn't collocate. In 「足がだんだん冷えてきました」, daily running should make your legs 「強くなる」 (stronger), and running actually generates heat, which is the opposite of 「冷える」 (to get cold), so it fails. In 「気持ちが冷えています」, starting a new job usually brings nervousness or anticipation; 「気持ちが冷える」 doesn't make sense here and sounds unnatural." },
     exampleJapanese: "夜は体が冷えるので、上着を一枚持って行ってください。",
-    exampleMeaningZh: "晚上身體會著涼，請帶一件外套去。"
+    exampleMeaningZh: "晚上身體會著涼，請帶一件外套去。",
+    exampleMeaningI18n: { "ja": "夜は体が冷たくなってしまうので、上着を一枚持って行ってください。", "en": "Your body gets chilly at night, so please take a jacket with you." },
   }),
   examQuestion({
     id: "n4-context-sonoue",
@@ -4350,7 +4443,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「注意」＝ちゅうい（注ちゅう、意い）。「じゅうい」把語頭「ちゅ」誤讀成濁音「じゅ」，會變成另一個詞「獣医（獸醫）」，與提醒小心的語境不合；「ちゅい」漏掉了「注（ちゅう）」的長音；「ちょうい」把拗音「ちゅ」誤讀成「ちょ」，會變成另一個詞「弔意（弔唁之意）」，語意不合。三者皆不被母語者接受，唯「ちゅうい」正確。",
     explanationI18n: { "ja": "「注意」＝ちゅうい(注:ちゅう、意:い)。「じゅうい」は語頭の「ちゅ」を濁音の「じゅ」と読み誤ったもので、別の語「獣医」になってしまい、注意を促す文脈に合いません。「ちゅい」は「注(ちゅう)」の長音が抜けています。「ちょうい」は拗音の「ちゅ」を「ちょ」と読み誤ったもので、別の語「弔意」になり意味が合いません。三つとも母語話者には受け入れられず、「ちゅうい」のみが正しいです。", "en": "「注意」 = ちゅうい (注 = ちゅう, 意 = い). 「じゅうい」 misreads the initial 「ちゅ」 as the voiced 「じゅ」, turning it into a different word, 「獣医」 (veterinarian), which doesn't fit a warning to be careful. 「ちゅい」 drops the long vowel of 「注（ちゅう）」. 「ちょうい」 misreads the contracted sound 「ちゅ」 as 「ちょ」, turning it into a different word, 「弔意」 (condolences), which doesn't fit the meaning. None of the three are accepted by native speakers; only 「ちゅうい」 is correct." },
     exampleJapanese: "道がこおっていてすべりやすいので、歩くときは注意してください。",
-    exampleMeaningZh: "路面結冰很滑，走路時請小心。"
+    exampleMeaningZh: "路面結冰很滑，走路時請小心。",
+    exampleMeaningI18n: { "ja": "道が凍っていて滑りやすいので、歩くときは気をつけてください。", "en": "The road is icy and slippery, so please be careful when walking." },
   }),
   examQuestion({
     id: "n4-kanji-shakai",
@@ -4370,7 +4464,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「社会」＝しゃかい（社しゃ、会かい）。「じゃかい」把語頭「しゃ」誤讀成濁音「じゃ」，不是正規讀音；「しゃがい」把「会（かい）」誤讀成濁音「がい」，會變成另一個詞「社外（公司外）」，與踏入社會工作的語境不合；「しゃかいい」在詞尾多了一個不存在的「い」。三者皆不成立，唯「しゃかい」正確。",
     explanationI18n: { "ja": "「社会」＝しゃかい(社:しゃ、会:かい)。「じゃかい」は語頭の「しゃ」を濁音の「じゃ」と読み誤ったもので、正しい読みではありません。「しゃがい」は「会(かい)」を濁音の「がい」と読み誤ったもので、別の語「社外」になってしまい、社会に出て働く文脈に合いません。「しゃかいい」は語尾に存在しない「い」が余計に付いています。三つとも成り立たず、「しゃかい」のみが正しいです。", "en": "「社会」 = しゃかい (社 = しゃ, 会 = かい). 「じゃかい」 misreads the initial 「しゃ」 as the voiced 「じゃ」, which is not a proper reading. 「しゃがい」 misreads 「会（かい）」 as the voiced 「がい」, turning it into a different word, 「社外」 (outside the company), which doesn't fit the context of entering society to work. 「しゃかいい」 adds a nonexistent 「い」 at the end. None of the three work; only 「しゃかい」 is correct." },
     exampleJapanese: "大学を出て、来月からいよいよ社会に出て働きます。",
-    exampleMeaningZh: "大學畢業後，下個月終於要踏入社會工作了。"
+    exampleMeaningZh: "大學畢業後，下個月終於要踏入社會工作了。",
+    exampleMeaningI18n: { "ja": "大学を卒業して、来月からいよいよ社会人として働き始めます。", "en": "After graduating from university, next month I'll finally go out into the working world." },
   }),
   examQuestion({
     id: "n4-syn-toutou",
@@ -4392,7 +4487,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「とうとう」表示經過長時間或過程後最終的結果，與「ついに」(到最後、終究)同義，套入後「ついに来なかった」(終究沒來)語意完全吻合，為唯一正解。干擾「とつぜん」是「突然」，但等了三小時不是突發狀況，語意相反不成立；「ときどき」是「有時」，與「最終結果」無關，且「ときどき来なかった」不自然；「だんだん」是「漸漸」表示程度逐步變化，無法接「来なかった」這種一次性結果，語意不通。",
     explanationI18n: { "ja": "「とうとう」は長い時間や過程を経た末の最終的な結果を表し、「ついに(最後には、結局)」と同義で、入れ替えると「ついに来なかった(結局来なかった)」となり意味がぴったり合うため、唯一の正解です。誤答「とつぜん」は「突然」ですが、三時間も待ったのは突発的な出来事ではなく、意味が反対で成り立ちません。「ときどき」は「時々」で「最終的な結果」とは関係がなく、しかも「ときどき来なかった」は不自然です。「だんだん」は「だんだん」で程度が段階的に変化することを表し、「来なかった」という一回きりの結果には付けられず、意味が通りません。", "en": "「とうとう」 expresses the final result after a long time or process, and is synonymous with 「ついに」 (in the end, ultimately). Substituting it, 「ついに来なかった」 (in the end didn't come) matches the meaning perfectly, making it the only correct answer. The distractor 「とつぜん」 means 'suddenly,' but waiting three hours isn't a sudden event, so the meaning is opposite and it doesn't work. 「ときどき」 means 'sometimes,' which is unrelated to a 'final result,' and 「ときどき来なかった」 is unnatural. 「だんだん」 means 'gradually,' expressing a step-by-step change in degree, which can't attach to a one-time result like 「来なかった」, so it makes no sense." },
     exampleJapanese: "三時間も待って、彼はついに来なかった。",
-    exampleMeaningZh: "等了整整三個小時，他終究還是沒來。"
+    exampleMeaningZh: "等了整整三個小時，他終究還是沒來。",
+    exampleMeaningI18n: { "ja": "三時間も待ったのに、彼は結局最後まで来ませんでした。", "en": "I waited a full three hours, but in the end he never came." },
   }),
   examQuestion({
     id: "n4-syn-nedan",
@@ -4414,7 +4510,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「値段」指商品的售價，與「価格」同義，套入「価格を聞いた」(詢問價格)完全自然，為唯一正解。干擾「色」是「顏色」、「重さ」是「重量」、「形」是「形狀」，三者都是商品的其他屬性，接續上「色/重さ/形を聞いた」雖文法成立，但都不是「値段」的意思，與被考詞語意明確不同。",
     explanationI18n: { "ja": "「値段」は商品の売値を指し、「価格」と同義で、入れ替えると「価格を聞いた(価格を尋ねた)」となり完全に自然で、唯一の正解です。誤答「色」は「色」、「重さ」は「重さ」、「形」は「形」で、三つとも商品の別の属性であり、「色/重さ/形を聞いた」は文法的には成り立っても、いずれも「値段」の意味ではなく、問われている語とは意味がはっきり異なります。", "en": "「値段」 refers to the selling price of an item and is synonymous with 「価格」; substituting it, 「価格を聞いた」 (asked the price) is completely natural, making it the only correct answer. The distractors 「色」 (color), 「重さ」 (weight), and 「形」 (shape) are all other attributes of the product; although 「色/重さ/形を聞いた」 is grammatically fine, none of them mean 「値段」 and each is clearly different from the tested word." },
     exampleJapanese: "このかばんの価格を店員に聞いた。",
-    exampleMeaningZh: "我向店員詢問了這個包包的價格。"
+    exampleMeaningZh: "我向店員詢問了這個包包的價格。",
+    exampleMeaningI18n: { "ja": "このかばんがいくらなのか、店員にたずねました。", "en": "I asked the shop clerk the price of this bag." },
   }),
   examQuestion({
     id: "n4-usage-aisatsu",
@@ -4436,7 +4533,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「あいさつをします」＝早上見到人時打招呼、寒暄，搭配「人に会ったら」最自然。干擾一「つめたいあいさつを飲みました」應改用「お茶」或「水」，喉嚨渴是喝飲料，あいさつ無法用「飲む」；干擾二「あいさつを食べました」應改用「ごはん」類食物，早餐吃的不是あいさつ；干擾三「あついあいさつを着て」應改用「コート／服」，穿在身上的是衣物而非あいさつ。四句都含「あいさつ」，但只有第一句的動詞搭配（あいさつをする）成立，其餘三句的飲む／食べる／着る都與あいさつ語意不通。",
     explanationI18n: { "ja": "正解「あいさつをします」＝朝、人に会ったときにあいさつを交わすことで、「人に会ったら」と最も自然に結びつきます。誤答一「つめたいあいさつを飲みました」は「お茶」や「水」にすべきで、のどが渇いたら飲み物を飲むのであり、あいさつを「飲む」ことはできません。誤答二「あいさつを食べました」は「ごはん」類の食べ物にすべきで、朝食に食べるのはあいさつではありません。誤答三「あついあいさつを着て」は「コート/服」にすべきで、身につけるのは衣類であってあいさつではありません。四文とも「あいさつ」を含みますが、動詞の組み合わせ(あいさつをする)が成り立つのは第一文だけで、残る三文の飲む/食べる/着るはいずれもあいさつと意味が通りません。", "en": "Correct answer 「あいさつをします」 = greeting and exchanging pleasantries when you meet someone in the morning, pairing most naturally with 「人に会ったら」. Distractor 1, 「つめたいあいさつを飲みました」, should use 「お茶」 or 「水」 — when you're thirsty you drink a beverage, and あいさつ can't take 「飲む」. Distractor 2, 「あいさつを食べました」, should use food like 「ごはん」 — you don't eat あいさつ for breakfast. Distractor 3, 「あついあいさつを着て」, should use 「コート／服」 — what you wear is clothing, not あいさつ. All four sentences contain 「あいさつ」, but only the first has a valid verb collocation (あいさつをする); the 飲む/食べる/着る in the other three all clash with the meaning of あいさつ." },
     exampleJapanese: "朝、会社で人に会ったら、元気にあいさつをします。",
-    exampleMeaningZh: "早上在公司見到人時，會精神地打招呼。"
+    exampleMeaningZh: "早上在公司見到人時，會精神地打招呼。",
+    exampleMeaningI18n: { "ja": "朝、会社で人に会ったら、元気に「おはようございます」と声をかけます。", "en": "When I see people at the office in the morning, I greet them cheerfully." },
   }),
   examQuestion({
     id: "n4-usage-sodan",
@@ -4458,7 +4556,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "正解「先生に相談しました」＝自己一個人無法決定，找老師商量、徵詢意見，與「決められない」的語境完全吻合，相談する是地道搭配。干擾一「相談を食べました」應改用「ごはん／料理」，相談不能用「食べる」；干擾二「つめたい相談を飲みました」應改用「お茶／水」，相談不能用「飲む」；干擾三「相談をさして歩きました」應改用「傘」，撐著走的是傘而非相談。四句都含「相談」，但只有第一句的動詞搭配（相談する）與語意成立，其餘三句的食べる／飲む／さす都與相談不通。",
     explanationI18n: { "ja": "正解「先生に相談しました」＝一人では決められず、先生に相談して意見を求めることで、「決められない」という文脈にぴったり合い、「相談する」は自然な組み合わせです。誤答一「相談を食べました」は「ごはん/料理」にすべきで、相談を「食べる」ことはできません。誤答二「つめたい相談を飲みました」は「お茶/水」にすべきで、相談を「飲む」ことはできません。誤答三「相談をさして歩きました」は「傘」にすべきで、さして歩くのは傘であって相談ではありません。四文とも「相談」を含みますが、動詞の組み合わせ(相談する)と意味が成り立つのは第一文だけで、残る三文の食べる/飲む/さすはいずれも相談と通りません。", "en": "Correct answer 「先生に相談しました」 = unable to decide alone, consulting the teacher and seeking advice, which fits the 「決められない」 context perfectly; 相談する is an authentic collocation. Distractor 1, 「相談を食べました」, should use 「ごはん／料理」 — you can't 「食べる」 相談. Distractor 2, 「つめたい相談を飲みました」, should use 「お茶／水」 — you can't 「飲む」 相談. Distractor 3, 「相談をさして歩きました」, should use 「傘」 — what you hold up as you walk is an umbrella, not 相談. All four sentences contain 「相談」, but only the first has a valid verb collocation (相談する) and meaning; the 食べる/飲む/さす in the other three all clash with 相談." },
     exampleJapanese: "一人で決められないので、先生に相談しました。",
-    exampleMeaningZh: "因為一個人決定不了，所以找老師商量了。"
+    exampleMeaningZh: "因為一個人決定不了，所以找老師商量了。",
+    exampleMeaningI18n: { "ja": "一人では決められないので、先生に話して意見を聞きました。", "en": "I couldn't decide on my own, so I talked it over with my teacher." },
   }),
   examQuestion({
     id: "n4-context-soretomo",
@@ -4718,7 +4817,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「咲く」讀作「さく」,意為花朵綻放。干擾項「さぐ」把清音濁化、「しく」「せく」都改了第一個假名,均非此字讀音,在此句也不成立,正解唯一為「さく」。",
     explanationI18n: { "ja": "「咲く」は「さく」と読み、花が咲くことを意味します。誤答の「さぐ」は清音を濁音にし、「しく」「せく」は最初の仮名を変えており、いずれもこの字の読み方ではなく、この文でも成立しないため、正解は「さく」だけです。", "en": "「咲く」 is read さく and means for flowers to bloom. The distractor さぐ voices the plain consonant, while しく and せく both change the first kana; none is the reading of this character, and none works in the sentence, so さく is the only correct answer." },
     exampleJapanese: "庭の花がまた「咲く」季節になったね。",
-    exampleMeaningZh: "庭院的花,又到了綻放的季節了呢。"
+    exampleMeaningZh: "庭院的花,又到了綻放的季節了呢。",
+    exampleMeaningI18n: { "ja": "庭の花がまた開く季節になったね。", "en": "It's that season again when the flowers in the garden bloom." },
   }),
   examQuestion({
     id: "n4-kanji-namida",
@@ -4738,7 +4838,8 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「涙」讀作「なみだ」,意為眼淚。干擾項「なみた」把濁音清化、「なまだ」「なびだ」改了中間假名,皆非此字讀音,在此句也不成立,正解唯一為「なみだ」。",
     explanationI18n: { "ja": "「涙」は「なみだ」と読み、涙を意味します。誤答の「なみた」は濁音を清音にし、「なまだ」「なびだ」は中間の仮名を変えており、いずれもこの字の読み方ではなく、この文でも成立しないため、正解は「なみだ」だけです。", "en": "「涙」 is read なみだ and means tears. The distractor なみた unvoices the voiced sound, while なまだ and なびだ change the middle kana; none is the reading of this character, and none works in the sentence, so なみだ is the only correct answer." },
     exampleJapanese: "駅で手を振ると、「涙」が出た。",
-    exampleMeaningZh: "在車站揮手的時候,眼淚就掉了下來。"
+    exampleMeaningZh: "在車站揮手的時候,眼淚就掉了下來。",
+    exampleMeaningI18n: { "ja": "駅で手を振ったとき、思わず涙がこぼれました。", "en": "As I waved at the station, tears came to my eyes." },
   }),
   examQuestion({
     id: "n4-kanji-senaka",
@@ -4758,6 +4859,7 @@ export const n4Items: PracticeQuestion[] = [
     explanation: "「背中」讀作「せなか」,指人的後背、背影。干擾項中「せたか」(濁音化)、「せいなか」(多了長音)、「せなが」(尾音濁音化)都不是「背中」的讀音,在此語境也無法成立,故唯一正解為「せなか」。",
     explanationI18n: { "ja": "「背中」は「せなか」と読み、人の背中や後ろ姿を指します。誤答のうち「せたか」（濁音化）、「せいなか」（長音が余分）、「せなが」（語尾が濁音化）はいずれも「背中」の読み方ではなく、この文脈でも成立しないため、唯一の正解は「せなか」です。", "en": "「背中」 is read せなか and refers to a person's back or the figure seen from behind. Among the distractors, せたか (voicing), せいなか (an extra long vowel), and せなが (voicing the final sound) are none of them the reading of 「背中」, and none works in this context, so せなか is the only correct answer." },
     exampleJapanese: "信号が青に変わると、あの人の背中がどんどん遠くなっていく。",
-    exampleMeaningZh: "綠燈一亮,那個人的背影就漸漸地越來越遠了。"
+    exampleMeaningZh: "綠燈一亮,那個人的背影就漸漸地越來越遠了。",
+    exampleMeaningI18n: { "ja": "信号が青に変わると、あの人のうしろ姿がだんだん遠ざかっていきます。", "en": "When the light turns green, that person's back grows farther and farther away." },
   })
 ];

--- a/src/domain/exam/items/n5.ts
+++ b/src/domain/exam/items/n5.ts
@@ -120,7 +120,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「学」在「校（こう）」前促音化讀「がっ」、「校」讀長音「こう」，故「学校」＝がっこう。「がくこう」沒促音化；「がっこ」漏掉長音；「かっこう」沒把「学」讀濁音「がっ」（且 かっこう＝格好）。",
     explanationI18n: { "ja": "「学」は「校（こう）」の前で促音化して「がっ」と読み、「校」は長音で「こう」と読むので、「学校」＝がっこう となります。「がくこう」は促音化していません。「がっこ」は長音がぬけています。「かっこう」は「学」を濁音「がっ」で読んでいません（しかも かっこう＝格好 です）。", "en": "Before 「校 (こう)」, 「学」 becomes a geminated 「がっ」, and 「校」 is the long vowel 「こう」, so 「学校」 is がっこう. がくこう lacks the gemination, がっこ drops the long vowel, and かっこう doesn't voice 「学」 into 「がっ」 (and かっこう means 格好)." },
     exampleJapanese: "毎日、自転車で学校へ行きます。",
-    exampleMeaningZh: "每天騎腳踏車去學校。"
+    exampleMeaningZh: "每天騎腳踏車去學校。",
+    exampleMeaningI18n: { "ja": "毎日、自転車で学校へ行きます。", "en": "I ride my bike to school every day." },
   }),
   examQuestion({
     id: "n5-grammar-ha-watashi-gakusei",
@@ -400,7 +401,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「先」讀「せん」、「生」在此讀長音「せい」，故「先生」＝せんせい。「せんせ」漏掉長音；「ぜんせい」把「先」誤濁音化成「ぜん」；「せいせい」把「先」誤讀成「せい」。",
     explanationI18n: { "ja": "「先」は「せん」と読み、「生」はここでは長音で「せい」と読むので、「先生」＝せんせい となります。「せんせ」は長音がぬけています。「ぜんせい」は「先」をまちがって濁音化して「ぜん」と読んでいます。「せいせい」は「先」をまちがって「せい」と読んでいます。", "en": "「先」 reads 「せん」 and 「生」 here reads as the long vowel 「せい」, so 「先生」 is せんせい. せんせ drops the long vowel, ぜんせい wrongly voices 「先」 into 「ぜん」, and せいせい misreads 「先」 as 「せい」." },
     exampleJapanese: "山田先生は とても やさしいです。",
-    exampleMeaningZh: "山田老師非常親切。"
+    exampleMeaningZh: "山田老師非常親切。",
+    exampleMeaningI18n: { "ja": "山田先生はとてもやさしいです。", "en": "Yamada-sensei is very kind." },
   }),
   examQuestion({
     id: "n5-kanji-mainichi",
@@ -420,7 +422,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「毎」讀「まい」、「日」在此讀「にち」，故「毎日」＝まいにち。「めいにち」把「毎」誤讀成「めい」（那是「命日」的讀音）；「まいひ」把「日」讀成訓讀「ひ」；「まいにつ」把「にち」誤讀成促音「につ」。",
     explanationI18n: { "ja": "「毎」は「まい」と読み、「日」はここでは「にち」と読むので、「毎日」＝まいにち となります。「めいにち」は「毎」をまちがって「めい」と読んでいます（それは「命日」の読み方です）。「まいひ」は「日」を訓読みの「ひ」で読んでいます。「まいにつ」は「にち」をまちがって促音の「につ」と読んでいます。", "en": "「毎」 reads 「まい」 and 「日」 here reads 「にち」, so 「毎日」 is まいにち. めいにち misreads 「毎」 as 「めい」 (which is the reading of 「命日」), まいひ reads 「日」 with the kun reading 「ひ」, and まいにつ misreads 「にち」 as the geminated 「につ」." },
     exampleJapanese: "わたしは 毎日 コーヒーを のみます。",
-    exampleMeaningZh: "我每天喝咖啡。"
+    exampleMeaningZh: "我每天喝咖啡。",
+    exampleMeaningI18n: { "ja": "わたしは毎日コーヒーを飲みます。", "en": "I drink coffee every day." },
   }),
   examQuestion({
     id: "n5-kanji-taberu",
@@ -440,7 +443,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「食」訓讀「た」、送りがな「べます」，故「食べます」＝たべます。「だべます」把「た」誤濁音成「だ」；「たへます」沒把「べ」讀濁音；「ためます」把「べ」誤讀成「め」。",
     explanationI18n: { "ja": "「食」は訓読みで「た」、送りがなは「べます」なので、「食べます」＝たべます となります。「だべます」は「た」をまちがって濁音の「だ」にしています。「たへます」は「べ」を濁音で読んでいません。「ためます」は「べ」をまちがって「め」と読んでいます。", "en": "「食」 has the kun reading 「た」 with the okurigana 「べます」, so 「食べます」 is たべます. だべます wrongly voices 「た」 into 「だ」, たへます fails to voice 「べ」, and ためます misreads 「べ」 as 「め」." },
     exampleJapanese: "あさ、くだものを 食べます。",
-    exampleMeaningZh: "早上吃水果。"
+    exampleMeaningZh: "早上吃水果。",
+    exampleMeaningI18n: { "ja": "朝、果物を食べます。", "en": "I eat fruit in the morning." },
   }),
   examQuestion({
     id: "n5-grammar-kara-atama-itai",
@@ -740,7 +744,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「水」單獨當名詞時用訓讀「みず」。「みす」漏掉濁音（ず→す）；「すい」是音讀（用於「水曜日」等複合詞）、單獨的『水』不這樣讀；「みづ」是歷史假名遣的舊寫法、現代標準寫作「みず」。此處單獨名詞唯「みず」成立。",
     explanationI18n: { "ja": "「水」を単独で名詞として使うときは訓読みの「みず」です。「みす」は濁音が抜けています（ず→す）。「すい」は音読みで（「水曜日」などの複合語で使う）、単独の『水』はこう読みません。「みづ」は歴史的仮名遣いの古い表記で、現代では標準的に「みず」と書きます。ここは単独の名詞なので成り立つのは「みず」だけです。", "en": "As a standalone noun, 「水」 takes the kun reading 「みず」. みす drops the voicing (ず→す); すい is the on reading (used in compounds like 「水曜日」) and standalone 「水」 isn't read that way; みづ is the old historical kana spelling, while the modern standard is 「みず」. As a standalone noun here, only みず works." },
     exampleJapanese: "あついので、つめたい水を のみます。",
-    exampleMeaningZh: "因為很熱，所以喝冰涼的水。"
+    exampleMeaningZh: "因為很熱，所以喝冰涼的水。",
+    exampleMeaningI18n: { "ja": "暑いので、冷たい水を飲みます。", "en": "It's hot, so I drink cold water." },
   }),
   examQuestion({
     id: "n5-kanji-tomodachi",
@@ -760,7 +765,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「友」訓讀「とも」、「達」在此讀濁音「だち」，故「友達」＝ともだち。「ともたち」沒把「達」讀濁音（たち→應為だち）；「ゆうだち」把「友」誤用音讀「ゆう」（且 ゆうだち＝夕立、午後雷陣雨）；「とまだち」把「とも」誤讀成「とま」。此處唯「ともだち」成立。",
     explanationI18n: { "ja": "「友」は訓読みで「とも」、「達」はここでは濁音で「だち」と読むので、「友達」＝ともだち、となります。「ともたち」は「達」を濁音で読んでいません（たち→だちが正しい）。「ゆうだち」は「友」を音読みの「ゆう」と誤読しています（しかも ゆうだち＝夕立、午後の雷雨のことです）。「とまだち」は「とも」を「とま」と誤読しています。ここで成り立つのは「ともだち」だけです。", "en": "「友」 has the kun reading 「とも」 and 「達」 here is voiced as 「だち」, so 「友達」 is ともだち. ともたち fails to voice 「達」 (たち → should be だち); ゆうだち wrongly uses the on reading 「ゆう」 for 「友」 (and ゆうだち means 夕立, a sudden afternoon shower); とまだち misreads 「とも」 as 「とま」. Here only ともだち works." },
     exampleJapanese: "あした友達と こうえんで あそびます。",
-    exampleMeaningZh: "明天和朋友在公園玩。"
+    exampleMeaningZh: "明天和朋友在公園玩。",
+    exampleMeaningI18n: { "ja": "明日、友達と公園で遊びます。", "en": "Tomorrow I'm going to play with a friend at the park." },
   }),
   examQuestion({
     id: "n5-kanji-yasumu",
@@ -780,7 +786,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「休」訓讀「やす」、送りがな「みます」，故「休みます」＝やすみます。「やしみます」把「やす」誤讀成「やし」；「きゅうみます」把「休」誤用音讀「きゅう」（用於「休日」等複合詞）；「やすめます」是可能形/別的活用、與辭書形「休む」的ます形不符。此處唯「やすみます」成立。",
     explanationI18n: { "ja": "「休」は訓読みで「やす」、送りがなが「みます」なので、「休みます」＝やすみます、となります。「やしみます」は「やす」を「やし」と誤読しています。「きゅうみます」は「休」を音読みの「きゅう」と誤読しています（「休日」などの複合語で使う読み方です）。「やすめます」は可能形や別の活用で、辞書形「休む」のます形とは一致しません。ここで成り立つのは「やすみます」だけです。", "en": "「休」 has the kun reading 「やす」 with the okurigana 「みます」, so 「休みます」 is やすみます. やしみます misreads 「やす」 as 「やし」; きゅうみます wrongly uses the on reading 「きゅう」 for 「休」 (used in compounds like 「休日」); やすめます is a potential/other conjugation and doesn't match the ます-form of the dictionary form 「休む」. Here only やすみます works." },
     exampleJapanese: "かぜを ひいたので、きょうは かいしゃを 休みます。",
-    exampleMeaningZh: "因為感冒了，今天向公司請假。"
+    exampleMeaningZh: "因為感冒了，今天向公司請假。",
+    exampleMeaningI18n: { "ja": "風邪をひいたので、今日は会社を休みます。", "en": "I caught a cold, so I'm taking today off from work." },
   }),
   examQuestion({
     id: "n5-kanji-ame",
@@ -800,7 +807,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「雨」單獨當名詞時用訓讀「あめ」。「あま」是複合詞時的讀法（如「雨水＝あまみず」）、單獨的『雨』不這樣讀；「う」是音讀（用於「雨天」等）、此處非複合詞；「あね」與「雨」無關（あね＝姉、姊姊）。此處單獨名詞唯「あめ」成立。",
     explanationI18n: { "ja": "「雨」を単独で名詞として使うときは訓読みの「あめ」です。「あま」は複合語のときの読み方で（例：「雨水＝あまみず」）、単独の『雨』はこう読みません。「う」は音読みで（「雨天」などで使う）、ここは複合語ではありません。「あね」は「雨」とは関係ありません（あね＝姉、お姉さんのこと）。ここは単独の名詞なので成り立つのは「あめ」だけです。", "en": "As a standalone noun, 「雨」 takes the kun reading 「あめ」. あま is the reading in compounds (as in 「雨水＝あまみず」) and standalone 「雨」 isn't read that way; う is the on reading (used in 「雨天」 etc.), but this isn't a compound; あね has nothing to do with 「雨」 (あね means 姉, older sister). As a standalone noun here, only あめ works." },
     exampleJapanese: "そとは雨なので、かさを もって いきます。",
-    exampleMeaningZh: "外面在下雨，所以帶傘出門。"
+    exampleMeaningZh: "外面在下雨，所以帶傘出門。",
+    exampleMeaningI18n: { "ja": "外は雨なので、傘を持って行きます。", "en": "It's raining outside, so I'll take an umbrella." },
   }),
   examQuestion({
     id: "n5-syn-takusan",
@@ -822,7 +830,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「たくさん」表示數量多，本句「公園裡有很多小孩」用「いっぱい」（滿滿、很多）替換後語意相同。「すこし」是『一點點』（量少，相反）；「ぜんぜん」是『完全（不）』（用於否定）；「ときどき」是『有時』（頻率，不是數量）。表數量多唯「いっぱい」與「たくさん」同義。",
     explanationI18n: { "ja": "「たくさん」は数量が多いことを表し、この文の「公園に子どもがたくさんいた」は「いっぱい」（いっぱい、たくさん）に置き換えても意味が同じになります。「すこし」は『少し』（量が少なく、反対）です。「ぜんぜん」は『全然（…ない）』（否定に使う）です。「ときどき」は『時々』（頻度であって数量ではない）です。数量が多いことを表すとき「たくさん」と同義になるのは「いっぱい」だけです。", "en": "「たくさん」means a large quantity, so in \"there were lots of children in the park,\" replacing it with「いっぱい」(full; a lot) keeps the same meaning.「すこし」means 'a little' (a small amount — the opposite);「ぜんぜん」means '(not) at all' (used with negatives);「ときどき」means 'sometimes' (frequency, not quantity). For expressing a large quantity, only「いっぱい」is synonymous with「たくさん」." },
     exampleJapanese: "日曜日、こうえんに 子どもが いっぱい いました。",
-    exampleMeaningZh: "星期天，公園裡有很多小孩。"
+    exampleMeaningZh: "星期天，公園裡有很多小孩。",
+    exampleMeaningI18n: { "ja": "日曜日、公園に子どもがたくさんいました。", "en": "On Sunday there were lots of children in the park." },
   }),
   examQuestion({
     id: "n5-syn-totemo",
@@ -844,7 +853,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「とても」修飾形容詞、表示程度很高，本句「這本書非常有趣」用副詞「たいへん」（非常）替換後語意相同。「あまり」是『不太』（用於否定，程度低）；「すこし」是『稍微』（程度低）；「だんだん」是『漸漸』（表變化，不是程度）。表程度高唯「たいへん」與「とても」同義。",
     explanationI18n: { "ja": "「とても」は形容詞を修飾して程度が非常に高いことを表し、この文の「この本はとても面白い」は副詞「たいへん」（大変、非常に）に置き換えても意味が同じになります。「あまり」は『あまり…ない』（否定に使い、程度が低い）です。「すこし」は『少し』（程度が低い）です。「だんだん」は『だんだん』（変化を表し、程度ではない）です。程度が高いことを表すとき「とても」と同義になるのは「たいへん」だけです。", "en": "「とても」modifies adjectives to express a high degree, so in \"this book is very interesting,\" replacing it with the adverb「たいへん」(very; extremely) keeps the same meaning.「あまり」means 'not very' (used with negatives, low degree);「すこし」means 'slightly' (low degree);「だんだん」means 'gradually' (change, not degree). For expressing a high degree, only「たいへん」is synonymous with「とても」." },
     exampleJapanese: "この 本は たいへん おもしろいです。",
-    exampleMeaningZh: "這本書非常有趣。"
+    exampleMeaningZh: "這本書非常有趣。",
+    exampleMeaningI18n: { "ja": "この本はとてもおもしろいです。", "en": "This book is very interesting." },
   }),
   examQuestion({
     id: "n5-syn-tokidoki",
@@ -866,7 +876,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「ときどき」表示頻率不高的「有時」，本句用「たまに」（偶爾）替換後語意相同。「いつも」是『總是』（頻率最高，相反）；「すぐに」是『馬上』（表時間快，不是頻率）；「だんだん」是『漸漸』（表變化）。表頻率中低唯「たまに」與「ときどき」同義。",
     explanationI18n: { "ja": "「ときどき」は頻度が高くない『時々』を表し、この文は「たまに」（たまに）に置き換えても意味が同じになります。「いつも」は『いつも』（頻度が最も高く、反対）です。「すぐに」は『すぐに』（時間の速さを表し、頻度ではない）です。「だんだん」は『だんだん』（変化を表す）です。頻度が中〜低いことを表すとき「ときどき」と同義になるのは「たまに」だけです。", "en": "「ときどき」expresses the low-frequency 'sometimes,' so replacing it with「たまに」(occasionally) keeps the same meaning.「いつも」means 'always' (the highest frequency — the opposite);「すぐに」means 'right away' (speed of timing, not frequency);「だんだん」means 'gradually' (change). For expressing a low-to-moderate frequency, only「たまに」is synonymous with「ときどき」." },
     exampleJapanese: "わたしは たまに きっさてんで コーヒーを 飲みます。",
-    exampleMeaningZh: "我有時會在咖啡店喝咖啡。"
+    exampleMeaningZh: "我有時會在咖啡店喝咖啡。",
+    exampleMeaningI18n: { "ja": "わたしはときどき喫茶店でコーヒーを飲みます。", "en": "I sometimes drink coffee at a café." },
   }),
   examQuestion({
     id: "n5-syn-kyonen",
@@ -888,7 +899,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「きょねん」與「さくねん」都指『去年』，是同義詞，替換後語意完全相同。「らいねん」是『明年』（還沒到，相反方向）；「ことし」是『今年』（現在這一年）；「まいとし」是『每年』（表頻率，不是特定一年）。指前一年唯「さくねん」與「きょねん」同義。",
     explanationI18n: { "ja": "「きょねん」と「さくねん」はどちらも『去年』を指す同義語で、置き換えても意味は全く同じです。「らいねん」は『来年』（まだ来ておらず、反対方向）です。「ことし」は『今年』（今の年）です。「まいとし」は『毎年』（頻度を表し、特定の一年ではない）です。前の年を指すとき「きょねん」と同義になるのは「さくねん」だけです。", "en": "「きょねん」and「さくねん」both mean 'last year' — they are synonyms, so swapping them keeps exactly the same meaning.「らいねん」means 'next year' (still to come — the opposite direction);「ことし」means 'this year' (the current year);「まいとし」means 'every year' (frequency, not a specific year). For referring to the previous year, only「さくねん」is synonymous with「きょねん」." },
     exampleJapanese: "わたしは さくねん 日本へ 行きました。",
-    exampleMeaningZh: "我去年去了日本。"
+    exampleMeaningZh: "我去年去了日本。",
+    exampleMeaningI18n: { "ja": "わたしは去年、日本へ行きました。", "en": "I went to Japan last year." },
   }),
   examQuestion({
     id: "n5-usage-arau",
@@ -910,7 +922,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「洗う」是用水把東西弄乾淨，本句「每天早上起床後洗臉」最自然。修理壞掉的時鐘要用「直す」（直しました）；開電燈要用「つける」；和朋友碰面要用「会う」。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「洗う」は水でものをきれいにすることで、この文の「毎朝起きてから顔を洗う」が最も自然です。壊れた時計は「直す」（直しました）を使い、電気（明かり）をつけるには「つける」を使い、友達と会うには「会う」を使います。後ろの三文は組み合わせがどれも通らず、成り立つのは一つ目の文だけです。", "en": "「洗う」means to clean something with water, so \"every morning after getting up, I wash my face\" is the most natural.\nRepairing a broken clock needs「直す」(直しました); turning on a light needs「つける」; meeting a friend needs「会う」. The last three sentences don't work — only the first one is valid." },
     exampleJapanese: "まいあさ おきてから、かおを 洗います。",
-    exampleMeaningZh: "每天早上起床後洗臉。"
+    exampleMeaningZh: "每天早上起床後洗臉。",
+    exampleMeaningI18n: { "ja": "毎朝、起きてから顔を洗います。", "en": "I wash my face every morning after getting up." },
   }),
   examQuestion({
     id: "n5-usage-samui",
@@ -932,7 +945,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「寒い」用來形容氣溫低、身體覺得冷的環境，本句「冬天下雪，非常冷」最自然。摸到的水或湯要用「つめたい」（つめたい水／つめたいスープ）；題目難要用「難しい」，不會用「寒い」形容。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「寒い」は気温が低く体が冷えるような環境を形容するときに使い、この文の「冬は雪が降ってとても寒い」が最も自然です。触れた水やスープには「つめたい」（つめたい水／つめたいスープ）を使い、問題が難しいには「難しい」を使うのであって、「寒い」では形容しません。後ろの三文は組み合わせがどれも通らず、成り立つのは一つ目の文だけです。", "en": "「寒い」describes an environment with a low temperature that makes your body feel cold, so \"in winter it snows and it's very cold\" is the most natural.\nWater or soup you touch needs「つめたい」(つめたい水／つめたいスープ); a hard problem needs「難しい」— you wouldn't use「寒い」for it. The last three sentences don't work — only the first one is valid." },
     exampleJapanese: "ふゆは ゆきが ふって、とても 寒いです。",
-    exampleMeaningZh: "冬天下雪，非常冷。"
+    exampleMeaningZh: "冬天下雪，非常冷。",
+    exampleMeaningI18n: { "ja": "冬は雪が降って、とても寒いです。", "en": "In winter it snows and it's very cold." },
   }),
   examQuestion({
     id: "n5-usage-oyogu",
@@ -954,7 +968,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「泳ぐ」是在水裡前進，本句「喜歡夏天在海裡游泳」最自然。搭電車去公司要用「行く」；吃飯要用「食べる」；看電視要用「見る」。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「泳ぐ」は水の中で進むことで、この文の「夏に海で泳ぐのが好き」が最も自然です。電車で会社へ行くには「行く」を使い、ご飯を食べるには「食べる」を使い、テレビを見るには「見る」を使います。後ろの三文は組み合わせがどれも通らず、成り立つのは一つ目の文だけです。", "en": "「泳ぐ」means to move through water, so \"I like swimming in the sea in summer\" is the most natural.\nTaking the train to work needs「行く」; eating a meal needs「食べる」; watching TV needs「見る」. The last three sentences don't work — only the first one is valid." },
     exampleJapanese: "なつに うみで 泳ぐのが すきです。",
-    exampleMeaningZh: "喜歡夏天在海裡游泳。"
+    exampleMeaningZh: "喜歡夏天在海裡游泳。",
+    exampleMeaningI18n: { "ja": "夏に海で泳ぐのが好きです。", "en": "I like swimming in the sea in summer." },
   }),
   examQuestion({
     id: "n5-usage-kasu",
@@ -976,7 +991,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「貸す」是把自己的東西讓給別人用（東西從自己流向對方），本句「把筆借給忘記帶筆的朋友」方向正確、最自然。在圖書館取得書是『借入』，要用「借りる」；在蔬果店取得蔬菜要用「買う」；把行李搬到二樓要用「運ぶ」。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「貸す」は自分のものを人に使わせること（ものが自分から相手へ流れる）で、この文の「ペンを忘れた友達にペンを貸した」は方向が正しく、最も自然です。図書館で本を手に入れるのは『借りる』ので「借りる」を使い、八百屋で野菜を手に入れるには「買う」を使い、荷物を二階へ運ぶには「運ぶ」を使います。後ろの三文は組み合わせがどれも通らず、成り立つのは一つ目の文だけです。", "en": "「貸す」means to let someone else use something of yours (the item flows from you to them), so \"I lent a pen to a friend who had forgotten theirs\" has the right direction and is the most natural.\nGetting a book at the library is 'borrowing,' which needs「借りる」; getting vegetables at a greengrocer needs「買う」; carrying luggage up to the second floor needs「運ぶ」. The last three sentences don't work — only the first one is valid." },
     exampleJapanese: "ペンを わすれた ともだちに、ペンを 貸しました。",
-    exampleMeaningZh: "把筆借給忘記帶筆的朋友。"
+    exampleMeaningZh: "把筆借給忘記帶筆的朋友。",
+    exampleMeaningI18n: { "ja": "ペンを忘れた友達に、ペンを貸しました。", "en": "I lent a pen to a friend who had forgotten theirs." },
   }),
   examQuestion({
     id: "n5-context-soshite",
@@ -998,7 +1014,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "前句「好吃」與後句「便宜」都是優點、方向相同，後句再追加一項，用表並列追加的「そして」（而且）。「でも」是逆接『可是』（好吃與便宜不相反）；「だから」是因果『所以』（『所以便宜』不合邏輯）；「それとも」是選擇『還是』。表同方向追加唯「そして」成立。",
     explanationI18n: { "ja": "前の文「おいしい」と後の文「安い」はどちらも長所で方向が同じで、後の文でもう一つ付け足しているので、並列・追加を表す「そして」（そして）を使います。「でも」は逆接の『でも』（おいしいと安いは反対ではない）です。「だから」は因果の『だから』（『だから安い』は論理が合わない）です。「それとも」は選択の『それとも』です。同じ方向で付け足すとき成り立つのは「そして」だけです。", "en": "Both the first clause 'delicious' and the second 'cheap' are positive points going in the same direction, and the second adds one more, so use「そして」(and; moreover), which lists and adds.「でも」is the contrastive 'but' (delicious and cheap aren't opposites);「だから」is causal 'so' ('so it's cheap' isn't logical);「それとも」is 'or' for choices. For adding a point in the same direction, only「そして」works." },
     exampleJapanese: "この みせの ケーキは おいしいです。そして、ねだんも 安いです。",
-    exampleMeaningZh: "這家店的蛋糕很好吃。而且價錢也便宜。"
+    exampleMeaningZh: "這家店的蛋糕很好吃。而且價錢也便宜。",
+    exampleMeaningI18n: { "ja": "この店のケーキはおいしいです。それに、値段も安いです。", "en": "The cakes at this shop are delicious. And the prices are low, too." },
   }),
   examQuestion({
     id: "n5-context-sorekara",
@@ -1020,7 +1037,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "前句「洗臉」與後句「吃早餐」是依時間先後發生的兩個動作，用表時間順序的「それから」（接著、然後）。「しかし」是逆接『可是』（前後不相反）；「だから」是因果『所以』（『所以吃早餐』不自然）；「それとも」是選擇『還是』。表時間先後唯「それから」成立。",
     explanationI18n: { "ja": "前の文「顔を洗う」と後の文「朝ご飯を食べる」は時間の前後に従って起こる二つの動作なので、時間の順序を表す「それから」（それから、その後）を使います。「しかし」は逆接の『しかし』（前後は反対ではない）です。「だから」は因果の『だから』（『だから朝ご飯を食べる』は不自然）です。「それとも」は選択の『それとも』です。時間の前後を表すとき成り立つのは「それから」だけです。", "en": "The first clause 'washed my face' and the second 'ate breakfast' are two actions that happen in time order, so use「それから」(then; after that), which shows time sequence.「しかし」is the contrastive 'but' (the two aren't opposites);「だから」is causal 'so' ('so I ate breakfast' is unnatural);「それとも」is 'or' for choices. For showing time sequence, only「それから」works." },
     exampleJapanese: "あさ おきて、かおを あらいました。それから、あさごはんを 食べました。",
-    exampleMeaningZh: "早上起床洗了臉。接著吃了早餐。"
+    exampleMeaningZh: "早上起床洗了臉。接著吃了早餐。",
+    exampleMeaningI18n: { "ja": "朝起きて、顔を洗いました。そのあと、朝ごはんを食べました。", "en": "I got up in the morning and washed my face. After that, I ate breakfast." },
   }),
   examQuestion({
     id: "n5-context-shikashi",
@@ -1042,7 +1060,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "前句「昨天好天氣」讓人期待今天也好，後句卻是「下雨」，前後相反，用逆接的「しかし」（但是）。「だから」是因果『所以』（『所以下雨』邏輯矛盾）；「そして」是並列『而且』（無法表轉折）；「それから」是時間先後『接著』（前後不是順接）。表逆接唯「しかし」成立。",
     explanationI18n: { "ja": "前の文「昨日はいい天気だった」からは今日も晴れると期待されますが、後ろの文は「雨」で、前後が反対になっています。逆接を表す「しかし」（けれども）が正解です。「だから」は因果関係の『それゆえに』（『だから雨だ』では論理が矛盾）、「そして」は並列の『そのうえ』（転換を表せない）、「それから」は時間の前後関係の『その次に』（前後が順接になっていない）。逆接を表せるのは「しかし」だけです。", "en": "The first clause 'yesterday was nice' leads you to expect today to be nice too, but the second clause is 'it's raining' — the two are opposed, so use the contrastive「しかし」(but; however).「だから」is causal 'so' ('so it's raining' is a logical contradiction);「そして」is 'and' for listing (can't show a turn);「それから」is the sequential 'then' (this isn't a smooth continuation). For a contrast, only「しかし」works." },
     exampleJapanese: "きのうは いい てんきでした。しかし、きょうは あさから 雨です。",
-    exampleMeaningZh: "昨天是好天氣。但是今天從早上就下雨。"
+    exampleMeaningZh: "昨天是好天氣。但是今天從早上就下雨。",
+    exampleMeaningI18n: { "ja": "昨日はいい天気でした。でも、今日は朝から雨です。", "en": "The weather was nice yesterday. But today it's been raining since morning." },
   }),
   examQuestion({
     id: "n5-context-soretomo",
@@ -1064,7 +1083,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "前後是「咖啡」與「茶」兩個選項，句子在問對方要二擇一，用表選擇的「それとも」（還是）。「そして」是並列『而且』（不是二擇一）；「だから」是因果『所以』（句中無因果）；「しかし」是逆接『可是』（兩者非相反對立）。表二選一的疑問唯「それとも」成立。",
     explanationI18n: { "ja": "前後は「コーヒー」と「お茶」という二つの選択肢で、相手にどちらか一つを選ぶよう尋ねているので、選択を表す「それとも」（あるいは）が正解です。「そして」は並列の『そのうえ』（二者択一ではない）、「だから」は因果関係の『それゆえに』（文中に因果関係はない）、「しかし」は逆接の『けれども』（両者は反対・対立の関係ではない）。二者択一の疑問を表せるのは「それとも」だけです。", "en": "The two options are 'coffee' and 'tea,' and the sentence asks the other person to pick one of the two, so use「それとも」(or), which offers a choice.「そして」is 'and' for listing (not a choice between two);「だから」is causal 'so' (there's no cause here);「しかし」is the contrastive 'but' (the two aren't opposed). For a question offering a choice between two, only「それとも」works." },
     exampleJapanese: "のみものは コーヒーが いいですか。それとも、おちゃが いいですか。",
-    exampleMeaningZh: "飲料要咖啡好呢？還是茶好呢？"
+    exampleMeaningZh: "飲料要咖啡好呢？還是茶好呢？",
+    exampleMeaningI18n: { "ja": "飲み物はコーヒーとお茶、どちらがいいですか。", "en": "Would you like coffee to drink? Or would you prefer tea?" },
   }),
   examQuestion({
     id: "n5-kanji-kawa",
@@ -1084,7 +1104,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「かわ」：「川」單獨當名詞時讀訓讀 かわ，句中是『那條河』，正確。干擾「がわ」：濁音化只在複合詞（例：かわ→がわ 如 みぎがわ 右側）才發生，單獨的「川」不濁音，此語境不成立。干擾「かわあ」：多了長音，N5 的 川 無長音，發音不對。干擾「かっわ」：插入促音，無此讀法。陷阱類型＝清濁混淆＋長音／促音干擾。",
     explanationI18n: { "ja": "正解「かわ」：「川」を単独の名詞として使うときは訓読みの かわ と読み、文中は『あの川』なので正しい読み方です。誤答「がわ」：濁音化は複合語（例：かわ→がわ、みぎがわ 右側 のように）でのみ起こり、単独の「川」は濁りません。この文脈では成り立ちません。誤答「かわあ」：長音が余分に付いており、N5 の 川 に長音はないので発音が違います。誤答「かっわ」：促音が入っていますが、そのような読み方はありません。ひっかけの型＝清濁の混同＋長音・促音による攪乱です。", "en": "Correct answer「かわ」: when「川」stands alone as a noun it takes the kun-reading かわ; here it means 'that river,' so this is correct. Distractor「がわ」: the voicing to が only happens in compounds (e.g. かわ→がわ, as in みぎがわ 'right side'); a standalone「川」isn't voiced, so it doesn't fit here. Distractor「かわあ」: this adds a long vowel, but N5's 川 has no long vowel, so the pronunciation is wrong. Distractor「かっわ」: this inserts a small っ (geminate), which is not a valid reading. Trap type = voiced/unvoiced confusion + long-vowel/geminate distractors." },
     exampleJapanese: "あの川で 魚が およいで います。",
-    exampleMeaningZh: "那條河裡有魚在游。"
+    exampleMeaningZh: "那條河裡有魚在游。",
+    exampleMeaningI18n: { "ja": "あの川で魚が泳いでいます。", "en": "Fish are swimming in that river." },
   }),
   examQuestion({
     id: "n5-kanji-yama",
@@ -1104,7 +1125,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「やま」：「山」單獨名詞讀訓讀 やま，句中『爬上高山』，正確。干擾「さん」：是音讀，只用於複合詞（如 ふじさん 富士山），此處 山 是單獨名詞、前面被『たかい』修飾，不讀音讀，明確不成立。干擾「やあま」：多了長音，發音不對。干擾「やっま」：插入促音，無此讀法。陷阱類型＝音訓混淆＋長音／促音干擾。",
     explanationI18n: { "ja": "正解「やま」：「山」を単独の名詞として使うときは訓読みの やま と読み、文中は『高い山に登った』なので正しい読み方です。誤答「さん」：音読みで、複合語（富士山 ふじさん など）でのみ使います。ここの 山 は単独の名詞で、前を『高い』が修飾しているので音読みにはならず、明らかに成り立ちません。誤答「やあま」：長音が余分に付いており発音が違います。誤答「やっま」：促音が入っていますが、そのような読み方はありません。ひっかけの型＝音読みと訓読みの混同＋長音・促音による攪乱です。", "en": "Correct answer「やま」: as a standalone noun「山」takes the kun-reading やま; here it means 'climbed a high mountain,' so this is correct. Distractor「さん」: this is the on-reading, used only in compounds (e.g. ふじさん 'Mt. Fuji'); here 山 is a standalone noun modified by the preceding 'たかい,' so it isn't read with the on-reading — clearly invalid. Distractor「やあま」: this adds a long vowel, so the pronunciation is wrong. Distractor「やっま」: this inserts a small っ (geminate), which is not a valid reading. Trap type = on/kun confusion + long-vowel/geminate distractors." },
     exampleJapanese: "なつ休みに たかい山に のぼりました。",
-    exampleMeaningZh: "暑假時爬了高高的山。"
+    exampleMeaningZh: "暑假時爬了高高的山。",
+    exampleMeaningI18n: { "ja": "夏休みに高い山に登りました。", "en": "I climbed a tall mountain during summer vacation." },
   }),
   examQuestion({
     id: "n5-kanji-asa",
@@ -1124,7 +1146,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「あさ」：「朝」單獨名詞讀訓讀 あさ，句中『每天早上六點』指時段，正確。干擾「あざ」：把 さ 濁化成 ざ，あざ 是別的詞（瘀青／痣），讀音與語意都不對。干擾「あっさ」：插入促音，無此讀法。干擾「あさあ」：多了長音，發音不對。陷阱類型＝清濁混淆（會變成別的詞）＋促音／長音干擾。",
     explanationI18n: { "ja": "正解「あさ」：「朝」を単独の名詞として使うときは訓読みの あさ と読み、文中の『毎朝六時に』は時間帯を指すので正しい読み方です。誤答「あざ」：さ を濁らせて ざ にしたもので、あざ は別の言葉（あざ＝内出血・ほくろ）になり、読み方も意味も違います。誤答「あっさ」：促音が入っていますが、そのような読み方はありません。誤答「あさあ」：長音が余分に付いており発音が違います。ひっかけの型＝清濁の混同（別の言葉になってしまう）＋促音・長音による攪乱です。", "en": "Correct answer「あさ」: as a standalone noun「朝」takes the kun-reading あさ; here 'six every morning' refers to a time of day, so this is correct. Distractor「あざ」: voicing さ into ざ makes あざ, which is a different word (a bruise / a birthmark) — both the reading and the meaning are wrong. Distractor「あっさ」: this inserts a small っ (geminate), which is not a valid reading. Distractor「あさあ」: this adds a long vowel, so the pronunciation is wrong. Trap type = voiced/unvoiced confusion (produces a different word) + geminate/long-vowel distractors." },
     exampleJapanese: "まいにち朝 六じに おきます。",
-    exampleMeaningZh: "每天早上六點起床。"
+    exampleMeaningZh: "每天早上六點起床。",
+    exampleMeaningI18n: { "ja": "毎日、朝六時に起きます。", "en": "I get up at six every morning." },
   }),
   examQuestion({
     id: "n5-kanji-namae",
@@ -1144,7 +1167,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「なまえ」：「名前」讀 なまえ（名 な＋前 まえ），句意『請在這裡寫上你的名字』，正確。干擾「なまへ」：把 え 寫成近形假名 へ（讀音為 he），不成立。干擾「なめえ」：把第二拍 ま 誤替換成 め（なめえ），假名拼錯，非此詞讀音。干擾「なっまえ」：多插入促音 っ，無此讀法。陷阱類型＝近形假名（え/へ）＋假名替換錯誤＋促音干擾。",
     explanationI18n: { "ja": "正解「なまえ」：「名前」は なまえ（名 な＋前 まえ）と読み、文意は『ここにあなたの名前を書いてください』なので正しい読み方です。誤答「なまへ」：え を形の似た仮名 へ（読みは he）に書き換えたもので、成り立ちません。誤答「なめえ」：二拍目の ま を誤って め に置き換えたもの（なめえ）で、仮名の綴りが間違っており、この語の読み方ではありません。誤答「なっまえ」：促音 っ を余分に入れたもので、そのような読み方はありません。ひっかけの型＝形の似た仮名（え/へ）＋仮名の置き換えミス＋促音による攪乱です。", "en": "Correct answer「なまえ」:「名前」reads なまえ (名 な + 前 まえ), and the sentence means 'please write your name here,' so this is correct. Distractor「なまへ」: this writes the final え as the look-alike kana へ (read 'he'), which is invalid. Distractor「なめえ」: this wrongly replaces the second mora ま with め (なめえ) — the kana is misspelled and isn't this word's reading. Distractor「なっまえ」: this inserts an extra small っ (geminate), which is not a valid reading. Trap type = look-alike kana (え/へ) + kana-substitution error + geminate distractor." },
     exampleJapanese: "ここに あなたの名前を かいて ください。",
-    exampleMeaningZh: "請在這裡寫上你的名字。"
+    exampleMeaningZh: "請在這裡寫上你的名字。",
+    exampleMeaningI18n: { "ja": "ここにあなたの名前を書いてください。", "en": "Please write your name here." },
   }),
   examQuestion({
     id: "n5-kanji-tatsu",
@@ -1164,7 +1188,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「たって」：「立つ」的 て形是 たって（促音便），句中『老師站在前面』，正確。干擾「だって」：把 た 濁化成 だ，だって 是別的詞（接續助詞「可是」），讀音與意思都不對。干擾「たて」：少了促音變成 たて（另是『縱』或命令形語感），與『立って います』的 て形不符，發音也不同。干擾「たあって」：多了長音，發音不對。陷阱類型＝清濁混淆（變別詞）＋促音脫落＋長音干擾。",
     explanationI18n: { "ja": "正解「たって」：「立つ」の て形は たって（促音便）で、文中は『先生が前に立っている』なので正しい読み方です。誤答「だって」：た を濁らせて だ にしたもので、だって は別の言葉（接続助詞の「でも」）になり、読み方も意味も違います。誤答「たて」：促音が抜けて たて になっており（別に『縦』や命令形のような語感になる）、『立って います』の て形とは合わず、発音も違います。誤答「たあって」：長音が余分に付いており発音が違います。ひっかけの型＝清濁の混同（別の言葉になる）＋促音の脱落＋長音による攪乱です。", "en": "Correct answer「たって」: the te-form of「立つ」is たって (with a sound change to っ), and the sentence means 'the teacher is standing in front,' so this is correct. Distractor「だって」: voicing た into だ makes だって, a different word (the conjunctive particle 'but') — both the reading and the meaning are wrong. Distractor「たて」: dropping the small っ gives たて (which has the feel of 'vertical' or an imperative form), which doesn't match the te-form in '立って います' and is pronounced differently. Distractor「たあって」: this adds a long vowel, so the pronunciation is wrong. Trap type = voiced/unvoiced confusion (produces a different word) + dropped geminate + long-vowel distractor." },
     exampleJapanese: "せんせいが きょうしつの まえに 立って います。",
-    exampleMeaningZh: "老師站在教室前面。"
+    exampleMeaningZh: "老師站在教室前面。",
+    exampleMeaningI18n: { "ja": "先生が教室の前に立っています。", "en": "The teacher is standing at the front of the classroom." },
   }),
   examQuestion({
     id: "n5-kanji-takai",
@@ -1184,7 +1209,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「たかい」：「高い」形容詞讀 たかい，句中『大樓非常高』，正確。干擾「だかい」：把開頭 た 濁化成 だ，無此讀法。干擾「たがい」：把 か 濁化成 が，たがい 會聯想到別詞（互い 互相），讀音與意思都不對。干擾「たかあい」：在 か 後加長音，發音不對。陷阱類型＝清濁混淆（兩處）＋長音干擾。",
     explanationI18n: { "ja": "正解「たかい」：「高い」は形容詞で たかい と読み、文中は『ビルがとても高い』なので正しい読み方です。誤答「だかい」：語頭の た を濁らせて だ にしたもので、そのような読み方はありません。誤答「たがい」：か を濁らせて が にしたもので、たがい は別の言葉（互い 互いに）を連想させ、読み方も意味も違います。誤答「たかあい」：か の後に長音を加えたもので発音が違います。ひっかけの型＝清濁の混同（二か所）＋長音による攪乱です。", "en": "Correct answer「たかい」: the adjective「高い」reads たかい, and the sentence means 'the building is very tall,' so this is correct. Distractor「だかい」: voicing the initial た into だ gives an invalid reading. Distractor「たがい」: voicing か into が gives たがい, which evokes a different word (互い 'mutual') — both the reading and the meaning are wrong. Distractor「たかあい」: this adds a long vowel after か, so the pronunciation is wrong. Trap type = voiced/unvoiced confusion (two spots) + long-vowel distractor." },
     exampleJapanese: "この ビルは とても 高いです。",
-    exampleMeaningZh: "這棟大樓非常高。"
+    exampleMeaningZh: "這棟大樓非常高。",
+    exampleMeaningI18n: { "ja": "このビルはとても高いです。", "en": "This building is very tall." },
   }),
   examQuestion({
     id: "n5-vocab-denwa",
@@ -1444,7 +1470,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "單獨當「人」這個名詞時訓讀「ひと」。「びと」是錯誤地把詞頭濁化（旅人たびびと那種連濁只在複合詞後半才出現，句首單獨的「人」不濁）；「じん」「にん」都是音讀，只用在日本人にほんじん、三人さんにん這類複合詞，單獨指「那個人」不能用。故只有「ひと」成立。",
     explanationI18n: { "ja": "「人」を単独の名詞として使うときは訓読みの「ひと」です。「びと」は誤って語頭を濁らせたもの（旅人 たびびと のような連濁は複合語の後半にだけ現れ、文頭で単独の「人」は濁りません）、「じん」「にん」はどちらも音読みで、日本人 にほんじん、三人 さんにん のような複合語にだけ使い、単独で「あの人」を指すときには使えません。したがって成り立つのは「ひと」だけです。", "en": "When 「人」 stands alone as this noun, it takes the kun'yomi 「ひと」. 「びと」 wrongly voices the beginning of the word (the sequential voicing in 旅人 たびびと only appears in the second half of a compound; a standalone 「人」 at the head of a phrase is not voiced). 「じん」 and 「にん」 are both on'yomi, used only in compounds like 日本人 にほんじん and 三人 さんにん, and can't be used for a standalone \"that person.\" So only 「ひと」 works." },
     exampleJapanese: "あの人はわたしの となりに すんでいます。",
-    exampleMeaningZh: "那個人住在我的隔壁。"
+    exampleMeaningZh: "那個人住在我的隔壁。",
+    exampleMeaningI18n: { "ja": "あの人はわたしの隣に住んでいます。", "en": "That person lives next door to me." },
   }),
   examQuestion({
     id: "n5-kanji-ue",
@@ -1464,7 +1491,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "表示位置「上面」時訓讀「うえ」。「した」是「下」的讀音、意思相反（下面），語意明確不對；「うへ」把第二拍誤寫成へ，是錯讀；「じょう」是音讀，用在屋上おくじょう這類複合詞，單獨指「桌上」不能用。故只有「うえ」成立。",
     explanationI18n: { "ja": "位置の「上」を表すときは訓読みの「うえ」です。「した」は「下」の読みで意味が反対（下）になり、明らかに合いません。「うへ」は二拍目を誤って へ と書いたもので誤読です。「じょう」は音読みで、屋上 おくじょう のような複合語に使い、単独で「机の上」を指すときには使えません。したがって成り立つのは「うえ」だけです。", "en": "When it indicates the position \"on top,\" 「上」 takes the kun'yomi 「うえ」. 「した」 is the reading of 「下」 with the opposite meaning (below), clearly wrong in meaning. 「うへ」 mistakenly writes the second mora as へ and is an incorrect reading. 「じょう」 is the on'yomi, used in compounds like 屋上 おくじょう, and can't be used for a standalone \"on the desk.\" So only 「うえ」 works." },
     exampleJapanese: "つくえの 上に ねこが います。",
-    exampleMeaningZh: "桌子上面有一隻貓。"
+    exampleMeaningZh: "桌子上面有一隻貓。",
+    exampleMeaningI18n: { "ja": "机の上に猫がいます。", "en": "There is a cat on the desk." },
   }),
   examQuestion({
     id: "n5-kanji-en",
@@ -1484,7 +1512,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "貨幣單位「円」讀「えん」。「けん」是「件」「軒」等別字的讀音；「げん」把えん誤濁化、也不是此字讀音；「まる」是圓圈符號「○」的訓讀，不用在金額。一百圓只能用「えん」，故唯一成立。",
     explanationI18n: { "ja": "通貨の単位「円」は「えん」と読みます。「けん」は「件」「軒」など別の字の読み、「げん」は えん を誤って濁らせたもので、これもこの字の読みではありません。「まる」は円の記号「○」の訓読みで、金額には使いません。百円は「えん」しか使えないので、これだけが成り立ちます。", "en": "The currency unit 「円」 is read 「えん」. 「けん」 is the reading of different characters like 「件」 and 「軒」. 「げん」 mistakenly voices えん and isn't a reading of this character. 「まる」 is the kun'yomi for the circle symbol 「○」 and isn't used for money amounts. \"One hundred yen\" can only be 「えん」, so it's the only one that works." },
     exampleJapanese: "この りんごは ひゃく円です。",
-    exampleMeaningZh: "這顆蘋果是一百日圓。"
+    exampleMeaningZh: "這顆蘋果是一百日圓。",
+    exampleMeaningI18n: { "ja": "このりんごは百円です。", "en": "This apple costs 100 yen." },
   }),
   examQuestion({
     id: "n5-kanji-deru",
@@ -1504,7 +1533,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "自動詞「出る」的ます形是「でます」（出去、離開）。「てます」漏掉濁點是錯讀；「だします」是他動詞「出す」（拿出、交出）的讀音，需要受詞、和「いえを出る＝離開家」的自動詞用法不同（這裡的を是離開的起點）；「ではます」多塞了は是錯讀。故只有「でます」成立。",
     explanationI18n: { "ja": "自動詞「出る」のます形は「でます」（出て行く、離れる）です。「てます」は濁点が抜けており誤読です。「だします」は他動詞「出す」（取り出す、提出する）の読みで、目的語を必要とし、「家を出る＝家を離れる」という自動詞の使い方とは異なります（ここの を は出発点を表します）。「ではます」は は が余分に入っており誤読です。したがって成り立つのは「でます」だけです。", "en": "The masu-form of the intransitive verb 「出る」 is 「でます」 (to go out, to leave). 「てます」 drops the voicing mark and is an incorrect reading. 「だします」 is the reading of the transitive verb 「出す」 (to take out, to hand in), which requires an object and differs from the intransitive use in 「いえを出る」 (to leave the house) — here を marks the starting point of departure. 「ではます」 stuffs in an extra は and is an incorrect reading. So only 「でます」 works." },
     exampleJapanese: "まいあさ 七時に いえを 出ます。",
-    exampleMeaningZh: "每天早上七點出門。"
+    exampleMeaningZh: "每天早上七點出門。",
+    exampleMeaningI18n: { "ja": "毎朝七時に家を出ます。", "en": "I leave the house at seven every morning." },
   }),
   examQuestion({
     id: "n5-kanji-haha",
@@ -1524,7 +1554,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "謙稱自己的母親時讀「はは」。「ばば」把詞頭濁化是錯讀（且語感粗俗）；「ちち」是「父」的讀音、指父親、語意相反；「はわ」把第二拍誤寫成わ是錯讀。提到自己的媽媽只能用「はは」，故唯一成立。",
     explanationI18n: { "ja": "自分の母親をへりくだって言うときは「はは」と読みます。「ばば」は語頭を濁らせたもので誤読です（しかも語感が下品になります）。「ちち」は「父」の読みで父親を指し、意味が反対です。「はわ」は二拍目を誤って わ と書いたもので誤読です。自分の母親について言うときは「はは」しか使えないので、これだけが成り立ちます。", "en": "When humbly referring to one's own mother, the reading is 「はは」. 「ばば」 voices the start of the word and is an incorrect reading (and sounds crude). 「ちち」 is the reading of 「父」, meaning father — the opposite meaning. 「はわ」 mistakenly writes the second mora as わ and is an incorrect reading. Referring to your own mom can only be 「はは」, so it's the only one that works." },
     exampleJapanese: "わたしの 母は りょうりが じょうずです。",
-    exampleMeaningZh: "我媽媽很會做菜。"
+    exampleMeaningZh: "我媽媽很會做菜。",
+    exampleMeaningI18n: { "ja": "私の母は料理が上手です。", "en": "My mother is good at cooking." },
   }),
   examQuestion({
     id: "n5-kanji-iu",
@@ -1544,7 +1575,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「言う」的ます形是「いいます」（說）。「います」漏掉一個い、變成存在動詞「居る」的讀音、意思是「在」、語意不對；「ゆいます」是錯讀（言う口語雖唸ゆう，但ます形寫成讀音時是いいます，ゆいます不成立）；「いえます」是可能形「言える」（能說）的讀音、和原句陳述習慣動作的「言います」不同。故只有「いいます」成立。",
     explanationI18n: { "ja": "「言う」のます形は「いいます」（言う・話す）です。「います」は「い」が一つ足りず、存在動詞「居る」の読みになってしまい、「（人が）いる」という意味になるので合いません。「ゆいます」は誤読で、「言う」は話し言葉で「ゆう」と発音することはありますが、ます形を仮名で書くと「いいます」であり、「ゆいます」という形は成り立ちません。「いえます」は可能形「言える」（言うことができる）の読みで、習慣的な動作を述べるこの文の「言います」とは意味が異なります。したがって「いいます」だけが正解です。", "en": "The masu-form of 「言う」 is 「いいます」 (to say). 「います」 drops one い and becomes the reading of the existence verb 「居る」, meaning \"to be present,\" which is wrong in meaning. 「ゆいます」 is an incorrect reading (although 言う is pronounced ゆう in casual speech, its masu-form is written and read as いいます, not ゆいます). 「いえます」 is the reading of the potential form 「言える」 (to be able to say), which differs from 「言います」 stating a habitual action in the original sentence. So only 「いいます」 works." },
     exampleJapanese: "あさ あう とき、「おはよう」と 言います。",
-    exampleMeaningZh: "早上見面時會說「早安」。"
+    exampleMeaningZh: "早上見面時會說「早安」。",
+    exampleMeaningI18n: { "ja": "朝会うとき、「おはよう」と言います。", "en": "When you meet someone in the morning, you say \"good morning.\"" },
   }),
   examQuestion({
     id: "n5-grammar-ka",
@@ -1646,7 +1678,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「待つ」是停在原地直到人或事物到來，本句「在車站等了朋友三十分鐘」最自然。第二句形容蘋果又紅，那是描述狀態，要用「おいしい」之類的形容詞，蘋果無法被『等』；第三句把茶倒進杯子要用「入れる」（入れました）；第四句早上穿上新鞋要用「はく」（はいて）。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「待つ」は、人や物事が来るまでその場にとどまることを表し、この文「駅で友達を30分待ちました」が最も自然です。二つ目の文はりんごが赤いという状態を表すもので、「おいしい」などの形容詞を使うべきであり、りんごを「待つ」ことはできません。三つ目の文はお茶をコップに注ぐので「入れる」（入れました）を使います。四つ目の文は朝、新しい靴を身につけるので「はく」（はいて）を使います。後ろの三つの文はどれも組み合わせが成り立たず、一つ目の文だけが正しいです。", "en": "「待つ」means to stay where you are until a person or thing arrives, so \"I waited for my friend at the station for thirty minutes\" is the natural fit. The second sentence describes an apple being red, which is a state and needs an adjective like「おいしい」— an apple can't be \"waited\"; the third sentence, about pouring tea into a cup, needs「入れる」(入れました); the fourth, about putting on new shoes in the morning, needs「はく」(はいて). The last three don't work, so only the first is correct." },
     exampleJapanese: "えきで 友達を 30ぷん 待ちました。",
-    exampleMeaningZh: "在車站等了朋友三十分鐘。"
+    exampleMeaningZh: "在車站等了朋友三十分鐘。",
+    exampleMeaningI18n: { "ja": "駅で友達を30分待ちました。", "en": "I waited for my friend at the station for thirty minutes." },
   }),
   examQuestion({
     id: "n5-usage-akarui",
@@ -1668,7 +1701,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「明るい」形容地方光線充足、看得清楚，本句「這個房間窗戶很大，非常明亮」最自然。第二句咖啡加了糖是味道甜，要用「あまい」；第三句題目簡單要用「やさしい／かんたん」，無法用『明亮』形容；第四句行李小是體積，要用「ちいさい」，跟『明亮』無關。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「明るい」は場所に光が十分にあり、よく見える様子を表し、この文「この部屋は窓が大きくて、とても明るいです」が最も自然です。二つ目の文はコーヒーに砂糖を入れて甘いという意味なので「あまい」を使います。三つ目の文は問題が簡単だという意味なので「やさしい／かんたん」を使い、「明るい」で表すことはできません。四つ目の文は荷物が小さいという体積の話なので「ちいさい」を使い、「明るい」とは関係ありません。後ろの三つの文はどれも組み合わせが成り立たず、一つ目の文だけが正しいです。", "en": "「明るい」describes a place that has plenty of light and is easy to see in, so \"This room has big windows, so it's very bright\" is the natural fit. In the second sentence, coffee with sugar added is sweet, which needs「あまい」; in the third, an easy problem needs「やさしい／かんたん」and can't be described as \"bright\"; in the fourth, a small piece of luggage refers to size and needs「ちいさい」, which has nothing to do with brightness. The last three don't work, so only the first is correct." },
     exampleJapanese: "この へやは まどが おおきくて、とても 明るいです。",
-    exampleMeaningZh: "這個房間窗戶很大，非常明亮。"
+    exampleMeaningZh: "這個房間窗戶很大，非常明亮。",
+    exampleMeaningI18n: { "ja": "この部屋は窓が大きくて、とても明るいです。", "en": "This room has big windows and is very bright." },
   }),
   examQuestion({
     id: "n5-context-demo",
@@ -1750,7 +1784,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「ひま」是沒有事情要做、時間很多，本句「今天沒有工作，非常有空」最自然。第二句拉麵好吃要用「おいしい」，食物無法用『有空』形容；第三句山很高要用「たかい」，山的高度跟『有空』無關；第四句行李重要用「おもい」本身，重量跟『有空』無關。後三句搭配皆不通，唯第一句成立。",
     explanationI18n: { "ja": "「ひま」はすることがなく時間がたくさんある様子を表し、この文「今日は仕事がなくて、とても暇です」が最も自然です。二つ目の文はラーメンがおいしいという意味なので「おいしい」を使い、食べ物を「ひま」で表すことはできません。三つ目の文は山が高いという意味なので「たかい」を使い、山の高さと「ひま」は関係ありません。四つ目の文は荷物が重いという意味なので「おもい」を使い、重さと「ひま」は関係ありません。後ろの三つの文はどれも組み合わせが成り立たず、一つ目の文だけが正しいです。", "en": "「ひま」means having nothing to do and plenty of time, so \"I have no work today, so I'm very free\" is the natural fit. In the second sentence, tasty ramen needs「おいしい」— food can't be described as \"free\"; in the third, a tall mountain needs「たかい」, and a mountain's height has nothing to do with being \"free\"; in the fourth, heavy luggage needs「おもい」itself, and weight has nothing to do with being \"free.\" The last three don't work, so only the first is correct." },
     exampleJapanese: "きょうは しごとが なくて、とても ひまです。",
-    exampleMeaningZh: "今天沒有工作，非常有空。"
+    exampleMeaningZh: "今天沒有工作，非常有空。",
+    exampleMeaningI18n: { "ja": "今日は仕事がなくて、とても暇です。", "en": "I have no work today, so I'm completely free." },
   }),
   examQuestion({
     id: "n5-context-dakara",
@@ -1910,7 +1945,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "謙稱自己的父親時訓讀「ちち」。「はは」是「母」的讀音、指母親、語意相反；「じじ」把詞頭誤濁化（且語感是『老頭』、非父親）；「だい」是無關讀音，與「父」不符。提到自己的爸爸只能用「ちち」，故唯一成立。",
     explanationI18n: { "ja": "自分の父親をへりくだって言うときは訓読みで「ちち」です。「はは」は「母」の読みで母親を指し、意味が反対です。「じじ」は語頭を誤って濁音にしており（しかも語感は「じいさん」で父親ではありません）、誤りです。「だい」は無関係な読みで、「父」には合いません。自分の父親について言うときは「ちち」だけなので、唯一これが正解です。", "en": "When humbly referring to one's own father, the kun reading is「ちち」. 「はは」is the reading of「母」and means mother, which is the opposite; 「じじ」wrongly voices the initial syllable (and its nuance is \"old man,\" not father); 「だい」is an unrelated reading that doesn't match「父」. To refer to one's own dad, only「ちち」works, so it's the only correct answer." },
     exampleJapanese: "わたしの父は かいしゃいんです。",
-    exampleMeaningZh: "我爸爸是上班族。"
+    exampleMeaningZh: "我爸爸是上班族。",
+    exampleMeaningI18n: { "ja": "私の父は会社員です。", "en": "My father is a company employee." },
   }),
   examQuestion({
     id: "n5-kanji-inu",
@@ -1930,7 +1966,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "動物「犬」單獨當名詞時訓讀「いぬ」。「いね」（＝稲、稻子）語意不符；「いの」「えぬ」皆為音形錯讀。唯「いぬ」成立。",
     explanationI18n: { "ja": "動物の「犬」を単独で名詞として使うときは訓読みで「いぬ」です。「いね」（＝稲）は意味が合いません。「いの」「えぬ」はどちらも音や形の誤読です。「いぬ」だけが正しいです。", "en": "When the animal「犬」stands alone as a noun, the kun reading is「いぬ」. 「いね」(＝稲, rice plant) doesn't fit the meaning; 「いの」and「えぬ」are both mistaken readings of the sound/form. Only「いぬ」works." },
     exampleJapanese: "にわで しろい犬が あそんで います。",
-    exampleMeaningZh: "白色的狗在院子裡玩。"
+    exampleMeaningZh: "白色的狗在院子裡玩。",
+    exampleMeaningI18n: { "ja": "庭で白い犬が遊んでいます。", "en": "A white dog is playing in the yard." },
   }),
   examQuestion({
     id: "n5-kanji-kuruma",
@@ -1950,7 +1987,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "交通工具「車」單獨當名詞時訓讀「くるま」。「くろま」「くらま」「くりま」皆為母音/音形錯讀，非此字讀音。唯「くるま」成立。",
     explanationI18n: { "ja": "乗り物の「車」を単独で名詞として使うときは訓読みで「くるま」です。「くろま」「くらま」「くりま」はどれも母音や音の形の誤読で、この字の読みではありません。「くるま」だけが正しいです。", "en": "When the vehicle「車」stands alone as a noun, the kun reading is「くるま」. 「くろま」「くらま」「くりま」are all vowel/sound-form misreadings and aren't the reading of this character. Only「くるま」works." },
     exampleJapanese: "ちちは あたらしい車を かいました。",
-    exampleMeaningZh: "爸爸買了新車。"
+    exampleMeaningZh: "爸爸買了新車。",
+    exampleMeaningI18n: { "ja": "父は新しい車を買いました。", "en": "My father bought a new car." },
   }),
   examQuestion({
     id: "n5-kanji-shiroi",
@@ -1970,7 +2008,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "形容詞「白い」訓讀「しろい」。「じろい」把詞頭誤濁化、是錯讀；「しるい」把第二拍ろ誤讀成る、是近形錯讀；「くろい」是「黒い」（黑色的）的讀音、顏色相反、語意明確不對。形容白雲只能用「しろい」，故唯一成立。",
     explanationI18n: { "ja": "形容詞「白い」は訓読みで「しろい」です。「じろい」は語頭を誤って濁音にした誤読です。「しるい」は二拍目の「ろ」を「る」と誤読した、形の似た誤りです。「くろい」は「黒い」の読みで色が反対であり、明らかに意味が合いません。白い雲を形容するには「しろい」しかないので、唯一これが正解です。", "en": "The adjective「白い」has the kun reading「しろい」. 「じろい」wrongly voices the initial syllable and is a misreading; 「しるい」misreads the second mora ろ as る and is a look-alike misreading; 「くろい」is the reading of「黒い」(black), the opposite color, which is clearly wrong. To describe white clouds, only「しろい」works, so it's the only correct answer." },
     exampleJapanese: "そらに白い くもが あります。",
-    exampleMeaningZh: "天空中有白色的雲。"
+    exampleMeaningZh: "天空中有白色的雲。",
+    exampleMeaningI18n: { "ja": "空に白い雲があります。", "en": "There are white clouds in the sky." },
   }),
   examQuestion({
     id: "n5-kanji-chiisai",
@@ -1990,7 +2029,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "形容詞「小さい」訓讀「ちいさい」（ち＋長音い）。「ちさい」漏掉長音、是錯讀；「ぢいさい」把詞頭誤寫成ぢ（現代標準假名遣寫作ち）、是錯讀；「こいさい」把詞頭誤讀成こ、是近形錯讀。形容包包小只能用「ちいさい」，故唯一成立。",
     explanationI18n: { "ja": "形容詞「小さい」は訓読みで「ちいさい」（ち＋長音の「い」）です。「ちさい」は長音が抜けた誤読です。「ぢいさい」は語頭を誤って「ぢ」と書いており（現代の標準的な仮名遣いでは「ち」と書きます）、誤りです。「こいさい」は語頭を「こ」と誤読した、形の似た誤りです。かばんが小さいことを表すには「ちいさい」しかないので、唯一これが正解です。", "en": "The adjective「小さい」has the kun reading「ちいさい」(ち + the long vowel い). 「ちさい」drops the long vowel and is a misreading; 「ぢいさい」wrongly writes the initial syllable as ぢ (modern standard kana spells it ち) and is a misreading; 「こいさい」misreads the initial syllable as こ and is a look-alike misreading. To describe a small bag, only「ちいさい」works, so it's the only correct answer." },
     exampleJapanese: "この小さい かばんは こどもの ものです。",
-    exampleMeaningZh: "這個小包包是小孩的東西。"
+    exampleMeaningZh: "這個小包包是小孩的東西。",
+    exampleMeaningI18n: { "ja": "この小さいかばんは子どものものです。", "en": "This small bag belongs to a child." },
   }),
   examQuestion({
     id: "n5-kanji-otoko",
@@ -2010,7 +2050,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「男」單獨指男性時訓讀「おとこ」。「おんな」是「女」的讀音、指女性、語意相反；「おとご」把第三拍こ誤濁化成ご、是錯讀；「おどこ」把第二拍と誤濁化成ど、是錯讀。形容那位男性只能用「おとこ」，故唯一成立。",
     explanationI18n: { "ja": "「男」を単独で男性を指すときは訓読みで「おとこ」です。「おんな」は「女」の読みで女性を指し、意味が反対です。「おとご」は三拍目の「こ」を誤って濁音の「ご」にした誤読です。「おどこ」は二拍目の「と」を誤って濁音の「ど」にした誤読です。その男性を表すには「おとこ」しかないので、唯一これが正解です。", "en": "When「男」stands alone to mean a male, the kun reading is「おとこ」. 「おんな」is the reading of「女」and means a woman, which is the opposite; 「おとご」wrongly voices the third mora こ into ご and is a misreading; 「おどこ」wrongly voices the second mora と into ど and is a misreading. To describe that male, only「おとこ」works, so it's the only correct answer." },
     exampleJapanese: "あそこに せの たかい男の ひとが います。",
-    exampleMeaningZh: "那裡有一個個子高的男人。"
+    exampleMeaningZh: "那裡有一個個子高的男人。",
+    exampleMeaningI18n: { "ja": "あそこに背の高い男の人がいます。", "en": "There is a tall man over there." },
   }),
   examQuestion({
     id: "n5-grammar-doko",
@@ -2092,7 +2133,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「まどを 開けます」：房間悶熱、想讓空氣進來，對著窗戶用「開ける」＝打開，方向與搭配都正確。干擾「ぎゅうにゅうを コップに 開けます」：把牛奶倒進杯子要用「入れる」（入れます），液體不能用『打開』；干擾「ベッドから 開けます」：早上睡醒離開床要用「起きる」（起きます），『開ける』不能形容起身；干擾「子どもと 開けます」：和孩子在公園應是『玩』要用「あそぶ」（あそびます），『開ける』不能表示遊玩。四句都含「開ける」，但僅『打開窗戶』的搭配成立。",
     explanationI18n: { "ja": "正解の「まどを 開けます」は、部屋が蒸し暑くて空気を入れたいので、窓に対して「開ける」＝開ける、を使っており、方向も組み合わせも正しいです。誤答「ぎゅうにゅうを コップに 開けます」は、牛乳をコップに注ぐには「入れる（入れます）」を使い、液体に「開ける」は使えません。誤答「ベッドから 開けます」は、朝起きてベッドから離れるには「起きる（起きます）」を使い、起き上がることを「開ける」では表せません。誤答「子どもと 開けます」は、子どもと公園で過ごすのは「あそぶ（あそびます）」で、「開ける」に遊ぶという意味はありません。四つとも「開ける」を含みますが、「窓を開ける」という組み合わせだけが成立します。", "en": "Correct answer「まどを 開けます」: the room is stuffy and hot and you want to let air in, so using「開ける」＝ to open toward the window is correct in both direction and collocation. Distractor「ぎゅうにゅうを コップに 開けます」: pouring milk into a cup should use「入れる」(入れます); liquid cannot be 'opened'. Distractor「ベッドから 開けます」: getting out of bed after waking up should use「起きる」(起きます);『開ける』cannot describe getting up. Distractor「子どもと 開けます」: being with a child in a park should be 'play,' using「あそぶ」(あそびます);『開ける』cannot mean to play. All four sentences contain「開ける」, but only 'opening the window' is a valid collocation." },
     exampleJapanese: "へやが あついので、まどを 開けます。",
-    exampleMeaningZh: "因為房間很熱，所以打開窗戶。"
+    exampleMeaningZh: "因為房間很熱，所以打開窗戶。",
+    exampleMeaningI18n: { "ja": "部屋が暑いので、窓を開けます。", "en": "The room is hot, so I open the window." },
   }),
   examQuestion({
     id: "n5-usage-kirei",
@@ -2114,7 +2156,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「へやが きれいに なりました」：打掃過後房間變得乾淨整潔，這種狀態用「きれい」＝乾淨，最自然。干擾「にもつは きれいなので、一人では もてません」：拿不動是因為行李『重』要用「おもい」，『きれい』不能形容重量；干擾「さとうを 入れて、きれいに のみます」：加糖後咖啡是變『甜』要用「あまい」，『きれい』不能形容味道；干擾「手が きれいに なりました」：天冷手是變『冰冷』要用「つめたい」，『きれい』不能表示冷。四句都含「きれい」，但僅『房間變乾淨』的語境成立。",
     explanationI18n: { "ja": "正解の「へやが きれいに なりました」は、掃除をして部屋がすっきり清潔になった状態を「きれい」＝清潔、で表しており、最も自然です。誤答「にもつは きれいなので、一人では もてません」は、持てないのは荷物が「重い（おもい）」からで、「きれい」で重さは表せません。誤答「さとうを 入れて、きれいに のみます」は、砂糖を入れるとコーヒーは「甘く（あまい）」なるのであって、「きれい」で味は表せません。誤答「手が きれいに なりました」は、寒くて手が「冷たく（つめたい）」なったのであって、「きれい」で冷たさは表せません。四つとも「きれい」を含みますが、「部屋がきれいになる」という文脈だけが成立します。", "en": "Correct answer「へやが きれいに なりました」: after cleaning, the room became neat and tidy, and this state is described with「きれい」＝ clean, which is the most natural. Distractor「にもつは きれいなので、一人では もてません」: you cannot carry it because the luggage is 'heavy,' which needs「おもい」;『きれい』cannot describe weight. Distractor「さとうを 入れて、きれいに のみます」: after adding sugar, the coffee becomes 'sweet,' which needs「あまい」;『きれい』cannot describe taste. Distractor「手が きれいに なりました」: in the cold, your hands become 'cold,' which needs「つめたい」;『きれい』cannot mean cold. All four sentences contain「きれい」, but only 'the room became clean' fits." },
     exampleJapanese: "そうじを したので、へやが きれいに なりました。",
-    exampleMeaningZh: "因為打掃過了，所以房間變乾淨了。"
+    exampleMeaningZh: "因為打掃過了，所以房間變乾淨了。",
+    exampleMeaningI18n: { "ja": "掃除をしたので、部屋がきれいになりました。", "en": "The room is clean now because I tidied it up." },
   }),
   examQuestion({
     id: "n5-usage-wakaru",
@@ -2136,7 +2179,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「わかる」是『懂、明白』。正解『先生に きいたので、もんだいが わかりました』＝問了老師後就懂了。其餘誤用：『パンとたまごをわかりました』應為『食べました』；『本が三さつわかっています』應為『あります』；『えいがをわかります』應為『見ます』。唯第一句成立。",
     explanationI18n: { "ja": "「わかる」は「理解する・のみこむ」という意味です。正解の「先生に きいたので、もんだいが わかりました」は、先生に聞いて理解できた、という意味です。ほかは誤用で、「パンとたまごをわかりました」は「食べました」、「本が三さつわかっています」は「あります」、「えいがをわかります」は「見ます」とすべきです。したがって最初の文だけが成立します。", "en": "「わかる」means 'to understand; to get it.' Correct answer『先生に きいたので、もんだいが わかりました』＝ after asking the teacher, I understood. The others are misuses:『パンとたまごをわかりました』should be『食べました』;『本が三さつわかっています』should be『あります』;『えいがをわかります』should be『見ます』. Only the first sentence works." },
     exampleJapanese: "先生に きいたので、もんだいが わかりました。",
-    exampleMeaningZh: "因為老師為我說明了，所以題目我懂了。"
+    exampleMeaningZh: "因為老師為我說明了，所以題目我懂了。",
+    exampleMeaningI18n: { "ja": "先生が説明してくれたので、問題がわかりました。", "en": "After asking the teacher, I understood the problem." },
   }),
   examQuestion({
     id: "n5-context-sorede",
@@ -2276,7 +2320,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「左」讀作「ひだり」，意為左邊，正解。「びだり」把字首濁音化（ひ→び），不存在這個讀音。「ひたり」把第二音「だ」誤讀成清音「た」，不成立。「ひだと」把詞尾「り」誤成「と」，亦非「左」的讀音。四選項只有「ひだり」成立。",
     explanationI18n: { "ja": "「左」は「ひだり」と読み、左側という意味で、これが正解です。「びだり」は語頭を濁音にした形（ひ→び）ですが、この読み方は存在しません。「ひたり」は二音目の「だ」を清音の「た」と読み誤ったもので、成立しません。「ひだと」は語尾の「り」を「と」に誤ったもので、これも「左」の読み方ではありません。四つの選択肢のうち「ひだり」だけが成立します。", "en": "「左」is read「ひだり」, meaning left, so it is correct.「びだり」voices the first syllable (ひ→び), which is not a real reading.「ひたり」misreads the second syllable「だ」as the voiceless「た」, so it fails.「ひだと」changes the final「り」to「と」, which is also not a reading of「左」. Of the four options, only「ひだり」works." },
     exampleJapanese: "銀行は駅の左にあります。",
-    exampleMeaningZh: "銀行在車站的左邊。"
+    exampleMeaningZh: "銀行在車站的左邊。",
+    exampleMeaningI18n: { "ja": "銀行は駅の左側にあります。", "en": "The bank is to the left of the station." },
   }),
   examQuestion({
     id: "n5-kanji-kane",
@@ -2296,7 +2341,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「お金」讀作「おかね」，意為錢，正解。「おがね」把「か」濁化成「が」，不是正確讀音。「おかれ」把詞尾「ね」誤成形近的「れ」，不成立。「おっかね」多了促音「っ」，並無此讀法。只有「おかね」成立。",
     explanationI18n: { "ja": "「お金」は「おかね」と読み、お金という意味で、これが正解です。「おがね」は「か」を「が」と濁らせたもので、正しい読み方ではありません。「おかれ」は語尾の「ね」を形の似た「れ」と誤ったもので、成立しません。「おっかね」は促音の「っ」が余分に入っており、そのような読み方はありません。「おかね」だけが成立します。", "en": "「お金」is read「おかね」, meaning money, so it is correct.「おがね」voices「か」into「が」, which is not the correct reading.「おかれ」changes the final「ね」to the similar-looking「れ」, so it fails.「おっかね」adds an extra small tsu「っ」, and no such reading exists. Only「おかね」works." },
     exampleJapanese: "財布にお金がありません。",
-    exampleMeaningZh: "錢包裡沒有錢。"
+    exampleMeaningZh: "錢包裡沒有錢。",
+    exampleMeaningI18n: { "ja": "財布の中にお金がありません。", "en": "There is no money in my wallet." },
   }),
   examQuestion({
     id: "n5-kanji-ashita",
@@ -2316,7 +2362,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「明日」在日常口語常讀作「あした」，意為明天，正解。「あしだ」把詞尾「た」濁化成「だ」，不成立。「あった」把「し」誤成促音「っ」，並非此詞讀音。「あさた」把「し」誤成形近的「さ」，亦不成立。四選項僅「あした」成立。",
     explanationI18n: { "ja": "「明日」は日常の話し言葉ではよく「あした」と読み、明日という意味で、これが正解です。「あしだ」は語尾の「た」を「だ」と濁らせたもので、成立しません。「あった」は「し」を促音の「っ」と誤ったもので、この語の読み方ではありません。「あさた」は「し」を形の似た「さ」と誤ったもので、これも成立しません。四つの選択肢のうち「あした」だけが成立します。", "en": "「明日」is commonly read「あした」in everyday speech, meaning tomorrow, so it is correct.「あしだ」voices the final「た」into「だ」, so it fails.「あった」changes「し」to the small tsu「っ」, which is not this word's reading.「あさた」changes「し」to the similar-looking「さ」, which also fails. Of the four options, only「あした」works." },
     exampleJapanese: "明日、図書館へ行きます。",
-    exampleMeaningZh: "明天要去圖書館。"
+    exampleMeaningZh: "明天要去圖書館。",
+    exampleMeaningI18n: { "ja": "明日、図書館へ行きます。", "en": "I'm going to the library tomorrow." },
   }),
   examQuestion({
     id: "n5-kanji-eki-no-mae",
@@ -2336,7 +2383,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「前」讀作「まえ」，意為前面，正解。「まへ」把「え」寫成歷史假名「へ」，現代讀音不採用，不成立。「なえ」把字首「ま」誤成形近的「な」，並非此字讀音。「まいえ」多插了一個「い」，無此讀法。只有「まえ」成立。",
     explanationI18n: { "ja": "「前」は「まえ」と読み、前という意味で、これが正解です。「まへ」は「え」を歴史的仮名遣いの「へ」で書いたもので、現代の読み方では採用せず、成立しません。「なえ」は語頭の「ま」を形の似た「な」と誤ったもので、この字の読み方ではありません。「まいえ」は「い」が一つ余分に入っており、そのような読み方はありません。「まえ」だけが成立します。", "en": "「前」is read「まえ」, meaning front, so it is correct.「まへ」writes「え」as the historical kana「へ」, which modern readings do not use, so it fails.「なえ」changes the first syllable「ま」to the similar-looking「な」, which is not this character's reading.「まいえ」inserts an extra「い」, and no such reading exists. Only「まえ」works." },
     exampleJapanese: "コンビニは駅の前にあります。",
-    exampleMeaningZh: "便利商店在車站前面。"
+    exampleMeaningZh: "便利商店在車站前面。",
+    exampleMeaningI18n: { "ja": "コンビニは駅の前にあります。", "en": "The convenience store is in front of the station." },
   }),
   examQuestion({
     id: "n5-syn-isogashii",
@@ -2358,7 +2406,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「することが多い」（要做的事很多）與「いそがしい」（忙碌）意思最接近，代回「今週はしごとで することが多いです」自然成立，兩者都表沒有空閒、事情多。干擾「ひまだ」是「いそがしい」的反義（空閒），明確不成立；「おもしろい」（有趣）描述趣味而非忙碌程度，語意不對；「つかれない」（不累）方向相反且與忙碌無關，皆不可接受。",
     explanationI18n: { "ja": "正解の「することが多い」（やることが多い）は「いそがしい」（忙しい）に最も意味が近く、元の文に戻して「今週はしごとで することが多いです」も自然に成立し、どちらも暇がなく用事が多いことを表します。誤答「ひまだ」は「いそがしい」の反対語（暇）で、明らかに成立しません。「おもしろい」（面白い）は面白さを表すもので忙しさの度合いではなく、意味が合いません。「つかれない」（疲れない）は方向が逆で忙しさとも無関係で、いずれも認められません。", "en": "The correct answer「することが多い」(have a lot to do) is closest to「いそがしい」(busy); substituting back,「今週はしごとで することが多いです」is natural, and both mean having no free time with many things to do. Distractor「ひまだ」is the opposite of「いそがしい」(free), so it clearly fails;「おもしろい」(interesting) describes fun rather than how busy you are, so the meaning is wrong;「つかれない」(not tired) points the opposite direction and has nothing to do with being busy, so none are acceptable." },
     exampleJapanese: "今週はしごとで することが多いです。",
-    exampleMeaningZh: "這一週工作要做的事很多。"
+    exampleMeaningZh: "這一週工作要做的事很多。",
+    exampleMeaningI18n: { "ja": "今週は仕事ですることがたくさんあります。", "en": "I have a lot of work to do this week." },
   }),
   examQuestion({
     id: "n5-syn-taihen",
@@ -2380,7 +2429,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「とてもむずかしい」（很難、很吃力）與「たいへん」（辛苦、不容易）意思最接近。干擾「かんたん」（簡單）是反義，明確不成立；「うれしい」（高興）是情緒，與辛苦程度無關；「しずか」（安靜）描述環境聲音，語意完全不對，皆不可接受。",
     explanationI18n: { "ja": "正解の「とてもむずかしい」（とても難しい・骨が折れる）は「たいへん」（大変・容易でない）に最も意味が近いです。誤答「かんたん」（簡単）は反対語で、明らかに成立しません。「うれしい」（うれしい）は感情で、大変さの度合いとは無関係です。「しずか」（静か）は環境の音を表すもので、意味がまったく合わず、いずれも認められません。", "en": "The correct answer「とてもむずかしい」(very hard, very demanding) is closest to「たいへん」(tough, not easy). Distractor「かんたん」(easy) is the opposite, so it clearly fails;「うれしい」(happy) is an emotion, unrelated to how demanding something is;「しずか」(quiet) describes the sound of a place, entirely the wrong meaning, so none are acceptable." },
     exampleJapanese: "ひとりでこのしごとをするのはとてもむずかしいです。",
-    exampleMeaningZh: "一個人做這份工作很難、很吃力。"
+    exampleMeaningZh: "一個人做這份工作很難、很吃力。",
+    exampleMeaningI18n: { "ja": "一人でこの仕事をするのは、とても難しくて骨が折れます。", "en": "Doing this job alone is very difficult and demanding." },
   }),
   examQuestion({
     id: "n5-syn-kitanai",
@@ -2402,7 +2452,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「よごれている」（弄髒了、不乾淨）與「きたない」（髒）意思最接近。干擾「ひろい」（寬敞）講空間大小，與乾淨與否無關；「あたらしい」（新的）講新舊，且髒亂房間多半不新，方向不對；「あかるい」（明亮）講光線，皆與髒乾淨無關，不可接受。",
     explanationI18n: { "ja": "正解の「よごれている」（汚れている・清潔でない）は「きたない」（汚い）に最も意味が近いです。誤答「ひろい」（広い）は空間の大きさを表すもので、清潔かどうかとは無関係です。「あたらしい」（新しい）は新旧を表し、しかも散らかった部屋は新しくないことが多く、方向が合いません。「あかるい」（明るい）は光を表し、いずれも汚いかきれいかとは無関係で、認められません。", "en": "The correct answer「よごれている」(has gotten dirty, not clean) is closest to「きたない」(dirty). Distractor「ひろい」(spacious) is about size, unrelated to being clean or not;「あたらしい」(new) is about newness, and a dirty messy room is usually not new, so the direction is wrong;「あかるい」(bright) is about light, all unrelated to being dirty or clean, so they are not acceptable." },
     exampleJapanese: "このへやはそうじをしていないので、とてもよごれています。",
-    exampleMeaningZh: "這個房間沒有打掃，所以非常髒。"
+    exampleMeaningZh: "這個房間沒有打掃，所以非常髒。",
+    exampleMeaningI18n: { "ja": "この部屋は掃除をしていないので、とても汚れています。", "en": "This room hasn't been cleaned, so it's very dirty." },
   }),
   examQuestion({
     id: "n5-usage-amai",
@@ -2424,7 +2475,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解：「このケーキはとてもあまいです」——蛋糕甜，符合「あまい＝甜」的味覺形容用法。其餘干擾搭配不成立：「コーヒーはとてもあまい音です（咖啡是很甜的聲音）」把味覺的「あまい」硬接到「音（聲音）」上，語意完全錯亂，聲音不能用甜形容；「きょうはあまいですから、まどをしめます（因為今天很甜所以關窗）」天氣不能用甜形容，應是「さむい(冷)」之類；「そのかばんはあまいですね（那個包包很甜）」包包不是可嚐味道的東西，搭配不成立。",
     explanationI18n: { "ja": "正解は「このケーキはとてもあまいです」——ケーキが甘い、で「あまい＝甘い」という味覚の形容の用法に合っています。ほかの誤答は組み合わせが成立しません。「コーヒーはとてもあまい音です（コーヒーは甘い音です）」は味覚の「あまい」を無理に「音」につないでおり、意味がまったく破綻していて、音を甘いとは言えません。「きょうはあまいですから、まどをしめます（今日は甘いので窓を閉めます）」は天気を甘いとは言えず、「さむい（寒い）」などとすべきです。「そのかばんはあまいですね（そのかばんは甘いですね）」はかばんは味わえるものではなく、組み合わせが成立しません。", "en": "Correct answer:「このケーキはとてもあまいです」— the cake is sweet, matching the taste-adjective use of「あまい＝ sweet」. The other distractors are invalid collocations:「コーヒーはとてもあまい音です (the coffee is a very sweet sound)」forces the taste word「あまい」onto「音 (sound)」, which is completely incoherent since sound cannot be sweet;「きょうはあまいですから、まどをしめます (because today is sweet, I close the window)」— weather cannot be described as sweet and should be something like「さむい (cold)」;「そのかばんはあまいですね (that bag is sweet)」— a bag is not something you taste, so the collocation fails." },
     exampleJapanese: "このケーキはとてもあまいです。",
-    exampleMeaningZh: "這個蛋糕非常甜。"
+    exampleMeaningZh: "這個蛋糕非常甜。",
+    exampleMeaningI18n: { "ja": "このケーキはとても甘いです。", "en": "This cake is very sweet." },
   }),
   examQuestion({
     id: "n5-vocab-kiru",
@@ -2524,7 +2576,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「はな」是「花」的訓讀，指花朵，句中「きれいな花がさいています（漂亮的花正在開）」完全成立。干擾「ばな」是把開頭濁音化的錯誤讀音，「花」單獨讀時不濁音，母語者不接受。干擾「はね」是「羽（羽毛）」的讀音、字形相近但語意不對，不能放在「さいています（開花）」前。干擾「はま」是「浜（海濱）」的讀音，與「公園のきれいな○がさく」語境不搭，明確不成立。",
     explanationI18n: { "ja": "正解の「はな」は「花」の訓読みで、花を指し、文中の「きれいな花がさいています（きれいな花が咲いています）」に完全に合います。誤答「ばな」は語頭を濁らせた誤った読み方で、「花」は単独で読むとき濁らず、ネイティブは受け入れません。誤答「はね」は「羽（羽根）」の読み方で、字形は近いものの意味が合わず、「さいています（咲いています）」の前には置けません。誤答「はま」は「浜（海浜）」の読み方で、「公園のきれいな○がさく」という文脈に合わず、明らかに成立しません。", "en": "The answer「はな」is the kun'yomi of「花」, meaning flower, and「きれいな花がさいています（beautiful flowers are blooming）」in the sentence works perfectly. Distractor「ばな」is an incorrect reading that voices the initial sound;「花」on its own is not voiced, so native speakers wouldn't accept it. Distractor「はね」is the reading of「羽（feather）」—the character shape is similar but the meaning is wrong, and it can't go before「さいています（blooming）」. Distractor「はま」is the reading of「浜（seashore）」, which doesn't fit the context of「公園のきれいな○がさく」, so it clearly doesn't work." },
     exampleJapanese: "公園にきれいな花がたくさんさいています。",
-    exampleMeaningZh: "公園裡開著許多漂亮的花。"
+    exampleMeaningZh: "公園裡開著許多漂亮的花。",
+    exampleMeaningI18n: { "ja": "公園にきれいな花がたくさん咲いています。", "en": "Many beautiful flowers are blooming in the park." },
   }),
   examQuestion({
     id: "n5-kanji-soto",
@@ -2544,7 +2597,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「そと」是「外」的訓讀，指外面，句中「外であそびません（不在外面玩）」自然成立。干擾「そど」把第二音濁音化，「外」沒有這個讀音，母語者不接受。干擾「そとう」加了多餘長音，並非「外」的讀法。干擾「とそ」是把音節順序顛倒的錯誤形，字義不通，明確不成立。",
     explanationI18n: { "ja": "正解の「そと」は「外」の訓読みで、外を指し、文中の「外であそびません（外で遊びません）」が自然に成立します。誤答「そど」は二音目を濁らせたもので、「外」にこの読み方はなく、ネイティブは受け入れません。誤答「そとう」は余分な長音を加えたもので、「外」の読み方ではありません。誤答「とそ」は音節の順序を入れ替えた誤った形で、字義が通らず、明らかに成立しません。", "en": "The answer「そと」is the kun'yomi of「外」, meaning outside, and「外であそびません（not playing outside）」works naturally in the sentence. Distractor「そど」voices the second sound;「外」has no such reading, so native speakers wouldn't accept it. Distractor「そとう」adds an unnecessary long vowel and is not how「外」is read. Distractor「とそ」is an incorrect form with the syllable order reversed—it makes no sense, so it clearly doesn't work." },
     exampleJapanese: "さむいので、外であそびません。",
-    exampleMeaningZh: "因為很冷，所以不在外面玩。"
+    exampleMeaningZh: "因為很冷，所以不在外面玩。",
+    exampleMeaningI18n: { "ja": "寒いので、外では遊びません。", "en": "It's cold, so we don't play outside." },
   }),
   examQuestion({
     id: "n5-kanji-chikara",
@@ -2564,7 +2618,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「ちから」是「力」的訓讀，指力氣，句中「力が ありません（沒有力氣）」完全成立。干擾「ぢから」是用「ぢ」取代「ち」的錯誤假名，單獨的「力」開頭不濁，母語者不接受。干擾「ちがら」把第三音濁音化，並非「力」的讀音。干擾「ちかり」把詞尾「ら」誤成「り」，字形相近但不是正確讀法，明確不成立。",
     explanationI18n: { "ja": "正解の「ちから」は「力」の訓読みで、力・パワーを表し、文中の「力が ありません（力がない）」にぴったり合います。誤答「ぢから」は「ち」を「ぢ」に置き換えた誤った仮名で、単独の「力」は語頭が濁らないため、母語話者には受け入れられません。誤答「ちがら」は三つ目の音を濁音にしたもので、「力」の読み方ではありません。誤答「ちかり」は語末の「ら」を「り」と取り違えたもので、字形は似ていますが正しい読みではなく、明らかに成り立ちません。", "en": "The answer「ちから」is the kun'yomi of「力」, meaning strength, and「力が ありません（have no strength）」in the sentence works perfectly. Distractor「ぢから」is incorrect kana that replaces「ち」with「ぢ」; on its own,「力」doesn't start with a voiced sound, so native speakers wouldn't accept it. Distractor「ちがら」voices the third sound and is not the reading of「力」. Distractor「ちかり」mistakes the ending「ら」for「り」—the shape is similar but it's not the correct reading, so it clearly doesn't work." },
     exampleJapanese: "つかれて、もう力がありません。",
-    exampleMeaningZh: "累了，已經沒有力氣了。"
+    exampleMeaningZh: "累了，已經沒有力氣了。",
+    exampleMeaningI18n: { "ja": "疲れて、もう力がありません。", "en": "I'm tired and have no strength left." },
   }),
   examQuestion({
     id: "n5-syn-chikai",
@@ -2586,7 +2641,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「近い」表示距離短，與「遠くない」（不遠）意思最接近，故為正解。「遠い」是「近い」的反義詞，距離長，明確相反。「古い」指時間久遠、陳舊，與距離無關。「広い」指空間寬闊，與距離遠近無關。三個干擾在此語境都不成立，只有「遠くない」說得通。",
     explanationI18n: { "ja": "「近い」は距離が短いことを表し、「遠くない」と意味が最も近いため、これが正解です。「遠い」は「近い」の反対語で距離が長く、意味が明らかに逆です。「古い」は時間が経っている・古びていることを指し、距離とは関係ありません。「広い」は空間が広いことを指し、距離の遠近とは無関係です。三つの誤答はこの文脈では成り立たず、「遠くない」だけが自然につながります。", "en": "「近い」means a short distance, which is closest in meaning to「遠くない」(not far), so that is the answer.「遠い」is the antonym of「近い」—a long distance—so it's clearly the opposite.「古い」means old or long-established in time, unrelated to distance.「広い」means spacious, unrelated to how near or far something is. None of the three distractors work in this context; only「遠くない」makes sense." },
     exampleJapanese: "わたしの 家は 駅から 遠くないです。",
-    exampleMeaningZh: "我家離車站不遠。"
+    exampleMeaningZh: "我家離車站不遠。",
+    exampleMeaningI18n: { "ja": "私の家は駅から遠くありません。", "en": "My house is not far from the station." },
   }),
   examQuestion({
     id: "n5-syn-sugu",
@@ -2608,7 +2664,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「すぐに」表示動作毫不拖延地立刻發生，與「ただちに」（立刻、馬上）意思最接近且代入自然，故為正解。「あとで」是「之後、稍後」，時間上明確相反，不是立刻。「ゆっくり」是「慢慢地」，速度相反，與立刻矛盾。「もう一度」是「再一次」，表示次數重複，與時間的快慢無關。只有「ただちに」成立。",
     explanationI18n: { "ja": "「すぐに」は動作が遅れずただちに起こることを表し、「ただちに」と意味が最も近く、代入しても自然なので、これが正解です。「あとで」は「後で・後ほど」で、時間的に明らかに逆であり、すぐにではありません。「ゆっくり」は「ゆっくりと」で、速さが逆であり、すぐにという意味と矛盾します。「もう一度」は「もう一度」で、回数の繰り返しを表し、時間の速さとは無関係です。「ただちに」だけが成り立ちます。", "en": "「すぐに」means an action happens instantly with no delay, which is closest in meaning to「ただちに」(immediately, right away) and fits naturally when substituted in, so that is the answer.「あとで」means「later, afterward」, which is the clear opposite in timing—not immediate.「ゆっくり」means「slowly」, the opposite in speed and contradicting「immediately」.「もう一度」means「once more」, indicating repetition, unrelated to how fast or slow the timing is. Only「ただちに」works." },
     exampleJapanese: "電話が なったので、ただちに 出ました。",
-    exampleMeaningZh: "因為電話響了，所以立刻接了。"
+    exampleMeaningZh: "因為電話響了，所以立刻接了。",
+    exampleMeaningI18n: { "ja": "電話が鳴ったので、ただちに出ました。", "en": "The phone rang, so I answered it right away." },
   }),
   examQuestion({
     id: "n5-syn-shinsetsu",
@@ -2630,7 +2687,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「親切」表示待人體貼和善，與「やさしい」（溫柔、和善）意思最接近，故為正解。「こわい」是「可怕的」，態度令人害怕，與和善明確相反。「ねむい」是「想睡的」，描述生理狀態，與待人態度無關。「つよい」是「強壯、強的」，描述力量或強度，不是待人的和善。只有「やさしい」成立。",
     explanationI18n: { "ja": "「親切」は人に思いやりがあり優しいことを表し、「やさしい」と意味が最も近いため、これが正解です。「こわい」は「怖い」で、態度が人を怖がらせるものであり、優しさとは明らかに逆です。「ねむい」は「眠い」で、生理的な状態を表し、人への態度とは関係ありません。「つよい」は「強い」で、力や強さを表し、人への優しさではありません。「やさしい」だけが成り立ちます。", "en": "「親切」means being thoughtful and kind to others, which is closest in meaning to「やさしい」(gentle, kind), so that is the answer.「こわい」means「scary」—an intimidating manner—clearly the opposite of kind.「ねむい」means「sleepy」, describing a physical state, unrelated to how one treats others.「つよい」means「strong」, describing power or strength, not kindness toward others. Only「やさしい」works." },
     exampleJapanese: "あの 店の 人は とても やさしいです。",
-    exampleMeaningZh: "那家店的人非常和善。"
+    exampleMeaningZh: "那家店的人非常和善。",
+    exampleMeaningI18n: { "ja": "あの店の人はとても優しいです。", "en": "The people at that shop are very kind." },
   }),
   examQuestion({
     id: "n5-usage-oshieru",
@@ -2652,7 +2710,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「教える」是把知識或方法傳授給別人，本句「老師教學生漢字」搭配與語意都自然，唯一成立。干擾「じしょに 教えます」：不認識的詞要用字典「調べる」（調べます）去查，「じしょに教える」是把詞「教給字典」的明確誤用；干擾「でんしゃに 教えます」：搭電車要用「乗る」（乗ります），『教える』不能表示搭乘；干擾「しゃしんを ともだちに 教えます」：把照片給朋友看要用「見せる」（見せます），照片是給人看不是教。四句都含「教える」，但僅老師傳授漢字的搭配成立。",
     explanationI18n: { "ja": "「教える」は知識ややり方を人に伝えることで、この文「先生が学生に漢字を教える」は組み合わせも意味も自然で、唯一成り立ちます。誤答「じしょに 教えます」：知らない言葉は辞書で「調べる（調べます）」もので、「じしょに教える」は言葉を「辞書に教える」という明らかな誤用です。誤答「でんしゃに 教えます」：電車には「乗る（乗ります）」もので、「教える」に乗るという意味はありません。誤答「しゃしんを ともだちに 教えます」：写真は友だちに「見せる（見せます）」もので、写真は人に見せるものであって教えるものではありません。四文すべてに「教える」が含まれますが、先生が漢字を伝えるという組み合わせだけが成り立ちます。", "en": "「教える」means passing knowledge or a method on to someone, and this sentence,「the teacher teaches the students kanji」, works naturally in both pairing and meaning—the only one that fits. Distractor「じしょに 教えます」: for a word you don't know, you look it up in a dictionary with「調べる」(調べます), so「じしょに教える」is a clear misuse that「teaches the word to the dictionary」. Distractor「でんしゃに 教えます」: to board a train you use「乗る」(乗ります);「教える」can't express boarding. Distractor「しゃしんを ともだちに 教えます」: to show a friend a photo you use「見せる」(見せます)—a photo is shown, not taught. All four sentences contain「教える」, but only the teacher-teaching-kanji pairing works." },
     exampleJapanese: "先生は 学生に かんじを 教えます。",
-    exampleMeaningZh: "老師教學生漢字。"
+    exampleMeaningZh: "老師教學生漢字。",
+    exampleMeaningI18n: { "ja": "先生は学生に漢字を教えます。", "en": "The teacher teaches kanji to the students." },
   }),
   examQuestion({
     id: "n5-usage-kirai",
@@ -2674,7 +2733,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「嫌い」表示對人事物的厭惡，本句「妹妹討厭狗，一看到就逃走」用『逃走』把厭惡的情緒鎖死，唯一成立。干擾「嫌いで、とても おいしいです」：蛋糕好吃應該是喜歡，要用「好き」，與『おいしい』搭配矛盾；干擾「てんきが 嫌いで、そとで あそびます」：在外面玩表示天氣好，要用「いい」（てんきが いい），與討厭矛盾；干擾「サービスが 嫌いで、また 来たいです」：還想再來表示喜歡那家店，要用「いい／好き」，與『また来たい』矛盾。四句都含「嫌い」，但僅妹妹怕狗逃走的句子語意一致。",
     explanationI18n: { "ja": "「嫌い」は人や物事への嫌悪を表し、この文「妹は犬が嫌いで、見ると逃げる」は「逃げる」で嫌悪の気持ちを裏づけており、唯一成り立ちます。誤答「嫌いで、とても おいしいです」：ケーキがおいしいなら好きなはずで「好き」を使うべきであり、「おいしい」との組み合わせが矛盾します。誤答「てんきが 嫌いで、そとで あそびます」：外で遊ぶのは天気がよいことを表し「いい（てんきが いい）」を使うべきで、嫌いと矛盾します。誤答「サービスが 嫌いで、また 来たいです」：また来たいのはその店が好きなことを表し「いい／好き」を使うべきで、「また来たい」と矛盾します。四文すべてに「嫌い」が含まれますが、妹が犬を怖がって逃げる文だけが意味的に一貫しています。", "en": "「嫌い」expresses dislike for a person or thing, and this sentence,「my little sister hates dogs and runs away when she sees one」, locks in that feeling of aversion with「runs away」—the only one that works. Distractor「嫌いで、とても おいしいです」: if the cake is delicious you'd like it, so you'd use「好き」; it contradicts「おいしい」. Distractor「てんきが 嫌いで、そとで あそびます」: playing outside means the weather is good, so you'd use「いい」(てんきが いい), contradicting「dislike」. Distractor「サービスが 嫌いで、また 来たいです」: wanting to come again means you like the shop, so you'd use「いい／好き」, contradicting「また来たい」. All four sentences contain「嫌い」, but only the one about the sister fearing dogs and running away is consistent in meaning." },
     exampleJapanese: "いもうとは いぬが 嫌いで、見ると にげます。",
-    exampleMeaningZh: "妹妹討厭狗，一看到就逃走。"
+    exampleMeaningZh: "妹妹討厭狗，一看到就逃走。",
+    exampleMeaningI18n: { "ja": "妹は犬が嫌いで、見ると逃げます。", "en": "My little sister hates dogs and runs away whenever she sees one." },
   }),
   examQuestion({
     id: "n5-context-deha",
@@ -2794,7 +2854,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「学生」唯一正讀為「がくせい」，指就學中的人，此句說哥哥是大學的學生，語境與讀音皆成立。「がくぜい」把第二音節錯成濁音「ぜ」，日語無此讀法；「かくせい」首音清化成「か」，「学」在此須讀濁音「が」，不成立；「がくせえ」把長音以「え」拼寫，「せい」的長音須寫「せい」，拼寫錯誤。三個干擾皆為清濁、長音或拼寫之誤，母語者均不接受。",
     explanationI18n: { "ja": "「学生」の唯一の正しい読みは「がくせい」で、学んでいる人を指します。この文は兄が大学の学生だと言っており、文脈も読みも成り立ちます。「がくぜい」は二つ目の音節を誤って濁音「ぜ」にしたもので、日本語にこの読みはありません。「かくせい」は語頭を清音「か」にしたもので、ここでの「学」は濁音「が」と読む必要があり、成り立ちません。「がくせえ」は長音を「え」で表記したもので、「せい」の長音は「せい」と書く必要があり、表記の誤りです。三つの誤答はいずれも清濁・長音・表記の誤りで、母語話者には受け入れられません。", "en": "The only correct reading of「学生」is「がくせい」, meaning someone enrolled in school; this sentence says the older brother is a university student, so both context and reading hold.「がくぜい」wrongly voices the second syllable into「ぜ」—Japanese has no such reading.「かくせい」unvoices the first sound into「か」, but「学」must be read with the voiced「が」here, so it doesn't work.「がくせえ」spells the long vowel with「え」, but the long vowel of「せい」must be written「せい」—a spelling error. All three distractors are errors of voicing, long vowels, or spelling that native speakers wouldn't accept." },
     exampleJapanese: "わたしの あには だいがくの「学生」です。",
-    exampleMeaningZh: "我哥哥是大學的學生。"
+    exampleMeaningZh: "我哥哥是大學的學生。",
+    exampleMeaningI18n: { "ja": "私の兄は大学の学生です。", "en": "My older brother is a university student." },
   }),
   examQuestion({
     id: "n5-kanji-shigoto",
@@ -2814,7 +2875,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「仕事」唯一正讀為「しごと」，意為工作，此句說父親每天早上去工作，讀音與語境相符。「じごと」把首音「し」濁化成「じ」，不存在此讀；「しこと」把「ご」清化成「こ」，「事」在此須讀濁音「ご」，不成立；「しごど」把詞尾「と」濁化成「ど」，亦無此讀法。三個干擾都是清濁混淆的誤讀，母語者皆不接受。",
     explanationI18n: { "ja": "「仕事」の唯一の正しい読みは「しごと」で、仕事を意味します。この文は父が毎朝仕事に行くと言っており、読みも文脈も合っています。「じごと」は語頭の「し」を濁らせて「じ」にしたもので、この読みは存在しません。「しこと」は「ご」を清音「こ」にしたもので、ここでの「事」は濁音「ご」と読む必要があり、成り立ちません。「しごど」は語末の「と」を濁らせて「ど」にしたもので、この読みもありません。三つの誤答はいずれも清濁を取り違えた誤読で、母語話者には受け入れられません。", "en": "The only correct reading of「仕事」is「しごと」, meaning work; this sentence says the father goes to work every morning, so reading and context match.「じごと」voices the first sound「し」into「じ」—no such reading exists.「しこと」unvoices「ご」into「こ」, but「事」must be read with the voiced「ご」here, so it doesn't work.「しごど」voices the ending「と」into「ど」, and there's no such reading either. All three distractors are misreadings that confuse voiced and unvoiced sounds, which native speakers wouldn't accept." },
     exampleJapanese: "ちちは まいあさ「仕事」に 行きます。",
-    exampleMeaningZh: "父親每天早上去工作。"
+    exampleMeaningZh: "父親每天早上去工作。",
+    exampleMeaningI18n: { "ja": "父は毎朝、仕事に行きます。", "en": "My father goes to work every morning." },
   }),
   examQuestion({
     id: "n5-kanji-kyou",
@@ -2834,7 +2896,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「今日」唯一正讀為「きょう」，意為今天，此句聊到今天天氣很好，讀音與語境相符。「きょお」把長音以「お」拼寫，「きょう」的長音須寫「う」，拼寫錯誤；「きよう」少了拗音小字「ょ」，變成不同音節組合，並非此詞讀法；「きゅう」把拗音換成「ゅ」，讀成別的音，亦不成立。三個干擾分別為長音拼寫、拗音脫落與拗音換音之誤，母語者皆不接受。",
     explanationI18n: { "ja": "「今日」の唯一の正しい読みは「きょう」で、今日を意味します。この文は今日の天気がとてもよいと話しており、読みも文脈も合っています。「きょお」は長音を「お」で表記したもので、「きょう」の長音は「う」と書く必要があり、表記の誤りです。「きよう」は拗音の小さい「ょ」がなく、別の音節の組み合わせになってしまい、この語の読みではありません。「きゅう」は拗音を「ゅ」に変えたもので、別の音になってしまい、これも成り立ちません。三つの誤答はそれぞれ長音の表記・拗音の脱落・拗音の入れ替えの誤りで、母語話者には受け入れられません。", "en": "The only correct reading of「今日」is「きょう」, meaning today; this sentence chats about the nice weather today, so reading and context match.「きょお」spells the long vowel with「お」, but the long vowel of「きょう」must be written「う」—a spelling error.「きよう」drops the small contracted-sound「ょ」, becoming a different syllable combination that isn't this word's reading.「きゅう」swaps the contracted sound to「ゅ」, reading it as a different sound, so it doesn't work either. The three distractors are errors of long-vowel spelling, dropping the contracted sound, and swapping the contracted sound, none of which native speakers would accept." },
     exampleJapanese: "「今日」は とても いい てんきですね。",
-    exampleMeaningZh: "今天天氣真的很好呢。"
+    exampleMeaningZh: "今天天氣真的很好呢。",
+    exampleMeaningI18n: { "ja": "今日はとてもいい天気ですね。", "en": "The weather is really nice today, isn't it?" },
   }),
   examQuestion({
     id: "n5-syn-benri",
@@ -2856,7 +2919,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「便利」指方便、好用，與「使いやすい（好用、用起來方便）」意思最接近，皆形容對生活有幫助、用起來順手。干擾項：「つまらない」是無聊，與方便無關且方向不同；「きびしい」是嚴格／嚴峻，用在規定或態度上，不能形容車站的方便；「さびしい」是寂寞、冷清，與「店も多くて」矛盾，方向完全相反。只有「使いやすい」能在此句成立。",
     explanationI18n: { "ja": "「便利」は便利で使いやすいことを指し、「使いやすい」と意味が最も近く、どちらも生活の役に立ち、使い勝手がよいことを表します。誤答：「つまらない」はつまらないという意味で、便利とは無関係で方向も違います。「きびしい」は厳しい・厳格という意味で、規則や態度に使うもので、駅の便利さを表せません。「さびしい」は寂しい・ひっそりしているという意味で、「店も多くて」と矛盾し、方向が完全に逆です。「使いやすい」だけがこの文で成り立ちます。", "en": "「便利」means convenient and handy, which is closest in meaning to「使いやすい（easy to use, convenient to use）」—both describe something helpful for daily life and easy to make use of. Distractors:「つまらない」means boring, unrelated to convenience and pointing a different direction;「きびしい」means strict/harsh, used for rules or attitudes and can't describe a station's convenience;「さびしい」means lonely or deserted, contradicting「店も多くて」and pointing in the completely opposite direction. Only「使いやすい」works in this sentence." },
     exampleJapanese: "この駅は店も多くて、とても使いやすいです。",
-    exampleMeaningZh: "這個車站商店也很多，非常好用。"
+    exampleMeaningZh: "這個車站商店也很多，非常好用。",
+    exampleMeaningI18n: { "ja": "この駅はお店も多くて、とても使いやすいです。", "en": "This station has lots of shops, too, and is very handy." },
   }),
   examQuestion({
     id: "n5-syn-yumei",
@@ -2878,7 +2942,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「有名」指出名、廣為人知，與「よく知られている（廣為人知）」意思最接近。干擾項：「ねむそうだ」是看起來想睡，與是否出名無關；「つかれている」是疲累，不能形容拉麵的知名度；「こわれている」是壞掉、故障，用在物品損壞上，與「全国で」這個範圍語境衝突。只有「よく知られている」成立。",
     explanationI18n: { "ja": "「有名」は名が知られ、広く知られていることを指し、「よく知られている」と意味が最も近いです。誤答：「ねむそうだ」は眠そうだという意味で、有名かどうかとは無関係です。「つかれている」は疲れているという意味で、ラーメンの知名度を表せません。「こわれている」は壊れている・故障しているという意味で、物が壊れることに使うもので、「全国で」という範囲の文脈と衝突します。「よく知られている」だけが成り立ちます。", "en": "「有名」means famous or widely known, which is closest to「よく知られている」(widely known). Distractors: 「ねむそうだ」means looking sleepy, which has nothing to do with fame; 「つかれている」means tired, which cannot describe how well-known ramen is; 「こわれている」means broken or out of order, used for damaged objects, and clashes with the「全国で」(nationwide) context. Only 「よく知られている」works." },
     exampleJapanese: "この町のラーメンは全国でよく知られています。",
-    exampleMeaningZh: "這個鎮的拉麵全國各地都廣為人知。"
+    exampleMeaningZh: "這個鎮的拉麵全國各地都廣為人知。",
+    exampleMeaningI18n: { "ja": "この町のラーメンは、全国でよく知られています。", "en": "This town's ramen is well known all over the country." },
   }),
   examQuestion({
     id: "n5-syn-tabun",
@@ -2900,7 +2965,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「たぶん」表示推測、大概，與「おそらく（恐怕、大概）」意思最接近，兩者都用於不確定的預測並常配「でしょう」。干擾項：「ぜんぜん」後接否定，意為完全（不），與肯定推測句不合；「やっと」是好不容易、終於，強調等待後實現，與這裡的天氣推測語意不符；「もう」是已經，指動作完成，與「降るでしょう」這個未發生的推測矛盾。只有「おそらく」成立。",
     explanationI18n: { "ja": "「たぶん」は推測・おそらくを表し、「おそらく」と意味が最も近く、どちらも不確かな予測に使われ、よく「でしょう」と一緒に用いられます。誤答：「ぜんぜん」は後ろに否定を伴い「まったく（〜ない）」という意味で、肯定の推測文とは合いません。「やっと」はやっと・ようやくという意味で、待った末に実現したことを強調し、ここでの天気の推測とは意味が合いません。「もう」はもうという意味で、動作の完了を指し、「降るでしょう」というまだ起きていない推測と矛盾します。「おそらく」だけが成り立ちます。", "en": "「たぶん」expresses a guess or likelihood, closest to「おそらく」(probably, likely); both are used for uncertain predictions and often pair with「でしょう」. Distractors: 「ぜんぜん」is followed by a negative and means \"(not) at all,\" which does not fit an affirmative prediction; 「やっと」means finally or at last, stressing something realized after waiting, which does not match a weather forecast; 「もう」means already and refers to a completed action, contradicting「降るでしょう」, which predicts something that has not yet happened. Only 「おそらく」works." },
     exampleJapanese: "空が暗いから、おそらく雨が降るでしょう。",
-    exampleMeaningZh: "因為天空很暗，大概會下雨吧。"
+    exampleMeaningZh: "因為天空很暗，大概會下雨吧。",
+    exampleMeaningI18n: { "ja": "空が暗いから、たぶん雨が降るでしょう。", "en": "The sky is dark, so it will probably rain." },
   }),
   examQuestion({
     id: "n5-syn-isogu",
@@ -2922,7 +2988,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「急ぐ」指趕緊、加快動作，「急ぎましょう」與「いそいで行きましょう（趕快走吧）」意思最接近，都是催促對方加快腳步前往。干擾項：「止まりましょう」是停下來，與趕時間方向相反；「休みましょう」是休息吧，剩五分鐘還休息語意矛盾；「並びましょう」是排隊吧，與催促加速無關。只有「いそいで行きましょう」成立。",
     explanationI18n: { "ja": "「急ぐ」は急ぐ・動作を速めることを指し、「急ぎましょう」は「いそいで行きましょう」と意味が最も近く、どちらも相手に足を速めて向かうよう促すものです。誤答：「止まりましょう」は止まろうという意味で、時間を急ぐのとは方向が逆です。「休みましょう」は休もうという意味で、あと五分なのに休むのは意味が矛盾します。「並びましょう」は並ぼうという意味で、急ぐよう促すこととは無関係です。「いそいで行きましょう」だけが成り立ちます。", "en": "「急ぐ」means to hurry or move faster, so「急ぎましょう」is closest to「いそいで行きましょう」(let's hurry and go); both urge the other person to pick up the pace and get moving. Distractors: 「止まりましょう」means let's stop, the opposite of hurrying; 「休みましょう」means let's rest, which contradicts hurrying with only five minutes left; 「並びましょう」means let's line up, unrelated to urging someone to speed up. Only 「いそいで行きましょう」works." },
     exampleJapanese: "電車の時間まであと五分だから、いそいで行きましょう。",
-    exampleMeaningZh: "距離電車發車只剩五分鐘，趕快走吧。"
+    exampleMeaningZh: "距離電車發車只剩五分鐘，趕快走吧。",
+    exampleMeaningI18n: { "ja": "電車の時間まであと五分しかないので、急いで行きましょう。", "en": "There are only five minutes until the train leaves, so let's hurry." },
   }),
   examQuestion({
     id: "n5-usage-aruku",
@@ -2944,7 +3011,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「うちは学校に近いので、毎朝歩いて行きます」：距離近、用雙腳步行去學校，「歩く」用法正確自然。干擾一「空に鳥が…歩いています」：鳥在天空中應是「飛ぶ（飛）」，天上不能「歩く」，語意明確不成立。干擾二「プールで一時間ぐらい歩く」：在游泳池裡一小時應是「泳ぐ（游）」才自然，雖文法接得上但搭配明確錯誤。干擾三「バスに歩いて」：搭巴士應是「バスに乗って（乘坐）」，「バスに歩いて」語意不通。故只有第一句成立。",
     explanationI18n: { "ja": "正解「うちは学校に近いので、毎朝歩いて行きます」：距離が近く、自分の足で歩いて学校へ行くので、「歩く」の使い方が正しく自然です。誤答一「空に鳥が…歩いています」：鳥は空では「飛ぶ」ものであり、空を「歩く」ことはできず、意味が明らかに成り立ちません。誤答二「プールで一時間ぐらい歩く」：プールでの一時間は「泳ぐ」が自然で、文法はつながっても組み合わせが明らかに誤りです。誤答三「バスに歩いて」：バスには「バスに乗って」と言うべきで、「バスに歩いて」は意味が通りません。したがって最初の文だけが成り立ちます。", "en": "Correct answer「うちは学校に近いので、毎朝歩いて行きます」: the distance is short and one goes to school on foot, so「歩く」is used correctly and naturally. Distractor 1「空に鳥が…歩いています」: a bird in the sky should「飛ぶ」(fly); you cannot「歩く」in the sky, so it clearly fails. Distractor 2「プールで一時間ぐらい歩く」: spending an hour in a pool should be「泳ぐ」(swim) to be natural; although grammatically it connects, the collocation is clearly wrong. Distractor 3「バスに歩いて」: taking a bus should be「バスに乗って」(to ride); 「バスに歩いて」makes no sense. So only the first sentence works." },
     exampleJapanese: "うちは学校に近いので、毎朝歩いて行きます。",
-    exampleMeaningZh: "我家離學校很近，所以每天早上走路去。"
+    exampleMeaningZh: "我家離學校很近，所以每天早上走路去。",
+    exampleMeaningI18n: { "ja": "うちは学校から近いので、毎朝歩いて行きます。", "en": "My house is close to the school, so I walk there every morning." },
   }),
   examQuestion({
     id: "n5-usage-urusai",
@@ -2966,7 +3034,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「となりのテレビの音がうるさくて、よく寝られません」：因為聲音很吵而睡不好，「音がうるさい」搭配正確自然。干擾一「ラーメンはうるさいので」：對食物的負評應是「まずい（難吃）」，味道不會用「うるさい」，語意明確錯誤。干擾二「夜になると道がうるさくて、何も見えません」：看不見東西的原因應是「暗い（くらい，昏暗）」，「うるさい」與「看不見」無關。干擾三「この川はうるさいですから」：水深危險不能進去應是「深い（ふかい，深的）」，河川不會因「吵」而不能進去。故只有第一句成立。",
     explanationI18n: { "ja": "正解「となりのテレビの音がうるさくて、よく寝られません」：音がうるさくてよく眠れないので、「音がうるさい」の組み合わせが正しく自然です。誤答一「ラーメンはうるさいので」：食べ物への悪評は「まずい」であるべきで、味に「うるさい」は使わず、意味が明らかに誤りです。誤答二「夜になると道がうるさくて、何も見えません」：何も見えない原因は「暗い（くらい）」であるべきで、「うるさい」は「見えない」とは無関係です。誤答三「この川はうるさいですから」：水が深くて危険で入れないなら「深い（ふかい）」であるべきで、川は「うるさい」から入れないわけではありません。したがって最初の文だけが成り立ちます。", "en": "Correct answer「となりのテレビの音がうるさくて、よく寝られません」: unable to sleep well because the sound is loud, so「音がうるさい」is a correct, natural collocation. Distractor 1「ラーメンはうるさいので」: a negative comment about food should be「まずい」(tastes bad); flavor is not described with「うるさい」, so it is clearly wrong. Distractor 2「夜になると道がうるさくて、何も見えません」: the reason you can't see should be「暗い」(dark); 「うるさい」has nothing to do with not being able to see. Distractor 3「この川はうるさいですから」: a river being too dangerous to enter should be「深い」(deep); a river is not off-limits because it is \"noisy.\" So only the first sentence works." },
     exampleJapanese: "となりのテレビの音がうるさくて、よく寝られません。",
-    exampleMeaningZh: "隔壁電視的聲音很吵，讓我睡不好。"
+    exampleMeaningZh: "隔壁電視的聲音很吵，讓我睡不好。",
+    exampleMeaningI18n: { "ja": "となりのテレビの音がうるさくて、よく眠れません。", "en": "The TV next door is so noisy that I can't sleep well." },
   }),
   examQuestion({
     id: "n5-context-keredomo",
@@ -3146,7 +3215,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「手」單獨當名詞時用訓讀「て」，「手をあらいます」＝洗手。「で」是把「て」誤讀成濁音的干擾；「た」是把母音由え段誤讀成あ段的干擾；「ち」是假名字形/發音相近的干擾，皆非「手」單獨成詞時的讀音。此處唯「て」成立。",
     explanationI18n: { "ja": "「手」が単独で名詞のときは訓読みの「て」で、「手をあらいます」＝手を洗う、です。「で」は「て」を濁音に読み間違えた誤答、「た」は母音をえ段からあ段に読み間違えた誤答、「ち」は仮名の字形や発音が似ていることによる誤答で、いずれも「手」が単独で語になるときの読みではありません。ここでは「て」だけが成り立ちます。", "en": "When「手」stands alone as a noun it takes the kun reading「て」, so「手をあらいます」= wash one's hands. 「で」is a distractor that misreads「て」as a voiced sound; 「た」is a distractor that shifts the vowel from the え-row to the あ-row; 「ち」is a distractor with a similar kana shape and sound—none is the reading of「手」as a standalone word. Here only「て」works." },
     exampleJapanese: "ごはんの まえに、せっけんで 手を あらいます。",
-    exampleMeaningZh: "吃飯前用肥皂洗手。"
+    exampleMeaningZh: "吃飯前用肥皂洗手。",
+    exampleMeaningI18n: { "ja": "ご飯の前に、せっけんで手を洗います。", "en": "I wash my hands with soap before eating." },
   }),
   examQuestion({
     id: "n5-kanji-mise",
@@ -3166,7 +3236,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「店」單獨當名詞時用訓讀「みせ」，「この店」＝這家店。「みぜ」把「せ」誤讀成濁音（せ→ぜ）；「みす」把「せ」誤讀成「す」、不成讀音；「めせ」把第一個假名「み」誤讀成「め」。此處單獨名詞唯「みせ」成立。",
     explanationI18n: { "ja": "「店」が単独で名詞のときは訓読みの「みせ」で、「この店」＝この店、です。「みぜ」は「せ」を濁音に読み間違えたもの（せ→ぜ）、「みす」は「せ」を「す」に読み間違えたもので読みとして成り立ちません。「めせ」は最初の仮名「み」を「め」に読み間違えたものです。ここでは単独の名詞として「みせ」だけが成り立ちます。", "en": "When「店」stands alone as a noun it takes the kun reading「みせ」, so「この店」= this shop. 「みぜ」misreads「せ」as a voiced sound (せ→ぜ); 「みす」misreads「せ」as「す」, which is not a valid reading; 「めせ」misreads the first kana「み」as「め」. For this standalone noun, only「みせ」works." },
     exampleJapanese: "この店では やすい くだものを うっています。",
-    exampleMeaningZh: "這家店賣便宜的水果。"
+    exampleMeaningZh: "這家店賣便宜的水果。",
+    exampleMeaningI18n: { "ja": "この店では、安い果物を売っています。", "en": "This shop sells inexpensive fruit." },
   }),
   examQuestion({
     id: "n5-kanji-sakana",
@@ -3186,7 +3257,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「魚」單獨當名詞時用訓讀「さかな」，「魚をやいて」＝烤魚。「さがな」把「か」誤讀成濁音（か→が）；「ざかな」把第一個假名「さ」誤讀成濁音（さ→ざ）；「さなか」把「か」「な」順序對調、不成讀音。此處單獨名詞唯「さかな」成立。",
     explanationI18n: { "ja": "「魚」が単独で名詞のときは訓読みの「さかな」で、「魚をやいて」＝魚を焼いて、です。「さがな」は「か」を濁音に読み間違えたもの（か→が）、「ざかな」は最初の仮名「さ」を濁音に読み間違えたもの（さ→ざ）、「さなか」は「か」と「な」の順序を入れ替えたもので読みとして成り立ちません。ここでは単独の名詞として「さかな」だけが成り立ちます。", "en": "When「魚」stands alone as a noun it takes the kun reading「さかな」, so「魚をやいて」= grill fish. 「さがな」misreads「か」as a voiced sound (か→が); 「ざかな」misreads the first kana「さ」as a voiced sound (さ→ざ); 「さなか」swaps the order of「か」and「な」, which is not a valid reading. For this standalone noun, only「さかな」works." },
     exampleJapanese: "ばんごはんに、おいしい 魚を やいて たべました。",
-    exampleMeaningZh: "晚餐烤了好吃的魚來吃。"
+    exampleMeaningZh: "晚餐烤了好吃的魚來吃。",
+    exampleMeaningI18n: { "ja": "晩ご飯に、おいしい魚を焼いて食べました。", "en": "For dinner, I grilled some delicious fish and ate it." },
   }),
   examQuestion({
     id: "n5-syn-amari",
@@ -3208,7 +3280,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「あまり〜ない」表示程度不高，與「そんなに〜ない」同義，都是「不太、不怎麼」，代回「そんなにおいしくない」自然成立。「とても」是「非常」，語意相反（程度高），不對。「ぜんぶ」是「全部」，與程度無關，搭配「ない」語意不成立。「もっと」是「更加」，方向相反且語意不通。只有「そんなに」成立。",
     explanationI18n: { "ja": "「あまり〜ない」は程度が高くないことを表し、「そんなに〜ない」と同義で、どちらも「あまり、それほど～ない」の意味です。当てはめると「そんなにおいしくない」が自然に成り立ちます。「とても」は「非常に」で、程度が高く意味が逆になるので違います。「ぜんぶ」は「全部」で程度とは関係がなく、「ない」との組み合わせでも意味が通りません。「もっと」は「さらに」で方向が逆で意味も通りません。「そんなに」だけが成り立ちます。", "en": "「あまり〜ない」indicates a low degree, synonymous with「そんなに〜ない」; both mean \"not very, not particularly,\" so「そんなにおいしくない」fits naturally. 「とても」means \"very,\" the opposite in meaning (a high degree), so it's wrong. 「ぜんぶ」means \"all,\" unrelated to degree, and doesn't make sense paired with「ない」. 「もっと」means \"more,\" the opposite direction and nonsensical here. Only 「そんなに」works." },
     exampleJapanese: "この料理はそんなにおいしくないです。",
-    exampleMeaningZh: "這道菜不怎麼好吃。"
+    exampleMeaningZh: "這道菜不怎麼好吃。",
+    exampleMeaningI18n: { "ja": "この料理は、あまりおいしくないです。", "en": "This dish isn't very tasty." },
   }),
   examQuestion({
     id: "n5-syn-joubu",
@@ -3230,7 +3303,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「じょうぶ」指東西結實耐用、不容易壞，與「こわれにくい」（不易損壞）語意最接近，代回「このかばんはこわれにくいですね」自然成立。「こわれやすい」是「容易壞」，語意完全相反，不對。「かるい」是「輕」，講的是重量不是堅固度，語意不同。「ふるい」是「舊」，與耐用無關。只有「こわれにくい」成立。",
     explanationI18n: { "ja": "「じょうぶ」は物が頑丈で長持ちし、壊れにくいことを指し、「こわれにくい」（壊れにくい）が最も意味が近く、当てはめると「このかばんはこわれにくいですね」が自然に成り立ちます。「こわれやすい」は「壊れやすい」で意味が正反対なので違います。「かるい」は「軽い」で重さのことであり頑丈さの話ではないので意味が異なります。「ふるい」は「古い」で長持ちとは関係がありません。「こわれにくい」だけが成り立ちます。", "en": "「じょうぶ」describes something sturdy and durable, not easily broken, closest to「こわれにくい」(hard to break), so「このかばんはこわれにくいですね」fits naturally. 「こわれやすい」means \"easily broken,\" the exact opposite, so it's wrong. 「かるい」means \"light,\" referring to weight rather than durability, so the meaning differs. 「ふるい」means \"old,\" unrelated to durability. Only 「こわれにくい」works." },
     exampleJapanese: "このかばんはこわれにくいですね。",
-    exampleMeaningZh: "這個包包很耐用呢。"
+    exampleMeaningZh: "這個包包很耐用呢。",
+    exampleMeaningI18n: { "ja": "このかばんは丈夫で、長持ちしますね。", "en": "This bag is really sturdy, isn't it?" },
   }),
   examQuestion({
     id: "n5-syn-mainichi",
@@ -3252,7 +3326,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「いつも」表示「總是、每次都這樣」，與「まいにち」（每天）在「天天都固定如此」的語意上最接近，代回「わたしはまいにち六時におきます」自然成立。「ときどき」是「偶爾」，頻率明顯較低且非總是，語意不同。「たまに」是「偶爾、難得」，頻率低、與每次相反，不成立。「もう」是「已經」，講的不是頻率，語意不通。只有「まいにち」與「いつも」同義。",
     explanationI18n: { "ja": "「いつも」は「いつも、毎回そうする」ことを表し、「まいにち」（毎日）と「毎日決まってそうする」という意味で最も近く、当てはめると「わたしはまいにち六時におきます」が自然に成り立ちます。「ときどき」は「ときどき」で頻度が明らかに低く、いつもではないので意味が異なります。「たまに」は「たまに、まれに」で頻度が低く「毎回」とは逆なので成り立ちません。「もう」は「もう、すでに」で頻度の話ではなく意味が通りません。「まいにち」だけが「いつも」と同義です。", "en": "「いつも」means \"always, every time,\" closest to「まいにち」(every day) in the sense of \"doing the same thing regularly day after day,\" so「わたしはまいにち六時におきます」fits naturally. 「ときどき」means \"sometimes,\" a clearly lower frequency and not \"always,\" so the meaning differs. 「たまに」means \"occasionally, rarely,\" a low frequency and the opposite of \"every time,\" so it fails. 「もう」means \"already,\" which is not about frequency and makes no sense here. Only 「まいにち」is synonymous with「いつも」." },
     exampleJapanese: "わたしはまいにち六時におきます。",
-    exampleMeaningZh: "我每天六點起床。"
+    exampleMeaningZh: "我每天六點起床。",
+    exampleMeaningI18n: { "ja": "わたしは毎日、六時に起きます。", "en": "I get up at six o'clock every day." },
   }),
   examQuestion({
     id: "n5-usage-ushiro",
@@ -3274,7 +3349,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「わたしの いすの 後ろに かばんが あります」用「Xの後ろに」表示位置在椅子背後，是後ろ的標準用法。「あの店は後ろが高いです」要表達價格貴應用「値段」，後ろ在此不通。「りんごを後ろ食べました」是時間先後，應用「あとで」，後ろ(空間)不能修飾動詞。「きょうは後ろがいい天気です」要講今天天氣應直接說「きょうはいい天気です」，後ろ在此完全不成立。",
     explanationI18n: { "ja": "正解「わたしの いすの 後ろに かばんが あります」は「Xの後ろに」で位置が椅子の背後にあることを表しており、後ろの標準的な使い方です。「あの店は後ろが高いです」は値段が高いことを言いたいなら「値段」を使うべきで、後ろではここで通りません。「りんごを後ろ食べました」は時間の前後を言いたいので「あとで」を使うべきで、（空間の）後ろは動詞を修飾できません。「きょうは後ろがいい天気です」は今日の天気を言うなら「きょうはいい天気です」と言えばよく、後ろはここでは全く成り立ちません。", "en": "Correct answer「わたしの いすの 後ろに かばんが あります」uses「Xの後ろに」to place the location behind the chair—the standard use of 後ろ. 「あの店は後ろが高いです」should use「値段」to say the price is high; 後ろ makes no sense here. 「りんごを後ろ食べました」refers to time order and should use「あとで」; 後ろ (spatial) cannot modify a verb. 「きょうは後ろがいい天気です」should simply say「きょうはいい天気です」to talk about today's weather; 後ろ does not work here at all." },
     exampleJapanese: "わたしの いすの 後ろに かばんが あります。",
-    exampleMeaningZh: "我的椅子後面有一個包包。"
+    exampleMeaningZh: "我的椅子後面有一個包包。",
+    exampleMeaningI18n: { "ja": "わたしのいすの後ろに、かばんがあります。", "en": "There is a bag behind my chair." },
   }),
   examQuestion({
     id: "n5-usage-motsu",
@@ -3296,7 +3372,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「かばんを手に持って、駅へ行きました」用「Nを持つ」表示用手拿著包包，是持つ的核心用法。「あさ七時に持ちました」要表達起床的時間動作，意思不成立，這裡需要的是別的動詞。「ともだちと公園を持ちました」要表達在公園散步或玩，持つ不能搭配公園這樣的場所做受詞。「このみずはとても持ちます」要形容水的性質(冷、好喝等)，持つ無法形容水，語意完全不通。",
     explanationI18n: { "ja": "正解「かばんを手に持って、駅へ行きました」は「Nを持つ」で手にかばんを持っていることを表しており、持つの中心的な使い方です。「あさ七時に持ちました」は起きる時間の動作を表したいなら意味が成り立たず、ここでは別の動詞が必要です。「ともだちと公園を持ちました」は公園で散歩したり遊んだりすることを表したいのでしょうが、持つは公園のような場所を目的語にできません。「このみずはとても持ちます」は水の性質（冷たい、おいしいなど）を表したいのでしょうが、持つは水を形容できず、意味が全く通りません。", "en": "The correct answer, \"かばんを手に持って、駅へ行きました,\" uses the pattern \"Nを持つ\" to mean holding a bag in your hand — the core use of 持つ. \"あさ七時に持ちました\" is trying to express the action of getting up at a certain time, which makes no sense; a different verb is needed here. \"ともだちと公園を持ちました\" is trying to say strolling or playing in a park, but 持つ cannot take a place like a park as its object. \"このみずはとても持ちます\" is trying to describe a quality of water (cold, tasty, etc.), but 持つ cannot describe water, so the meaning is completely broken." },
     exampleJapanese: "かばんを 手に 持って、駅へ 行きました。",
-    exampleMeaningZh: "手上拿著包包去了車站。"
+    exampleMeaningZh: "手上拿著包包去了車站。",
+    exampleMeaningI18n: { "ja": "かばんを手に持って、駅へ行きました。", "en": "I went to the station carrying a bag in my hand." },
   }),
   examQuestion({
     id: "n5-usage-byouki",
@@ -3318,7 +3395,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「病気できょうは学校を休みました」用「病気で」表示因為生病而請假，是病気的典型用法。「このりょうりはとても病気です」要形容料理(好吃、辣等)，病気不能形容食物味道。「あの山は病気がたかいです」要說山的高度應用「高さ」，病気在此完全不通。「あたらしいくつを病気で買いました」要說在某地或用某種方式買鞋，病気不能當買鞋的手段或場所，語意不成立。",
     explanationI18n: { "ja": "正解「病気できょうは学校を休みました」は「病気で」で病気のために休んだことを表しており、病気の典型的な使い方です。「このりょうりはとても病気です」は料理の味（おいしい、辛いなど）を表したいのでしょうが、病気は食べ物の味を形容できません。「あの山は病気がたかいです」は山の高さを言うなら「高さ」を使うべきで、病気はここでは全く通りません。「あたらしいくつを病気で買いました」はどこで、あるいはどんな方法で靴を買ったかを言いたいのでしょうが、病気は靴を買う手段や場所にはできず、意味が成り立ちません。", "en": "The correct answer, \"病気できょうは学校を休みました,\" uses \"病気で\" to mean taking time off because of illness — the typical use of 病気. \"このりょうりはとても病気です\" is trying to describe food (delicious, spicy, etc.), but 病気 cannot describe the taste of food. \"あの山は病気がたかいです\" is trying to state a mountain's height, which should use \"高さ\"; 病気 makes no sense here. \"あたらしいくつを病気で買いました\" is trying to say buying shoes somewhere or by some means, but 病気 cannot serve as the means or place for buying shoes, so the meaning doesn't hold." },
     exampleJapanese: "病気で きょうは 学校を 休みました。",
-    exampleMeaningZh: "因為生病，今天向學校請了假。"
+    exampleMeaningZh: "因為生病，今天向學校請了假。",
+    exampleMeaningI18n: { "ja": "病気で、今日は学校を休みました。", "en": "I was sick, so I stayed home from school today." },
   }),
   examQuestion({
     id: "n5-context-suruto",
@@ -3518,7 +3596,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「右」訓讀「みぎ」（後字濁音ぎ）。「みき」漏掉濁點，是「幹（みき）」的讀音，非此字；「にぎ」把首音み誤成に，是近形誤讀，不是右的讀音；「みぎり」多了一個り，非「右」單字的讀音，此語境也只能讀みぎ。",
     explanationI18n: { "ja": "「右」は訓読みで「みぎ」（後ろの字は濁音ぎ）です。「みき」は濁点が抜けており、「幹（みき）」の読みで、この字ではありません。「にぎ」は最初の音「み」を「に」に読み間違えたもので、字形が似ていることによる誤読で、右の読みではありません。「みぎり」は「り」が余分で、「右」単体の読みではなく、この文脈でも「みぎ」としか読めません。", "en": "「右」 has the kun reading \"みぎ\" (the second syllable is voiced, ぎ). \"みき\" drops the voicing mark and is the reading of \"幹 (みき, trunk),\" not this character; \"にぎ\" mistakes the first sound み for に, a similar-looking misreading and not the reading of 右; \"みぎり\" adds an extra り and is not the reading of the single word \"右,\" which in this context can only be read みぎ." },
     exampleJapanese: "つぎの かどを 右に まがって ください。",
-    exampleMeaningZh: "請在下一個路口往右轉。"
+    exampleMeaningZh: "請在下一個路口往右轉。",
+    exampleMeaningI18n: { "ja": "次の角を右に曲がってください。", "en": "Please turn right at the next corner." },
   }),
   examQuestion({
     id: "n5-kanji-ima",
@@ -3538,7 +3617,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「今」單獨使用時讀訓讀「いま」。「いな」把第二音ま誤成な，近形誤讀，非此字讀音；「いわ」把ま誤成わ，是「岩（いわ）」的讀音，非此字；「きん」是別字「金」的音讀，與「今」無關。此語境問現在幾點，只能讀いま。",
     explanationI18n: { "ja": "「今」を単独で使うときは訓読みの「いま」と読みます。「いな」は二番目の音「ま」を「な」に読み間違えたもので、字形が似ていることによる誤読であり、この字の読みではありません。「いわ」は「ま」を「わ」に読み間違えたもので、「岩（いわ）」の読みで、この字ではありません。「きん」は別の字「金」の音読みで、「今」とは関係がありません。この文脈は今何時かをたずねており、「いま」としか読めません。", "en": "When 「今」 is used on its own, it takes the kun reading \"いま.\" \"いな\" mistakes the second sound ま for な, a similar-looking misreading and not this character's reading; \"いわ\" mistakes ま for わ and is the reading of \"岩 (いわ, rock),\" not this character; \"きん\" is the on reading of the different character \"金\" and has nothing to do with \"今.\" In this context asking the current time, it can only be read いま." },
     exampleJapanese: "今、なんじですか。",
-    exampleMeaningZh: "現在幾點呢？"
+    exampleMeaningZh: "現在幾點呢？",
+    exampleMeaningI18n: { "ja": "今、何時ですか。", "en": "What time is it now?" },
   }),
   examQuestion({
     id: "n5-kanji-mimi",
@@ -3558,7 +3638,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "「耳」訓讀「みみ」（兩音皆清音み）。「みび」把第二音誤加濁點，非此字讀音；「めめ」把み誤成め，近形誤讀，不成詞；「みめ」是「見目（みめ／容貌）」的讀音，與身體部位「耳」無關。此語境講身體部位變紅，只能讀みみ。",
     explanationI18n: { "ja": "「耳」は訓読みで「みみ」（どちらの音も清音のみ）です。「みび」は二番目の音に濁点を付け足したもので、この字の読みではありません。「めめ」は「み」を「め」に読み間違えたもので、字形が似ていることによる誤読で、語になりません。「みめ」は「見目（みめ／容貌）」の読みで、体の部位である「耳」とは関係がありません。この文脈は体の部位が赤くなったと言っており、「みみ」としか読めません。", "en": "「耳」 has the kun reading \"みみ\" (both syllables are voiceless み). \"みび\" wrongly adds a voicing mark to the second syllable and isn't this character's reading; \"めめ\" mistakes み for め, a similar-looking misreading that isn't a word; \"みめ\" is the reading of \"見目 (みめ, appearance)\" and has nothing to do with the body part \"ear.\" In this context about a body part turning red, it can only be read みみ." },
     exampleJapanese: "さむいので 耳が あかく なった。",
-    exampleMeaningZh: "因為很冷，耳朵變紅了。"
+    exampleMeaningZh: "因為很冷，耳朵變紅了。",
+    exampleMeaningI18n: { "ja": "寒くて、耳が赤くなりました。", "en": "It was so cold that my ears turned red." },
   }),
   examQuestion({
     id: "n5-syn-dandan",
@@ -3580,7 +3661,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「少しずつ」＝一點一點地，與「だんだん」(漸漸地、隨時間逐步變化) 同義，代回句子「少しずつあたたかくなりました」自然成立。干擾「急に」＝突然，與「逐步」相反，方向相左不成立。「もうすぐ」＝再過不久(指未來尚未發生)，但句尾已是「なりました」過去完成，語意不合。「ときどき」＝有時(表頻率非表程度漸進)，無法描述持續變暖的過程，母語者不會接受。只有「少しずつ」成立。",
     explanationI18n: { "ja": "正解「少しずつ」＝少しずつ、で、「だんだん」（だんだん、時間とともに徐々に変わる）と同義であり、文に戻すと「少しずつあたたかくなりました」が自然に成り立ちます。誤答「急に」＝突然、で「徐々に」とは逆で、方向が食い違うため成り立ちません。「もうすぐ」＝もうすぐ（まだ起きていない未来を指す）ですが、文末はすでに「なりました」と過去完了なので意味が合いません。「ときどき」＝ときどき（頻度を表し、程度の漸進は表さない）で、続けて暖かくなる過程を描写できず、母語話者は受け入れません。「少しずつ」だけが成り立ちます。", "en": "The correct answer, \"少しずつ\" = little by little, is synonymous with \"だんだん\" (gradually, changing step by step over time), and plugging it back in gives the natural \"少しずつあたたかくなりました.\" The distractor \"急に\" = suddenly is the opposite of \"gradually,\" so its direction is wrong and it fails. \"もうすぐ\" = soon (referring to something in the future that hasn't happened yet), but the sentence ends in \"なりました,\" a completed past, so the meaning doesn't fit. \"ときどき\" = sometimes (marking frequency, not progressive degree) cannot describe an ongoing process of warming, and a native speaker wouldn't accept it. Only \"少しずつ\" works." },
     exampleJapanese: "三月になって、少しずつあたたかくなりました。",
-    exampleMeaningZh: "進入三月後，一點一點地變暖了。"
+    exampleMeaningZh: "進入三月後，一點一點地變暖了。",
+    exampleMeaningI18n: { "ja": "三月になって、少しずつ暖かくなりました。", "en": "Once March came, it gradually got warmer, little by little." },
   }),
   examQuestion({
     id: "n5-syn-taitei",
@@ -3602,7 +3684,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「ほとんどいつも」＝幾乎總是，與「たいてい」(大多數情況、大抵) 同義，代回「ほとんどいつも家にいます」自然成立。干擾「たまに」＝偶爾(頻率低)，與「大抵=高頻」相反不成立。「ぜんぜん」＝完全(不)，後面須接否定，與肯定句「います」搭配錯誤且語意相反。「これから」＝從現在起(指未來)，無法表達習慣性高頻率，母語者不會接受。只有「ほとんどいつも」成立。",
     explanationI18n: { "ja": "正解「ほとんどいつも」は「たいてい」（多くの場合・大部分）と同じ意味で、入れ替えても「ほとんどいつも家にいます」と自然に成り立ちます。誤答の「たまに」は『時々』（頻度が低い）で、『たいてい＝高い頻度』とは反対なので合いません。「ぜんぜん」は『全く（〜ない）』で後ろに否定が必要なため、肯定文の「います」とは結びつかず、意味も逆になります。「これから」は『これから先』（未来を指す）で、習慣的な高い頻度は表せず、日本語話者には受け入れられません。成り立つのは「ほとんどいつも」だけです。", "en": "The correct answer, \"ほとんどいつも\" = almost always, is synonymous with \"たいてい\" (in most cases, usually), and plugging it back in gives the natural \"ほとんどいつも家にいます.\" The distractor \"たまに\" = occasionally (low frequency) is the opposite of \"usually = high frequency,\" so it fails. \"ぜんぜん\" = (not) at all must be followed by a negative, so it mismatches the affirmative \"います\" and means the opposite. \"これから\" = from now on (referring to the future) cannot express a habitual high frequency, and a native speaker wouldn't accept it. Only \"ほとんどいつも\" works." },
     exampleJapanese: "わたしは日曜日、ほとんどいつも家にいます。",
-    exampleMeaningZh: "我星期天幾乎總是待在家裡。"
+    exampleMeaningZh: "我星期天幾乎總是待在家裡。",
+    exampleMeaningI18n: { "ja": "わたしは日曜日、ほとんどいつも家にいます。", "en": "On Sundays I'm almost always at home." },
   }),
   examQuestion({
     id: "n5-syn-zenbu",
@@ -3624,7 +3707,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「のこらず」＝一點不剩、全部，與「ぜんぶ」(全部) 同義，代回「りょうりをのこらず食べました」自然成立。干擾「はんぶん」＝一半，數量明確不同。「すこし」＝一點點，與「全部」量相反。「べつべつに」＝分開地(指方式而非數量，例如各付各的)，無法表示份量全部，母語者不會接受。只有「のこらず」成立。",
     explanationI18n: { "ja": "正解「のこらず」は『少しも残さず・全部』という意味で「ぜんぶ」（全部）と同じであり、入れ替えても「料理をのこらず食べました」と自然に成り立ちます。誤答の「はんぶん」は『半分』で、数量がはっきり異なります。「すこし」は『少しだけ』で、『全部』とは量が逆になります。「べつべつに」は『別々に』（数量ではなく方法を表す。例：会計を別々にする）で、量がすべてであることは表せず、日本語話者には受け入れられません。成り立つのは「のこらず」だけです。", "en": "The correct answer, \"のこらず\" = without leaving any, all of it, is synonymous with \"ぜんぶ\" (all), and plugging it back in gives the natural \"りょうりをのこらず食べました.\" The distractor \"はんぶん\" = half is a clearly different quantity. \"すこし\" = a little bit is the opposite amount of \"all.\" \"べつべつに\" = separately (referring to manner rather than quantity, e.g. paying separately) can't express eating the whole amount, and a native speaker wouldn't accept it. Only \"のこらず\" works." },
     exampleJapanese: "お皿のりょうりをのこらず食べました。",
-    exampleMeaningZh: "把盤子裡的菜一點不剩地全吃完了。"
+    exampleMeaningZh: "把盤子裡的菜一點不剩地全吃完了。",
+    exampleMeaningI18n: { "ja": "お皿の料理を、残さず全部食べました。", "en": "I ate everything on the plate without leaving a single bite." },
   }),
   examQuestion({
     id: "n5-usage-hiroi",
@@ -3646,7 +3730,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「この部屋はとても広いです」中，「広い」用來形容房間的空間寬敞，搭配自然。干擾一「このコーヒーは広いです」應改用「熱い」(燙)，咖啡無法用「廣」形容。干擾二「きょうは…広いです」應改用「寒い」(冷)，天氣冷暖不會用「廣」。干擾三「この本は広いので」應改用「おもしろい」(有趣)或「やさしい」(簡單)，書能不能兩小時讀完取決於難易或趣味，而非寬廣。三個干擾雖接續正確，但語意與搭配都不成立，故唯一正解為房間句。",
     explanationI18n: { "ja": "正解「この部屋はとても広いです」では、「広い」が部屋の空間が広々としている様子を表していて、組み合わせが自然です。誤答一「このコーヒーは広いです」は「熱い」にすべきで、コーヒーを『広い』とは言えません。誤答二「きょうは…広いです」は「寒い」にすべきで、天気の寒暖に『広い』は使いません。誤答三「この本は広いので」は「おもしろい」（面白い）か「やさしい」（易しい）にすべきで、本を二時間で読めるかどうかは難易や面白さによるもので、広さとは関係ありません。三つの誤答は接続こそ正しいものの、意味も組み合わせも成り立たないため、唯一の正解は部屋の文です。", "en": "In the correct answer \"この部屋はとても広いです,\" \"広い\" describes the room being spacious, which is a natural pairing. Distractor 1 \"このコーヒーは広いです\" should use \"熱い\" (hot) instead, since coffee can't be described as \"wide.\" Distractor 2 \"きょうは…広いです\" should use \"寒い\" (cold) instead, since weather warmth/coldness isn't described with \"wide.\" Distractor 3 \"この本は広いので\" should use \"おもしろい\" (interesting) or \"やさしい\" (easy) instead, since whether a book can be read in two hours depends on its difficulty or interest, not on being wide. Though the three distractors attach grammatically, their meaning and collocation both fail, so the only correct answer is the room sentence." },
     exampleJapanese: "この部屋はとても広いです。",
-    exampleMeaningZh: "這個房間非常寬敞。"
+    exampleMeaningZh: "這個房間非常寬敞。",
+    exampleMeaningI18n: { "ja": "この部屋はとても広いです。", "en": "This room is very spacious." },
   }),
   examQuestion({
     id: "n5-usage-nugu",
@@ -3668,7 +3753,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「家に入る前に、くつを脱ぎます」中，「脱ぐ」用於脫鞋，搭配自然。干擾一「ぎゅうにゅうを脱ぎます」應改用「飲む」(喝)，牛奶是用喝的。干擾二「本を脱ぎました」應改用「読む」(讀)，書是用讀的。干擾三「手紙を脱ぎました」應改用「書く」(寫)，信是用寫的。三個干擾的受詞都不能用「脫」，語意明確錯誤，故唯一正解為脫鞋句。",
     explanationI18n: { "ja": "正解「家に入る前に、くつを脱ぎます」では、「脱ぐ」が靴を脱ぐ動作に使われていて、組み合わせが自然です。誤答一「ぎゅうにゅうを脱ぎます」は「飲む」にすべきで、牛乳は飲むものです。誤答二「本を脱ぎました」は「読む」にすべきで、本は読むものです。誤答三「手紙を脱ぎました」は「書く」にすべきで、手紙は書くものです。三つの誤答はどれも目的語に『脱ぐ』が使えず、意味がはっきり間違っているため、唯一の正解は靴を脱ぐ文です。", "en": "In the correct answer \"家に入る前に、くつを脱ぎます,\" \"脱ぐ\" is used for taking off shoes, a natural pairing. Distractor 1 \"ぎゅうにゅうを脱ぎます\" should use \"飲む\" (drink) instead, since milk is drunk. Distractor 2 \"本を脱ぎました\" should use \"読む\" (read) instead, since a book is read. Distractor 3 \"手紙を脱ぎました\" should use \"書く\" (write) instead, since a letter is written. None of the three distractors' objects can take \"take off,\" so their meanings are clearly wrong, and the only correct answer is the taking-off-shoes sentence." },
     exampleJapanese: "家に入る前に、くつを脱ぎます。",
-    exampleMeaningZh: "進屋之前要脫鞋子。"
+    exampleMeaningZh: "進屋之前要脫鞋子。",
+    exampleMeaningI18n: { "ja": "家に入る前に、くつを脱ぎます。", "en": "I take off my shoes before going into the house." },
   }),
   examQuestion({
     id: "n5-usage-eiga",
@@ -3690,7 +3776,8 @@ export const n5Items: PracticeQuestion[] = [
     explanation: "正解「週末に友達と映画を見ました」中，「映画」搭配「見る」(看)，是看電影的自然說法。干擾一「映画を飲みました」應改用「お茶」或「水」，喉嚨渴是喝飲料而非電影。干擾二「映画を食べました」應改用「ごはん」或「ごはん類」，早餐吃的是食物而非電影。干擾三「映画で帰りました」應改用「電車」或「バス」，從車站回家的交通工具不是電影。三個干擾的動詞與助詞都把語意鎖死，唯一成立的是看電影句。",
     explanationI18n: { "ja": "正解「週末に友達と映画を見ました」では、「映画」が「見る」と組み合わさっていて、映画を見るという自然な言い方になっています。誤答一「映画を飲みました」は「お茶」か「水」にすべきで、のどが渇いたら飲むのは飲み物であって映画ではありません。誤答二「映画を食べました」は「ごはん」などにすべきで、朝食に食べるのは食べ物であって映画ではありません。誤答三「映画で帰りました」は「電車」か「バス」にすべきで、駅から家へ帰る交通手段は映画ではありません。三つの誤答は動詞と助詞によって意味が固定されてしまい、成り立つのは映画を見る文だけです。", "en": "In the correct answer \"週末に友達と映画を見ました,\" \"映画\" pairs with \"見る\" (watch) — the natural way to say watching a movie. Distractor 1 \"映画を飲みました\" should use \"お茶\" or \"水\" instead, since when you're thirsty you drink a beverage, not a movie. Distractor 2 \"映画を食べました\" should use \"ごはん\" or something in the rice/meal category instead, since breakfast is food, not a movie. Distractor 3 \"映画で帰りました\" should use \"電車\" or \"バス\" instead, since the means of getting home from the station isn't a movie. In all three distractors the verb and particle lock the meaning down, so the only sentence that works is the watching-a-movie one." },
     exampleJapanese: "週末に友達と映画を見ました。",
-    exampleMeaningZh: "週末和朋友一起看了電影。"
+    exampleMeaningZh: "週末和朋友一起看了電影。",
+    exampleMeaningI18n: { "ja": "週末に友達と映画を見ました。", "en": "I watched a movie with a friend on the weekend." },
   }),
   examQuestion({
     id: "n5-grammar-ichiban-se-takai",


### PR DESCRIPTION
i18n(exam): translate the 550 custom example meanings + add the field to the pipeline (#400)

Closes the codex should-fix on #424: items with a CUSTOM exampleMeaningZh
(550 across N1-N5) still rendered a Chinese post-answer example line in en/ja.

- Pipeline: add { exampleMeaningZh -> exampleMeaningI18n } to FIELDS in
  scripts/ai-translate-content.mjs; the old anchor-guard test (which asserted
  the field was NOT translatable) is rewritten to pin no cross-contamination
  between meaningZh and exampleMeaningZh in either direction.
- Data: en + ja overlays for all 550 custom example meanings (Claude subagent
  chunks; validated per-item, strict shape, no CRLF). Combined with #424's
  promptContextI18n threading, every exam item's post-answer example line now
  follows the UI language; gap scan reports en=0 / ja=0 across all fields.

Build green, full suite 564 green, git diff --check clean.
