### PR TITLE
i18n: launch with zh-Hant / ja / en only; gate unlaunched locales everywhere

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, Globe, Languages, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import { countDueReviews } from "./domain/srs";
-import { copy, type Language } from "./i18n";
+import { copy, LAUNCHED_LANGUAGES, type Language } from "./i18n";
 import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
 import { LanguageFlag } from "./components/LanguageFlag";
@@ -53,9 +53,10 @@ const GrammarPointPage = lazy(() =>
 type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about" | "grammar";
 type DrillPreset = LearningBlockDrillPreset;
 
-// The UI locales, in menu order, for the header language <select>. Each
+// The LAUNCHED locales, in menu order, for the header language picker. Each
 // option's label is that locale's own native name (copy[code].languageName).
-const LANGUAGE_OPTIONS: readonly Language[] = ["zh-Hant", "ja", "en", "th", "id", "ko", "vi", "my"];
+// Locales with untranslated content stay hidden until they ship (i18n.ts).
+const LANGUAGE_OPTIONS: readonly Language[] = LAUNCHED_LANGUAGES;
 
 // Lightweight URL routing: each top-level view maps to a path so the browser
 // back/forward buttons, refresh, and shareable/bookmarkable links all work

--- a/src/hooks/useLanguage.test.ts
+++ b/src/hooks/useLanguage.test.ts
@@ -26,6 +26,10 @@ function resetBrowserLanguages() {
 }
 
 // Priority: URL ?lang= > stored > browser language (navigator) > ja fallback.
+// Only the LAUNCHED languages (zh-Hant / ja / en) are selectable anywhere;
+// locales whose CONTENT isn't translated yet (th/id/ko/vi/my) are ignored at
+// every layer until they ship, so their visitors get the ja fallback instead
+// of a UI-only translation over Chinese content.
 describe("useLanguage", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -58,6 +62,15 @@ describe("useLanguage", () => {
     expect(result.current.language).toBe("ja");
   });
 
+  it("ignores a stored NOT-YET-LAUNCHED locale and falls back to ja", () => {
+    // e.g. a preference stored before the launch set was narrowed.
+    localStorage.setItem(KEY, "ko");
+
+    const { result } = renderHook(() => useLanguage());
+
+    expect(result.current.language).toBe("ja");
+  });
+
   it("falls back to ja when nothing is stored and the browser language is unsupported", () => {
     const { result } = renderHook(() => useLanguage());
 
@@ -83,11 +96,11 @@ describe("useLanguage", () => {
   it("setLanguage updates the value and persists it", () => {
     const { result } = renderHook(() => useLanguage());
 
-    act(() => result.current.setLanguage("ko"));
+    act(() => result.current.setLanguage("en"));
 
-    expect(result.current.language).toBe("ko");
-    expect(localStorage.getItem(KEY)).toBe("ko");
-    expect(document.documentElement.lang).toBe("ko");
+    expect(result.current.language).toBe("en");
+    expect(localStorage.getItem(KEY)).toBe("en");
+    expect(document.documentElement.lang).toBe("en");
   });
 });
 
@@ -115,22 +128,29 @@ describe("getInitialLanguage priority", () => {
   it("URL param wins over stored and browser language", () => {
     localStorage.setItem(KEY, "zh-Hant");
     setBrowserLanguages(["ja"]);
-    setLocationSearch("?lang=id");
+    setLocationSearch("?lang=en");
 
-    expect(getInitialLanguage()).toBe("id");
+    expect(getInitialLanguage()).toBe("en");
   });
 
-  it("accepts a BCP-47 tag and maps it by prefix (?lang=vi-VN -> vi)", () => {
-    setLocationSearch("?lang=vi-VN");
+  it("ignores a NOT-YET-LAUNCHED ?lang= and falls through to stored (?lang=id)", () => {
+    localStorage.setItem(KEY, "zh-Hant");
+    setLocationSearch("?lang=id");
 
-    expect(getInitialLanguage()).toBe("vi");
+    expect(getInitialLanguage()).toBe("zh-Hant");
+  });
+
+  it("accepts a BCP-47 tag and maps it by prefix (?lang=en-US -> en)", () => {
+    setLocationSearch("?lang=en-US");
+
+    expect(getInitialLanguage()).toBe("en");
   });
 
   it("ignores an unsupported ?lang= and falls through to stored", () => {
-    localStorage.setItem(KEY, "th");
+    localStorage.setItem(KEY, "zh-Hant");
     setLocationSearch("?lang=fr");
 
-    expect(getInitialLanguage()).toBe("th");
+    expect(getInitialLanguage()).toBe("zh-Hant");
   });
 
   it("case-insensitive ?lang= matching (JA -> ja)", () => {
@@ -154,18 +174,26 @@ describe("getInitialLanguage priority", () => {
 
   // ---- Browser-language detection (navigator layer) ----
 
-  it("detects a supported browser language when nothing is stored (ko-KR -> ko)", () => {
+  it("detects a launched browser language when nothing is stored (en-US -> en)", () => {
+    setLocationSearch("");
+    setBrowserLanguages(["en-US"]);
+
+    expect(getInitialLanguage()).toBe("en");
+  });
+
+  it("a NOT-YET-LAUNCHED browser language gets the ja fallback (ko-KR -> ja)", () => {
     setLocationSearch("");
     setBrowserLanguages(["ko-KR"]);
 
-    expect(getInitialLanguage()).toBe("ko");
+    expect(getInitialLanguage()).toBe("ja");
   });
 
-  it("picks the first supported entry from navigator.languages", () => {
+  it("picks the first LAUNCHED entry from navigator.languages", () => {
     setLocationSearch("");
+    // fr/de unsupported, ko not launched -> en is the first usable entry.
     setBrowserLanguages(["fr-FR", "de", "ko", "en"]);
 
-    expect(getInitialLanguage()).toBe("ko");
+    expect(getInitialLanguage()).toBe("en");
   });
 
   it("maps zh variants to zh-Hant (zh-CN -> zh-Hant)", () => {
@@ -176,11 +204,11 @@ describe("getInitialLanguage priority", () => {
   });
 
   it("stored preference wins over the browser language", () => {
-    localStorage.setItem(KEY, "th");
+    localStorage.setItem(KEY, "zh-Hant");
     setLocationSearch("");
     setBrowserLanguages(["ja"]);
 
-    expect(getInitialLanguage()).toBe("th");
+    expect(getInitialLanguage()).toBe("zh-Hant");
   });
 
   it("falls back to ja when the browser language is unsupported (fr -> ja)", () => {

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,13 +1,15 @@
 import { useEffect, useState } from "react";
 import { readStored, writeStored } from "../domain/safeStorage";
-import type { Language } from "../i18n";
+import { LAUNCHED_LANGUAGES, type Language } from "../i18n";
 
 const LANGUAGE_STORAGE_KEY = "jabiko.lang";
 
-const SUPPORTED_LANGUAGES: readonly Language[] = ["zh-Hant", "ja", "en", "th", "id", "ko", "vi", "my"];
-
+// Every selection layer (URL / stored / navigator) gates on the LAUNCHED set:
+// a locale whose content isn't translated yet behaves as if it doesn't exist
+// (its visitors get the ja fallback), and a preference stored before the
+// launch set was narrowed degrades gracefully instead of resurfacing it.
 function isSupportedLanguage(value: string | null): value is Language {
-  return value !== null && (SUPPORTED_LANGUAGES as readonly string[]).includes(value);
+  return value !== null && (LAUNCHED_LANGUAGES as readonly string[]).includes(value);
 }
 
 function languageForTag(tag: string | undefined): Language | null {
@@ -15,12 +17,9 @@ function languageForTag(tag: string | undefined): Language | null {
   const lower = tag.toLowerCase();
   if (lower.startsWith("ja")) return "ja";
   if (lower.startsWith("en")) return "en";
-  if (lower.startsWith("th")) return "th";
-  if (lower.startsWith("id")) return "id";
-  if (lower.startsWith("ko")) return "ko";
-  if (lower.startsWith("vi")) return "vi";
-  if (lower.startsWith("my")) return "my";
   if (lower.startsWith("zh")) return "zh-Hant";
+  // th/id/ko/vi/my: Copy files exist but their content isn't launched yet --
+  // deliberately unmapped so detection falls through to the ja fallback.
   return null;
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,6 +7,14 @@ import type { ModeCopyKey } from "./domain/practiceMode";
 // is the same set, kept as the UI-facing name.
 export type Language = LocaleCode;
 
+// Languages that are LIVE for users: picker options, URL ?lang=, stored
+// preference, and browser detection all gate on this list. A locale stays off
+// it until its CONTENT (exam bank, study chapters, …) is translated -- UI
+// chrome alone would render menus in the user's language over Chinese
+// content. th/id/ko/vi/my ship their Copy files already; launching one later
+// is just adding it here.
+export const LAUNCHED_LANGUAGES: readonly Language[] = ["zh-Hant", "ja", "en"];
+
 export type Copy = {
   languageName: string;
   languageSwitchLabel: string;


### PR DESCRIPTION
i18n: launch with zh-Hant / ja / en only; gate unlaunched locales everywhere

Product decision: go live with the three languages whose CONTENT is fully
translated (zh-Hant source, ja, en). th/id/ko/vi/my have UI chrome only --
showing them would render menus in the user's language over Chinese content,
so they stay hidden until their content ships.

- New single source of truth `LAUNCHED_LANGUAGES` (i18n.ts) = ["zh-Hant",
  "ja", "en"]. Launching a locale later is adding it to this one list.
- useLanguage gates every selection layer on it: the URL ?lang= param, the
  stored preference (a pre-narrowing stored "ko" degrades gracefully), and
  browser detection (a th/ko/... browser now falls through to the ja
  fallback, preserving the Japanese-language-school default).
- App's header picker options now come from LAUNCHED_LANGUAGES (3 entries).
- Copy files, LocaleCode union, and the i18n completeness guard keep all 8
  locales -- nothing is deleted, only ungated selection.

TDD: 4 new RED tests (stored/URL/navigator unlaunched-locale gating + first
LAUNCHED navigator entry) plus updated expectations. Full suite 567 green,
build green, no CRLF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Language selection now shows only currently available locales, keeping the picker aligned with live language support.

* **Bug Fixes**
  * Improved language fallback behavior so unsupported or not-yet-available locale values are ignored consistently.
  * Updated language detection to handle browser settings, URL parameters, and saved preferences more predictably.
  * BCP-47 language tags like `en-US` now resolve to the closest supported language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->