### PR TITLE
i18n(read-paths): stop dropping existing overlays on study/drill surfaces (#427)

### DIFF
--- a/src/components/GrammarPointPage.test.tsx
+++ b/src/components/GrammarPointPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { GrammarPointPage } from "./GrammarPointPage";
+import { cleanExplanation, GrammarPointPage } from "./GrammarPointPage";
 import { allGrammarSurfaces, buildGrammarPoint } from "../domain/grammarPoints";
 import { grammarNotes } from "../domain/grammarNotes";
 import { copy } from "../i18n";
@@ -45,5 +45,30 @@ describe("GrammarPointPage", () => {
     expect(screen.getByRole("heading", { level: 1, name: "存在しない文法zzz" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: t.reviewDoneExit }));
     expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders localized meaning and usage notes for an un-noted point in en (#427)", () => {
+    const surface = allGrammarSurfaces().find((s) => {
+      const p = buildGrammarPoint(s);
+      return p !== null && !p.note && p.explanations.length > 0 && Boolean(p.meaningI18n?.en);
+    })!;
+    const point = buildGrammarPoint(surface)!;
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+
+    expect(screen.getByText(point.meaningI18n!.en!)).toBeInTheDocument();
+    const firstUsage = point.explanations
+      .map((entry) => cleanExplanation(entry.i18n?.en ?? entry.zh))
+      .filter(Boolean)[0];
+    expect(firstUsage).toBeTruthy();
+    expect(screen.getByText(firstUsage)).toBeInTheDocument();
+  });
+
+  it("strips the quiz answer lead-in per locale (#427)", () => {
+    expect(cleanExplanation("正解是「たとえ」，因為後句是假設。")).toBe("因為後句是假設。");
+    expect(cleanExplanation("正解は「たとえ」です。後半は仮定を表します。")).toBe("後半は仮定を表します。");
+    expect(cleanExplanation("The correct answer is 「たとえ」: it pairs with a hypothetical.")).toBe(
+      "it pairs with a hypothetical."
+    );
+    expect(cleanExplanation("沒有前綴的內容原樣通過。")).toBe("沒有前綴的內容原樣通過。");
   });
 });

--- a/src/components/GrammarPointPage.tsx
+++ b/src/components/GrammarPointPage.tsx
@@ -1,14 +1,20 @@
 import { ArrowLeft, GraduationCap } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { buildGrammarPoint } from "../domain/grammarPoints";
+import { pickLocalized } from "../domain/localizedContent";
 import { GrammarNoteCard } from "./GrammarNoteCard";
 
 // Strip a leading "正解是「…」，" answer-explanation lead-in (#339): the exam
 // bank's explanations are written for a quiz ("the correct answer is X,
 // because…"), which reads wrong on a study page. Drop that prefix so what's
 // left reads as a usage note; non-matching strings pass through untouched.
-function cleanExplanation(text: string): string {
-  return text.replace(/^正解是「[^」]*」[，、。]?\s*/, "");
+// The en/ja overlays carry their own translated lead-ins (#427), so each
+// launched content locale gets its own pattern. Exported for tests.
+export function cleanExplanation(text: string): string {
+  return text
+    .replace(/^正解是「[^」]*」[，、。]?\s*/, "")
+    .replace(/^正解は「[^」]*」(?:です)?[。、，]?\s*/, "")
+    .replace(/^The correct answer is\s*["「][^"」]*["」]\s*[,.:;]?\s*/i, "");
 }
 
 // Standalone study page for a single 文法点 (issue #281, redesigned in #339).
@@ -54,7 +60,10 @@ export function GrammarPointPage({
   // A curated point shows everything (meaning / rule / examples / confusions)
   // inside GrammarNoteCard, so the page adds nothing more. An un-noted point
   // gets a usage card + an examples card built from the exam bank.
-  const usageNotes = point.explanations.map(cleanExplanation).filter(Boolean).slice(0, 2);
+  const usageNotes = point.explanations
+    .map((entry) => cleanExplanation(pickLocalized(entry.zh, entry.i18n, language)))
+    .filter(Boolean)
+    .slice(0, 2);
   const showExamples = !point.note && point.examples.length > 0;
 
   return (
@@ -74,7 +83,9 @@ export function GrammarPointPage({
         </div>
         {/* The curated card carries its own meaning; only lead with it here when
             there's no note, to avoid showing the same line twice. */}
-        {point.note ? null : <p className="gp-meaning">{point.meaningZh}</p>}
+        {point.note ? null : (
+          <p className="gp-meaning">{pickLocalized(point.meaningZh, point.meaningI18n, language)}</p>
+        )}
       </header>
 
       {point.note ? (
@@ -99,7 +110,9 @@ export function GrammarPointPage({
                 <span className="gp-ex-ja" lang="ja">
                   {example.ja}
                 </span>
-                {example.zh ? <span className="gp-ex-zh">{example.zh}</span> : null}
+                {example.zh ? (
+                  <span className="gp-ex-zh">{pickLocalized(example.zh, example.zhI18n, language)}</span>
+                ) : null}
               </li>
             ))}
           </ul>

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -3,6 +3,7 @@ import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
 import { kanjiMeaning } from "../domain/kanjiOnyomi.i18n";
+import { pickLocalized } from "../domain/localizedContent";
 import { SpeakButton } from "./SpeakButton";
 import { InkstoneSpot, MagnifierKanjiSpot } from "../illustrations";
 
@@ -136,7 +137,9 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
                     <SpeakButton text={example.surface} language={language} />
                   </span>
                   <span className="kanji-example-reading">{example.reading}</span>
-                  <span className="kanji-example-mean">{example.meaningZh}</span>
+                  <span className="kanji-example-mean">
+                    {pickLocalized(example.meaningZh, example.meaningI18n, language)}
+                  </span>
                 </li>
               ))}
             </ul>

--- a/src/components/challenge/DrillPanel.test.tsx
+++ b/src/components/challenge/DrillPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DrillPanel } from "./DrillPanel";
+import type { PracticeQuestion } from "../../domain/types";
+import type { Language } from "../../i18n";
+
+const question: PracticeQuestion = {
+  id: "kaku:te",
+  vocabulary: {
+    id: "kaku",
+    surface: "書く",
+    reading: "かく",
+    meaningZh: "寫",
+    meaningI18n: { en: "to write", ja: "文字や文章をしるすこと" },
+    partOfSpeech: "verb",
+    group: "godan",
+    lesson: null,
+    tags: [],
+    examples: []
+  },
+  targetForm: "te",
+  expectedAnswers: ["書いて"],
+  explanation: "一類動詞的て形會產生音便。"
+};
+
+function renderPanel(language: Language) {
+  return render(
+    <DrillPanel
+      language={language}
+      questionIndex={0}
+      sessionTotal={null}
+      selectedChoice={null}
+      feedback={null}
+      attempts={[]}
+      practiceMode="basic"
+      currentQuestion={question}
+      reviewEmpty={false}
+      sessionExhausted={false}
+      choiceOptions={["書いて", "書いた", "書かない", "書きます"]}
+      correctCount={0}
+      nextButtonRef={{ current: null }}
+      setPracticeMode={vi.fn()}
+      setPracticeFilter={vi.fn()}
+      handleChoiceSubmit={vi.fn()}
+      nextQuestion={vi.fn()}
+      resetSession={vi.fn()}
+      revealAnswer={vi.fn()}
+      handleDrillKeyDown={vi.fn()}
+      onExit={vi.fn()}
+    />
+  );
+}
+
+describe("DrillPanel", () => {
+  it("localizes the pre-answer meaning gloss (#427)", () => {
+    renderPanel("en");
+    expect(screen.getByText("to write")).toBeInTheDocument();
+    expect(screen.queryByText("寫")).not.toBeInTheDocument();
+  });
+
+  it("keeps the zh gloss for zh-Hant", () => {
+    renderPanel("zh-Hant");
+    expect(screen.getByText("寫")).toBeInTheDocument();
+  });
+});

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -3,6 +3,7 @@ import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech } from "../../domain/types";
 import { DarumaSpot, PaperNoteSpot, TeaCupSpot } from "../../illustrations";
 import { isReadingPrompt } from "../../domain/furigana";
+import { pickLocalized } from "../../domain/localizedContent";
 import { ExamPrompt } from "../ExamPrompt";
 import { FeedbackPanel } from "../FeedbackPanel";
 import { Ruby } from "../Ruby";
@@ -159,7 +160,13 @@ export function DrillPanel({
                   />
                 </p>
                 {currentQuestion.targetForm === "meaning" ? null : (
-                  <p className="meaning">{currentQuestion.vocabulary.meaningZh}</p>
+                  <p className="meaning">
+                    {pickLocalized(
+                      currentQuestion.vocabulary.meaningZh,
+                      currentQuestion.vocabulary.meaningI18n,
+                      language
+                    )}
+                  </p>
                 )}
               </>
             )}

--- a/src/domain/grammarPoints.test.ts
+++ b/src/domain/grammarPoints.test.ts
@@ -57,4 +57,20 @@ describe("grammarPoints", () => {
     // Curated examples are folded into the example list.
     expect(point!.examples.length).toBeGreaterThanOrEqual(point!.note!.examples.length);
   });
+
+  it("threads the exam items' i18n overlays into the point (#427)", () => {
+    // Every exam item carries meaningI18n / explanationI18n / promptContextI18n
+    // since #400; the aggregation must not drop them. Use an un-noted point so
+    // the tested fields are the ones the page actually renders.
+    const surface = allGrammarSurfaces().find((s) => {
+      const p = buildGrammarPoint(s);
+      return p !== null && !p.note && p.explanations.length > 0 && p.examples.length > 0;
+    });
+    expect(surface).toBeDefined();
+
+    const point = buildGrammarPoint(surface!)!;
+    expect(point.meaningI18n?.en).toBeTruthy();
+    expect(point.explanations.some((entry) => entry.i18n?.en)).toBe(true);
+    expect(point.examples.some((example) => example.zhI18n?.en)).toBe(true);
+  });
 });

--- a/src/domain/grammarPoints.ts
+++ b/src/domain/grammarPoints.ts
@@ -7,23 +7,32 @@
 // new authored content. This module reaches into examBlocks + grammarNotes, so
 // it carries the lazy exam-bank weight -- it MUST only be imported by the lazy
 // GrammarPointPage, never from an eager path (see bundle-codesplit discipline).
-import type { JlptLevel, PracticeQuestion } from "./types";
+import type { JlptLevel, LocalizedText, PracticeQuestion } from "./types";
 import { examStyleQuestions } from "./examBlocks";
 import { grammarNotes, type GrammarNote } from "./grammarNotes";
 
-export type GrammarPointExample = { ja: string; zh: string };
+export type GrammarPointExample = { ja: string; zh: string; zhI18n?: LocalizedText };
+
+/** One usage note with its per-locale overlay, so the page can pickLocalized. */
+export type GrammarPointExplanation = { zh: string; i18n?: LocalizedText };
 
 export type GrammarPoint = {
   /** The grammar-point surface; also the route id (`/grammar/<surface>`). */
   surface: string;
   level: JlptLevel | null;
   meaningZh: string;
+  /**
+   * Per-locale meaning overlay (#427). Only set for un-noted points (the only
+   * case the page renders `meaningZh` -- noted points show GrammarNoteCard's
+   * own localized meaning), so it always pairs with the vocab-derived source.
+   */
+  meaningI18n?: LocalizedText;
   /** Curated reference note (rule / usage / confusions), when one exists. */
   note: GrammarNote | null;
   /** Worked example sentences: curated first, then exam-item-derived. */
   examples: GrammarPointExample[];
   /** Distinct exam explanations -- the "rule" content for un-noted points. */
-  explanations: string[];
+  explanations: GrammarPointExplanation[];
   /** How many exam questions drill this point (a "練習這個文法" entry hint). */
   questionCount: number;
 };
@@ -45,7 +54,7 @@ function exampleFromQuestion(question: PracticeQuestion): GrammarPointExample | 
   const ja = question.promptText.includes(BLANK)
     ? question.promptText.replace(BLANK, answer)
     : question.promptText;
-  return { ja, zh: question.promptContextZh ?? "" };
+  return { ja, zh: question.promptContextZh ?? "", zhI18n: question.promptContextI18n };
 }
 
 // Curated note lookup, tolerant of a leading 〜/～ on the surface.
@@ -96,12 +105,20 @@ export function buildGrammarPoint(surface: string): GrammarPoint | null {
     examples.push(example);
   }
 
-  const explanations = [...new Set(items.map((item) => item.explanation).filter(Boolean))];
+  // Dedupe by the zh text (the stable key), keeping each note's i18n overlay.
+  const seenExplanations = new Set<string>();
+  const explanations: GrammarPointExplanation[] = [];
+  for (const item of items) {
+    if (!item.explanation || seenExplanations.has(item.explanation)) continue;
+    seenExplanations.add(item.explanation);
+    explanations.push({ zh: item.explanation, i18n: item.explanationI18n });
+  }
 
   return {
     surface,
     level: items[0].vocabulary.level ?? note?.jlptLevel ?? null,
     meaningZh: note?.meaningZh ?? items[0].vocabulary.meaningZh,
+    meaningI18n: note ? undefined : items[0].vocabulary.meaningI18n,
     note,
     examples,
     explanations,

--- a/src/domain/kanjiOnyomi.test.ts
+++ b/src/domain/kanjiOnyomi.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { kanjiOnyomi, kanjiExamples } from "./kanjiOnyomi";
+import type { VocabularyItem } from "./types";
 
 // Readings are stored as plain hiragana (long-vowel ー allowed), no okurigana
 // dots -- matching the reading drills + the panel's grouping/display.
@@ -54,5 +55,27 @@ describe("kanjiOnyomi", () => {
       .filter((entry) => kanjiExamples(entry.kanji).length === 0)
       .map((entry) => entry.kanji);
     expect(empty, `kanji with no example words: ${empty.join(", ")}`).toEqual([]);
+  });
+
+  it("passes vocab meaningI18n through to kanji example words (#427)", () => {
+    const deck: VocabularyItem[] = [
+      {
+        id: "x-書道",
+        surface: "書道",
+        reading: "しょどう",
+        meaningZh: "書法",
+        meaningI18n: { en: "calligraphy", ja: "毛筆で文字を書く芸術" },
+        partOfSpeech: "noun",
+        group: null,
+        lesson: null,
+        tags: [],
+        examples: []
+      }
+    ];
+
+    const examples = kanjiExamples("書", 6, deck);
+    expect(examples).toHaveLength(1);
+    expect(examples[0].meaningI18n?.en).toBe("calligraphy");
+    expect(examples[0].meaningI18n?.ja).toBe("毛筆で文字を書く芸術");
   });
 });

--- a/src/domain/kanjiOnyomi.ts
+++ b/src/domain/kanjiOnyomi.ts
@@ -1,4 +1,4 @@
-import type { JlptLevel } from "./types";
+import type { JlptLevel, LocalizedText, VocabularyItem } from "./types";
 import { vocabulary } from "./vocabulary";
 
 // 漢字 reading study table (#195) -- a self-authored set, NOT imported from
@@ -696,19 +696,31 @@ export const kanjiOnyomi: KanjiOnyomiEntry[] = [
   { kanji: "狼", onyomi: ["ろう"], kunyomi: ["おおかみ"], meaningZh: "狼、狼狽", level: "N1" }
 ];
 
-export type KanjiExample = { surface: string; reading: string; meaningZh: string };
+export type KanjiExample = {
+  surface: string;
+  reading: string;
+  meaningZh: string;
+  /** Per-locale translations of `meaningZh`; falls back to the zh source (#427). */
+  meaningI18n?: LocalizedText;
+};
 
 /**
  * Real words from the vocab deck that contain this kanji -- the example
  * compounds shown on the kanji card. Sorted shortest-first (the simplest
  * compound reads most clearly) and capped, since a kanji card only needs a
  * few illustrative words. Uses the full `vocabulary` deck (basic N5 + JLPT
- * N2/N1) so lower-level kanji also resolve example words.
+ * N2/N1) so lower-level kanji also resolve example words. `deck` is
+ * injectable for tests only.
  */
-export function kanjiExamples(kanji: string, limit = 6): KanjiExample[] {
-  return vocabulary
+export function kanjiExamples(kanji: string, limit = 6, deck: VocabularyItem[] = vocabulary): KanjiExample[] {
+  return deck
     .filter((item) => item.surface.includes(kanji))
     .sort((a, b) => a.surface.length - b.surface.length)
     .slice(0, limit)
-    .map((item) => ({ surface: item.surface, reading: item.reading, meaningZh: item.meaningZh }));
+    .map((item) => ({
+      surface: item.surface,
+      reading: item.reading,
+      meaningZh: item.meaningZh,
+      meaningI18n: item.meaningI18n
+    }));
 }


### PR DESCRIPTION
Part of #427 (Phase C read-path batch 1). 修四條 en/ja 下漏中文的 render path：grammarPoints 聚合層丟棄 exam item 既有 overlay（meaning/explanation/promptContext）、DrillPanel 作答前詞義行、漢字卡例詞 gloss、cleanExplanation 只認 zh 開頭語。全部改走 pickLocalized；kanjiExamples 增加可注入 deck 供測試。TDD：7 個新測試先 RED；pnpm test 582 全綠、build 過。