### PR TITLE
i18n(registry): single locale source + generalize hardcoded en/ja structures (#434)

### DIFF
--- a/scripts/_locales.mjs
+++ b/scripts/_locales.mjs
@@ -1,0 +1,57 @@
+// Runtime locale registry for the .mjs scripts.
+//
+// The TS source of truth is `LOCALE_CODES` in src/domain/types.ts (an
+// `as const` tuple so the LocaleCode union derives from it). Node scripts
+// can't import a .ts at runtime, so we read that one array back out here.
+// `src/domain/locales.test.ts` asserts this parse equals the real array, so a
+// reformat or drift breaks CI rather than silently desyncing.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TYPES_PATH = join(HERE, "..", "src", "domain", "types.ts");
+
+function parseLocaleCodes() {
+  const src = readFileSync(TYPES_PATH, "utf8");
+  const match = src.match(/LOCALE_CODES\s*=\s*\[([^\]]+)\]\s*as const/);
+  if (!match) {
+    throw new Error("could not find `LOCALE_CODES = [...] as const` in src/domain/types.ts");
+  }
+  const codes = [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (codes.length === 0) {
+    throw new Error("parsed an empty LOCALE_CODES array from src/domain/types.ts");
+  }
+  return codes;
+}
+
+/** Every locale code, in the order declared in types.ts. */
+export const LOCALE_CODES = parseLocaleCodes();
+
+/** The zh-Hant source locale (content is authored here). */
+export const SOURCE_LOCALE = "zh-Hant";
+
+/** Han-script locales — Han residue in these is NOT an untranslated signal. */
+export const HAN_LOCALES = new Set([SOURCE_LOCALE, "ja"]);
+
+/** Translation targets: everything except the source. */
+export const TARGET_LOCALES = LOCALE_CODES.filter((code) => code !== SOURCE_LOCALE);
+
+/**
+ * Locales whose values should contain NO Han ideographs, so leftover Han flags
+ * an untranslated string. Everything except the two Han-script locales
+ * (zh-Hant source + ja). Derived, so ko/my are covered automatically.
+ */
+export const NON_HAN_LOCALES = new Set(LOCALE_CODES.filter((code) => !HAN_LOCALES.has(code)));
+
+/** Human-readable language names, for translation prompts. */
+export const LOCALE_NAME = {
+  "zh-Hant": "Traditional Chinese",
+  ja: "Japanese",
+  en: "English",
+  th: "Thai",
+  id: "Indonesian",
+  ko: "Korean",
+  vi: "Vietnamese",
+  my: "Burmese"
+};

--- a/scripts/ai-translate-content.mjs
+++ b/scripts/ai-translate-content.mjs
@@ -33,10 +33,12 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { LOCALE_NAME, TARGET_LOCALES } from "./_locales.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ITEMS_DIR = path.join(REPO_ROOT, "src", "domain", "exam", "items");
-const LOCALES = new Set(["ja", "en", "th", "id", "ko", "vi", "my"]); // zh-Hant is the source
+// Translation targets from the single locale registry (#434); zh-Hant is the source.
+const LOCALES = new Set(TARGET_LOCALES);
 
 // Every translatable Chinese content field and its per-locale overlay sibling.
 // exampleMeaningZh only exists on items with a CUSTOM example sentence; items
@@ -294,11 +296,6 @@ export function applyOverlays(text, items, locale) {
 // ---------------------------------------------------------------------------
 // prompt + Gemini call
 // ---------------------------------------------------------------------------
-const LOCALE_NAME = {
-  ja: "Japanese", en: "English", th: "Thai", id: "Indonesian",
-  ko: "Korean", vi: "Vietnamese", my: "Burmese"
-};
-
 const FIELD_NOTE = {
   meaningZh: "the word/phrase meaning",
   instructionZh: "the task instruction (e.g. 'choose the most natural word')",

--- a/scripts/check-i18n-coverage.mjs
+++ b/scripts/check-i18n-coverage.mjs
@@ -46,13 +46,15 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { NON_HAN_LOCALES, SOURCE_LOCALE } from "./_locales.mjs";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const LOCALES_DIR = path.join(REPO_ROOT, "src", "locales");
 const EXAM_ITEMS_DIR = path.join(REPO_ROOT, "src", "domain", "exam", "items");
-const SOURCE_LOCALE = "zh-Hant";
-// locales whose script is NOT Han-based; Han ideographs there are suspected residue.
-const NON_HAN_LOCALES = new Set(["en", "th", "id", "vi"]);
+// SOURCE_LOCALE + NON_HAN_LOCALES come from the single locale registry (#434):
+// non-Han = every locale except zh-Hant (source) and ja, so ko/my are covered
+// (the old hardcoded set omitted them). Han ideographs in a non-Han locale are
+// suspected untranslated residue.
 
 const HAN_RE = /[一-鿿㐀-䶿]/;
 

--- a/src/domain/cloze.ts
+++ b/src/domain/cloze.ts
@@ -1,5 +1,14 @@
 import { conjugate, TARGET_FORM_LABELS, TARGET_FORM_LABELS_I18N } from "./conjugation";
-import type { ConjugationResult, JlptLevel, LocalizedText, PracticeQuestion, TargetForm, VocabularyItem } from "./types";
+import {
+  CONTENT_LOCALES,
+  type ConjugationResult,
+  type ContentLocale,
+  type JlptLevel,
+  type LocalizedText,
+  type PracticeQuestion,
+  type TargetForm,
+  type VocabularyItem
+} from "./types";
 
 export interface ClozeSentence {
   id: string;
@@ -82,16 +91,13 @@ export function buildClozeQuestionPool(
       targetForm: sentence.targetForm,
       expectedAnswers: correctResult.answers,
       explanation: explanation.zh,
-      explanationI18n: { en: explanation.en, ja: explanation.ja },
+      explanationI18n: explanation.overlay,
       promptLabel: `文中変化・${sentence.grammarPoint}`,
       promptText,
       promptContextZh: sentence.translationZh,
       promptContextI18n: sentence.translationI18n,
       instructionZh: "從句意挑出正確的變化形。",
-      instructionI18n: {
-        en: "Choose the form that fits the meaning of the sentence.",
-        ja: "文の意味に合う形を選んでください。"
-      },
+      instructionI18n: { ...CLOZE_INSTRUCTION },
       options
     });
   }
@@ -99,37 +105,60 @@ export function buildClozeQuestionPool(
   return questions;
 }
 
+// Per-CONTENT_LOCALE chrome for the generated cloze explanation + instruction
+// (#434). Typed against the registry, so adding a code to CONTENT_LOCALES
+// compile-forces its phrasing here. The zh source lives inline in
+// buildExplanation / the `instructionZh` literal.
+const CLOZE_INSTRUCTION: Record<ContentLocale, string> = {
+  en: "Choose the form that fits the meaning of the sentence.",
+  ja: "文の意味に合う形を選んでください。"
+};
+
+const CLOZE_EXPLANATION_TEMPLATE: Record<
+  ContentLocale,
+  { meaningLine: (translation: string) => string; grammarLine: (parts: GrammarLineParts) => string }
+> = {
+  en: {
+    meaningLine: (t) => `Sentence meaning: ${t}`,
+    grammarLine: ({ grammarPoint, label, answer, surface }) =>
+      `Grammar point: ${grammarPoint} → this blank needs the ${label} 「${answer}」 (the ${label} of ${surface}).`
+  },
+  ja: {
+    meaningLine: (t) => `文の意味：${t}`,
+    grammarLine: ({ grammarPoint, label, answer, surface }) =>
+      `文法ポイント：${grammarPoint} → ここには${label}「${answer}」（${surface}の${label}）が入ります。`
+  }
+};
+
+type GrammarLineParts = { grammarPoint: string; label: string; answer: string; surface: string };
+
 function buildExplanation(
   sentence: ClozeSentence,
   vocab: VocabularyItem,
   correctAnswer: string,
   correctResult: ConjugationResult
-): { zh: string; en: string; ja: string } {
+): { zh: string; overlay: LocalizedText } {
   const targetLabel = TARGET_FORM_LABELS[sentence.targetForm] ?? sentence.targetForm;
-  const labelI18n = TARGET_FORM_LABELS_I18N[sentence.targetForm];
-  const labelEn = labelI18n?.en ?? sentence.targetForm;
-  const labelJa = labelI18n?.ja ?? sentence.targetForm;
-  // Sentence translations fall back to zh until per-locale data lands (#427).
-  const translationEn = sentence.translationI18n?.en ?? sentence.translationZh;
-  const translationJa = sentence.translationI18n?.ja ?? sentence.translationZh;
+  const zh = [
+    `句意：${sentence.translationZh}`,
+    `文法重點：${sentence.grammarPoint} → 此處需要${targetLabel}「${correctAnswer}」（${vocab.surface}的${targetLabel}）。`,
+    correctResult.explanation
+  ].join("\n");
 
-  return {
-    zh: [
-      `句意：${sentence.translationZh}`,
-      `文法重點：${sentence.grammarPoint} → 此處需要${targetLabel}「${correctAnswer}」（${vocab.surface}的${targetLabel}）。`,
-      correctResult.explanation
-    ].join("\n"),
-    en: [
-      `Sentence meaning: ${translationEn}`,
-      `Grammar point: ${sentence.grammarPoint} → this blank needs the ${labelEn} 「${correctAnswer}」 (the ${labelEn} of ${vocab.surface}).`,
-      correctResult.explanationI18n?.en ?? correctResult.explanation
-    ].join("\n"),
-    ja: [
-      `文の意味：${translationJa}`,
-      `文法ポイント：${sentence.grammarPoint} → ここには${labelJa}「${correctAnswer}」（${vocab.surface}の${labelJa}）が入ります。`,
-      correctResult.explanationI18n?.ja ?? correctResult.explanation
-    ].join("\n")
-  };
+  const overlay: LocalizedText = {};
+  for (const loc of CONTENT_LOCALES) {
+    const template = CLOZE_EXPLANATION_TEMPLATE[loc];
+    const label = TARGET_FORM_LABELS_I18N[sentence.targetForm]?.[loc] ?? sentence.targetForm;
+    // Sentence translations fall back to zh until per-locale data lands (#427).
+    const translation = sentence.translationI18n?.[loc] ?? sentence.translationZh;
+    const base = correctResult.explanationI18n?.[loc] ?? correctResult.explanation;
+    overlay[loc] = [
+      template.meaningLine(translation),
+      template.grammarLine({ grammarPoint: sentence.grammarPoint, label, answer: correctAnswer, surface: vocab.surface }),
+      base
+    ].join("\n");
+  }
+  return { zh, overlay };
 }
 
 function sortDeterministic(values: string[], seed: string): string[] {

--- a/src/domain/conjugation.ts
+++ b/src/domain/conjugation.ts
@@ -1,4 +1,13 @@
-import type { ConjugationResult, TargetForm, VocabularyItem } from "./types";
+import {
+  LOCALE_CODES,
+  SOURCE_LOCALE,
+  type ConjugationResult,
+  type ContentLocale,
+  type LocaleCode,
+  type LocalizedText,
+  type TargetForm,
+  type VocabularyItem
+} from "./types";
 
 // Keys are ordered so る comes first. When rule candidates are generated for an
 // ichidan verb (all of which end in る) the godan-style "wrong rule" attempt --
@@ -135,9 +144,11 @@ export const TARGET_FORM_LABELS: Record<TargetForm, string> = {
   plainPastNegative: "普通形・過去否定"
 };
 
-// en/ja counterparts of TARGET_FORM_LABELS for localized explanations (#427).
-// zh stays in TARGET_FORM_LABELS as the canonical source.
-export const TARGET_FORM_LABELS_I18N: Record<TargetForm, { en: string; ja: string }> = {
+// Per-CONTENT_LOCALE counterparts of TARGET_FORM_LABELS for localized
+// explanations (#427). zh stays in TARGET_FORM_LABELS as the canonical source.
+// Typed against the locale registry (#434): adding a code to CONTENT_LOCALES
+// compile-forces a label for it in every entry here.
+export const TARGET_FORM_LABELS_I18N: Record<TargetForm, Record<ContentLocale, string>> = {
   dictionary: { en: "dictionary form", ja: "辞書形" },
   masu: { en: "ます form", ja: "ます形" },
   nai: { en: "ない form", ja: "ない形" },
@@ -161,23 +172,24 @@ export const TARGET_FORM_LABELS_I18N: Record<TargetForm, { en: string; ja: strin
 };
 
 /**
- * Explanation text in the three launched content locales. zh is the canonical
- * source stored on `explanation`; en/ja feed `explanationI18n` (#427). Absent
- * locales in the UI fall back to zh via `pickLocalized`.
+ * Explanation text for one drill. `zh` is the canonical source stored on
+ * `explanation`; the locale keys feed `explanationI18n` (#427). Every
+ * CONTENT_LOCALE is REQUIRED (so adding one to the registry compile-forces a
+ * string in every template, #434); any other locale is optional, letting a
+ * pilot language (#435) add strings without joining CONTENT_LOCALES. Absent
+ * locales in the UI fall back via `pickLocalized`.
  */
-interface LocalizedExplanation {
-  zh: string;
-  en: string;
-  ja: string;
-}
+type LocalizedExplanation = { zh: string } & Record<ContentLocale, string> &
+  Partial<Record<LocaleCode, string>>;
 
 function explained(targetForm: TargetForm, answers: string[], text: LocalizedExplanation): ConjugationResult {
-  return {
-    targetForm,
-    answers,
-    explanation: text.zh,
-    explanationI18n: { en: text.en, ja: text.ja }
-  };
+  const explanationI18n: LocalizedText = {};
+  for (const code of LOCALE_CODES) {
+    if (code === SOURCE_LOCALE) continue; // zh-Hant is the source, not an overlay
+    const value = text[code];
+    if (typeof value === "string") explanationI18n[code] = value;
+  }
+  return { targetForm, answers, explanation: text.zh, explanationI18n };
 }
 
 export const VERB_FORMS: TargetForm[] = [

--- a/src/domain/locales.test.ts
+++ b/src/domain/locales.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { CONTENT_LOCALES, LOCALE_CODES, SOURCE_LOCALE } from "./types";
+// @ts-expect-error -- plain .mjs tooling module, no types
+import { LOCALE_CODES as SCRIPT_LOCALE_CODES, LOCALE_NAME, NON_HAN_LOCALES, SOURCE_LOCALE as SCRIPT_SOURCE_LOCALE, TARGET_LOCALES } from "../../scripts/_locales.mjs";
+
+// The .mjs scripts can't import the TS union, so they regex-read LOCALE_CODES
+// back out of types.ts. This is the guard that the two never drift (a reformat
+// of the const, or a code added to one side only, fails here — not silently).
+describe("locale registry (TS <-> scripts)", () => {
+  it("the script-side parse matches the TS source of truth exactly", () => {
+    expect(SCRIPT_LOCALE_CODES).toEqual([...LOCALE_CODES]);
+    expect(SCRIPT_SOURCE_LOCALE).toBe(SOURCE_LOCALE);
+  });
+
+  it("every locale has a human-readable name for translation prompts", () => {
+    for (const code of LOCALE_CODES) {
+      expect(LOCALE_NAME[code], code).toBeTruthy();
+    }
+  });
+
+  it("TARGET_LOCALES is every code except the source", () => {
+    expect(TARGET_LOCALES).toEqual(LOCALE_CODES.filter((c) => c !== SOURCE_LOCALE));
+  });
+
+  it("NON_HAN_LOCALES covers ko and my (the historical omission) but not ja", () => {
+    expect(NON_HAN_LOCALES.has("ko")).toBe(true);
+    expect(NON_HAN_LOCALES.has("my")).toBe(true);
+    expect(NON_HAN_LOCALES.has("ja")).toBe(false);
+    expect(NON_HAN_LOCALES.has(SOURCE_LOCALE)).toBe(false);
+  });
+
+  it("CONTENT_LOCALES is a subset of LOCALE_CODES and excludes the source", () => {
+    for (const code of CONTENT_LOCALES) {
+      expect(LOCALE_CODES).toContain(code);
+      expect(code).not.toBe(SOURCE_LOCALE);
+    }
+  });
+});

--- a/src/domain/mockExam.test.ts
+++ b/src/domain/mockExam.test.ts
@@ -46,16 +46,18 @@ describe("getMockExamBlueprint", () => {
     }
   });
 
-  it("localizes section subtitles: en label per section, none in ja UI (#427)", () => {
+  it("localizes section subtitles: en label per section, none in ja UI (#427/#434)", () => {
     const HAN = /[㐀-鿿]/;
     for (const bp of [N1_BLUEPRINT, N2_BLUEPRINT, N3_BLUEPRINT]) {
       for (const section of bp.sections) {
-        expect(section.labelEn, `${bp.level}:${section.id}`).toBeTruthy();
-        expect(HAN.test(section.labelEn), `${bp.level}:${section.id} labelEn must be Han-free`).toBe(false);
-        expect(sectionSubtitle(section, "en")).toBe(section.labelEn);
+        expect(section.labelI18n.en, `${bp.level}:${section.id}`).toBeTruthy();
+        expect(HAN.test(section.labelI18n.en!), `${bp.level}:${section.id} labelI18n.en must be Han-free`).toBe(false);
+        expect(sectionSubtitle(section, "en")).toBe(section.labelI18n.en);
         // The main label already IS the official Japanese name -- no subtitle.
         expect(sectionSubtitle(section, "ja")).toBeNull();
         expect(sectionSubtitle(section, "zh-Hant")).toBe(section.labelZh);
+        // A locale with no labelI18n entry falls back to the zh hint (#434).
+        expect(sectionSubtitle(section, "ko")).toBe(section.labelZh);
       }
     }
   });

--- a/src/domain/mockExam.ts
+++ b/src/domain/mockExam.ts
@@ -11,7 +11,7 @@
 // (An earlier version composed and ran a full timed paper here; that was
 // dropped for the lighter section picker. See git history if a timed
 // full-paper mode is ever wanted again.)
-import type { JlptLevel, LocaleCode } from "./types";
+import type { JlptLevel, LocaleCode, LocalizedText } from "./types";
 
 export type MockExamLevel = Extract<JlptLevel, "N1" | "N2" | "N3">;
 
@@ -22,8 +22,13 @@ export interface MockExamSection {
   labelJa: string;
   /** Short 中文 hint for the section. */
   labelZh: string;
-  /** Short English hint for the section (#427). */
-  labelEn: string;
+  /**
+   * Per-locale subtitle hints (#427/#434). `en` ships today; adding another
+   * locale is just another key — `sectionSubtitle` reads whatever is here and
+   * falls back to the zh hint. `ja` is intentionally absent: labelJa already
+   * IS the official Japanese name, so ja needs no subtitle.
+   */
+  labelI18n: LocalizedText;
   /**
    * Matched against PracticeQuestion.promptLabel to gather a section's
    * questions. MUST match the strings authored in `examBlocks.ts`
@@ -42,15 +47,14 @@ export interface MockExamBlueprint {
 }
 
 /**
- * The subtitle under a section's Japanese name, per UI locale (#427):
- * en gets the English hint, ja gets none (the main label already IS the
- * Japanese name), everything else falls back to the zh hint -- matching
- * the app-wide zh-fallback rule for content locales.
+ * The subtitle under a section's Japanese name, per UI locale (#427/#434):
+ * ja gets none (labelJa already IS the Japanese name); every other locale
+ * reads its labelI18n entry and falls back to the zh hint when absent --
+ * matching the app-wide zh-fallback rule for content locales.
  */
 export function sectionSubtitle(section: MockExamSection, locale: LocaleCode): string | null {
   if (locale === "ja") return null;
-  if (locale === "en") return section.labelEn;
-  return section.labelZh;
+  return section.labelI18n[locale] ?? section.labelZh;
 }
 
 // Official JLPT 1 回 structure (言語知識・読解 paper only -- 聴解 is its own
@@ -61,20 +65,20 @@ export const N2_BLUEPRINT: MockExamBlueprint = {
   level: "N2",
   totalMinutes: 105,
   sections: [
-    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelEn: "Kanji reading", promptLabel: "漢字読み", targetCount: 5 },
-    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelEn: "Orthography (kanji writing)", promptLabel: "表記", targetCount: 5 },
-    { id: "go-keisei", labelJa: "語形成", labelZh: "詞形成（N2 限定）", labelEn: "Word formation (N2 only)", promptLabel: "語形成", targetCount: 3 },
-    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelEn: "Vocabulary in context", promptLabel: "詞彙填空", targetCount: 7 },
-    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelEn: "Paraphrase (synonyms)", promptLabel: "類義替換", targetCount: 5 },
-    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelEn: "Word usage", promptLabel: "詞彙用法", targetCount: 5 },
-    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelEn: "Grammar form selection", promptLabel: "文法形式選擇", targetCount: 12 },
-    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelEn: "Sentence assembly (★)", promptLabel: "語順組合", targetCount: 5 },
-    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelEn: "Passage cloze", promptLabel: "文章脈絡", targetCount: 5 },
-    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelEn: "Reading: short passages", promptLabel: "内容理解（短文）", targetCount: 5 },
-    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelEn: "Reading: mid-length passages", promptLabel: "内容理解（中文）", targetCount: 9 },
-    { id: "togo", labelJa: "統合理解", labelZh: "綜合理解（雙文）", labelEn: "Integrated comprehension (two texts)", promptLabel: "統合理解", targetCount: 2 },
-    { id: "shucho", labelJa: "主張理解（長文）", labelZh: "主張理解（長文）", labelEn: "Thesis comprehension (long passage)", promptLabel: "主張理解", targetCount: 3 },
-    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelEn: "Information retrieval", promptLabel: "情報検索", targetCount: 2 }
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelI18n: { en: "Kanji reading" }, promptLabel: "漢字読み", targetCount: 5 },
+    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelI18n: { en: "Orthography (kanji writing)" }, promptLabel: "表記", targetCount: 5 },
+    { id: "go-keisei", labelJa: "語形成", labelZh: "詞形成（N2 限定）", labelI18n: { en: "Word formation (N2 only)" }, promptLabel: "語形成", targetCount: 3 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelI18n: { en: "Vocabulary in context" }, promptLabel: "詞彙填空", targetCount: 7 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelI18n: { en: "Paraphrase (synonyms)" }, promptLabel: "類義替換", targetCount: 5 },
+    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelI18n: { en: "Word usage" }, promptLabel: "詞彙用法", targetCount: 5 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelI18n: { en: "Grammar form selection" }, promptLabel: "文法形式選擇", targetCount: 12 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelI18n: { en: "Sentence assembly (★)" }, promptLabel: "語順組合", targetCount: 5 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelI18n: { en: "Passage cloze" }, promptLabel: "文章脈絡", targetCount: 5 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelI18n: { en: "Reading: short passages" }, promptLabel: "内容理解（短文）", targetCount: 5 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelI18n: { en: "Reading: mid-length passages" }, promptLabel: "内容理解（中文）", targetCount: 9 },
+    { id: "togo", labelJa: "統合理解", labelZh: "綜合理解（雙文）", labelI18n: { en: "Integrated comprehension (two texts)" }, promptLabel: "統合理解", targetCount: 2 },
+    { id: "shucho", labelJa: "主張理解（長文）", labelZh: "主張理解（長文）", labelI18n: { en: "Thesis comprehension (long passage)" }, promptLabel: "主張理解", targetCount: 3 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelI18n: { en: "Information retrieval" }, promptLabel: "情報検索", targetCount: 2 }
   ]
 };
 
@@ -82,18 +86,18 @@ export const N1_BLUEPRINT: MockExamBlueprint = {
   level: "N1",
   totalMinutes: 110,
   sections: [
-    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelEn: "Kanji reading", promptLabel: "漢字読み", targetCount: 6 },
-    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelEn: "Vocabulary in context", promptLabel: "詞彙填空", targetCount: 7 },
-    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelEn: "Paraphrase (synonyms)", promptLabel: "類義替換", targetCount: 6 },
-    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelEn: "Word usage", promptLabel: "詞彙用法", targetCount: 6 },
-    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelEn: "Grammar form selection", promptLabel: "文法形式選擇", targetCount: 10 },
-    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelEn: "Sentence assembly (★)", promptLabel: "語順組合", targetCount: 5 },
-    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelEn: "Passage cloze", promptLabel: "文章脈絡", targetCount: 5 },
-    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelEn: "Reading: short passages", promptLabel: "内容理解（短文）", targetCount: 4 },
-    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelEn: "Reading: mid-length passages", promptLabel: "内容理解（中文）", targetCount: 9 },
-    { id: "togo", labelJa: "統合理解", labelZh: "綜合理解（雙文）", labelEn: "Integrated comprehension (two texts)", promptLabel: "統合理解", targetCount: 2 },
-    { id: "shucho", labelJa: "主張理解（長文）", labelZh: "主張理解（長文）", labelEn: "Thesis comprehension (long passage)", promptLabel: "主張理解", targetCount: 4 },
-    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelEn: "Information retrieval", promptLabel: "情報検索", targetCount: 2 }
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelI18n: { en: "Kanji reading" }, promptLabel: "漢字読み", targetCount: 6 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelI18n: { en: "Vocabulary in context" }, promptLabel: "詞彙填空", targetCount: 7 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelI18n: { en: "Paraphrase (synonyms)" }, promptLabel: "類義替換", targetCount: 6 },
+    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelI18n: { en: "Word usage" }, promptLabel: "詞彙用法", targetCount: 6 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelI18n: { en: "Grammar form selection" }, promptLabel: "文法形式選擇", targetCount: 10 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelI18n: { en: "Sentence assembly (★)" }, promptLabel: "語順組合", targetCount: 5 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelI18n: { en: "Passage cloze" }, promptLabel: "文章脈絡", targetCount: 5 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelI18n: { en: "Reading: short passages" }, promptLabel: "内容理解（短文）", targetCount: 4 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelI18n: { en: "Reading: mid-length passages" }, promptLabel: "内容理解（中文）", targetCount: 9 },
+    { id: "togo", labelJa: "統合理解", labelZh: "綜合理解（雙文）", labelI18n: { en: "Integrated comprehension (two texts)" }, promptLabel: "統合理解", targetCount: 2 },
+    { id: "shucho", labelJa: "主張理解（長文）", labelZh: "主張理解（長文）", labelI18n: { en: "Thesis comprehension (long passage)" }, promptLabel: "主張理解", targetCount: 4 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelI18n: { en: "Information retrieval" }, promptLabel: "情報検索", targetCount: 2 }
   ]
 };
 
@@ -107,18 +111,18 @@ export const N3_BLUEPRINT: MockExamBlueprint = {
   level: "N3",
   totalMinutes: 100,
   sections: [
-    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelEn: "Kanji reading", promptLabel: "漢字読み", targetCount: 8 },
-    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelEn: "Orthography (kanji writing)", promptLabel: "表記", targetCount: 6 },
-    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelEn: "Vocabulary in context", promptLabel: "詞彙填空", targetCount: 11 },
-    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelEn: "Paraphrase (synonyms)", promptLabel: "類義替換", targetCount: 5 },
-    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelEn: "Word usage", promptLabel: "詞彙用法", targetCount: 5 },
-    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelEn: "Grammar form selection", promptLabel: "文法形式選擇", targetCount: 13 },
-    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelEn: "Sentence assembly (★)", promptLabel: "語順組合", targetCount: 5 },
-    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelEn: "Passage cloze", promptLabel: "文章脈絡", targetCount: 5 },
-    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelEn: "Reading: short passages", promptLabel: "内容理解（短文）", targetCount: 4 },
-    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelEn: "Reading: mid-length passages", promptLabel: "内容理解（中文）", targetCount: 6 },
-    { id: "dokkai-long", labelJa: "内容理解（長文）", labelZh: "長文閱讀", labelEn: "Reading: long passages", promptLabel: "内容理解（長文）", targetCount: 4 },
-    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelEn: "Information retrieval", promptLabel: "情報検索", targetCount: 2 }
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelI18n: { en: "Kanji reading" }, promptLabel: "漢字読み", targetCount: 8 },
+    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelI18n: { en: "Orthography (kanji writing)" }, promptLabel: "表記", targetCount: 6 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelI18n: { en: "Vocabulary in context" }, promptLabel: "詞彙填空", targetCount: 11 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelI18n: { en: "Paraphrase (synonyms)" }, promptLabel: "類義替換", targetCount: 5 },
+    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelI18n: { en: "Word usage" }, promptLabel: "詞彙用法", targetCount: 5 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelI18n: { en: "Grammar form selection" }, promptLabel: "文法形式選擇", targetCount: 13 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelI18n: { en: "Sentence assembly (★)" }, promptLabel: "語順組合", targetCount: 5 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelI18n: { en: "Passage cloze" }, promptLabel: "文章脈絡", targetCount: 5 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelI18n: { en: "Reading: short passages" }, promptLabel: "内容理解（短文）", targetCount: 4 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelI18n: { en: "Reading: mid-length passages" }, promptLabel: "内容理解（中文）", targetCount: 6 },
+    { id: "dokkai-long", labelJa: "内容理解（長文）", labelZh: "長文閱讀", labelI18n: { en: "Reading: long passages" }, promptLabel: "内容理解（長文）", targetCount: 4 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelI18n: { en: "Information retrieval" }, promptLabel: "情報検索", targetCount: 2 }
   ]
 };
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -5,12 +5,38 @@ export type VerbGroup = "godan" | "ichidan" | "irregular";
 export type JlptLevel = "N5" | "N4" | "N3" | "N2" | "N1";
 
 /**
- * Supported UI locale codes. Single source of truth in the domain layer so
- * content overlays (e.g. `explanationI18n`) and the i18n `Language` type can
- * both reference it without the UI layer owning a domain concept. `i18n.ts`
- * derives `Language` from this.
+ * Every locale code the app knows about, in menu order. THE single source of
+ * truth for the locale set — `LocaleCode` derives from it, `i18n.ts` derives
+ * `Language`, and the `.mjs` scripts read this exact array back out (see
+ * `scripts/_locales.mjs`, guarded by `locales.test.ts`). Keep it on ONE line
+ * so the script-side regex parse stays robust; don't reformat.
  */
-export type LocaleCode = "zh-Hant" | "ja" | "en" | "th" | "id" | "ko" | "vi" | "my";
+export const LOCALE_CODES = ["zh-Hant", "ja", "en", "th", "id", "ko", "vi", "my"] as const;
+
+/**
+ * Supported UI locale codes. Derived from {@link LOCALE_CODES} so the union and
+ * the runtime list can never drift.
+ */
+export type LocaleCode = (typeof LOCALE_CODES)[number];
+
+/**
+ * The zh-Hant SOURCE locale: content is authored here and every `*Zh` field
+ * stores it. Overlays translate away from this base.
+ */
+export const SOURCE_LOCALE = "zh-Hant" satisfies LocaleCode;
+
+/**
+ * Locales with a CONTENT-translation obligation: code that synthesizes
+ * per-locale text (drill explanations, section subtitles, …) produces an
+ * overlay entry for each of these, and adding a code here compile-forces every
+ * such structure to supply that locale's string. Distinct from
+ * `LAUNCHED_LANGUAGES` (user-facing) — a pilot locale can be a CONTENT locale
+ * without being launched, or launched later once its content lands.
+ */
+export const CONTENT_LOCALES = ["ja", "en"] as const satisfies readonly LocaleCode[];
+
+/** A locale that carries authored content overlays (see {@link CONTENT_LOCALES}). */
+export type ContentLocale = (typeof CONTENT_LOCALES)[number];
 
 /**
  * Per-locale translation overlay for a Chinese-source content field. Absent

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { readStored, writeStored } from "../domain/safeStorage";
+import { LOCALE_CODES } from "../domain/types";
 import { LAUNCHED_LANGUAGES, type Language } from "../i18n";
 
 const LANGUAGE_STORAGE_KEY = "jabiko.lang";
@@ -12,15 +13,20 @@ function isSupportedLanguage(value: string | null): value is Language {
   return value !== null && (LAUNCHED_LANGUAGES as readonly string[]).includes(value);
 }
 
+// Primary BCP-47 subtag -> locale code, derived from the registry (#434):
+// "zh-Hant" -> "zh", "ja" -> "ja", … So a new locale is detectable the moment
+// it launches, with no hand-maintained prefix table.
+const PRIMARY_SUBTAG_TO_CODE: Record<string, Language> = Object.fromEntries(
+  LOCALE_CODES.map((code) => [code.split("-")[0], code])
+);
+
 function languageForTag(tag: string | undefined): Language | null {
   if (!tag) return null;
-  const lower = tag.toLowerCase();
-  if (lower.startsWith("ja")) return "ja";
-  if (lower.startsWith("en")) return "en";
-  if (lower.startsWith("zh")) return "zh-Hant";
-  // th/id/ko/vi/my: Copy files exist but their content isn't launched yet --
-  // deliberately unmapped so detection falls through to the ja fallback.
-  return null;
+  const primary = tag.toLowerCase().split("-")[0];
+  const code = PRIMARY_SUBTAG_TO_CODE[primary];
+  // Only launched locales resolve; a gated locale's tag falls through to the
+  // ja fallback, so unfinished content is never surfaced by detection.
+  return code && isSupportedLanguage(code) ? code : null;
 }
 
 export function languageFromSearch(search: string): Language | null {


### PR DESCRIPTION
Implements #434（scope 已縮為工作項 1＋2；docs/add-a-language.md 移到 pilot #435）。目的：把「加一個新語言」變成純資料工作。

## Registry（單一來源）
- `src/domain/types.ts`：`LOCALE_CODES` as-const tuple 成為**唯一**來源，`LocaleCode` 從它 derive；新增 `SOURCE_LOCALE`、`CONTENT_LOCALES`（翻譯義務清單，與 `LAUNCHED_LANGUAGES` 正交）、`ContentLocale` 型別。
- `scripts/_locales.mjs`：node 讀不到 TS，故從 types.ts regex 讀回 `LOCALE_CODES`；`src/domain/locales.test.ts` 守著 parse 不漂移；`NON_HAN_LOCALES` 改**推導**（zh-Hant/ja 以外全算），自動補上舊硬編碼漏掉的 **ko/my**。

## 通用化（加 CONTENT_LOCALE 即編譯期強制補齊；pilot 語言維持 optional）
- `conjugation.ts`：`TARGET_FORM_LABELS_I18N`、`LocalizedExplanation` 改 keyed by `ContentLocale`；`explained()` 依 registry 迭代產 overlay。
- `cloze.ts`：解說／instruction 模板改 `CONTENT_LOCALES` 驅動。
- `mockExam.ts`：`labelEn` → `labelI18n: LocalizedText`；`sectionSubtitle` 讀它（ja 無副標、其餘 fallback zh hint）。

## Wiring（消手動同步點）
- `ai-translate-content.mjs`＋`check-i18n-coverage.mjs` 改吃 registry（不再手同步 LOCALES / LOCALE_NAME / NON_HAN_LOCALES）。
- `useLanguage.languageForTag` 的 BCP-47 前綴表改從 registry derive，仍 gate 在 LAUNCHED（gated 語言不被偵測）。

## 驗收
- zh-Hant/ja/en 行為零變化；`pnpm test` 597 全綠；`pnpm build` 過。
- initial chunk 509KB（持平）、examBlocks 6.21MB 不變、precache 在上限內。
- `check:i18n` 現正確標出 ko/my 的殘留（原本漏掉）——標出的是刻意保留的作者名例外，非新 bug。
- registry drift guard：TS↔scripts parse 一致、CONTENT_LOCALES ⊂ LOCALE_CODES。

Follow-up：#435 pilot（用真實語言跑一遍＋寫 SOP）、#433 日文中心 fallback（不急）。