### PR TITLE
fix(content): 修正兩題使用者回報的題目問題

### DIFF
--- a/src/domain/exam/items/n2.ts
+++ b/src/domain/exam/items/n2.ts
@@ -317,7 +317,7 @@ export const n2Items: PracticeQuestion[] = [
     instructionZh: "句中填空：依文脈選最自然的文法。",
     instructionI18n: { "ja": "空欄補充：文脈に最も自然に合う文法を選びましょう。", "en": "Fill in the blank: choose the grammar that fits the context most naturally." },
     promptText: "宿題は終わる ___ 、まだ半分もやっていない。",
-    promptContextZh: "別說作業沒寫完，連一半都還沒做。",
+    promptContextZh: "別說寫完了，作業連一半都還沒做。",
     promptContextI18n: { "ja": "宿題は終わるどころか、まだ半分もやっていません。", "en": "Far from finishing the homework, I haven't even done half of it." },
     expectedAnswer: "どころか",
     options: ["どころか", "ばかりか", "うえに", "に加えて"],

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -183,12 +183,12 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "免許と運転の関係。"
     },
     "promptContextI18n": {
-      "en": "Only people who have a license may drive a car.",
-      "ja": "免許を持っている人だけが、車を運転してもいい。"
+      "en": "If you have a license, you may drive a car.",
+      "ja": "免許を持っていれば、車を運転してもいい。"
     },
     "explanationI18n": {
-      "en": "「免許を持っている人だけ」 pins down the condition, and the clause expresses \"only then is it permitted\" → 「てもいい」. 「なくてもいい」 means \"don't have to drive\"; 「なければならない」 means \"must drive\"; 「てはいけない」 means \"must not drive\" (contradicts the first clause).",
-      "ja": "「免許を持っている人だけ」で条件を限定し、後件は「初めて許可される」を表す →「てもいい」。「なくてもいい」は「運転しなくてよい」、「なければならない」は「運転しなければならない」、「てはいけない」は「運転してはいけない」（前件と矛盾）。"
+      "en": "「免許を持っていれば」 states the condition, and the clause expresses \"under this condition it is permitted\" → 「てもいい」. 「なくてもいい」 means \"don't have to drive\"; 「なければならない」 means \"must drive\"; 「てはいけない」 means \"must not drive\" (contradicts the first clause).",
+      "ja": "「免許を持っていれば」で条件を示し、後件は「その条件で許可される」を表す →「てもいい」。「なくてもいい」は「運転しなくてよい」、「なければならない」は「運転しなければならない」、「てはいけない」は「運転してはいけない」（前件と矛盾）。"
     }
   },
   "pattern-nakute-mo-ii-005": {

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -231,9 +231,9 @@ const NAKUTE_MO_II_ITEMS: SentencePatternItem[] = [
   {
     id: "pattern-nakute-mo-ii-004",
     patternId: "nakute-mo-ii",
-    promptText: "免許を持っている人だけが、車を ___ 。",
+    promptText: "免許を持っていれば、車を ___ 。",
     hintZh: "駕照與開車的關係。",
-    promptContextZh: "只有有駕照的人才可以開車。",
+    promptContextZh: "有駕照的話，就可以開車。",
     expectedAnswer: "運転してもいい",
     options: [
       "運転してもいい",
@@ -242,7 +242,7 @@ const NAKUTE_MO_II_ITEMS: SentencePatternItem[] = [
       "運転してはいけない"
     ],
     explanation:
-      "「免許を持っている人だけ」鎖定條件，後句表「才獲得許可」→ 「てもいい」。「なくてもいい」是「不必開」；「なければならない」是「必須開」；「てはいけない」是「不可開」（與前句矛盾）。"
+      "「免許を持っていれば」是條件，後句表「在此條件下就獲得許可」→ 「てもいい」。「なくてもいい」是「不必開」；「なければならない」是「必須開」；「てはいけない」是「不可開」（與前句矛盾）。"
   },
   {
     id: "pattern-nakute-mo-ii-005",


### PR DESCRIPTION
修正 in-app feedback 回報的兩題（截圖來自 Supabase feedback 表）。

## 修正

**1. `n2-grammar-dokoroka` — 中文翻譯語序倒置**（回報：「這題翻譯是不是有錯」）
`宿題は終わるどころか、まだ半分もやっていない` = 「別說寫完，連一半都還沒做」。原 `promptContextZh`「別說作業沒寫完，連一半都還沒做」把否定句放進「別說 X」的 X，語意倒了。
→ 改為「別說寫完了，作業連一半都還沒做。」（ja/en overlay 本來就正確，只有 zh 源錯。）

**2. `pattern-nakute-mo-ii-004` — 句子不自然**（回報：awkwardMeaning）
`免許を持っている人だけが、車を〜てもいい`：排他的「だけが」配許可的「てもいい」不自然（排他性慣用 しか／可能形）。
→ 改為自然條件句「免許を持っていれば、車を〜」，zh + en/ja overlay 同步更新；四個干擾項對比仍成立、答案不變。

## 一併查核、判定無誤（不改）
- `n3-kanji-korobu`（回報：讀音和正確答案不一致）：`転ぶ→ころぶ` 正確；漢字読み 題幹本來就排除 furigana（build-furigana.mjs 明確排除），答題後例句顯示 `転(ころ)ぶ` 是正常送假名，無不一致。
- `n2-grammar-nishiro`（ja 使用者：無中文）：題目正確；ja 模式無中文是 #427 後的預期行為。

## 驗證
`pnpm check:exam`（13/13）＋ `pnpm test`（597/597）＋ `pnpm build` 全綠。examBlocks chunk 不變。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined several Japanese and Chinese learning prompts to use clearer, more natural phrasing.
  * Adjusted example wording in one pattern lesson to better reflect a conditional “if you…” meaning.
  * Updated related explanations so the guidance matches the revised examples and grammar usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->