### PR TITLE
feat(grammar): 三層防線防止 AI 移除語言閘門

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,34 @@
 - 所有領域邏輯必須在 `src/domain/`，不要在 `src/components/` 放商業邏輯
 - pnpm 為唯一套件管理工具，不產生 npm/yarn/bun lockfile
 
+## 內容可見性規則（Content visibility — product ownership boundary）
+
+這些是產品決定，不是工程決定。AI **禁止**在沒有人工明確批准的情況下變更。
+
+### 語言隔離規則
+
+- `*Zh` 結尾的欄位（`meaningZh`、`hintZh`、`instructionZh`、`lineZh`、`contextZh`、
+  `promptContextZh`、`explanation`、`commonMistakes`）是未翻譯的中文內容，**不得**對
+  `zh-Hant` 以外的語言渲染，除非透過 `pickLocalized()` 或 `pickLocalizedOptional()`
+  並有有效的 i18n overlay。
+- `formation` 是單向中文接續規則，等同 `meaningZh` 處理。
+- `lineZh` 和 `contextZh` 即使在子元件內部也必須受 `isZhHant` 保護。
+- `isZhHant`（`language === "zh-Hant"`）是唯一的閘門變數。**禁止**引入其他閘門慣例。
+
+### 禁止事項（AI 必須先問）
+
+- 移除保護 `*Zh` 欄位的 `isZhHant`。
+- 新增渲染 `*Zh` 欄位但沒有語言閘門的元件。
+- 變更 `src/i18n.ts` 的 `LAUNCHED_LANGUAGES`（決定使用者看到哪些語系）。
+- 新增語系代碼到 `LocaleCode`（需要內容翻譯計畫）。
+- 變更 `pickLocalized()` 的行為或其 fallback chain。
+- 如果認為應該移除語言閘門：**停下來問使用者**。
+
+## 工作空間隔離
+
+- 所有會修改檔案的實作任務**必須**在 git worktree 中進行（`EnterWorktree`），不得直接在工作目錄上修改
+- 純查詢、讀取、搜尋不需 worktree
+
 ## 程式碼慣例
 
 - TypeScript strict mode 全開，禁止 `any`，除非有明確註解說明

--- a/scripts/check-content-gates.mjs
+++ b/scripts/check-content-gates.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// check-content-gates.mjs — scan .tsx for zh-only content rendered without
+// an isZhHant language gate or pickLocalized wrapper.
+//
+// Conservative heuristic: flag suspicious lines; CI compares against a
+// stored baseline. New violations → exit 1; known baseline → exit 0 with
+// informational output.
+//
+// This is defense-in-depth. The primary enforcement is in the test suite
+// (GrammarPointPage.test.tsx content language gates).
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+const SCRIPT_DIR = new URL(".", import.meta.url).pathname;
+const BASELINE_PATH = join(SCRIPT_DIR, "content-gate-baseline.json");
+
+// Field name patterns that carry untranslated Chinese prose.
+const ZH_PATTERN = /\b(meaningZh|hintZh|instructionZh|lineZh|contextZh|promptContextZh|explanation)\b/;
+const FORMATION_PATTERN = /\bformation\b/;
+const MISTAKES_PATTERN = /\bcommonMistakes\b/;
+
+function matchField(trimmed) {
+  const zh = trimmed.match(ZH_PATTERN);
+  if (zh) return zh[1];
+  const fm = trimmed.match(FORMATION_PATTERN);
+  if (fm && !/\bgrammarFilterFormation\b/.test(trimmed)) return fm[1];
+  const cm = trimmed.match(MISTAKES_PATTERN);
+  if (cm) return cm[1];
+  return null;
+}
+
+function collectTsxFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    if (entry.isDirectory()) {
+      results.push(...collectTsxFiles(join(dir, entry.name)));
+    } else if (entry.name.endsWith(".tsx") && !entry.name.includes(".test.")) {
+      results.push(join(dir, entry.name));
+    }
+  }
+  return results;
+}
+
+/**
+ * Is this line protected by one of the recognized safe patterns?
+ *
+ * Safe patterns:
+ *  1. pickLocalized(field, ...)  — data-layer language routing
+ *  2. pickLocalizedOptional(...)
+ *  3. localize*(...)
+ *  4. Inside an isZhHant-guarded block (checked via look-back window)
+ *  5. Type annotations / destructuring (no actual rendering)
+ *  6. File has an early-return `if (!isZhHant)` wrapper protecting the line
+ */
+function isProtected(line, contextLines, hasEarlyReturnNonZh, hasLocalizeNote) {
+  const trimmed = line.trim();
+
+  if (trimmed.startsWith("//")) return true;
+  if (trimmed.includes("pickLocalized(") || trimmed.includes("pickLocalizedOptional(")) return true;
+  if (trimmed.includes("localize") && trimmed.includes("(")) return true;
+  if (trimmed.includes("isZhHant")) return true;
+  if (/^(const|let|var)\s*\{/.test(trimmed)) return true; // destructuring
+  if (/^\s*\*\s/.test(trimmed)) return true; // JSDoc
+  if (/^import\b/.test(trimmed)) return true; // import
+  if (trimmed.startsWith("//") || trimmed.startsWith(" *")) return true;
+  if (!trimmed.includes("{") && !trimmed.includes("<")) return true; // no JSX
+
+  // Validated by the early-return pattern (database-only branch in GrammarPointPage)
+  if (hasEarlyReturnNonZh) return true;
+
+  // data-layer localized (GrammarNoteCard etc.)
+  if (hasLocalizeNote) return true;
+
+  return false;
+}
+
+function scanFile(filePath) {
+  const src = readFileSync(filePath, "utf-8");
+  const lines = src.split("\n");
+  const violations = [];
+
+  // Files that use data-layer localization — their *Zh fields are safe
+  const hasLocalizeNote = src.includes("localizeGrammarNote(");
+
+  // Detect the "early-return non-zh-Hant" pattern:
+  //   if (!isZhHant) { return <minimal> }
+  // Everything after this block (until the next major return) that renders
+  // *Zh fields is protected because non-zh-Hant users never reach it.
+  const hasEarlyReturnNonZh = /if\s*\(\s*!\s*isZhHant\s*\)/.test(src);
+
+  // Build a set of lines that are inside `{isZhHant && ...}` JSX blocks.
+  // Approximate: when we see `isZhHant &&`, mark the next N lines as gated
+  // until we see the matching closing `}` of the JSX expression.
+  const gatedLines = new Set();
+  for (let i = 0; i < lines.length; i++) {
+    if (/\{isZhHant\s*&&/.test(lines[i])) {
+      // Mark this line and scan forward until balanced braces
+      let depth = 0;
+      for (let j = i; j < Math.min(i + 30, lines.length); j++) {
+        gatedLines.add(j);
+        const opens = (lines[j].match(/\{/g) || []).length;
+        const closes = (lines[j].match(/\}/g) || []).length;
+        depth += opens - closes;
+        if (depth <= 0) break;
+      }
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const field = matchField(lines[i].trim());
+    if (!field) continue;
+    if (gatedLines.has(i)) continue;
+
+    // Look-back context: 5 lines before
+    const contextStart = Math.max(0, i - 5);
+    const contextLines = lines.slice(contextStart, i + 1);
+
+    if (isProtected(lines[i], contextLines, hasEarlyReturnNonZh, hasLocalizeNote)) continue;
+
+    violations.push({
+      line: i + 1,
+      field,
+      text: lines[i].trim().substring(0, 150),
+    });
+  }
+
+  return violations;
+}
+
+// ---- main ---------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const mode = args.includes("--baseline") ? "baseline"
+  : args.includes("--json") ? "json"
+  : "check";
+
+const srcDir = new URL("../src", import.meta.url).pathname;
+const files = collectTsxFiles(srcDir);
+
+const all = [];
+for (const file of files) {
+  const violations = scanFile(file);
+  if (violations.length > 0) all.push({ file, violations });
+}
+
+if (mode === "json") {
+  console.log(JSON.stringify(all, null, 2));
+  process.exit(all.length > 0 ? 1 : 0);
+}
+
+if (mode === "baseline") {
+  const baseline = {};
+  for (const { file, violations } of all) {
+    baseline[file] = violations.map((v) => ({ line: v.line, field: v.field }));
+  }
+  writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + "\n");
+  const nFiles = Object.keys(baseline).length;
+  const nItems = Object.values(baseline).reduce((s, a) => s + a.length, 0);
+  console.log(`Baseline saved: ${nFiles} files, ${nItems} violations accepted.`);
+  process.exit(0);
+}
+
+// mode === "check"
+let baseline = {};
+if (existsSync(BASELINE_PATH)) {
+  baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf-8"));
+}
+
+let exitCode = 0;
+for (const { file, violations } of all) {
+  const baselined = new Set((baseline[file] || []).map((b) => `${b.line}:${b.field}`));
+  const fresh = violations.filter((v) => !baselined.has(`${v.line}:${v.field}`));
+  const known = violations.filter((v) => baselined.has(`${v.line}:${v.field}`));
+
+  if (known.length > 0) {
+    console.log(`${file} (${known.length} in baseline):`);
+    for (const v of known) console.log(`  L${v.line} [${v.field}] ${v.text}`);
+  }
+  if (fresh.length > 0) {
+    exitCode = 1;
+    console.log(`${file} (${fresh.length} NEW):`);
+    for (const v of fresh) console.log(`  L${v.line} [${v.field}] ${v.text}`);
+  }
+}
+
+if (exitCode === 0 && all.length === 0) {
+  console.log("OK: no content gate violations detected.");
+} else if (exitCode === 0) {
+  console.log("OK: no NEW content gate violations.");
+}
+
+process.exit(exitCode);

--- a/scripts/content-gate-baseline.json
+++ b/scripts/content-gate-baseline.json
@@ -1,0 +1,36 @@
+{
+  "/Users/tachikoma/Developer/Jabiko/src/components/GrammarIndexPage.tsx": [
+    {
+      "line": 315,
+      "field": "meaningZh"
+    }
+  ],
+  "/Users/tachikoma/Developer/Jabiko/src/components/GrammarPointPage.tsx": [
+    {
+      "line": 97,
+      "field": "meaningZh"
+    },
+    {
+      "line": 108,
+      "field": "meaningZh"
+    },
+    {
+      "line": 135,
+      "field": "meaningZh"
+    },
+    {
+      "line": 319,
+      "field": "lineZh"
+    },
+    {
+      "line": 331,
+      "field": "contextZh"
+    }
+  ],
+  "/Users/tachikoma/Developer/Jabiko/src/components/LearningPanel.tsx": [
+    {
+      "line": 208,
+      "field": "explanation"
+    }
+  ]
+}

--- a/src/components/GrammarPointPage.test.tsx
+++ b/src/components/GrammarPointPage.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { cleanExplanation, GrammarPointPage } from "./GrammarPointPage";
 import { allGrammarSurfaces, buildGrammarPoint } from "../domain/grammarPoints";
+import { findPatternBySurface } from "../domain/grammarIndex";
 import { grammarNotes } from "../domain/grammarNotes";
 import { grammarPatterns } from "../domain/grammarDatabase";
 import { copy } from "../i18n";
@@ -49,9 +50,6 @@ describe("GrammarPointPage", () => {
   });
 
   it("renders a database-only pattern's Chinese content in zh-Hant but hides it in en (#438/#427)", () => {
-    // A pattern that lives ONLY in grammarDatabase (no exam-bank point), so it
-    // hits the database-only branch — the exact path whose zh-Hant gate must
-    // hold (its content has no i18n overlay yet, so en/ja must see none of it).
     const dbOnly = grammarPatterns.find((p) => buildGrammarPoint(p.pattern.replace(/^[〜～]/, "")) === null);
     expect(dbOnly, "expected at least one database-only pattern").toBeDefined();
     const surface = dbOnly!.pattern.replace(/^[〜～]/, "");
@@ -89,5 +87,100 @@ describe("GrammarPointPage", () => {
       "it pairs with a hypothetical."
     );
     expect(cleanExplanation("沒有前綴的內容原樣通過。")).toBe("沒有前綴的內容原樣通過。");
+  });
+});
+// Content language gates — product contract (#437 / #427)
+describe("content language gates", () => {
+  it("renders database-enriched sections for zh-Hant on an un-noted exam-data surface", () => {
+    const surface = allGrammarSurfaces().find((s) => {
+      const p = buildGrammarPoint(s);
+      const db = findPatternBySurface(s);
+      return p !== null && !p.note && db !== undefined && db.examples.length > 0;
+    })!;
+    expect(surface).toBeTruthy();
+    render(<GrammarPointPage surface={surface} language="zh-Hant" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText(copy["zh-Hant"].grammarDatabaseExamples)).toBeInTheDocument();
+  });
+
+  it("renders all Chinese content for zh-Hant on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null; })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="zh-Hant" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole("heading", { level: 1, name: surface })).toBeInTheDocument();
+    expect(screen.getByText(dbOnly.meaningZh)).toBeInTheDocument();
+    expect(screen.getByText(dbOnly.formation)).toBeInTheDocument();
+  });
+
+  it("hides database-enriched sections from en users on a noted exam-data surface", () => {
+    render(<GrammarPointPage surface={notedSurface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole("heading", { level: 1, name: notedSurface })).toBeInTheDocument();
+    expect(screen.queryByText(copy.en.grammarDatabaseExamples)).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.en.grammarMediaExamples)).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.en.grammarRelatedPatterns)).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.en.grammarCommonMistakes)).not.toBeInTheDocument();
+  });
+
+  it("hides database-enriched sections from en users on an un-noted exam-data surface", () => {
+    const surface = allGrammarSurfaces().find((s) => {
+      const p = buildGrammarPoint(s);
+      const db = findPatternBySurface(s);
+      return p !== null && !p.note && db !== undefined && db.examples.length > 0;
+    })!;
+    expect(surface).toBeTruthy();
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.queryByText(copy.en.grammarDatabaseExamples)).not.toBeInTheDocument();
+  });
+
+  it("hides database-enriched sections from ja users", () => {
+    render(<GrammarPointPage surface={notedSurface} language="ja" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.queryByText(copy.ja.grammarMediaExamples)).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.ja.grammarRelatedPatterns)).not.toBeInTheDocument();
+    expect(screen.queryByText(copy.ja.grammarCommonMistakes)).not.toBeInTheDocument();
+  });
+
+  it("does not render meaningZh or formation for en users on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null; })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole("heading", { level: 1, name: surface })).toBeInTheDocument();
+    expect(screen.queryByText(dbOnly.meaningZh)).not.toBeInTheDocument();
+    expect(screen.queryByText(dbOnly.formation)).not.toBeInTheDocument();
+  });
+
+  it("does not render example Chinese translations for en users on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null && p.examples.some((ex) => ex.meaningZh); })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    for (const ex of dbOnly.examples) { if (ex.meaningZh) { expect(screen.queryByText(ex.meaningZh)).not.toBeInTheDocument(); } }
+  });
+
+  it("does not render related-pattern Chinese meanings for en users on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null && p.relatedPatternIds.length > 0; })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    const related = grammarPatterns.filter((p) => dbOnly.relatedPatternIds.includes(p.id));
+    expect(related.length).toBeGreaterThan(0);
+    for (const rp of related) { expect(screen.queryByText(rp.meaningZh)).not.toBeInTheDocument(); }
+  });
+
+  it("does not render commonMistakes for en users on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null && p.commonMistakes && p.commonMistakes.length > 0; })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="en" onPractice={vi.fn()} onBack={vi.fn()} />);
+    for (const mistake of dbOnly.commonMistakes!) { expect(screen.queryByText(mistake)).not.toBeInTheDocument(); }
+  });
+
+  it("does not render meaningZh or formation for ja users on a database-only surface", () => {
+    const dbOnly = grammarPatterns.find((p) => { const s = p.pattern.replace(/^[〜～]/, ""); return buildGrammarPoint(s) === null; })!;
+    expect(dbOnly).toBeTruthy();
+    const surface = dbOnly.pattern.replace(/^[〜～]/, "");
+    render(<GrammarPointPage surface={surface} language="ja" onPractice={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.queryByText(dbOnly.meaningZh)).not.toBeInTheDocument();
+    expect(screen.queryByText(dbOnly.formation)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

7 次 AI 越權決策都發生在「使用者看到什麼內容」的邊界上。最近的 `5faea8a` 移除了 `isZhHant` 閘門，讓 en/ja 使用者看到整片中文。這不只是修 bug，需要系統性的防線。

## 三層防線

1. **測試合約**（主要防線）：`GrammarPointPage.test.tsx` 新增 10 個 content gate 測試 — en/ja 不該看到中文內容 + zh-Hant 控制組。當 AI 移除閘門時測試直接紅燈。

2. **CLAUDE.md 規則**（阻止規劃階段）：定義 `*Zh` 欄位為產品邊界，明列 AI 禁止事項（移除閘門、新增無閘門元件、改 LAUNCHED_LANGUAGES、改 pickLocalized 行為），以及強制 worktree 隔離。

3. **CI gate-lint 腳本**（縱深防禦）：`scripts/check-content-gates.mjs` 掃描 `.tsx` 偵測無閘門中文渲染，已知項目進 baseline，新違規 → CI fail。

## Test plan

- [x] `pnpm build` passed
- [x] `pnpm test` — 1952 tests passed
- [x] `node scripts/check-content-gates.mjs` — no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)