### PR TITLE
feat(domain): 正式網域遷移到 jabiko.app（無損向後相容）

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ points. Open it and practise; nothing to install, no account needed.
 
 > 免費、免註冊、開源的 **JLPT 日檢自習室**：N5〜N1 文法、漢字讀音、單字與依官方題型的練習，答錯自動排進間隔重複複習，跨裝置同步，打開就能練。
 
-**▶ Live: [jabiko.pages.dev](https://jabiko.pages.dev/)**
+**▶ Live: [jabiko.app](https://jabiko.app/)**
 
 ![Jabiko](public/og-image.png)
 

--- a/index.html
+++ b/index.html
@@ -15,18 +15,18 @@
     <link rel="icon" type="image/png" sizes="192x192" href="/pwa-192x192.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
-    <link rel="canonical" href="https://jabiko.pages.dev/" />
+    <link rel="canonical" href="https://jabiko.app/" />
 
     <!-- Open Graph (Facebook, LINE, Discord, Slack link previews) -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Jabiko" />
-    <meta property="og:url" content="https://jabiko.pages.dev/" />
+    <meta property="og:url" content="https://jabiko.app/" />
     <meta property="og:title" content="Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       property="og:description"
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
-    <meta property="og:image" content="https://jabiko.pages.dev/og-image.png" />
+    <meta property="og:image" content="https://jabiko.app/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="zh_TW" />
@@ -38,7 +38,7 @@
       name="twitter:description"
       content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
-    <meta name="twitter:image" content="https://jabiko.pages.dev/og-image.png" />
+    <meta name="twitter:image" content="https://jabiko.app/og-image.png" />
 
     <!-- Structured data: free educational web app (rich-result eligibility) -->
     <script type="application/ld+json">
@@ -47,7 +47,7 @@
         "@type": "WebApplication",
         "name": "Jabiko",
         "alternateName": "Jabiko · JLPT 自習室",
-        "url": "https://jabiko.pages.dev/",
+        "url": "https://jabiko.app/",
         "applicationCategory": "EducationalApplication",
         "operatingSystem": "Web",
         "inLanguage": "zh-Hant",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,19 @@
-# Cloudflare Pages SPA fallback: client-side routes (/about, /mock, /learn …)
-# have no built file, so serve the app shell and let the in-app router resolve
-# the view. Real static assets (/assets/*, /icon.svg, …) are matched first and
-# served directly, so this only catches unknown paths.
+# Domain move (#jabiko-app-domain): jabiko.app is the canonical origin.
+# Rules are evaluated top-down, first match wins.
+#
+# 1. The origin-migration bridge must stay reachable on the OLD origin —
+#    jabiko.app iframes it to pull a visitor's localStorage across. A 200
+#    rewrite-to-itself exempts it from the host-wide 301 below.
+https://jabiko.pages.dev/migration-bridge.html /migration-bridge.html 200
+
+# 2. Permanent-redirect the shared pages.dev host to the custom domain
+#    (old links / bookmarks keep working; SEO signals consolidate). Preview
+#    deployments (<hash>.jabiko.pages.dev) don't match this host and are
+#    unaffected. Query strings are carried over automatically.
+https://jabiko.pages.dev/* https://jabiko.app/:splat 301
+
+# 3. Cloudflare Pages SPA fallback: client-side routes (/about, /mock, /learn …)
+#    have no built file, so serve the app shell and let the in-app router
+#    resolve the view. Real static assets (/assets/*, /icon.svg, …) are matched
+#    first and served directly, so this only catches unknown paths.
 /*  /index.html  200

--- a/public/migration-bridge.html
+++ b/public/migration-bridge.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex" />
+    <title>Jabiko migration bridge</title>
+  </head>
+  <body>
+    <!--
+      Origin-migration bridge (see src/domain/originMigration.ts for the full
+      design). Served ONLY on jabiko.pages.dev — public/_redirects exempts
+      this one path from the 301 to jabiko.app so the new origin can iframe
+      it and pull the visitor's old localStorage across.
+
+      Plain JS mirror of the allowlist/protocol constants in
+      originMigration.ts (a static page cannot import TS); the constants test
+      there is the drift guard for this copy.
+    -->
+    <script>
+      (function () {
+        var TARGET_ORIGIN = "https://jabiko.app";
+        var REQUEST = "jabiko:migration-request";
+        var PAYLOAD = "jabiko:migration-payload";
+        var EXACT_KEYS = [
+          "jabiko:attempts",
+          "jabiko:targetLevel",
+          "jabiko:howItWorksDismissed",
+          "jabiko.lang",
+          "jabiko.theme",
+          "jabiko.furigana",
+          "jabiko.sessionLength"
+        ];
+
+        function isMigratable(key) {
+          return EXACT_KEYS.indexOf(key) !== -1 || key.indexOf("sb-") === 0;
+        }
+
+        function collect() {
+          var entries = [];
+          try {
+            for (var i = 0; i < localStorage.length; i++) {
+              var key = localStorage.key(i);
+              if (key === null || !isMigratable(key)) continue;
+              var value = localStorage.getItem(key);
+              if (value === null) continue;
+              entries.push({ key: key, value: value });
+            }
+          } catch (e) {
+            /* storage blocked (private mode etc.) -> answer with nothing */
+          }
+          return entries;
+        }
+
+        window.addEventListener("message", function (event) {
+          // Answer only the real new-origin app; ignore everything else.
+          if (event.origin !== TARGET_ORIGIN) return;
+          if (!event.data || event.data.type !== REQUEST) return;
+          if (!event.source) return;
+          event.source.postMessage({ type: PAYLOAD, entries: collect() }, TARGET_ORIGIN);
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://jabiko.pages.dev/sitemap.xml
+Sitemap: https://jabiko.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jabiko.pages.dev/</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/learn</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/learn</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/challenge</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/challenge</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/mock</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/mock</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/kanji</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/kanji</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/rules</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/rules</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jabiko.pages.dev/about</loc>
-    <lastmod>2026-06-28</lastmod>
+    <loc>https://jabiko.app/about</loc>
+    <lastmod>2026-07-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
 import { useFurigana } from "./hooks/useFurigana";
 import { useLanguage } from "./hooks/useLanguage";
+import { useOriginMigration } from "./hooks/useOriginMigration";
 import { useSeoMeta } from "./hooks/useSeoMeta";
 import { isSupabaseConfigured } from "./lib/supabase";
 import { useAuth } from "./hooks/useAuth";
@@ -163,6 +164,10 @@ export default function App() {
   // Per-view <title>/description/canonical/og so each route surfaces its own
   // metadata to crawlers (SPA otherwise shares one static shell). See seo.ts.
   useSeoMeta(appView, grammarSurface);
+
+  // One-time localStorage pull from jabiko.pages.dev after the domain move
+  // (#jabiko-app-domain); no-op everywhere except a fresh jabiko.app visit.
+  useOriginMigration();
 
   // UI language: stored preference > ja default. The hook owns the <html lang>
   // side-effect and persistence; copy[language] re-renders the whole tree on

--- a/src/domain/originMigration.test.ts
+++ b/src/domain/originMigration.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMigrationPayload,
+  BRIDGE_PATH,
+  collectMigrationEntries,
+  isMigratableKey,
+  MIGRATION_MESSAGE_PAYLOAD,
+  MIGRATION_MESSAGE_REQUEST,
+  MIGRATION_SOURCE_ORIGIN,
+  shouldAttemptMigration
+} from "./originMigration";
+
+// In-memory Storage stand-in (jsdom localStorage works too, but an explicit
+// map keeps each case isolated and lets us model the OLD origin's storage).
+function fakeStorage(initial: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(initial));
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => void map.set(k, v)
+  };
+}
+
+describe("originMigration (pages.dev -> jabiko.app, #jabiko-app-domain)", () => {
+  it("only allows app keys and the Supabase session prefix", () => {
+    expect(isMigratableKey("jabiko:attempts")).toBe(true);
+    expect(isMigratableKey("jabiko:targetLevel")).toBe(true);
+    expect(isMigratableKey("jabiko:howItWorksDismissed")).toBe(true);
+    expect(isMigratableKey("jabiko.lang")).toBe(true);
+    expect(isMigratableKey("jabiko.theme")).toBe(true);
+    expect(isMigratableKey("jabiko.furigana")).toBe(true);
+    expect(isMigratableKey("jabiko.sessionLength")).toBe(true);
+    expect(isMigratableKey("sb-abcdef-auth-token")).toBe(true);
+
+    // Never ferry unrelated or attacker-chosen keys across origins.
+    expect(isMigratableKey("__proto__")).toBe(false);
+    expect(isMigratableKey("randomKey")).toBe(false);
+    expect(isMigratableKey("jabikoX")).toBe(false);
+    expect(isMigratableKey("jabiko:migrated")).toBe(false); // flags stay per-origin
+    expect(isMigratableKey("jabiko:migrationAttempts")).toBe(false);
+  });
+
+  it("collects only migratable entries from the source storage", () => {
+    const source = fakeStorage({
+      "jabiko:attempts": "[1]",
+      "jabiko.lang": "ja",
+      "sb-xyz-auth-token": "tok",
+      junk: "no",
+      "jabiko:migrated": "1"
+    });
+
+    const entries = collectMigrationEntries(source);
+    const keys = entries.map((e) => e.key).sort();
+    expect(keys).toEqual(["jabiko.lang", "jabiko:attempts", "sb-xyz-auth-token"]);
+    expect(entries.find((e) => e.key === "jabiko.lang")?.value).toBe("ja");
+  });
+
+  it("applies a payload without overwriting existing local values", () => {
+    const target = fakeStorage({ "jabiko.lang": "en" });
+    const imported = applyMigrationPayload(
+      [
+        { key: "jabiko.lang", value: "ja" }, // must NOT clobber the local choice
+        { key: "jabiko:attempts", value: "[42]" },
+        { key: "evil", value: "x" }, // filtered
+        { key: "sb-xyz-auth-token", value: "tok" }
+      ],
+      target
+    );
+
+    expect(imported).toBe(2);
+    expect(target.getItem("jabiko.lang")).toBe("en");
+    expect(target.getItem("jabiko:attempts")).toBe("[42]");
+    expect(target.getItem("sb-xyz-auth-token")).toBe("tok");
+    expect(target.getItem("evil")).toBeNull();
+  });
+
+  it("rejects malformed payloads defensively", () => {
+    const target = fakeStorage();
+    expect(applyMigrationPayload(null as never, target)).toBe(0);
+    expect(applyMigrationPayload([{ key: 1, value: "x" }] as never, target)).toBe(0);
+    expect(applyMigrationPayload([{ key: "jabiko.lang" }] as never, target)).toBe(0);
+  });
+
+  it("attempts migration only on the new origin, when empty, and under the retry cap", () => {
+    const empty = fakeStorage();
+    expect(shouldAttemptMigration("jabiko.app", empty)).toBe(true);
+
+    // Old origin never migrates from itself.
+    expect(shouldAttemptMigration("jabiko.pages.dev", empty)).toBe(false);
+    expect(shouldAttemptMigration("localhost", empty)).toBe(false);
+
+    // Already has progress -> nothing to do.
+    expect(shouldAttemptMigration("jabiko.app", fakeStorage({ "jabiko:attempts": "[1]" }))).toBe(false);
+
+    // Completed or exhausted -> stop retrying.
+    expect(shouldAttemptMigration("jabiko.app", fakeStorage({ "jabiko:migrated": "1" }))).toBe(false);
+    expect(shouldAttemptMigration("jabiko.app", fakeStorage({ "jabiko:migrationAttempts": "5" }))).toBe(false);
+    expect(shouldAttemptMigration("jabiko.app", fakeStorage({ "jabiko:migrationAttempts": "2" }))).toBe(true);
+  });
+
+  it("pins the protocol constants the bridge page mirrors", () => {
+    // public/migration-bridge.html hand-copies these values (it cannot import
+    // TS); this test is the drift guard for that copy.
+    expect(MIGRATION_SOURCE_ORIGIN).toBe("https://jabiko.pages.dev");
+    expect(BRIDGE_PATH).toBe("/migration-bridge.html");
+    expect(MIGRATION_MESSAGE_REQUEST).toBe("jabiko:migration-request");
+    expect(MIGRATION_MESSAGE_PAYLOAD).toBe("jabiko:migration-payload");
+  });
+});

--- a/src/domain/originMigration.ts
+++ b/src/domain/originMigration.ts
@@ -1,0 +1,103 @@
+// One-time localStorage migration from the old shared-domain origin
+// (jabiko.pages.dev) to the custom domain (jabiko.app).
+//
+// Why: localStorage is per-origin. The 301 redirect that moves users to
+// jabiko.app would otherwise strand an anonymous learner's progress
+// (attempts / streaks / preferences) on the old origin. On first load of the
+// new origin, the app embeds a hidden iframe of the OLD origin's bridge page
+// (public/migration-bridge.html, excluded from the 301 in public/_redirects),
+// asks it for the allowlisted keys via postMessage, and imports them here.
+//
+// Security model: both origins are ours. The bridge only answers windows on
+// MIGRATION_TARGET_ORIGIN, we only accept payloads from
+// MIGRATION_SOURCE_ORIGIN, and only ALLOWLISTED keys ever cross — an
+// arbitrary key can neither be exfiltrated nor injected.
+//
+// Known limit: a visitor whose old service worker still controls pages.dev
+// gets the stale app shell instead of the bridge page (old workbox
+// navigateFallback). That attempt times out harmlessly; the navigation
+// itself triggers the SW update, so a later visit succeeds — hence the retry
+// counter instead of a single shot. Logged-in users are covered by Supabase
+// sync regardless.
+
+export const MIGRATION_SOURCE_ORIGIN = "https://jabiko.pages.dev";
+export const MIGRATION_TARGET_ORIGIN = "https://jabiko.app";
+export const BRIDGE_PATH = "/migration-bridge.html";
+export const MIGRATION_MESSAGE_REQUEST = "jabiko:migration-request";
+export const MIGRATION_MESSAGE_PAYLOAD = "jabiko:migration-payload";
+
+/** Local-only bookkeeping keys — never migrated themselves. */
+export const MIGRATED_FLAG_KEY = "jabiko:migrated";
+export const MIGRATION_ATTEMPTS_KEY = "jabiko:migrationAttempts";
+export const MIGRATION_MAX_ATTEMPTS = 5;
+
+// Exact app keys that may cross origins. Mirrored by hand in
+// public/migration-bridge.html (plain JS can't import TS) — the
+// originMigration.test.ts constants test guards the protocol side of that
+// copy, and check-i18n/build don't touch it.
+const EXACT_KEYS = new Set([
+  "jabiko:attempts",
+  "jabiko:targetLevel",
+  "jabiko:howItWorksDismissed",
+  "jabiko.lang",
+  "jabiko.theme",
+  "jabiko.furigana",
+  "jabiko.sessionLength"
+]);
+
+// Supabase stores its session as `sb-<project-ref>-auth-token` (+ variants);
+// migrating it keeps the learner signed in across the domain move.
+const SUPABASE_PREFIX = "sb-";
+
+export type MigrationEntry = { key: string; value: string };
+
+export function isMigratableKey(key: string): boolean {
+  return EXACT_KEYS.has(key) || key.startsWith(SUPABASE_PREFIX);
+}
+
+/** Bridge side: gather every allowlisted entry from the OLD origin's storage. */
+export function collectMigrationEntries(storage: Storage): MigrationEntry[] {
+  const entries: MigrationEntry[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key === null || !isMigratableKey(key)) continue;
+    const value = storage.getItem(key);
+    if (value === null) continue;
+    entries.push({ key, value });
+  }
+  return entries;
+}
+
+/**
+ * App side: import a bridge payload. Defensive about shape (it crossed a
+ * postMessage boundary), re-filters by the allowlist, and NEVER overwrites a
+ * value the new origin already has (a fresh local choice beats stale data).
+ * Returns how many entries were written.
+ */
+export function applyMigrationPayload(payload: unknown, storage: Storage): number {
+  if (!Array.isArray(payload)) return 0;
+  let imported = 0;
+  for (const entry of payload) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const { key, value } = entry as Record<string, unknown>;
+    if (typeof key !== "string" || typeof value !== "string") continue;
+    if (!isMigratableKey(key)) continue;
+    if (storage.getItem(key) !== null) continue;
+    storage.setItem(key, value);
+    imported++;
+  }
+  return imported;
+}
+
+/**
+ * Run the migration only where it can help: on the new origin, before any
+ * progress exists locally, not already done, and under the retry cap (see
+ * the stale-service-worker note in the header).
+ */
+export function shouldAttemptMigration(hostname: string, storage: Storage): boolean {
+  if (hostname !== "jabiko.app") return false;
+  if (storage.getItem(MIGRATED_FLAG_KEY) !== null) return false;
+  if (storage.getItem("jabiko:attempts") !== null) return false;
+  const attempts = Number(storage.getItem(MIGRATION_ATTEMPTS_KEY) ?? "0");
+  return attempts < MIGRATION_MAX_ATTEMPTS;
+}

--- a/src/domain/seo.test.ts
+++ b/src/domain/seo.test.ts
@@ -36,10 +36,10 @@ describe("seo", () => {
   });
 
   it("builds an absolute canonical URL rooted at the production origin", () => {
-    expect(SITE_ORIGIN).toBe("https://jabiko.pages.dev");
-    expect(seoForView("home").canonical).toBe("https://jabiko.pages.dev/");
-    expect(seoForView("mock").canonical).toBe("https://jabiko.pages.dev/mock");
-    expect(seoForView("kanji").canonical).toBe("https://jabiko.pages.dev/kanji");
+    expect(SITE_ORIGIN).toBe("https://jabiko.app");
+    expect(seoForView("home").canonical).toBe("https://jabiko.app/");
+    expect(seoForView("mock").canonical).toBe("https://jabiko.app/mock");
+    expect(seoForView("kanji").canonical).toBe("https://jabiko.app/kanji");
   });
 
   it("keeps descriptions within a sane SEO length (<=160 chars)", () => {

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -12,7 +12,7 @@
 export type SeoView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about" | "grammar";
 
 /** Production origin; canonical URLs are absolute so crawlers dedupe cleanly. */
-export const SITE_ORIGIN = "https://jabiko.pages.dev";
+export const SITE_ORIGIN = "https://jabiko.app";
 
 interface PageSeo {
   title: string;

--- a/src/domain/share.ts
+++ b/src/domain/share.ts
@@ -10,7 +10,7 @@
 //   - Threads: the intent endpoint DOES prefill text.
 //   - LINE: the msg/text deep link prefills a message (text incl. the URL).
 
-export const SHARE_URL = "https://jabiko.pages.dev/";
+export const SHARE_URL = "https://jabiko.app/";
 
 /** Result message + the site URL on its own line (used for clipboard / text intents). */
 export function composeMessage(text: string, url: string = SHARE_URL): string {

--- a/src/hooks/useOriginMigration.test.tsx
+++ b/src/hooks/useOriginMigration.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useOriginMigration } from "./useOriginMigration";
+import {
+  BRIDGE_PATH,
+  MIGRATED_FLAG_KEY,
+  MIGRATION_ATTEMPTS_KEY,
+  MIGRATION_MESSAGE_PAYLOAD,
+  MIGRATION_SOURCE_ORIGIN
+} from "../domain/originMigration";
+
+function bridgeReply(entries: Array<{ key: string; value: string }>, origin = MIGRATION_SOURCE_ORIGIN) {
+  window.dispatchEvent(
+    new MessageEvent("message", { origin, data: { type: MIGRATION_MESSAGE_PAYLOAD, entries } })
+  );
+}
+
+// The shared setup pins jabiko.lang but does NOT clear storage between tests,
+// so the migration bookkeeping written by one case would silently disable the
+// hook in the next (a fake green). Reset exactly the keys this suite touches.
+beforeEach(() => {
+  localStorage.removeItem(MIGRATED_FLAG_KEY);
+  localStorage.removeItem(MIGRATION_ATTEMPTS_KEY);
+  localStorage.removeItem("jabiko:attempts");
+});
+
+afterEach(() => {
+  document.querySelectorAll("iframe").forEach((f) => f.remove());
+});
+
+describe("useOriginMigration", () => {
+  it("does nothing off the new origin (default test hostname)", () => {
+    renderHook(() => useOriginMigration());
+    expect(document.querySelector("iframe")).toBeNull();
+  });
+
+  it("mounts the hidden bridge iframe and imports the reply on jabiko.app", async () => {
+    localStorage.removeItem("jabiko:attempts");
+    const reload = vi.fn();
+    renderHook(() => useOriginMigration({ hostname: "jabiko.app", reload }));
+
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe!.src).toBe(`${MIGRATION_SOURCE_ORIGIN}${BRIDGE_PATH}`);
+    // The attempt is counted up front so a hung bridge still burns a retry.
+    expect(localStorage.getItem(MIGRATION_ATTEMPTS_KEY)).toBe("1");
+
+    bridgeReply([{ key: "jabiko:attempts", value: "[7]" }]);
+
+    await waitFor(() => expect(localStorage.getItem("jabiko:attempts")).toBe("[7]"));
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("1");
+    expect(reload).toHaveBeenCalledTimes(1); // imported > 0 -> re-init the app
+    expect(document.querySelector("iframe")).toBeNull(); // cleaned up
+  });
+
+  it("marks migration done without reloading when the old origin had nothing", async () => {
+    localStorage.removeItem("jabiko:attempts");
+    const reload = vi.fn();
+    renderHook(() => useOriginMigration({ hostname: "jabiko.app", reload }));
+
+    bridgeReply([]);
+
+    await waitFor(() => expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBe("1"));
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("ignores replies from any other origin", async () => {
+    localStorage.removeItem("jabiko:attempts");
+    const reload = vi.fn();
+    renderHook(() => useOriginMigration({ hostname: "jabiko.app", reload }));
+
+    bridgeReply([{ key: "jabiko:attempts", value: "[666]" }], "https://evil.example");
+
+    // Nothing may be imported from a foreign origin.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(localStorage.getItem("jabiko:attempts")).toBeNull();
+    expect(localStorage.getItem(MIGRATED_FLAG_KEY)).toBeNull();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useOriginMigration.ts
+++ b/src/hooks/useOriginMigration.ts
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import {
+  applyMigrationPayload,
+  BRIDGE_PATH,
+  MIGRATED_FLAG_KEY,
+  MIGRATION_ATTEMPTS_KEY,
+  MIGRATION_MESSAGE_PAYLOAD,
+  MIGRATION_MESSAGE_REQUEST,
+  MIGRATION_SOURCE_ORIGIN,
+  shouldAttemptMigration
+} from "../domain/originMigration";
+
+// How long we wait for the old origin's bridge to answer before giving up
+// this attempt (offline, or a stale service worker served the old app shell
+// instead of the bridge — see originMigration.ts for that failure mode).
+const BRIDGE_TIMEOUT_MS = 5000;
+
+/**
+ * One-time pull of the visitor's localStorage from jabiko.pages.dev after the
+ * domain move (#jabiko-app-domain). Runs at App mount; a no-op everywhere
+ * except a fresh jabiko.app visit (see shouldAttemptMigration). On a
+ * successful import it reloads once so the whole app re-initializes from the
+ * migrated state (attempts, streaks, language, theme, Supabase session).
+ *
+ * `options` exists for tests: jsdom can neither run on the real hostname nor
+ * be allowed to actually reload.
+ */
+export function useOriginMigration(options?: { hostname?: string; reload?: () => void }) {
+  const hostname = options?.hostname ?? window.location.hostname;
+  const reload = options?.reload ?? (() => window.location.reload());
+
+  useEffect(() => {
+    let storage: Storage;
+    try {
+      storage = window.localStorage;
+    } catch {
+      return; // storage blocked (private mode) -> nothing we could migrate into
+    }
+    if (!shouldAttemptMigration(hostname, storage)) return;
+
+    // Count the attempt up front so a bridge that never answers still burns
+    // one of the retries instead of looping forever.
+    const attempts = Number(storage.getItem(MIGRATION_ATTEMPTS_KEY) ?? "0");
+    storage.setItem(MIGRATION_ATTEMPTS_KEY, String(attempts + 1));
+
+    let settled = false;
+    const iframe = document.createElement("iframe");
+    iframe.src = `${MIGRATION_SOURCE_ORIGIN}${BRIDGE_PATH}`;
+    iframe.style.display = "none";
+    iframe.setAttribute("aria-hidden", "true");
+    iframe.tabIndex = -1;
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      window.clearTimeout(timer);
+      iframe.remove();
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      // Only the real old origin may hand us data.
+      if (event.origin !== MIGRATION_SOURCE_ORIGIN) return;
+      const data: unknown = event.data;
+      if (typeof data !== "object" || data === null) return;
+      if ((data as { type?: unknown }).type !== MIGRATION_MESSAGE_PAYLOAD) return;
+      if (settled) return;
+      settled = true;
+
+      const imported = applyMigrationPayload((data as { entries?: unknown }).entries, storage);
+      storage.setItem(MIGRATED_FLAG_KEY, "1");
+      cleanup();
+      // Re-initialize the app only when something actually came across —
+      // an empty old origin means this was already a fresh start.
+      if (imported > 0) reload();
+    };
+
+    const timer = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup(); // attempt already counted; a later visit retries
+    }, BRIDGE_TIMEOUT_MS);
+
+    window.addEventListener("message", onMessage);
+    const request = () => {
+      iframe.contentWindow?.postMessage({ type: MIGRATION_MESSAGE_REQUEST }, MIGRATION_SOURCE_ORIGIN);
+    };
+    iframe.addEventListener("load", request);
+    document.body.appendChild(iframe);
+
+    return cleanup;
+    // hostname/reload are stable for the lifetime of the app; this must run once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
         // the app shell for navigations so deep links / refresh work offline
         // too (the host's public/_redirects covers the online first-load).
         navigateFallback: "index.html",
+        // The origin-migration bridge (#jabiko-app-domain) must be served as
+        // its real static file, not the app shell — jabiko.app iframes it on
+        // the OLD origin to pull the visitor's localStorage across the move.
+        navigateFallbackDenylist: [/^\/migration-bridge\.html/],
         // Code/markup only here; static images (icons / hero / og) are
         // precached via includeAssets above. Keeping them out of
         // globPatterns avoids duplicate precache entries for the same URL.


### PR DESCRIPTION
把正式網域從共用的 `jabiko.pages.dev` 遷移到自有的 **`jabiko.app`**（SEO 權重集中）。三個向後相容軸全覆蓋：

## 1. 舊連結不斷
`public/_redirects` 前置 host 301：`jabiko.pages.dev/* → jabiko.app/:splat`。已發貼文/書籤照常可點、自動轉新網域；preview deployments（`<hash>.jabiko.pages.dev`）不受影響；query string 自動保留。

## 2. SEO 傳承
`index.html`（canonical/og/twitter/JSON-LD）、`seo.ts SITE_ORIGIN`、`share.ts SHARE_URL`（分享文案帶的網址）、`robots.txt`、`sitemap.xml`（lastmod 更新）全面指向 `https://jabiko.app`。合併後由 Search Console 做 Change of Address。

## 3. 使用者資料不失（關鍵）
localStorage 綁 origin——301 之後匿名使用者的答題紀錄/連續天數會留在舊 origin。解法＝**跨網域搬運橋**：
- `public/migration-bridge.html`（只在舊 origin 服務、`_redirects` 豁免於 301）
- `useOriginMigration`：jabiko.app 首訪且無資料時，隱藏 iframe 向橋請求，**雙向 origin 鎖死**、只搬 allowlist（7 個 app key＋`sb-*` Supabase session→連登入都保留）、**絕不覆蓋新 origin 已有值**，匯入 >0 才 reload 一次
- 已知雷已擋：舊 Service Worker 會把橋攔成舊版 app shell → `navigateFallbackDenylist` ＋ 重試上限 5 次（該次 timeout 無害、navigation 本身觸發 SW 更新、下次成功）；登入使用者另有 Supabase 同步兜底

## 驗證
- TDD：domain 層＋hook 共 10 個新測試（allowlist／不覆蓋／拒外來 origin／重試上限／橋協議常數 drift guard）
- 全套 666 綠、build 過；dist 驗證：bridge 檔在、301 規則在、SW denylist 烤進 sw.js、index.html canonical=jabiko.app

## ⚠️ 合併前置（順序重要）
**`jabiko.app` 必須先在 Pages Custom domains 掛上並 Active**，本 PR 才能合（否則 canonical 指向未生效網域）。合併後續步：Supabase Auth 加 `https://jabiko.app` 到 Redirect URLs、Search Console 新資源＋換址＋重交 sitemap。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seamless migration step when opening the app on the new domain, helping preserve saved settings and session data.
  * Updated site links, sharing previews, and search metadata to use the new `jabiko.app` address.

* **Bug Fixes**
  * Added redirects so old links continue working and users are automatically sent to the new domain.
  * Improved sitemap and robots metadata to match the current site location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->