### PR TITLE
fix(domain): pages.dev 301 改用 Pages Function（_redirects host 規則實測無效）

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,33 @@
+// Cloudflare Pages Functions middleware: 301 the old shared origin
+// (jabiko.pages.dev) to the canonical custom domain (#jabiko-app-domain).
+//
+// Why a Function and not _redirects: Pages' _redirects only supports
+// path-based sources — Netlify-style absolute-URL/host rules are silently
+// ignored (verified in prod: the host rule never fired). Host logic needs
+// code. _routes.json keeps static assets (hashed chunks, images, sw.js)
+// out of this middleware, so old links' OG previews still resolve and the
+// free Functions quota is only spent on navigations.
+//
+// The origin-migration bridge is exempt: jabiko.app iframes it ON the old
+// origin to pull a visitor's localStorage across (see
+// src/domain/originMigration.ts). Redirecting it would break that pull —
+// the iframe would land same-origin and the origin check would reject it.
+
+const CANONICAL_ORIGIN = "https://jabiko.app";
+const OLD_HOST = "jabiko.pages.dev";
+const BRIDGE_PREFIX = "/migration-bridge";
+
+/** Pure decision: the 301 target for `url`, or null to serve normally. */
+export function redirectTargetFor(url) {
+  const u = new URL(url);
+  // Exact host only: previews (<hash>.jabiko.pages.dev) must keep working.
+  if (u.hostname !== OLD_HOST) return null;
+  if (u.pathname.startsWith(BRIDGE_PREFIX)) return null;
+  return CANONICAL_ORIGIN + u.pathname + u.search;
+}
+
+export async function onRequest(context) {
+  const target = redirectTargetFor(context.request.url);
+  if (target !== null) return Response.redirect(target, 301);
+  return context.next();
+}

--- a/functions/_middleware.test.mjs
+++ b/functions/_middleware.test.mjs
@@ -1,0 +1,41 @@
+// Tests for the Pages Functions middleware that 301s the old shared origin
+// (jabiko.pages.dev) to the canonical custom domain. Plain .mjs on purpose:
+// Cloudflare Pages bundles functions/ itself, outside the app's tsc scope.
+import { describe, expect, it } from "vitest";
+import { onRequest, redirectTargetFor } from "./_middleware.js";
+
+describe("pages.dev -> jabiko.app middleware", () => {
+  it("301s old-origin pages to the same path+query on jabiko.app", () => {
+    expect(redirectTargetFor("https://jabiko.pages.dev/")).toBe("https://jabiko.app/");
+    expect(redirectTargetFor("https://jabiko.pages.dev/about")).toBe("https://jabiko.app/about");
+    expect(redirectTargetFor("https://jabiko.pages.dev/grammar/n5?lang=ja")).toBe(
+      "https://jabiko.app/grammar/n5?lang=ja"
+    );
+  });
+
+  it("exempts the origin-migration bridge (with and without .html)", () => {
+    expect(redirectTargetFor("https://jabiko.pages.dev/migration-bridge")).toBeNull();
+    expect(redirectTargetFor("https://jabiko.pages.dev/migration-bridge.html")).toBeNull();
+  });
+
+  it("never redirects the canonical domain or preview deployments", () => {
+    expect(redirectTargetFor("https://jabiko.app/about")).toBeNull();
+    expect(redirectTargetFor("https://abc123.jabiko.pages.dev/about")).toBeNull();
+    expect(redirectTargetFor("http://localhost:5173/")).toBeNull();
+  });
+
+  it("onRequest returns a 301 Response for the old origin and passes through otherwise", async () => {
+    const redirected = await onRequest({
+      request: new Request("https://jabiko.pages.dev/mock"),
+      next: () => Promise.resolve(new Response("shell"))
+    });
+    expect(redirected.status).toBe(301);
+    expect(redirected.headers.get("location")).toBe("https://jabiko.app/mock");
+
+    const passed = await onRequest({
+      request: new Request("https://jabiko.app/mock"),
+      next: () => Promise.resolve(new Response("shell"))
+    });
+    expect(await passed.text()).toBe("shell");
+  });
+});

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,19 +1,10 @@
-# Domain move (#jabiko-app-domain): jabiko.app is the canonical origin.
-# Rules are evaluated top-down, first match wins.
+# Cloudflare Pages SPA fallback: client-side routes (/about, /mock, /learn …)
+# have no built file, so serve the app shell and let the in-app router resolve
+# the view. Real static assets (/assets/*, /icon.svg, …) are matched first and
+# served directly, so this only catches unknown paths.
 #
-# 1. The origin-migration bridge must stay reachable on the OLD origin —
-#    jabiko.app iframes it to pull a visitor's localStorage across. A 200
-#    rewrite-to-itself exempts it from the host-wide 301 below.
-https://jabiko.pages.dev/migration-bridge.html /migration-bridge.html 200
-
-# 2. Permanent-redirect the shared pages.dev host to the custom domain
-#    (old links / bookmarks keep working; SEO signals consolidate). Preview
-#    deployments (<hash>.jabiko.pages.dev) don't match this host and are
-#    unaffected. Query strings are carried over automatically.
-https://jabiko.pages.dev/* https://jabiko.app/:splat 301
-
-# 3. Cloudflare Pages SPA fallback: client-side routes (/about, /mock, /learn …)
-#    have no built file, so serve the app shell and let the in-app router
-#    resolve the view. Real static assets (/assets/*, /icon.svg, …) are matched
-#    first and served directly, so this only catches unknown paths.
+# NOTE (#jabiko-app-domain): the pages.dev -> jabiko.app 301 does NOT live
+# here — Pages' _redirects ignores host/absolute-URL sources (Netlify-only
+# syntax; verified in prod). It lives in functions/_middleware.js instead,
+# scoped by public/_routes.json.
 /*  /index.html  200

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "description": "Run the redirect middleware (functions/_middleware.js) only for navigations: static assets are excluded so they serve directly from the CDN (old links' images/scripts keep resolving on pages.dev, and Functions invocations are spent only on page loads).",
+  "include": ["/*"],
+  "exclude": [
+    "/assets/*",
+    "/*.png",
+    "/*.svg",
+    "/*.webp",
+    "/*.ico",
+    "/*.js",
+    "/*.css",
+    "/*.woff2",
+    "/manifest.webmanifest"
+  ]
+}

--- a/src/domain/originMigration.test.ts
+++ b/src/domain/originMigration.test.ts
@@ -107,7 +107,7 @@ describe("originMigration (pages.dev -> jabiko.app, #jabiko-app-domain)", () => 
     // public/migration-bridge.html hand-copies these values (it cannot import
     // TS); this test is the drift guard for that copy.
     expect(MIGRATION_SOURCE_ORIGIN).toBe("https://jabiko.pages.dev");
-    expect(BRIDGE_PATH).toBe("/migration-bridge.html");
+    expect(BRIDGE_PATH).toBe("/migration-bridge");
     expect(MIGRATION_MESSAGE_REQUEST).toBe("jabiko:migration-request");
     expect(MIGRATION_MESSAGE_PAYLOAD).toBe("jabiko:migration-payload");
   });

--- a/src/domain/originMigration.ts
+++ b/src/domain/originMigration.ts
@@ -22,7 +22,10 @@
 
 export const MIGRATION_SOURCE_ORIGIN = "https://jabiko.pages.dev";
 export const MIGRATION_TARGET_ORIGIN = "https://jabiko.app";
-export const BRIDGE_PATH = "/migration-bridge.html";
+// Extensionless on purpose: Pages' pretty-URL normalization 308s
+// /migration-bridge.html -> /migration-bridge; loading the canonical form
+// skips that hop (functions/_middleware.js exempts both spellings).
+export const BRIDGE_PATH = "/migration-bridge";
 export const MIGRATION_MESSAGE_REQUEST = "jabiko:migration-request";
 export const MIGRATION_MESSAGE_PAYLOAD = "jabiko:migration-payload";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         // The origin-migration bridge (#jabiko-app-domain) must be served as
         // its real static file, not the app shell — jabiko.app iframes it on
         // the OLD origin to pull the visitor's localStorage across the move.
-        navigateFallbackDenylist: [/^\/migration-bridge\.html/],
+        navigateFallbackDenylist: [/^\/migration-bridge/],
         // Code/markup only here; static images (icons / hero / og) are
         // precached via includeAssets above. Keeping them out of
         // globPatterns avoids duplicate precache entries for the same URL.


### PR DESCRIPTION
#447 的 host-based `_redirects` 規則是 Netlify 方言，Cloudflare Pages 靜默忽略（prod 實測：root 照樣 200）。改用官方支援機制：

- **`functions/_middleware.js`**：精確比對 `jabiko.pages.dev` → 301 到 `jabiko.app/<path><query>`；`/migration-bridge*` 豁免（搬運橋必須留在舊 origin）；preview deployments 與 canonical 網域直接放行。純函式決策＋`onRequest`，TDD（4 測試）。
- **`public/_routes.json`**：middleware 只跑導航——靜態資產（hashed chunks／圖片／sw.js）維持 CDN 直出，舊貼文 OG 預覽不破、Functions 免費配額只花在 page load。
- `_redirects` 還原純 SPA fallback＋註記。
- `BRIDGE_PATH` 改無後綴 `/migration-bridge`（避開 Pages pretty-URL 的 308 多跳）；SW denylist 同步放寬。

670 測試綠、build 過。合併後以 curl 實地驗證 301／bridge 200／preview 不受影響。