### PR TITLE
fix(domain): SW 使用者的無縫跨網域交接（免重新登入）

### DIFF
--- a/src/domain/originMigration.test.ts
+++ b/src/domain/originMigration.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   applyMigrationPayload,
   BRIDGE_PATH,
   collectMigrationEntries,
   isMigratableKey,
+  legacyRedirectTarget,
   MIGRATION_MESSAGE_PAYLOAD,
   MIGRATION_MESSAGE_REQUEST,
   MIGRATION_SOURCE_ORIGIN,
+  MIGRATION_TARGET_ORIGIN,
+  runBridgeResponder,
   shouldAttemptMigration
 } from "./originMigration";
 
@@ -110,5 +113,60 @@ describe("originMigration (pages.dev -> jabiko.app, #jabiko-app-domain)", () => 
     expect(BRIDGE_PATH).toBe("/migration-bridge");
     expect(MIGRATION_MESSAGE_REQUEST).toBe("jabiko:migration-request");
     expect(MIGRATION_MESSAGE_PAYLOAD).toBe("jabiko:migration-payload");
+  });
+
+  it("legacyRedirectTarget moves top-level old-origin URLs to jabiko.app, keeping path/query/hash", () => {
+    // A service-worker-controlled visitor never reaches the edge 301 — the SW
+    // serves the cached shell — so the APP must also self-redirect (#449).
+    expect(legacyRedirectTarget("https://jabiko.pages.dev/")).toBe("https://jabiko.app/");
+    expect(legacyRedirectTarget("https://jabiko.pages.dev/mock?lang=ja#top")).toBe(
+      "https://jabiko.app/mock?lang=ja#top"
+    );
+
+    // The bridge iframe and every non-old-origin host must stay put.
+    expect(legacyRedirectTarget("https://jabiko.pages.dev/migration-bridge")).toBeNull();
+    expect(legacyRedirectTarget("https://jabiko.app/mock")).toBeNull();
+    expect(legacyRedirectTarget("https://abc123.jabiko.pages.dev/")).toBeNull();
+    expect(legacyRedirectTarget("http://localhost:5173/")).toBeNull();
+  });
+});
+
+describe("runBridgeResponder (in-app fallback when the SW serves the shell instead of the static bridge)", () => {
+  it("answers a migration request from jabiko.app with the allowlisted entries", () => {
+    const storage = fakeStorage({ "jabiko:attempts": "[9]", junk: "no" });
+    const stop = runBridgeResponder(storage);
+    const postMessage = vi.fn();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: MIGRATION_TARGET_ORIGIN,
+        data: { type: MIGRATION_MESSAGE_REQUEST },
+        source: { postMessage } as unknown as Window
+      })
+    );
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const [payload, targetOrigin] = postMessage.mock.calls[0];
+    expect(targetOrigin).toBe(MIGRATION_TARGET_ORIGIN);
+    expect(payload.type).toBe(MIGRATION_MESSAGE_PAYLOAD);
+    expect(payload.entries).toEqual([{ key: "jabiko:attempts", value: "[9]" }]);
+    stop();
+  });
+
+  it("ignores requests from any other origin", () => {
+    const storage = fakeStorage({ "jabiko:attempts": "[9]" });
+    const stop = runBridgeResponder(storage);
+    const postMessage = vi.fn();
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://evil.example",
+        data: { type: MIGRATION_MESSAGE_REQUEST },
+        source: { postMessage } as unknown as Window
+      })
+    );
+
+    expect(postMessage).not.toHaveBeenCalled();
+    stop();
   });
 });

--- a/src/domain/originMigration.ts
+++ b/src/domain/originMigration.ts
@@ -104,3 +104,47 @@ export function shouldAttemptMigration(hostname: string, storage: Storage): bool
   const attempts = Number(storage.getItem(MIGRATION_ATTEMPTS_KEY) ?? "0");
   return attempts < MIGRATION_MAX_ATTEMPTS;
 }
+
+/**
+ * Client-side twin of the edge 301 (functions/_middleware.js): a visitor
+ * whose old service worker still controls jabiko.pages.dev never reaches the
+ * edge — the SW serves the cached shell — so the app itself must move them.
+ * Returns the jabiko.app URL to replace() to, or null to stay (canonical
+ * domain, previews, localhost, and the bridge iframe all stay).
+ */
+export function legacyRedirectTarget(href: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  if (url.hostname !== "jabiko.pages.dev") return null;
+  if (url.pathname.startsWith(BRIDGE_PATH)) return null;
+  return MIGRATION_TARGET_ORIGIN + url.pathname + url.search + url.hash;
+}
+
+/**
+ * In-app bridge responder: when the old origin's service worker intercepts
+ * the bridge iframe's navigation, it serves the APP SHELL instead of the
+ * static public/migration-bridge.html. main.tsx detects that case (framed +
+ * bridge path) and calls this instead of rendering the app — same protocol,
+ * same allowlist, so the migration works on the very first attempt even for
+ * SW-controlled visitors. Returns a stop function (symmetry/testability).
+ */
+export function runBridgeResponder(storage: Storage): () => void {
+  const onMessage = (event: MessageEvent) => {
+    if (event.origin !== MIGRATION_TARGET_ORIGIN) return;
+    const data: unknown = event.data;
+    if (typeof data !== "object" || data === null) return;
+    if ((data as { type?: unknown }).type !== MIGRATION_MESSAGE_REQUEST) return;
+    if (!event.source) return;
+    // String targetOrigin form, matching the static bridge and the hook.
+    (event.source as Window).postMessage(
+      { type: MIGRATION_MESSAGE_PAYLOAD, entries: collectMigrationEntries(storage) },
+      MIGRATION_TARGET_ORIGIN
+    );
+  };
+  window.addEventListener("message", onMessage);
+  return () => window.removeEventListener("message", onMessage);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,28 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { BRIDGE_PATH, legacyRedirectTarget, runBridgeResponder } from "./domain/originMigration";
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
-);
+// Domain-move plumbing (#jabiko-app-domain), evaluated before any render:
+//
+// 1. Framed at the bridge path on the OLD origin: the visitor's service
+//    worker intercepted the bridge iframe and served this shell instead of
+//    the static migration-bridge.html. Act as the bridge (same protocol)
+//    and skip rendering the app entirely.
+// 2. Top-level on the OLD origin: the SW also hides the edge 301 (it serves
+//    the cached shell without touching the network), so hop to the
+//    canonical domain ourselves, preserving path/query/hash.
+const framedAtBridge = window.top !== window && window.location.pathname.startsWith(BRIDGE_PATH);
+const redirect = window.top === window ? legacyRedirectTarget(window.location.href) : null;
+
+if (framedAtBridge) {
+  runBridgeResponder(window.localStorage);
+} else if (redirect !== null) {
+  window.location.replace(redirect);
+} else {
+  createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+}


### PR DESCRIPTION
補 #447/#448 的最後一塊：**回訪的 PWA/SW 使用者看不到 edge 301**——舊 Service Worker 直接從 precache 端出 shell、不碰網路，所以他們會一直留在 pages.dev；橋 iframe 也被 SW 攔成 shell，第一次搬運 timeout（＝「換新網址要重新登入」的成因）。

兩個補強，都在 `main.tsx` render 前決策：

1. **`legacyRedirectTarget()`**：舊 origin 的頂層載入自行 `location.replace` 到 jabiko.app（保留 path/query/hash）——edge middleware 的 client 雙胞胎。橋 iframe／preview／localhost／canonical 網域不動。
2. **`runBridgeResponder()`**：被 SW 端出的 shell 若發現自己「被 iframe 嵌在 `/migration-bridge`」，就直接扮演橋（同協議、同 allowlist）而不 render app——**SW 使用者第一次就能搬完**（含 `sb-*` session＝自動保持登入）。

生效路徑：SW 使用者下次造訪 pages.dev → SW 背景更新拿到本版 shell（sw.js 是 must-revalidate）→ 之後的載入自動跳 jabiko.app、資料＋登入一次搬齊。

TDD：+3 測試（轉跳決策矩陣、responder 只回 canonical origin、拒外來 origin）；全套 673 綠、build 過。