### PR TITLE
fix(grammar): 修復文型總覽頁無法進入單一等級頁面的問題

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -497,6 +497,9 @@ export default function App() {
             onBackToOverview={() => {
               setGrammarSurface(null);
             }}
+            onSelectLevel={(lvl) => {
+              setGrammarSurface(lvl);
+            }}
           />
         </Suspense>
       ) : appView === "grammar" ? (

--- a/src/components/GrammarIndexPage.tsx
+++ b/src/components/GrammarIndexPage.tsx
@@ -18,12 +18,14 @@ export function GrammarIndexPage({
   onOpenPattern,
   onBack,
   onBackToOverview,
+  onSelectLevel,
 }: {
   language: Language;
   level: JlptLevel | null;
   onOpenPattern: (surface: string) => void;
   onBack: () => void;
   onBackToOverview?: () => void;
+  onSelectLevel?: (level: JlptLevel) => void;
 }) {
   const t = copy[language];
   const [searchQuery, setSearchQuery] = useState("");
@@ -230,6 +232,26 @@ export function GrammarIndexPage({
                     </>
                   )}
                 </span>
+                {onSelectLevel && (
+                  <span
+                    className="gi-level-enter"
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onSelectLevel(lvl);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onSelectLevel(lvl);
+                      }
+                    }}
+                  >
+                    {t.grammarBrowseLevel ?? "瀏覽"}
+                  </span>
+                )}
               </summary>
               {overviewPatterns.length === 0 ? (
                 <p className="gi-empty">{t.grammarNoPatterns}</p>

--- a/src/components/GrammarIndexPage.tsx
+++ b/src/components/GrammarIndexPage.tsx
@@ -237,7 +237,9 @@ export function GrammarIndexPage({
                     className="gi-level-enter"
                     role="button"
                     tabIndex={0}
+                    aria-label={`${t.grammarBrowseLevel} ${levelLabels[lvl]}`}
                     onClick={(e) => {
+                      e.preventDefault();
                       e.stopPropagation();
                       onSelectLevel(lvl);
                     }}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -279,6 +279,7 @@ export type Copy = {
   grammarDatabaseExamples: string;
   grammarRelatedPatterns: string;
   grammarCommonMistakes: string;
+  grammarBrowseLevel: string;
   grammarBackToIndex: string;
   grammarImportanceMustKnow: string;
   grammarImportanceHighFreq: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -296,6 +296,7 @@ export const en: Copy = {
   grammarDatabaseExamples: "Example sentences",
   grammarRelatedPatterns: "Related patterns",
   grammarCommonMistakes: "Common mistakes",
+  grammarBrowseLevel: "Browse",
   grammarBackToIndex: "Back to grammar index",
   grammar: "Grammar",
   grammarImportanceMustKnow: "Must know",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -296,6 +296,7 @@ export const id: Copy = {
   grammarDatabaseExamples: "Contoh kalimat",
   grammarRelatedPatterns: "Pola yang terkait",
   grammarCommonMistakes: "Kesalahan umum",
+  grammarBrowseLevel: "Jelajahi",
   grammarBackToIndex: "Kembali ke indeks tata bahasa",
   grammar: "Tata Bahasa",
   grammarImportanceMustKnow: "Harus tahu",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -304,6 +304,7 @@ export const ja: Copy = {
   grammarDatabaseExamples: "例文",
   grammarRelatedPatterns: "似ている文型との比較",
   grammarCommonMistakes: "よくある間違い",
+  grammarBrowseLevel: "閲覧",
   grammarBackToIndex: "文型一覧に戻る",
   grammar: "文型",
   grammarImportanceMustKnow: "必須",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -296,6 +296,7 @@ export const ko: Copy = {
   grammarDatabaseExamples: "예문",
   grammarRelatedPatterns: "유사 문형 비교",
   grammarCommonMistakes: "자주 하는 실수",
+  grammarBrowseLevel: "보기",
   grammarBackToIndex: "문형 목록으로 돌아가기",
   grammar: "문형",
   grammarImportanceMustKnow: "필수",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -296,6 +296,7 @@ export const my: Copy = {
   grammarDatabaseExamples: "နမူနာဝါကျများ",
   grammarRelatedPatterns: "ဆက်စပ်သော ပုံစံများ",
   grammarCommonMistakes: "အဖြစ်များသော အမှားများ",
+  grammarBrowseLevel: "ကြည့်ရှုရန်",
   grammarBackToIndex: "သဒ္ဒါညွှန်းသို့ ပြန်သွားရန်",
   grammar: "သဒ္ဒါ",
   grammarImportanceMustKnow: "သိထားရန်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -297,6 +297,7 @@ export const th: Copy = {
   grammarDatabaseExamples: "ประโยคตัวอย่าง",
   grammarRelatedPatterns: "รูปไวยากรณ์ที่ใกล้เคียง",
   grammarCommonMistakes: "ข้อผิดพลาดที่พบบ่อย",
+  grammarBrowseLevel: "เรียกดู",
   grammarBackToIndex: "กลับไปยังรายการรูปไวยากรณ์",
   grammar: "ไวยากรณ์",
   grammarImportanceMustKnow: "ต้องรู้",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -296,6 +296,7 @@ export const vi: Copy = {
   grammarDatabaseExamples: "Câu ví dụ",
   grammarRelatedPatterns: "Mẫu ngữ pháp liên quan",
   grammarCommonMistakes: "Lỗi thường gặp",
+  grammarBrowseLevel: "Xem",
   grammarBackToIndex: "Quay lại danh sách ngữ pháp",
   grammar: "Ngữ pháp",
   grammarImportanceMustKnow: "Phải biết",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -296,6 +296,7 @@ export const zhHant: Copy = {
   grammarDatabaseExamples: "文型例句",
   grammarRelatedPatterns: "相近文型比較",
   grammarCommonMistakes: "常見錯誤",
+  grammarBrowseLevel: "瀏覽",
   grammarBackToIndex: "回到文型一覽",
   grammar: "文型",
   grammarImportanceMustKnow: "必考",

--- a/src/styles/grammar.css
+++ b/src/styles/grammar.css
@@ -298,7 +298,21 @@
   gap: 0.4rem;
   font-size: 0.82rem;
   color: var(--muted);
+}
+
+.gi-level-enter {
+  font-size: 0.78rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: var(--radius-pill);
+  background: var(--matcha);
+  color: var(--selected-text, #fff);
+  cursor: pointer;
+  white-space: nowrap;
   margin-left: auto;
+}
+
+.gi-level-enter:hover {
+  opacity: 0.85;
 }
 
 .gi-pattern-list {


### PR DESCRIPTION
## Summary

文型總覽頁改用 `<details>` 內聯展開後，缺少進入單一等級專用頁面的按鈕，導致「高頻」等重要性的篩選器（只在等級頁面顯示）無法使用。

## Changes

- **GrammarIndexPage.tsx**: 新增 `onSelectLevel` prop，在每個等級的 `<summary>` 加入「瀏覽」按鈕
- **App.tsx**: 串接 `onSelectLevel` handler，設定 `grammarSurface` 以觸發路由切換到 `/grammar/N5` 等
- **i18n.ts + 8 locales**: 新增 `grammarBrowseLevel` 翻譯 key
- **grammar.css**: 新增 `.gi-level-enter` 按鈕樣式

## Test plan

- [x] `pnpm build` 通過
- [x] `pnpm test` 649 passed（2 個既有不相關失敗）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browse/enter action in the grammar index, letting you jump directly into a selected JLPT level.
  * Improved keyboard support for the new level action.

* **Style**
  * Added visual styling for the new grammar browse control, including hover feedback and improved alignment.

* **Documentation**
  * Updated localized text across supported languages for the new grammar browsing label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->