### PR TITLE
feat(feedback): show your pick, prominent report button, global feedback entry

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1028,4 +1028,13 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
   });
 
+  it("opens the feedback form from a persistent header button (any view, #456)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    // The feedback entry lives in the always-visible header, not just the
+    // homepage footer, so it's reachable from anywhere.
+    await user.click(screen.getByRole("button", { name: "意見回饋" }));
+    expect(await screen.findByRole("dialog", { name: "意見回饋" })).toBeInTheDocument();
+  });
+
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { BookOpen, ChevronDown, Globe, Languages, Moon, Sun } from "lucide-react";
+import { BookOpen, ChevronDown, Globe, Languages, MessageCircle, Moon, Sun } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
 import type { JlptLevel } from "./domain/types";
@@ -8,6 +8,8 @@ import { copy, LAUNCHED_LANGUAGES, type Language } from "./i18n";
 import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
 import { LanguageFlag } from "./components/LanguageFlag";
+import { FeedbackForm } from "./components/FeedbackForm";
+import type { FeedbackCategory } from "./domain/feedbackRemote";
 import { UpdateToast } from "./components/UpdateToast";
 import { usePwaUpdate } from "./hooks/usePwaUpdate";
 import { JabikoMark } from "./components/JabikoMark";
@@ -200,6 +202,9 @@ export default function App() {
   }, [appView, grammarIndexAvailable, grammarSurface, isGrammarLevelRoute]);
   // Language picker, opened from the header Globe button (#326).
   const [langPickerOpen, setLangPickerOpen] = useState(false);
+  // Persistent feedback entry (#456): the suggestion box was only reachable from
+  // the homepage footer; this opens the same form from the always-visible header.
+  const [feedbackKind, setFeedbackKind] = useState<FeedbackCategory | null>(null);
   // Service-worker update prompt (#327): toast when a new build is ready.
   const { needRefresh, updateApp } = usePwaUpdate();
 
@@ -287,6 +292,13 @@ export default function App() {
           closeLabel={t.feedbackClose}
         />
       )}
+      {feedbackKind ? (
+        <FeedbackForm
+          language={language}
+          category={feedbackKind}
+          onClose={() => setFeedbackKind(null)}
+        />
+      ) : null}
       <div className="app-heading" aria-label={t.appIntroLabel}>
         <div className="app-brand">
           <JabikoMark className="app-brand-mark" />
@@ -365,6 +377,16 @@ export default function App() {
             <button className="theme-toggle" type="button" aria-label={themeToggleLabel} onClick={toggleTheme}>
               <ThemeIcon aria-hidden="true" />
               <span className="toggle-text">{themeToggleLabel}</span>
+            </button>
+            <button
+              className="theme-toggle feedback-nav-button"
+              type="button"
+              aria-label={t.feedbackTitle}
+              aria-haspopup="dialog"
+              onClick={() => setFeedbackKind("wish")}
+            >
+              <MessageCircle aria-hidden="true" />
+              <span className="toggle-text">{t.feedbackTitle}</span>
             </button>
           </div>
         </div>

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -589,3 +589,43 @@ describe("FeedbackPanel vocab notes (#453)", () => {
     expect(container.querySelector(".vocab-notes")).toBeNull();
   });
 });
+
+describe("FeedbackPanel your-answer line (#456)", () => {
+  const q = readingPool[0];
+
+  it("shows the learner's own submitted answer when incorrect", () => {
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "incorrect", question: q, submittedAnswer: "ふうして" }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    const line = container.querySelector(".your-answer");
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain("你選的");
+    expect(line?.textContent).toContain("ふうして");
+  });
+
+  it("hides the your-answer line when the pick was correct", () => {
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "correct", question: q, submittedAnswer: "ふうじて" }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    expect(container.querySelector(".your-answer")).toBeNull();
+  });
+
+  it("hides the your-answer line when revealed/skipped (no submitted answer)", () => {
+    const { container } = render(
+      <FeedbackPanel
+        feedback={{ status: "revealed", question: q, submittedAnswer: null }}
+        language="zh-Hant"
+        options={[]}
+      />
+    );
+    expect(container.querySelector(".your-answer")).toBeNull();
+  });
+});

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -97,6 +97,11 @@ export function FeedbackPanel({
           </span>
         ) : null}
       </div>
+      {feedback.status === "incorrect" && feedback.submittedAnswer ? (
+        <p className="your-answer">
+          {t.feedbackYourAnswer}：<span lang="ja">{feedback.submittedAnswer}</span>
+        </p>
+      ) : null}
       <p className="answer-key">{t.answerKey}：{feedback.question.expectedAnswers.join(" / ")}</p>
       <p>{pickLocalized(feedback.question.explanation, feedback.question.explanationI18n, language)}</p>
       {distractorGlosses.length > 0 ? (

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -57,6 +57,7 @@ export type Copy = {
   feedbackError: string;
   feedbackFallback: string;
   // ---- Per-question "report this question" (#299) --------------------------
+  feedbackYourAnswer: string;
   reportQuestionCta: string;
   reportTitle: string;
   reportReasonLabel: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -59,6 +59,7 @@ export const en: Copy = {
   feedbackClose: "Close",
   feedbackError: "Send failed. Please try again later, or",
   feedbackFallback: "report via GitHub instead",
+  feedbackYourAnswer: "Your answer",
   reportQuestionCta: "Report this question",
   reportTitle: "Report a problem with this question",
   reportReasonLabel: "What's wrong?",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -59,6 +59,7 @@ export const id: Copy = {
   feedbackClose: "Tutup",
   feedbackError: "Gagal mengirim, coba lagi nanti, atau",
   feedbackFallback: "Laporkan lewat GitHub",
+  feedbackYourAnswer: "Jawaban kamu",
   reportQuestionCta: "Laporkan soal ini",
   reportTitle: "Laporkan masalah pada soal ini",
   reportReasonLabel: "Apa yang salah?",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -60,6 +60,7 @@ export const ja: Copy = {
   feedbackClose: "閉じる",
   feedbackError: "送信に失敗しました。しばらくしてからもう一度お試しいただくか、",
   feedbackFallback: "GitHub から報告する",
+  feedbackYourAnswer: "あなたの回答",
   reportQuestionCta: "この問題を報告",
   reportTitle: "問題の不具合を報告",
   reportReasonLabel: "問題の種類",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -59,6 +59,7 @@ export const ko: Copy = {
   feedbackClose: "닫기",
   feedbackError: "전송에 실패했어요. 잠시 후 다시 시도하거나,",
   feedbackFallback: "대신 GitHub으로 신고하기",
+  feedbackYourAnswer: "내 답",
   reportQuestionCta: "이 문제 신고하기",
   reportTitle: "이 문제의 오류 신고",
   reportReasonLabel: "무엇이 잘못됐나요?",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -59,6 +59,7 @@ export const my: Copy = {
   feedbackClose: "ပိတ်ရန်",
   feedbackError: "ပို့ခြင်း မအောင်မြင်ပါ။ နောက်မှ ထပ်ကြိုးစားပါ၊ သို့မဟုတ်",
   feedbackFallback: "GitHub မှတစ်ဆင့် တိုင်ကြားပါ",
+  feedbackYourAnswer: "သင့်အဖြေ",
   reportQuestionCta: "ဤမေးခွန်းကို တိုင်ကြားရန်",
   reportTitle: "ဤမေးခွန်း၏ ပြဿနာကို တိုင်ကြားရန်",
   reportReasonLabel: "ဘာ မှားနေသလဲ?",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -60,6 +60,7 @@ export const th: Copy = {
   feedbackClose: "ปิด",
   feedbackError: "ส่งไม่สำเร็จ โปรดลองใหม่ภายหลัง หรือ",
   feedbackFallback: "แจ้งผ่าน GitHub แทน",
+  feedbackYourAnswer: "คำตอบของคุณ",
   reportQuestionCta: "รายงานข้อนี้",
   reportTitle: "รายงานปัญหาของข้อสอบ",
   reportReasonLabel: "ปัญหาคืออะไร?",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -59,6 +59,7 @@ export const vi: Copy = {
   feedbackClose: "Đóng",
   feedbackError: "Gửi thất bại. Vui lòng thử lại sau, hoặc",
   feedbackFallback: "báo qua GitHub thay thế",
+  feedbackYourAnswer: "Câu trả lời của bạn",
   reportQuestionCta: "Báo lỗi câu này",
   reportTitle: "Báo lỗi về câu hỏi này",
   reportReasonLabel: "Vấn đề là gì?",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -59,6 +59,7 @@ export const zhHant: Copy = {
   feedbackClose: "關閉",
   feedbackError: "送出失敗，請稍後再試，或",
   feedbackFallback: "改用 GitHub 回報",
+  feedbackYourAnswer: "你選的",
   reportQuestionCta: "回報此題",
   reportTitle: "回報題目問題",
   reportReasonLabel: "問題類型",

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -427,6 +427,15 @@
   font-weight: 800;
 }
 
+/* The learner's own (wrong) pick, shown above the answer key so a mis-tap of a
+   look-alike option is obvious rather than reading as "the app marked me
+   wrong" (#456). */
+.your-answer {
+  color: var(--vermilion);
+  font-weight: 600;
+  margin-bottom: 0.15rem;
+}
+
 .distractor-gloss {
   color: var(--muted);
   font-size: 0.9rem;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -203,31 +203,34 @@
   margin-top: 0.4rem;
 }
 
+/* Prominent (not a muted text link) so a learner who thinks a question is
+   wrong can actually find it -- Duolingo-style report affordance (#456). */
 .report-question-cta {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
-  padding: 0.2rem 0.3rem;
-  border: 0;
-  background: none;
-  color: var(--muted);
+  gap: 0.4rem;
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-pill);
+  background: var(--paper);
+  color: var(--teal-dark);
   font: inherit;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   cursor: pointer;
-  border-radius: var(--radius-sm);
   flex-wrap: wrap;
   max-width: 100%;
   white-space: normal;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease;
 }
 
 .report-question-cta:hover {
-  color: var(--ink);
-  text-decoration: underline;
+  border-color: var(--teal-dark);
+  box-shadow: var(--button-hover-shadow);
 }
 
 .report-question-cta svg {
-  width: 0.9rem;
-  height: 0.9rem;
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 /* "深入學習這個文法 →" deep link to the grammar study page (#282). A clear,


### PR DESCRIPTION
## 緣起

忠實用戶在 Threads 回報 `封じて` 這題「正解被判錯」。實際上資料完全正確（`expectedAnswer` = ふうじて，逐位元組相符）——用戶是手滑點到長得極像的 `ふうして`（じ／し 只差一濁點），但面板**只顯示正解、不顯示你選了什麼**，才會誤以為是評分 bug。

## 三個改動（塔奇也提過回報要更明顯）

1. **顯示「你選的：X」**：答錯時在正解上方以紅字顯示使用者自己的作答，手滑／看錯一目了然，不再誤讀成「app 判錯」。
2. **錯題回報按鈕升級**：`回報此題` 從埋在最底的淡灰文字連結，改成有邊框、找得到的按鈕（Duolingo 風）。
3. **全站常駐 feedback 入口**：頂部工具列新增「意見回饋」按鈕，任何頁面都能開啟建議箱（原本只在首頁 footer）。開的是同一個 FeedbackForm。

新增 copy key `feedbackYourAnswer`（8 語系齊全）。

## 驗證

- TDD：FeedbackPanel「你選的」渲染/隱藏測試 ＋ App header feedback 按鈕測試（先 RED 再 GREEN）
- `pnpm test` ✓（684）、`pnpm build` ✓（examBlocks 仍 lazy、index 僅 +0.65KB）
- **瀏覽器實機驗證**：你選的紅字行、邊框回報按鈕、header 按鈕開表單，皆正常（截圖已附對話）
