### PR TITLE
feat(grammar): add prev/next pager on the grammar-point page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -532,6 +532,7 @@ export default function App() {
               setGrammarSurface(null);
               setAppView("grammar");
             }}
+            onNavigate={(surface) => setGrammarSurface(surface)}
           />
         </Suspense>
       ) : (

--- a/src/components/GrammarPointPage.test.tsx
+++ b/src/components/GrammarPointPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { cleanExplanation, GrammarPointPage } from "./GrammarPointPage";
 import { allGrammarSurfaces, buildGrammarPoint } from "../domain/grammarPoints";
-import { findPatternBySurface } from "../domain/grammarIndex";
+import { findPatternBySurface, getPatternsByLevel, patternSurface } from "../domain/grammarIndex";
 import { grammarNotes } from "../domain/grammarNotes";
 import { grammarPatterns } from "../domain/grammarDatabase";
 import { copy } from "../i18n";
@@ -182,5 +182,53 @@ describe("content language gates", () => {
     render(<GrammarPointPage surface={surface} language="ja" onPractice={vi.fn()} onBack={vi.fn()} />);
     expect(screen.queryByText(dbOnly.meaningZh)).not.toBeInTheDocument();
     expect(screen.queryByText(dbOnly.formation)).not.toBeInTheDocument();
+  });
+});
+
+describe("GrammarPointPage next/prev pager (#457)", () => {
+  const LEVEL_ORDER = ["N5", "N4", "N3", "N2", "N1"] as const;
+  const flat = LEVEL_ORDER.flatMap((lvl) => getPatternsByLevel(lvl));
+  const mid = Math.floor(flat.length / 2);
+  const surface = patternSurface(flat[mid]);
+  const nextSurface = patternSurface(flat[mid + 1]);
+  const prevSurface = patternSurface(flat[mid - 1]);
+
+  it("advances to the next grammar point without returning to the index (zh-Hant)", async () => {
+    const onNavigate = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <GrammarPointPage
+        surface={surface}
+        language="zh-Hant"
+        onPractice={vi.fn()}
+        onBack={vi.fn()}
+        onNavigate={onNavigate}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: new RegExp(t.grammarNext) }));
+    expect(onNavigate).toHaveBeenCalledWith(nextSurface);
+  });
+
+  it("goes back to the previous grammar point", async () => {
+    const onNavigate = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <GrammarPointPage
+        surface={surface}
+        language="zh-Hant"
+        onPractice={vi.fn()}
+        onBack={vi.fn()}
+        onNavigate={onNavigate}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: new RegExp(t.grammarPrev) }));
+    expect(onNavigate).toHaveBeenCalledWith(prevSurface);
+  });
+
+  it("renders no pager when onNavigate is not wired in", () => {
+    const { container } = render(
+      <GrammarPointPage surface={surface} language="zh-Hant" onPractice={vi.fn()} onBack={vi.fn()} />
+    );
+    expect(container.querySelector(".gp-pager")).toBeNull();
   });
 });

--- a/src/components/GrammarPointPage.tsx
+++ b/src/components/GrammarPointPage.tsx
@@ -1,10 +1,10 @@
-import { ArrowLeft, GraduationCap, Clapperboard, BookOpen, AlertTriangle } from "lucide-react";
+import { ArrowLeft, ArrowRight, GraduationCap, Clapperboard, BookOpen, AlertTriangle } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { buildGrammarPoint } from "../domain/grammarPoints";
 import { pickLocalized } from "../domain/localizedContent";
 import { GrammarNoteCard } from "./GrammarNoteCard";
 import { grammarPatterns } from "../domain/grammarDatabase";
-import { findPatternBySurface } from "../domain/grammarIndex";
+import { findPatternBySurface, getAdjacentPatterns, patternSurface } from "../domain/grammarIndex";
 import type { GrammarPattern, MediaLineExample } from "../domain/grammarDatabase";
 import type { JlptLevel } from "../domain/types";
 
@@ -34,12 +34,15 @@ export function GrammarPointPage({
   surface,
   language,
   onPractice,
-  onBack
+  onBack,
+  onNavigate
 }: {
   surface: string;
   language: Language;
   onPractice: () => void;
   onBack: () => void;
+  /** Jump to an adjacent grammar point in index order (#457). Omitted = no pager. */
+  onNavigate?: (surface: string) => void;
 }) {
   const t = copy[language];
   const point = buildGrammarPoint(surface);
@@ -60,6 +63,42 @@ export function GrammarPointPage({
       {t.grammarBackToIndex}
     </button>
   );
+
+  // Prev/next pager (#457): page through 文型 in index order without going back
+  // to the index. Only for the zh-Hant browse flow (the index is zh-only) and
+  // only when the surface is a database pattern with a neighbour.
+  const adjacent = getAdjacentPatterns(surface);
+  const pager =
+    onNavigate && isZhHant && (adjacent.prev || adjacent.next) ? (
+      <nav className="gp-pager" aria-label={t.grammarBackToIndex}>
+        {adjacent.prev ? (
+          <button
+            type="button"
+            className="ghost-button gp-pager-btn gp-pager-prev"
+            onClick={() => onNavigate(patternSurface(adjacent.prev!))}
+          >
+            <ArrowLeft aria-hidden="true" />
+            <span className="gp-pager-label">{t.grammarPrev}</span>
+            <span className="gp-pager-surface" lang="ja">{adjacent.prev.pattern}</span>
+          </button>
+        ) : (
+          <span className="gp-pager-spacer" />
+        )}
+        {adjacent.next ? (
+          <button
+            type="button"
+            className="ghost-button gp-pager-btn gp-pager-next"
+            onClick={() => onNavigate(patternSurface(adjacent.next!))}
+          >
+            <span className="gp-pager-label">{t.grammarNext}</span>
+            <span className="gp-pager-surface" lang="ja">{adjacent.next.pattern}</span>
+            <ArrowRight aria-hidden="true" />
+          </button>
+        ) : (
+          <span className="gp-pager-spacer" />
+        )}
+      </nav>
+    ) : null;
 
   // Unknown surface (stale/typo link): neither exam data nor database entry exists.
   if (!point) {
@@ -168,6 +207,7 @@ export function GrammarPointPage({
             </ul>
           </section>
         ) : null}
+        {pager}
       </section>
     );
   }
@@ -304,6 +344,8 @@ export function GrammarPointPage({
         <GraduationCap aria-hidden="true" />
         {t.startChallenge}
       </button>
+
+      {pager}
     </section>
   );
 }

--- a/src/domain/grammarIndex.test.ts
+++ b/src/domain/grammarIndex.test.ts
@@ -9,6 +9,8 @@ import {
   getPatternsWithMediaExamples,
   getPatternsByImportance,
   getLevelSummary,
+  getAdjacentPatterns,
+  patternSurface,
 } from "./grammarIndex";
 import { grammarPatterns } from "./grammarDatabase";
 
@@ -333,5 +335,48 @@ describe("getLevelSummary", () => {
         live.filter((p) => p.mediaExamples.length > 0).length
       );
     }
+  });
+});
+
+describe("getAdjacentPatterns / patternSurface (#457)", () => {
+  const LEVEL_ORDER = ["N5", "N4", "N3", "N2", "N1"] as const;
+  const flat = LEVEL_ORDER.flatMap((lvl) => getPatternsByLevel(lvl));
+
+  it("returns the prev/next patterns in index order for a middle pattern", () => {
+    const mid = Math.floor(flat.length / 2);
+    const { prev, next } = getAdjacentPatterns(patternSurface(flat[mid]));
+    expect(prev?.id).toBe(flat[mid - 1].id);
+    expect(next?.id).toBe(flat[mid + 1].id);
+  });
+
+  it("has no prev for the first pattern and links forward to the second", () => {
+    // flat[0] is the first N5 pattern (unique surface), so it resolves to
+    // itself: no previous, and next is flat[1]. (The flat-LAST is the N1 copy
+    // of the only duplicated surface 〜ざるを得ない, which findPatternBySurface
+    // resolves to its N2 twin, so we assert the forward boundary here instead.)
+    const { prev, next } = getAdjacentPatterns(patternSurface(flat[0]));
+    expect(prev).toBeNull();
+    expect(next?.id).toBe(flat[1].id);
+  });
+
+  it("returns a null next once index order is exhausted", () => {
+    // The genuinely-last reachable pattern (whose surface round-trips to itself)
+    // has no normal successor — only the unreachable duplicate can follow it.
+    const lastReachable = [...flat]
+      .reverse()
+      .find((p) => findPatternBySurface(patternSurface(p))?.id === p.id)!;
+    const { next } = getAdjacentPatterns(patternSurface(lastReachable));
+    expect(next === null || next.id === flat[flat.length - 1].id).toBe(true);
+  });
+
+  it("returns both null for a surface that is not a database pattern", () => {
+    expect(getAdjacentPatterns("そんな文型はないzzz")).toEqual({ prev: null, next: null });
+  });
+
+  it("patternSurface strips a leading 〜/～ and round-trips via findPatternBySurface", () => {
+    const withTilde = grammarPatterns.find((p) => /^[〜～]/.test(p.pattern));
+    expect(withTilde).toBeDefined();
+    expect(patternSurface(withTilde!)).toBe(withTilde!.pattern.replace(/^[〜～]/, ""));
+    expect(findPatternBySurface(patternSurface(withTilde!))?.id).toBe(withTilde!.id);
   });
 });

--- a/src/domain/grammarIndex.ts
+++ b/src/domain/grammarIndex.ts
@@ -44,6 +44,35 @@ export function findPatternBySurface(surface: string): GrammarPattern | undefine
   );
 }
 
+/** 文型的可導覽 surface（去掉開頭的 〜/～，與索引點擊 onOpenPattern 一致）。 */
+export function patternSurface(pattern: GrammarPattern): string {
+  return pattern.pattern.replace(/^[〜～]/, "");
+}
+
+const ADJACENCY_LEVEL_ORDER: JlptLevel[] = ["N5", "N4", "N3", "N2", "N1"];
+
+/**
+ * 依索引的自然閱讀順序（等級 N5→N1、等級內 id 排序，與
+ * getPatternsGroupedByLevel 一致）取得某文型的前／後相鄰文型，
+ * 讓學習頁能「下一個 / 上一個」直接翻頁、不必退回索引重選（#457）。
+ * 非資料庫文型（surface 找不到）回傳兩者皆 null。
+ */
+export function getAdjacentPatterns(surface: string): {
+  prev: GrammarPattern | null;
+  next: GrammarPattern | null;
+} {
+  const current = findPatternBySurface(surface);
+  if (!current) return { prev: null, next: null };
+  const grouped = getPatternsGroupedByLevel();
+  const flat = ADJACENCY_LEVEL_ORDER.flatMap((level) => grouped[level]);
+  const i = flat.findIndex((p) => p.id === current.id);
+  if (i === -1) return { prev: null, next: null };
+  return {
+    prev: i > 0 ? flat[i - 1] : null,
+    next: i < flat.length - 1 ? flat[i + 1] : null,
+  };
+}
+
 /** 依關鍵字搜尋文型和中文解釋 */
 export function searchPatterns(query: string): GrammarPattern[] {
   const q = query.trim().toLowerCase();

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -282,6 +282,8 @@ export type Copy = {
   grammarRelatedPatterns: string;
   grammarCommonMistakes: string;
   grammarBackToIndex: string;
+  grammarPrev: string;
+  grammarNext: string;
   grammarImportanceMustKnow: string;
   grammarImportanceHighFreq: string;
   grammarImportanceUnderstand: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -299,6 +299,8 @@ export const en: Copy = {
   grammarRelatedPatterns: "Related patterns",
   grammarCommonMistakes: "Common mistakes",
   grammarBackToIndex: "Back to grammar index",
+  grammarPrev: "Previous",
+  grammarNext: "Next",
   grammar: "Grammar",
   grammarImportanceMustKnow: "Must know",
   grammarImportanceHighFreq: "High frequency",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -299,6 +299,8 @@ export const id: Copy = {
   grammarRelatedPatterns: "Pola yang terkait",
   grammarCommonMistakes: "Kesalahan umum",
   grammarBackToIndex: "Kembali ke indeks tata bahasa",
+  grammarPrev: "Sebelumnya",
+  grammarNext: "Berikutnya",
   grammar: "Tata Bahasa",
   grammarImportanceMustKnow: "Harus tahu",
   grammarImportanceHighFreq: "Frekuensi tinggi",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -307,6 +307,8 @@ export const ja: Copy = {
   grammarRelatedPatterns: "似ている文型との比較",
   grammarCommonMistakes: "よくある間違い",
   grammarBackToIndex: "文型一覧に戻る",
+  grammarPrev: "前の文型",
+  grammarNext: "次の文型",
   grammar: "文型",
   grammarImportanceMustKnow: "必須",
   grammarImportanceHighFreq: "高頻度",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -299,6 +299,8 @@ export const ko: Copy = {
   grammarRelatedPatterns: "유사 문형 비교",
   grammarCommonMistakes: "자주 하는 실수",
   grammarBackToIndex: "문형 목록으로 돌아가기",
+  grammarPrev: "이전",
+  grammarNext: "다음",
   grammar: "문형",
   grammarImportanceMustKnow: "필수",
   grammarImportanceHighFreq: "고빈도",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -299,6 +299,8 @@ export const my: Copy = {
   grammarRelatedPatterns: "ဆက်စပ်သော ပုံစံများ",
   grammarCommonMistakes: "အဖြစ်များသော အမှားများ",
   grammarBackToIndex: "သဒ္ဒါညွှန်းသို့ ပြန်သွားရန်",
+  grammarPrev: "အရင်",
+  grammarNext: "နောက်တစ်ခု",
   grammar: "သဒ္ဒါ",
   grammarImportanceMustKnow: "သိထားရန်",
   grammarImportanceHighFreq: "မကြာခဏတွေ့",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -300,6 +300,8 @@ export const th: Copy = {
   grammarRelatedPatterns: "รูปไวยากรณ์ที่ใกล้เคียง",
   grammarCommonMistakes: "ข้อผิดพลาดที่พบบ่อย",
   grammarBackToIndex: "กลับไปยังรายการรูปไวยากรณ์",
+  grammarPrev: "ก่อนหน้า",
+  grammarNext: "ถัดไป",
   grammar: "ไวยากรณ์",
   grammarImportanceMustKnow: "ต้องรู้",
   grammarImportanceHighFreq: "พบบ่อย",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -299,6 +299,8 @@ export const vi: Copy = {
   grammarRelatedPatterns: "Mẫu ngữ pháp liên quan",
   grammarCommonMistakes: "Lỗi thường gặp",
   grammarBackToIndex: "Quay lại danh sách ngữ pháp",
+  grammarPrev: "Trước",
+  grammarNext: "Tiếp",
   grammar: "Ngữ pháp",
   grammarImportanceMustKnow: "Phải biết",
   grammarImportanceHighFreq: "Tần suất cao",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -299,6 +299,8 @@ export const zhHant: Copy = {
   grammarRelatedPatterns: "相近文型比較",
   grammarCommonMistakes: "常見錯誤",
   grammarBackToIndex: "回到文型一覽",
+  grammarPrev: "上一個",
+  grammarNext: "下一個",
   grammar: "文型",
   grammarImportanceMustKnow: "必考",
   grammarImportanceHighFreq: "高頻",

--- a/src/styles/grammar.css
+++ b/src/styles/grammar.css
@@ -148,6 +148,44 @@
   margin-top: 0.2rem;
 }
 
+/* Prev/next pager (#457): page through 文型 without returning to the index. */
+.gp-pager {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--panel-border);
+}
+
+.gp-pager-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  max-width: 48%;
+  flex-wrap: wrap;
+}
+
+.gp-pager-next {
+  margin-left: auto;
+  justify-content: flex-end;
+  text-align: right;
+}
+
+.gp-pager-label {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.gp-pager-surface {
+  font-weight: 700;
+}
+
+.gp-pager-spacer {
+  flex: 1;
+}
+
 /* ---- GrammaIndex (issue #437) ---- */
 .grammar-index {
   display: flex;


### PR DESCRIPTION
## 緣起（使用者回饋）

> 希望在（文型）可以增加下一頁或是下一句的按鈕，不用再跳出去重選

## 做法

在「文型」學習頁（GrammarPointPage）底部加「上一個 / 下一個」翻頁列，依**索引的順序**（等級 N5→N1、等級內 id 排序，跟索引列表一致）走訪文型，顯示相鄰文型的形式並直接跳過去——**不必退回索引重選**。

- **domain**：`getAdjacentPatterns(surface)` ＋ `patternSurface(pattern)`（商業邏輯放 `grammarIndex.ts`）
- **GrammarPointPage**：新增 optional `onNavigate` prop ＋ 翻頁列（gated 到 zh-Hant 瀏覽流程，且只在該 surface 是資料庫文型且有相鄰時顯示）
- **App**：`onNavigate` 串到 `setGrammarSurface`（同步更新 `/grammar/<surface>` 網址）
- 8 語系補 `grammarPrev`/`grammarNext`；`.gp-pager` 樣式

## 驗證

- TDD：`getAdjacentPatterns` 中段/邊界/未知 surface 測試 ＋ GrammarPointPage 翻頁 next/prev/無按鈕 測試（先 RED 再 GREEN）
- `pnpm test` ✓（692）、`pnpm build` ✓（examBlocks 仍 lazy、index 僅 +0.4KB）
- **瀏覽器實機驗證**：`ばかりに` → 點「下一個」→ `だけあって`，標題／網址／翻頁列同步更新（截圖已附對話）

## 備註（既有資料小瑕，非本 PR 範圍）

全庫 92 個文型中唯一重複去綴 surface＝`〜ざるを得ない`（N1 與 N2 各一份）。其 N1 版本本來就無法用 surface 路由抵達（`findPatternBySurface` 依陣列順序回 N2 那個），翻頁列也一致解析到 N2——與全 app 的 surface 路由行為相同。要不要把兩份合併是內容決定，可另議。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added previous/next navigation on grammar detail pages where available.
  * Navigation now updates the current grammar surface as you move between related items.
  * Added localized labels for the new grammar navigation controls.

* **Bug Fixes**
  * Improved consistency when browsing grammar items directly within a page.

* **Style**
  * Added styling for the grammar pager to match the existing page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->