### PR TITLE
[codex] Fix blog article route

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -601,7 +601,7 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://jabiko.app/blog/sweet-step-steady</loc>
+    <loc>https://jabiko.app/blog/sweet-steady-sweet-step</loc>
     <lastmod>2026-07-05</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -50,7 +50,7 @@ function grammarSurfaces() {
 // parse miss here can't silently ship.
 function blogArticleSlugs() {
   const src = readFileSync(path.join(ROOT, "src/domain/articlesMeta.ts"), "utf8");
-  const arr = src.match(/articleMetas[^=]*=\s*\[([\s\S]*?)\];/);
+  const arr = src.match(/(?:rawArticleMetas|articleMetas)[^=]*=\s*\[([\s\S]*?)\];/);
   if (!arr) return [];
   const slugs = [];
   for (const chunk of arr[1].split(/\},/)) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import type { SessionInit } from "./hooks/usePracticeSession";
 import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
 import type { LevelRange } from "./domain/levelRange";
+import { canonicalArticleSlug } from "./domain/articlesMeta";
 import "./styles.css";
 
 // Lazy routes. The challenge view owns the practice engine, which
@@ -131,6 +132,7 @@ function parseRoute(pathname: string): {
     } catch {
       // Malformed escape -- keep the raw segment.
     }
+    slug = canonicalArticleSlug(slug);
     return { view: "blog", grammarSurface: null, blogSlug: slug };
   }
   return { view: viewFromPath(pathname), grammarSurface: null, blogSlug: null };

--- a/src/components/BlogArticlePage.test.tsx
+++ b/src/components/BlogArticlePage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { BlogArticlePage } from "./BlogArticlePage";
+
+describe("BlogArticlePage", () => {
+  it("renders the SWEET STEP article from the canonical slug", () => {
+    render(
+      <BlogArticlePage
+        slug="sweet-steady-sweet-step"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /SWEET STEADY - SWEET STEP/ })
+    ).toBeInTheDocument();
+    expect(screen.getByText("ありのまま")).toBeInTheDocument();
+    expect(screen.getByText("（ありのまま）")).toBeInTheDocument();
+    expect(screen.getByText("強がる")).toBeInTheDocument();
+    expect(screen.getByText(/大輪の種はここにある/)).toBeInTheDocument();
+  });
+
+  it("keeps the old SWEET STEP slug readable as a legacy alias", () => {
+    render(
+      <BlogArticlePage
+        slug="sweet-step-steady"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /SWEET STEADY - SWEET STEP/ })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Article not found|文章不存在/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/BlogArticlePage.tsx
+++ b/src/components/BlogArticlePage.tsx
@@ -2,11 +2,8 @@ import { ArrowLeft, ArrowRight, ExternalLink } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { articleBySlug, type ArticleBlock, type ArticleCta } from "../domain/articles";
 
-// A single 文章 page (#483). Renders the article's structured block body
-// (headings / paragraphs / vocab tables / lyric-commentary / a closing
-// practice CTA). zh-Hant-only content, lazy-loaded. `onCta` routes the
-// end-of-article call-to-action back into real practice (App maps it to
-// openChallenge / openGrammar) -- the reader-to-drill-user moat (#483).
+// Single blog article page. The article body is zh-Hant original content and
+// is lazy-loaded from the blog route, so prose stays out of the initial bundle.
 export function BlogArticlePage({
   slug,
   language,
@@ -152,7 +149,6 @@ function ArticleBlockView({
         </div>
       );
     default: {
-      // Exhaustiveness guard: a new block kind must add a case above.
       const _never: never = block;
       return _never;
     }

--- a/src/domain/articles.test.ts
+++ b/src/domain/articles.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { articleBySlug, articles, publishedArticles, type ArticleBlock } from "./articles";
+import { canonicalArticleSlug } from "./articlesMeta";
 
 describe("blog articles data guard", () => {
   it("has at least one published article", () => {
@@ -11,6 +12,31 @@ describe("blog articles data guard", () => {
     expect(new Set(slugs).size).toBe(slugs.length);
     for (const slug of slugs) {
       expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    }
+  });
+
+  it("uses the canonical SWEET STEADY slug while keeping the old slug as an alias", () => {
+    expect(canonicalArticleSlug("sweet-step-steady")).toBe("sweet-steady-sweet-step");
+    expect(articleBySlug("sweet-steady-sweet-step")?.slug).toBe("sweet-steady-sweet-step");
+    expect(articleBySlug("sweet-step-steady")?.slug).toBe("sweet-steady-sweet-step");
+    expect(articles.map((a) => a.slug)).toContain("sweet-steady-sweet-step");
+    expect(articles.map((a) => a.slug)).not.toContain("sweet-step-steady");
+  });
+
+  it("serves the rewritten SWEET STEP body on both the canonical slug and the alias", () => {
+    for (const slug of ["sweet-steady-sweet-step", "sweet-step-steady"]) {
+      const article = articleBySlug(slug);
+      expect(article?.title).toContain("SWEET STEADY - SWEET STEP");
+      const bodyText = article?.body
+        .flatMap((block) => {
+          if ("text" in block) return [block.text];
+          if (block.kind === "vocab") return block.items.flatMap((item) => [item.word, item.reading, item.meaning]);
+          return [];
+        })
+        .join("\n");
+      expect(bodyText).toContain("ありのまま");
+      expect(bodyText).toContain("強がる");
+      expect(bodyText).toContain("大輪の種はここにある");
     }
   });
 

--- a/src/domain/articles.ts
+++ b/src/domain/articles.ts
@@ -566,7 +566,7 @@ const BODIES: Record<string, ReadonlyArray<ArticleBlock>> = {
 };
 
 const BODY_OVERRIDES: Partial<Record<string, ReadonlyArray<ArticleBlock>>> = {
-  "sweet-step-steady": sweetStepBody
+  "sweet-steady-sweet-step": sweetStepBody
 };
 
 function withBody(meta: ArticleMeta): BlogArticle {

--- a/src/domain/articlesMeta.ts
+++ b/src/domain/articlesMeta.ts
@@ -23,9 +23,13 @@ export interface ArticleMeta {
   draft?: boolean;
 }
 
+const BLOG_SLUG_ALIASES: Record<string, string> = {
+  "sweet-step-steady": "sweet-steady-sweet-step"
+};
+
 const rawArticleMetas: ReadonlyArray<ArticleMeta> = [
   {
-    slug: "sweet-step-steady",
+    slug: "sweet-steady-sweet-step",
     title: "從「SWEET STEP」學日文：在 ありのまま 裡找真正的自己",
     description:
       "SWEET STEADY〈SWEET STEP〉唱的是「其實我也不知道真正的自己」——ありのまま、妄想、取り繕う、キュン⋯⋯挑 20 幾個歌裡的日文點來學，例句全原創，附官方 MV 連結。",
@@ -43,7 +47,7 @@ const rawArticleMetas: ReadonlyArray<ArticleMeta> = [
 ];
 
 export const articleMetas: ReadonlyArray<ArticleMeta> = rawArticleMetas.map((article) =>
-  article.slug === "sweet-step-steady"
+  article.slug === "sweet-steady-sweet-step"
     ? {
         ...article,
         title: "從歌詞學日文系列 SWEET STEADY - SWEET STEP：在 ありのまま 裡找真正的自己",
@@ -56,6 +60,11 @@ export const articleMetas: ReadonlyArray<ArticleMeta> = rawArticleMetas.map((art
 
 export const publishedArticleMetas: ReadonlyArray<ArticleMeta> = articleMetas.filter((a) => !a.draft);
 
+export function canonicalArticleSlug(slug: string): string {
+  return BLOG_SLUG_ALIASES[slug] ?? slug;
+}
+
 export function articleMetaBySlug(slug: string): ArticleMeta | undefined {
-  return articleMetas.find((a) => a.slug === slug);
+  const canonicalSlug = canonicalArticleSlug(slug);
+  return articleMetas.find((a) => a.slug === canonicalSlug);
 }


### PR DESCRIPTION
﻿## What changed
- Canonicalize the SWEET STEP article URL to `/blog/sweet-steady-sweet-step`.
- Keep `/blog/sweet-step-steady` as a legacy alias so existing links still resolve and then sync to the canonical URL.
- Fix blog sitemap generation after the article metadata split so published blog articles are not dropped.
- Add a real BlogArticlePage render test for the canonical slug and legacy alias.

## Why
The merged article rewrite used the old reversed slug and the sitemap builder was no longer finding the article metadata array after the split. This hotfix restores article route resolution and updates the public canonical URL.

## Validation
- `corepack pnpm build:sitemap`
- `corepack pnpm vitest run src/components/BlogArticlePage.test.tsx src/domain/articles.test.ts src/domain/seo.test.ts src/domain/sitemap.test.ts`
- `corepack pnpm build`
- `corepack pnpm vitest run`
