### PR TITLE
完成卡重設計：戰報磚＋分享搬家＋滿分達摩＋feedback 入口

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -637,6 +637,7 @@ export default function App() {
             targetLevel={targetLevel}
             onExit={() => setAppView("home")}
             onOpenGrammar={openGrammar}
+            onOpenFeedback={() => setFeedbackKind("wish")}
           />
         </Suspense>
       )}

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -27,7 +27,8 @@ export function ChallengePanel({
   language,
   targetLevel = null,
   onExit,
-  onOpenGrammar
+  onOpenGrammar,
+  onOpenFeedback
 }: {
   init?: SessionInit;
   progressAttempts: Attempt[];
@@ -39,6 +40,8 @@ export function ChallengePanel({
   onExit: () => void;
   // Navigate to a grammar point's study page from the post-answer feedback (#282).
   onOpenGrammar?: (surface: string) => void;
+  // Open the in-app feedback form from the completion card (#456).
+  onOpenFeedback?: () => void;
 }) {
   const t = copy[language];
   const session = usePracticeSession({ language, init, progressAttempts, recordAttempt, targetLevel });
@@ -47,7 +50,13 @@ export function ChallengePanel({
     <section className="practice-layout" aria-label="Jabiko practice">
       <ModePicker language={language} {...session} />
 
-      <DrillPanel language={language} onExit={onExit} onOpenGrammar={onOpenGrammar} {...session} />
+      <DrillPanel
+        language={language}
+        onExit={onExit}
+        onOpenGrammar={onOpenGrammar}
+        onOpenFeedback={onOpenFeedback}
+        {...session}
+      />
 
       <aside className="review-panel" aria-label={t.mistakesLabel}>
         {session.showSessionLength ? (

--- a/src/components/challenge/DrillPanel.test.tsx
+++ b/src/components/challenge/DrillPanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { DrillPanel } from "./DrillPanel";
 import type { Attempt, PracticeQuestion } from "../../domain/types";
@@ -74,8 +75,9 @@ function renderDone(opts: {
   correct: number;
   accuracy: number;
   sessionSeed?: number;
+  onOpenFeedback?: () => void;
 }) {
-  const { language = "zh-Hant", total, correct, accuracy, sessionSeed = 0 } = opts;
+  const { language = "zh-Hant", total, correct, accuracy, sessionSeed = 0, onOpenFeedback } = opts;
   return render(
     <DrillPanel
       {...baseProps}
@@ -86,6 +88,7 @@ function renderDone(opts: {
       correctCount={correct}
       accuracy={accuracy}
       sessionSeed={sessionSeed}
+      onOpenFeedback={onOpenFeedback}
     />
   );
 }
@@ -124,6 +127,20 @@ describe("DrillPanel", () => {
     it("hides the perfect badge when at least one answer was wrong", () => {
       renderDone({ total: 5, correct: 4, accuracy: 80 });
       expect(screen.queryByText("全部答對")).not.toBeInTheDocument();
+    });
+
+    it("surfaces a feedback entry that fires the handler when provided", async () => {
+      const onOpenFeedback = vi.fn();
+      renderDone({ total: 5, correct: 4, accuracy: 80, onOpenFeedback });
+      const button = screen.getByRole("button", { name: "意見回饋" });
+      const user = userEvent.setup();
+      await user.click(button);
+      expect(onOpenFeedback).toHaveBeenCalledTimes(1);
+    });
+
+    it("omits the feedback entry when no handler is wired", () => {
+      renderDone({ total: 5, correct: 4, accuracy: 80 });
+      expect(screen.queryByRole("button", { name: "意見回饋" })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/challenge/DrillPanel.test.tsx
+++ b/src/components/challenge/DrillPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { DrillPanel } from "./DrillPanel";
-import type { PracticeQuestion } from "../../domain/types";
+import type { Attempt, PracticeQuestion } from "../../domain/types";
 import type { Language } from "../../i18n";
 
 const question: PracticeQuestion = {
@@ -23,33 +23,69 @@ const question: PracticeQuestion = {
   explanation: "一類動詞的て形會產生音便。"
 };
 
+const baseProps = {
+  questionIndex: 0,
+  sessionTotal: null,
+  selectedChoice: null,
+  feedback: null,
+  attempts: [] as Attempt[],
+  practiceMode: "basic" as const,
+  currentQuestion: question as PracticeQuestion | null,
+  reviewEmpty: false,
+  bookmarksEmpty: false,
+  sessionExhausted: false,
+  choiceOptions: ["書いて", "書いた", "書かない", "書きます"],
+  correctCount: 0,
+  accuracy: 0,
+  sessionSeed: 0,
+  nextButtonRef: { current: null },
+  setPracticeMode: vi.fn(),
+  setPracticeFilter: vi.fn(),
+  handleChoiceSubmit: vi.fn(),
+  nextQuestion: vi.fn(),
+  resetSession: vi.fn(),
+  revealAnswer: vi.fn(),
+  handleDrillKeyDown: vi.fn(),
+  isQuestionBookmarked: () => false,
+  onToggleBookmark: vi.fn(),
+  onExit: vi.fn()
+};
+
 function renderPanel(language: Language) {
+  return render(<DrillPanel {...baseProps} language={language} />);
+}
+
+function makeAttempts(total: number, correct: number): Attempt[] {
+  return Array.from({ length: total }, (_, i) => ({
+    vocabularyId: "kaku",
+    targetForm: "te",
+    prompt: "書く",
+    expectedAnswers: ["書いて"],
+    submittedAnswer: "書いて",
+    isCorrect: i < correct,
+    timestamp: 0,
+    responseTimeMs: 0
+  }));
+}
+
+function renderDone(opts: {
+  language?: Language;
+  total: number;
+  correct: number;
+  accuracy: number;
+  sessionSeed?: number;
+}) {
+  const { language = "zh-Hant", total, correct, accuracy, sessionSeed = 0 } = opts;
   return render(
     <DrillPanel
+      {...baseProps}
       language={language}
-      questionIndex={0}
-      sessionTotal={null}
-      selectedChoice={null}
-      feedback={null}
-      attempts={[]}
-      practiceMode="basic"
-      currentQuestion={question}
-      reviewEmpty={false}
-      bookmarksEmpty={false}
-      sessionExhausted={false}
-      choiceOptions={["書いて", "書いた", "書かない", "書きます"]}
-      correctCount={0}
-      nextButtonRef={{ current: null }}
-      setPracticeMode={vi.fn()}
-      setPracticeFilter={vi.fn()}
-      handleChoiceSubmit={vi.fn()}
-      nextQuestion={vi.fn()}
-      resetSession={vi.fn()}
-      revealAnswer={vi.fn()}
-      handleDrillKeyDown={vi.fn()}
-      isQuestionBookmarked={() => false}
-      onToggleBookmark={vi.fn()}
-      onExit={vi.fn()}
+      currentQuestion={null}
+      sessionExhausted
+      attempts={makeAttempts(total, correct)}
+      correctCount={correct}
+      accuracy={accuracy}
+      sessionSeed={sessionSeed}
     />
   );
 }
@@ -64,5 +100,30 @@ describe("DrillPanel", () => {
   it("keeps the zh gloss for zh-Hant", () => {
     renderPanel("zh-Hant");
     expect(screen.getByText("寫")).toBeInTheDocument();
+  });
+
+  describe("session-complete card", () => {
+    it("shows glanceable stat tiles for the finished session", () => {
+      renderDone({ total: 5, correct: 4, accuracy: 80 });
+      expect(screen.getByText("已答")).toBeInTheDocument();
+      expect(screen.getByText("正解率")).toBeInTheDocument();
+      expect(screen.getByText("80%")).toBeInTheDocument();
+    });
+
+    it("moves the share panel onto the completion card", () => {
+      renderDone({ total: 5, correct: 4, accuracy: 80 });
+      expect(screen.getByRole("button", { name: "Facebook" })).toBeInTheDocument();
+    });
+
+    it("celebrates a flawless run with the perfect badge", () => {
+      renderDone({ total: 5, correct: 5, accuracy: 100 });
+      expect(screen.getByText("全部答對")).toBeInTheDocument();
+      expect(screen.getByText("100%")).toBeInTheDocument();
+    });
+
+    it("hides the perfect badge when at least one answer was wrong", () => {
+      renderDone({ total: 5, correct: 4, accuracy: 80 });
+      expect(screen.queryByText("全部答對")).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { ArrowRight, Eye, GraduationCap, RotateCcw } from "lucide-react";
+import { ArrowRight, Eye, GraduationCap, MessageSquare, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech } from "../../domain/types";
 import {
@@ -92,7 +92,8 @@ export function DrillPanel({
   isQuestionBookmarked,
   onToggleBookmark,
   onExit,
-  onOpenGrammar
+  onOpenGrammar,
+  onOpenFeedback
 }: Pick<
   PracticeSession,
   | "questionIndex"
@@ -119,7 +120,14 @@ export function DrillPanel({
   | "handleDrillKeyDown"
   | "isQuestionBookmarked"
   | "onToggleBookmark"
-> & { language: Language; onExit: () => void; onOpenGrammar?: (surface: string) => void }) {
+> & {
+  language: Language;
+  onExit: () => void;
+  onOpenGrammar?: (surface: string) => void;
+  // Opens the in-app feedback form (#456) from the completion card, so a
+  // learner who just spotted a bad question can report it in context.
+  onOpenFeedback?: () => void;
+}) {
   const t = copy[language];
 
   // Completion-screen copy: daily / review have their own wording; every
@@ -304,6 +312,12 @@ export function DrillPanel({
             </button>
           </div>
           <ShareButtons language={language} text={t.shareText(attempts.length, accuracy)} />
+          {onOpenFeedback ? (
+            <button type="button" className="done-feedback" onClick={onOpenFeedback}>
+              <MessageSquare aria-hidden="true" />
+              {t.feedbackTitle}
+            </button>
+          ) : null}
           <p className="done-watermark">jabiko.app</p>
         </div>
       ) : reviewEmpty ? (

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -1,15 +1,40 @@
+import type { ComponentType } from "react";
 import { ArrowRight, Eye, GraduationCap, RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import type { PartOfSpeech } from "../../domain/types";
-import { DarumaSpot, PaperNoteSpot, TeaCupSpot } from "../../illustrations";
+import {
+  DarumaDoneSpot,
+  LanternSpot,
+  OmamoriSpot,
+  PaperNoteSpot,
+  SproutSpot,
+  TargetSpot,
+  TeaCupSpot,
+  ToriiSpot
+} from "../../illustrations";
 import { isReadingPrompt } from "../../domain/furigana";
+import { pickDoneSpot, type DoneSpotKey } from "../../domain/doneSpot";
 import { pickLocalized } from "../../domain/localizedContent";
 import { ExamPrompt } from "../ExamPrompt";
 import { FeedbackPanel } from "../FeedbackPanel";
 import { Ruby } from "../Ruby";
+import { ShareButtons } from "./ShareButtons";
 import { SpeakButton } from "../SpeakButton";
 import type { Feedback } from "../types";
 import type { PracticeSession } from "../../hooks/usePracticeSession";
+
+// The completion card's illustration key -> component. Lives here (not in the
+// domain) so doneSpot.ts stays JSX-free. "daruma" is the open-eye perfect-run
+// spot; the rest rotate for ordinary finishes.
+const DONE_SPOTS: Record<DoneSpotKey, ComponentType<{ size?: number; className?: string }>> = {
+  daruma: DarumaDoneSpot,
+  sprout: SproutSpot,
+  omamori: OmamoriSpot,
+  lantern: LanternSpot,
+  torii: ToriiSpot,
+  teacup: TeaCupSpot,
+  target: TargetSpot
+};
 
 function choiceOptionClass(choice: string, selectedChoice: string | null, feedback: Feedback): string {
   const classes = ["choice-option"];
@@ -54,6 +79,8 @@ export function DrillPanel({
   sessionExhausted,
   choiceOptions,
   correctCount,
+  accuracy,
+  sessionSeed,
   nextButtonRef,
   setPracticeMode,
   setPracticeFilter,
@@ -80,6 +107,8 @@ export function DrillPanel({
   | "sessionExhausted"
   | "choiceOptions"
   | "correctCount"
+  | "accuracy"
+  | "sessionSeed"
   | "nextButtonRef"
   | "setPracticeMode"
   | "setPracticeFilter"
@@ -108,6 +137,12 @@ export function DrillPanel({
   const doneBody = doneCopy.body(correctCount, wrongCount);
   const doneAgain = doneCopy.again;
   const doneExit = doneCopy.exit;
+
+  // A flawless run earns the open-eye daruma + a badge; every other finish
+  // rotates a celebratory spot keyed off the session counter, so the picture
+  // is stable while the card shows but varies session to session.
+  const isPerfectSession = attempts.length > 0 && wrongCount === 0;
+  const DoneSpot = DONE_SPOTS[pickDoneSpot(sessionSeed, isPerfectSession)];
 
   // Container-level answer state for embedded AI / browser automation:
   // collapse feedback into one result string so .drill-panel exposes the
@@ -238,10 +273,27 @@ export function DrillPanel({
           ) : null}
         </>
       ) : sessionExhausted ? (
-        <div className="empty-state review-done">
-          <DarumaSpot />
+        <div className="empty-state review-done session-done">
+          <DoneSpot />
+          {isPerfectSession ? (
+            <span className="done-perfect-badge">{t.donePerfectBadge}</span>
+          ) : null}
           <h2>{doneTitle}</h2>
-          <p>{doneBody}</p>
+          <dl className="done-stats" aria-label={t.scoreReportLabel}>
+            <div className="done-stat">
+              <dt>{t.answered}</dt>
+              <dd>{attempts.length}</dd>
+            </div>
+            <div className="done-stat done-stat-correct">
+              <dt>{t.correctShort}</dt>
+              <dd>{correctCount}</dd>
+            </div>
+            <div className="done-stat">
+              <dt>{t.accuracyShort}</dt>
+              <dd>{accuracy}%</dd>
+            </div>
+          </dl>
+          {isPerfectSession ? null : <p>{doneBody}</p>}
           <div className="review-done-actions">
             <button className="next-button" type="button" onClick={resetSession}>
               <RotateCcw aria-hidden="true" />
@@ -251,6 +303,8 @@ export function DrillPanel({
               {doneExit}
             </button>
           </div>
+          <ShareButtons language={language} text={t.shareText(attempts.length, accuracy)} />
+          <p className="done-watermark">jabiko.app</p>
         </div>
       ) : reviewEmpty ? (
         <div className="empty-state review-done">

--- a/src/components/challenge/ScoreReport.tsx
+++ b/src/components/challenge/ScoreReport.tsx
@@ -1,11 +1,13 @@
 import { copy, type Language } from "../../i18n";
 import type { PracticeSession } from "../../hooks/usePracticeSession";
-import { ShareButtons } from "./ShareButtons";
 
 // The 今日戰報 stats block: answered / correct / review counts, the
 // accuracy value, and the accuracy progress bar. Sits atop the right-hand
 // 錯題複習 column (since #81). Pure presentation over the session's score
 // figures; extracted from ChallengePanel with no behavioural change.
+//
+// Sharing lives on the session-complete card (the finish-line moment), not
+// here in the always-on side panel — see DrillPanel's sessionExhausted branch.
 //
 // `mistakeCount` is the length of the mistake-review list (shown as the
 // 待複習 figure); the list itself is rendered by ReviewList alongside this.
@@ -51,9 +53,6 @@ export function ScoreReport({
       >
         <span className="score-bar-fill" style={{ width: `${accuracy}%` }} />
       </div>
-      {attempts.length > 0 ? (
-        <ShareButtons language={language} text={t.shareText(attempts.length, accuracy)} />
-      ) : null}
     </div>
   );
 }

--- a/src/domain/doneSpot.test.ts
+++ b/src/domain/doneSpot.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { DONE_SPOT_POOL, pickDoneSpot, type DoneSpotKey } from "./doneSpot";
+
+describe("pickDoneSpot", () => {
+  it("returns the open-eye daruma for a flawless run regardless of seed", () => {
+    for (const seed of [0, 1, 5, 42, -3]) {
+      expect(pickDoneSpot(seed, true)).toBe("daruma");
+    }
+  });
+
+  it("never draws the perfect-only daruma from the ordinary pool", () => {
+    expect(DONE_SPOT_POOL).not.toContain("daruma");
+    for (let seed = 0; seed < 30; seed += 1) {
+      expect(pickDoneSpot(seed, false)).not.toBe("daruma");
+    }
+  });
+
+  it("picks the first pool entry for seed 0", () => {
+    expect(pickDoneSpot(0, false)).toBe(DONE_SPOT_POOL[0]);
+  });
+
+  it("cycles through the whole pool as the seed increments", () => {
+    const size = DONE_SPOT_POOL.length;
+    for (let seed = 0; seed < size * 2; seed += 1) {
+      expect(pickDoneSpot(seed, false)).toBe(DONE_SPOT_POOL[seed % size]);
+    }
+  });
+
+  it("wraps negative seeds to a valid pool entry", () => {
+    const size = DONE_SPOT_POOL.length;
+    const pool: DoneSpotKey[] = DONE_SPOT_POOL;
+    expect(pickDoneSpot(-1, false)).toBe(pool[size - 1]);
+    expect(pickDoneSpot(-size, false)).toBe(pool[0]);
+    expect(pool).toContain(pickDoneSpot(-13, false));
+  });
+
+  it("is deterministic for the same inputs", () => {
+    expect(pickDoneSpot(7, false)).toBe(pickDoneSpot(7, false));
+    expect(pickDoneSpot(7, true)).toBe(pickDoneSpot(7, true));
+  });
+});

--- a/src/domain/doneSpot.ts
+++ b/src/domain/doneSpot.ts
@@ -1,0 +1,42 @@
+// Which wafuu spot illustration to crown the session-complete card with.
+//
+// The completion card is the app's highest-emotion beat (and the thing users
+// screenshot to share), so it should not always show the same picture. A
+// flawless run earns the special open-eye daruma (両目 = 開眼, "wish
+// fulfilled"); every other finish rotates deterministically through a small
+// pool of celebratory motifs, keyed off the session counter so the picture is
+// stable while the card is on screen but varies from one session to the next.
+//
+// Pure + deterministic (no Math.random) so it is unit-testable and never
+// flickers on re-render. The DrillPanel maps the returned key to a component;
+// keeping this layer key-only keeps the domain free of React/JSX imports.
+
+export type DoneSpotKey =
+  | "daruma"
+  | "sprout"
+  | "omamori"
+  | "lantern"
+  | "torii"
+  | "teacup"
+  | "target";
+
+// The rotating pool for ordinary finishes. "daruma" is deliberately absent:
+// the open-eye daruma is reserved for a perfect (100%) run so it keeps meaning.
+export const DONE_SPOT_POOL: DoneSpotKey[] = [
+  "sprout",
+  "omamori",
+  "lantern",
+  "torii",
+  "teacup",
+  "target"
+];
+
+export function pickDoneSpot(seed: number, isPerfect: boolean): DoneSpotKey {
+  if (isPerfect) {
+    return "daruma";
+  }
+  const size = DONE_SPOT_POOL.length;
+  // Euclidean modulo so negative seeds still land on a valid index.
+  const index = ((Math.trunc(seed) % size) + size) % size;
+  return DONE_SPOT_POOL[index];
+}

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -497,6 +497,7 @@ export function usePracticeSession({
     sessionTotal,
     selectedForm,
     questionIndex,
+    sessionSeed,
     selectedChoice,
     feedback,
     attempts,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -235,6 +235,7 @@ export type Copy = {
   correctShort: string;
   reviewShort: string;
   accuracyLabel: string;
+  accuracyShort: string;
   scoreReportLabel: string;
   shareTitle: string;
   shareText: (attempts: number, accuracy: number) => string;
@@ -356,6 +357,7 @@ export type Copy = {
   sessionDoneBody: (cleared: number, remaining: number) => string;
   sessionDoneAgain: string;
   sessionDoneExit: string;
+  donePerfectBadge: string;
   speakAriaLabel: string;
   authSignIn: string;
   authSignOut: string;

--- a/src/illustrations.tsx
+++ b/src/illustrations.tsx
@@ -63,6 +63,26 @@ export function DarumaSpot({ size = 76, className }: SpotProps) {
   );
 }
 
+/** Daruma with BOTH eyes painted in (両目 = 開眼) plus a spark -- the
+ *  "wish fulfilled" payoff. Reserved for a flawless (100%) session so the
+ *  second eye stays meaningful. Mirrors DarumaSpot's outline exactly. */
+export function DarumaDoneSpot({ size = 76, className }: SpotProps) {
+  return (
+    <svg {...svgProps(size, className)}>
+      <path
+        {...stroke}
+        d="M50 14 C30 14 23 40 25 56 C27 78 42 90 50 90 C58 90 73 78 75 56 C77 40 70 14 50 14 Z"
+        fill="var(--vermilion)"
+      />
+      <ellipse {...stroke} cx="50" cy="48" rx="20" ry="23" fill="var(--paper)" />
+      <circle cx="42" cy="46" r="4" fill="currentColor" />
+      <circle cx="58" cy="46" r="4" fill="currentColor" />
+      <path {...stroke} d="M43 62 Q50 67 57 62" fill="none" />
+      <path d="M82 22 L84 30 L92 32 L84 34 L82 42 L80 34 L72 32 L80 30 Z" fill="var(--gold)" />
+    </svg>
+  );
+}
+
 /** Cup of tea with rising steam -- "rest / nothing due" motif. */
 export function TeaCupSpot({ size = 64, className }: SpotProps) {
   return (

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -252,6 +252,7 @@ export const en: Copy = {
   correctShort: "Correct",
   reviewShort: "Review",
   accuracyLabel: "Current accuracy",
+  accuracyShort: "Accuracy",
   scoreReportLabel: "Today's report",
   shareTitle: "Share your results",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const en: Copy = {
     `You did ${cleared + remaining} questions this set — ${cleared} correct, ${remaining} wrong. The misses go into weakness review and come back next time.`,
   sessionDoneAgain: "Another set",
   sessionDoneExit: "Back to home",
+  donePerfectBadge: "Perfect score",
   speakAriaLabel: "Read Japanese aloud",
   authSignIn: "Sign in with Google",
   authSignOut: "Sign out",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -252,6 +252,7 @@ export const id: Copy = {
   correctShort: "Benar",
   reviewShort: "Ulang",
   accuracyLabel: "Akurasi saat ini",
+  accuracyShort: "Akurasi",
   scoreReportLabel: "Skor hari ini",
   shareTitle: "Bagikan hasil",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const id: Copy = {
     `Set ini melatih ${cleared + remaining} soal, ${cleared} benar dan ${remaining} salah. Yang salah akan masuk ke ulangan kelemahan dan muncul lagi saat ulangan berikutnya.`,
   sessionDoneAgain: "Satu set lagi",
   sessionDoneExit: "Kembali ke beranda",
+  donePerfectBadge: "Skor sempurna",
   speakAriaLabel: "Bacakan bahasa Jepang",
   authSignIn: "Masuk dengan Google",
   authSignOut: "Keluar",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -260,6 +260,7 @@ export const ja: Copy = {
   correctShort: "正解",
   reviewShort: "復習",
   accuracyLabel: "現在の正答率",
+  accuracyShort: "正答率",
   scoreReportLabel: "今日の成績",
   shareTitle: "成績をシェア",
   shareText: (attempts, accuracy) =>
@@ -396,6 +397,7 @@ export const ja: Copy = {
     `このセットでは ${cleared + remaining} 問を練習し、正解 ${cleared} 問、不正解 ${remaining} 問。間違えた問題は弱点復習に入り、次の復習でまた出てきます。`,
   sessionDoneAgain: "もう1セット",
   sessionDoneExit: "ホームに戻る",
+  donePerfectBadge: "全問正解",
   speakAriaLabel: "日本語を読み上げる",
   authSignIn: "Google でログイン",
   authSignOut: "ログアウト",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -252,6 +252,7 @@ export const ko: Copy = {
   correctShort: "정답",
   reviewShort: "복습",
   accuracyLabel: "현재 정답률",
+  accuracyShort: "정답률",
   scoreReportLabel: "오늘의 리포트",
   shareTitle: "결과 공유하기",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const ko: Copy = {
     `이번 세트에서 ${cleared + remaining}문제를 풀었어요 — ${cleared}개 정답, ${remaining}개 오답. 틀린 것은 약점 복습으로 들어가 다음에 다시 나와요.`,
   sessionDoneAgain: "한 세트 더",
   sessionDoneExit: "홈으로 돌아가기",
+  donePerfectBadge: "만점",
   speakAriaLabel: "일본어 소리 내어 읽기",
   authSignIn: "Google로 로그인",
   authSignOut: "로그아웃",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -252,6 +252,7 @@ export const my: Copy = {
   correctShort: "မှန်",
   reviewShort: "ပြန်လေ့",
   accuracyLabel: "လက်ရှိ မှန်ကန်မှု",
+  accuracyShort: "မှန်ကန်မှု",
   scoreReportLabel: "ဒီနေ့ အစီရင်ခံစာ",
   shareTitle: "သင့်ရလဒ်များကို မျှဝေရန်",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const my: Copy = {
     `ဤစုတွင် မေးခွန်း ${cleared + remaining} ခု လုပ်ခဲ့သည် — ${cleared} ခု မှန်၊ ${remaining} ခု မှား။ မှားသည်များ အားနည်းချက် ပြန်လေ့ကျင့်ရန်သို့ ဝင်ပြီး နောက်တစ်ကြိမ် ပြန်လာသည်။`,
   sessionDoneAgain: "နောက်တစ်စု",
   sessionDoneExit: "ပင်မသို့ ပြန်ရန်",
+  donePerfectBadge: "အမှတ်ပြည့်",
   speakAriaLabel: "ဂျပန်စာ အသံထွက်ဖတ်ရန်",
   authSignIn: "Google ဖြင့် ဝင်ရောက်ရန်",
   authSignOut: "ထွက်ရန်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -253,6 +253,7 @@ export const th: Copy = {
   correctShort: "ถูก",
   reviewShort: "ทบทวน",
   accuracyLabel: "อัตราตอบถูกปัจจุบัน",
+  accuracyShort: "ความแม่นยำ",
   scoreReportLabel: "รายงานวันนี้",
   shareTitle: "แชร์ผลคะแนน",
   shareText: (attempts, accuracy) =>
@@ -389,6 +390,7 @@ export const th: Copy = {
     `ชุดนี้ฝึกไป ${cleared + remaining} ข้อ ตอบถูก ${cleared} ตอบผิด ${remaining} ข้อที่ตอบผิดจะเข้าทบทวนจุดอ่อน และกลับมาในการทบทวนครั้งหน้า`,
   sessionDoneAgain: "ฝึกอีกชุด",
   sessionDoneExit: "กลับหน้าแรก",
+  donePerfectBadge: "ตอบถูกทั้งหมด",
   speakAriaLabel: "อ่านออกเสียงภาษาญี่ปุ่น",
   authSignIn: "เข้าสู่ระบบด้วย Google",
   authSignOut: "ออกจากระบบ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -252,6 +252,7 @@ export const vi: Copy = {
   correctShort: "Đúng",
   reviewShort: "Ôn",
   accuracyLabel: "Độ chính xác hiện tại",
+  accuracyShort: "Độ chính xác",
   scoreReportLabel: "Báo cáo hôm nay",
   shareTitle: "Chia sẻ kết quả của bạn",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const vi: Copy = {
     `Bộ này bạn đã làm ${cleared + remaining} câu — ${cleared} đúng, ${remaining} sai. Những câu sai đi vào phần ôn điểm yếu và sẽ quay lại lần sau.`,
   sessionDoneAgain: "Thêm một bộ",
   sessionDoneExit: "Về trang chủ",
+  donePerfectBadge: "Đúng tất cả",
   speakAriaLabel: "Đọc to tiếng Nhật",
   authSignIn: "Đăng nhập bằng Google",
   authSignOut: "Đăng xuất",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -252,6 +252,7 @@ export const zhHant: Copy = {
   correctShort: "正解",
   reviewShort: "複習",
   accuracyLabel: "目前正解率",
+  accuracyShort: "正解率",
   scoreReportLabel: "今日戰報",
   shareTitle: "分享成績",
   shareText: (attempts, accuracy) =>
@@ -388,6 +389,7 @@ export const zhHant: Copy = {
     `這一組練了 ${cleared + remaining} 題，答對 ${cleared}、答錯 ${remaining}。答錯的會進入弱點複習，下次複習時會再出現。`,
   sessionDoneAgain: "再來一組",
   sessionDoneExit: "回首頁",
+  donePerfectBadge: "全部答對",
   speakAriaLabel: "朗讀日文",
   authSignIn: "Google 登入",
   authSignOut: "登出",

--- a/src/styles/review.css
+++ b/src/styles/review.css
@@ -119,6 +119,35 @@
   border-top: 1px solid var(--panel-border);
 }
 
+/* Low-key feedback entry: report a bad question / drop a wish right after a
+   session, not just from the home footer. Quiet so it never competes with the
+   primary actions. */
+.done-feedback {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.7rem;
+  padding: 0.25rem 0.5rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.done-feedback:hover {
+  color: var(--ink);
+  text-decoration: underline;
+}
+
+.done-feedback svg {
+  width: 0.95rem;
+  height: 0.95rem;
+  flex-shrink: 0;
+}
+
 /* Quiet brand watermark so a screenshot of the card carries the source. */
 .done-watermark {
   margin: 0.35rem 0 0;

--- a/src/styles/review.css
+++ b/src/styles/review.css
@@ -53,3 +53,76 @@
   justify-content: center;
   margin-top: 0.4rem;
 }
+
+/* --- Session-complete card (the 這組練完了 "戰報" card) --- */
+
+/* A flawless-run pill: 全部答對 in the brand gold. */
+.done-perfect-badge {
+  display: inline-flex;
+  align-items: center;
+  background: color-mix(in srgb, var(--gold) 16%, transparent);
+  color: var(--gold);
+  border-radius: var(--radius-pill);
+  padding: 0.18rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* Three glanceable stat tiles: 已答 / 正解 / 正解率. */
+.done-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(4rem, 1fr));
+  gap: 0.55rem;
+  width: 100%;
+  max-width: 22rem;
+  margin: 0.2rem 0;
+  padding: 0;
+}
+
+.done-stat {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  gap: 0.15rem;
+  margin: 0;
+  padding: 0.55rem 0.4rem;
+  background: var(--paper-deep);
+  border-radius: var(--radius-md);
+}
+
+.done-stat dt {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.done-stat dd {
+  margin: 0;
+  font-size: 1.45rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.done-stat-correct dd {
+  color: var(--teal-dark);
+}
+
+/* Share panel on the card: a hairline divider sets it off from the actions. */
+.session-done .share-panel {
+  width: 100%;
+  max-width: 22rem;
+  margin-top: 0.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--panel-border);
+}
+
+/* Quiet brand watermark so a screenshot of the card carries the source. */
+.done-watermark {
+  margin: 0.35rem 0 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}


### PR DESCRIPTION
## 這組練完了！卡片重設計

把原本很空的 session-complete「圖卡」升級成一張可分享的**戰報卡**，並順手把 feedback 入口拉過來。

### 改了什麼
- **戰績磚**：已答 / 正解 / 正解率 三格數字，一眼看到成就（取代原本單行敘述）。
- **分享搬家**：`ShareButtons` 從「今日戰報」側欄移到這張卡（剛練完＝最想分享的時刻）；側欄戰報不再放分享，收斂雜訊。
- **插圖輪替 + 滿分彩蛋**：每組隨機一張和風插圖（新芽／御守／燈籠／鳥居／茶／靶），用 `sessionSeed` 定住（顯示中不閃、每組會換）；**全對**改出**開眼達摩（両目＝開眼）**＋「全部答對」徽章，並藏掉多餘的敘述行。
- **`jabiko.app` 浮水印**：就算只截圖不按分享，品牌也跟著走。
- **意見回饋入口**：完成卡多一個低調的「意見回饋」連結（開同一張表單，可切 回報問題／許願／其他）。剛答完題正是回報爛題的時機。
- **贊助刻意不放**：留在首頁腳，不插進「勝利時刻」。

### 工程
- 新增純函式 `pickDoneSpot(seed, isPerfect)`（TDD，`doneSpot.test.ts`）＋ `DarumaDoneSpot` 插圖。
- `onOpenFeedback` 由 App → ChallengePanel → DrillPanel 傳遞（optional，沒接就不渲染）。
- i18n：`accuracyShort` + `donePerfectBadge`，8 語系全補。
- Bundle 紀律維持：`examBlocks` 仍是獨立 lazy chunk、index 沒膨脹。

### 驗證
- `tsc --noEmit` 乾淨、`pnpm test` 750 綠（含 domain + 完成卡結構 + 滿分/一般/feedback 分支）、`pnpm build` 過。
- 實機（preview）驗過：一般卡、滿分卡（達摩 2 眼填滿 + 徽章 + 100%）、分享在卡上、浮水印、feedback 點擊開 modal——light + dark 兩色都對。

備註：無上限（endless）模式不會觸發完成卡，因此那模式失去「分享成績」入口；首頁腳的分享網站入口不受影響。若要保留 endless 分享可再議。
