### PR TITLE
fix(blog): 文章在上、日文教學在下 — 兩篇歌曲文章重排 + 日文教學 divider

### DIFF
--- a/src/components/BlogArticlePage.test.tsx
+++ b/src/components/BlogArticlePage.test.tsx
@@ -53,6 +53,28 @@ describe("BlogArticlePage", () => {
     expect(screen.getAllByText(/推し活/).length).toBeGreaterThan(0);
   });
 
+  it("renders the 日文教學 divider that opens the teaching half", () => {
+    render(
+      <BlogArticlePage
+        slug="cho-saikyo-tokimeki"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    const divider = screen.getByRole("separator", { name: "日文教學" });
+    expect(divider).toBeInTheDocument();
+    // The divider sits BEFORE every vocab table in document order (essay top,
+    // teaching bottom).
+    const body = divider.closest(".blog-article-body")!;
+    const firstVocab = body.querySelector(".blog-vocab");
+    expect(firstVocab).not.toBeNull();
+    expect(
+      divider.compareDocumentPosition(firstVocab!) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("passes the article CTA payload to the app-level handler", async () => {
     const user = userEvent.setup();
     const onCta = vi.fn();

--- a/src/components/BlogArticlePage.tsx
+++ b/src/components/BlogArticlePage.tsx
@@ -138,6 +138,12 @@ function ArticleBlockView({
           </ul>
         </div>
       );
+    case "divider":
+      return (
+        <div className="blog-divider" role="separator" aria-label={block.label}>
+          <span className="blog-divider-label">{block.label}</span>
+        </div>
+      );
     case "cta":
       return (
         <div className="blog-cta-block">

--- a/src/domain/articleBodies/sweetStep.ts
+++ b/src/domain/articleBodies/sweetStep.ts
@@ -21,6 +21,17 @@ export const sweetStepBody: ReadonlyArray<ArticleBlock> = [
     text:
       "這也是這首歌很適合學日文的地方。歌裡一邊承認妄想、逞強、不坦率、反省、疲累，一邊又用可愛、甜點、咒語和舞步，把還不完整的自己包成禮物送出去。它唱的不是「我已經找到完美的自己」，比較像是「我還在摸索，但我還是想繼續跳、繼續喜歡、繼續往前」。"
   },
+  { kind: "heading", text: "還在摸索，也可以被肯定" },
+  {
+    kind: "paragraph",
+    text:
+      "〈SWEET STEP〉可愛的地方，不只是旋律甜、舞步好記，而是它把「還不完整」唱得很輕。真正的自己不一定一開始就看得清楚。可能一邊逞強，一邊反省；一邊覺得累，一邊還是想被喜歡。"
+  },
+  {
+    kind: "paragraph",
+    text:
+      "所以這裡的 ありのまま 不是一句空泛的鼓勵。它更像是：就算我還沒完全懂自己，也可以先帶著現在的我，繼續踏出下一步。"
+  },
   {
     kind: "links",
     label: "延伸觀看與資料",
@@ -43,6 +54,7 @@ export const sweetStepBody: ReadonlyArray<ArticleBlock> = [
       }
     ]
   },
+  { kind: "divider", label: "日文教學" },
   {
     kind: "callout",
     text:
@@ -210,17 +222,6 @@ export const sweetStepBody: ReadonlyArray<ArticleBlock> = [
           "來自英文 buzz，常見於社群和短影音語境。例：この曲のサビがSNSでバズっている。／這首歌的副歌在社群上爆紅。"
       }
     ]
-  },
-  { kind: "heading", text: "還在摸索，也可以被肯定" },
-  {
-    kind: "paragraph",
-    text:
-      "〈SWEET STEP〉可愛的地方，不只是旋律甜、舞步好記，而是它把「還不完整」唱得很輕。真正的自己不一定一開始就看得清楚。可能一邊逞強，一邊反省；一邊覺得累，一邊還是想被喜歡。"
-  },
-  {
-    kind: "paragraph",
-    text:
-      "所以這裡的 ありのまま 不是一句空泛的鼓勵。它更像是：就算我還沒完全懂自己，也可以先帶著現在的我，繼續踏出下一步。"
   },
   {
     kind: "cta",

--- a/src/domain/articles.test.ts
+++ b/src/domain/articles.test.ts
@@ -80,6 +80,8 @@ describe("blog articles data guard", () => {
         } else if (block.kind === "lyricPoint") {
           expect(block.lyric.trim().length).toBeGreaterThan(0);
           expect(block.points.length).toBeGreaterThan(0);
+        } else if (block.kind === "divider") {
+          expect(block.label.trim().length).toBeGreaterThan(0);
         } else if (block.kind === "cta") {
           expect(block.cta.label.trim().length).toBeGreaterThan(0);
           if (block.cta.kind === "grammar") {
@@ -87,6 +89,27 @@ describe("blog articles data guard", () => {
           }
         }
       }
+    }
+  });
+
+  it("keeps the essay on top and all teaching below a single 日文教學 divider", () => {
+    for (const a of publishedArticles) {
+      const dividerIndexes = a.body
+        .map((block, index) => (block.kind === "divider" ? index : -1))
+        .filter((index) => index >= 0);
+      // Exactly one divider splits 文章 (essay, top) from 日文教學 (teaching, bottom).
+      expect(dividerIndexes, a.slug).toHaveLength(1);
+      const divider = dividerIndexes[0];
+      a.body.forEach((block, index) => {
+        // Every vocab table lives BELOW the divider (no teaching in the essay)…
+        if (block.kind === "vocab") {
+          expect(index, `${a.slug}: vocab block above the divider`).toBeGreaterThan(divider);
+        }
+        // …and no essay-conclusion heading trails at the end (e.g. 「最後：…」).
+        if (block.kind === "heading") {
+          expect(block.text, a.slug).not.toMatch(/^最後/);
+        }
+      });
     }
   });
 

--- a/src/domain/articles.ts
+++ b/src/domain/articles.ts
@@ -39,6 +39,10 @@ export type ArticleBlock =
   // are the original Japanese-learning notes drawn from it. `timestamp` is an
   // optional "where it appears in the MV" tag, e.g. "01:23".
   | { kind: "lyricPoint"; lyric: string; timestamp?: string; points: ReadonlyArray<string> }
+  // A labelled section break splitting the essay (top) from the Japanese-
+  // teaching half (bottom). Rendered as a horizontal rule with a centred
+  // label; articles.test.ts guards that every vocab block sits below it.
+  | { kind: "divider"; label: string }
   | { kind: "cta"; cta: ArticleCta };
 
 export interface BlogArticle extends ArticleMeta {
@@ -49,291 +53,6 @@ export interface BlogArticle extends ArticleMeta {
 // here (articles.test.ts guards it: an article whose body resolves to []
 // fails the non-empty-body check).
 const BODIES: Record<string, ReadonlyArray<ArticleBlock>> = {
-  "sweet-step-steady": [
-    {
-      kind: "lead",
-      text: "〈SWEET STEP〉是 KAWAII LAB.（FRUITS ZIPPER 等團所屬的偶像企劃）旗下團體 SWEET STEADY 的代表曲。第一次聽可能會覺得它就是一首可愛、洗腦、很適合短影音的偶像歌；但越聽越會發現，它其實不是單純的甜歌——底下藏著一個關於「還不確定真正的自己是誰」的細膩主題。"
-    },
-    { kind: "heading", text: "這首歌在唱什麼" },
-    {
-      kind: "paragraph",
-      text: "這首歌的核心是一個很日常也很現代的問題：大家都說「做自己就好」，但「真正的自己」到底長什麼樣？歌裡的主角會妄想、會逞強、會不坦率、會反省，也會覺得自己有點遜——它沒有假裝自我肯定很容易，而是誠實承認「其實我也還在摸索」。"
-    },
-    {
-      kind: "paragraph",
-      text: "而它給的答案不是「想清楚再出發」，而是更任性也更溫柔的一句：那就先跳、先把停不下來的「喜歡」放下去，把真正的自己（連同那份不安）好好裝飾、包起來，用最可愛的方式送到你面前。這很偶像，也很 SWEET STEADY——不是把不安藏起來，而是把不安一起裝飾成可愛的一部分。"
-    },
-    { kind: "heading", text: "為什麼〈SWEET STEP〉像一首「入坑裝置」" },
-    {
-      kind: "paragraph",
-      text: "這首歌厲害的地方不只是好聽，而是它把偶像「入坑」會需要的元素都接了起來。開頭那串像咒語的副歌，其實是用各種語言在說「跳舞」（文末小專欄會拆），聽感像魔法、又緊扣「STEP／舞蹈」主題，非常洗腦。現場演出的版本又把這個設計放大，加上成員輪流帶名字的口上，讓它不只是一首可愛歌，更像 SWEET STEADY 整團的「團體名片」。而那段口上用「種子→開花」的意象，講的是一個「正在長大」的成長故事——聽到這裡，你會從「這首歌好可愛」變成「想看她們接下來怎麼開花」。"
-    },
-    {
-      kind: "links",
-      label: "先看官方 MV",
-      items: [
-        {
-          label: "SWEET STEADY「SWEET STEP」官方 MV（YouTube）",
-          url: "https://www.youtube.com/watch?v=1546cwoU6Wg"
-        }
-      ]
-    },
-    {
-      kind: "callout",
-      text: "下面挑的是歌裡出現的日文「單字與說法」，例句都是原創、跟歌詞無關。想看完整歌詞就點上面的官方 MV 邊聽邊看。"
-    },
-    { kind: "heading", text: "主題核心：自我摸索的一組詞" },
-    {
-      kind: "vocab",
-      items: [
-        {
-          word: "ありのまま",
-          reading: "ありのまま",
-          meaning: "原本的樣子、不加修飾的真實自己。",
-          note: "整首歌的題眼。例：ありのままの自分でいたい（想做真實的自己）。"
-        },
-        {
-          word: "妄想",
-          reading: "もうそう",
-          meaning: "妄想、（不切實際的）幻想。",
-          note: "口語常帶點自嘲。例：勝手に妄想が膨らむ（自顧自地越想越多）。"
-        },
-        {
-          word: "反省",
-          reading: "はんせい",
-          meaning: "反省、檢討自己。",
-          note: "例：ちゃんと反省してます（我有好好反省）。"
-        },
-        {
-          word: "取り繕う",
-          reading: "とりつくろう",
-          meaning: "敷衍掩飾、硬撐場面、裝沒事。",
-          note: "例：笑顔で取り繕う（用笑容硬撐過去）。"
-        },
-        {
-          word: "らしくない",
-          reading: "らしくない",
-          meaning: "不像（某人的）作風、不像平常的樣子。",
-          note: "「〜らしい」的否定。例：弱音を吐くなんて君らしくない（說喪氣話不像你）。"
-        },
-        {
-          word: "ダサい",
-          reading: "ダサい",
-          meaning: "土、遜、不酷。",
-          note: "口語形容詞。例：それ、ちょっとダサいかも（那個有點遜）。"
-        },
-        {
-          word: "充分",
-          reading: "じゅうぶん",
-          meaning: "足夠、充分（也寫「十分」）。",
-          note: "例：気持ちだけで充分だよ（有這份心意就夠了）。"
-        },
-        {
-          word: "退屈",
-          reading: "たいくつ",
-          meaning: "無聊、無趣。",
-          note: "例：退屈で死にそう（無聊到不行）。"
-        },
-        {
-          word: "丁度いい",
-          reading: "ちょうどいい",
-          meaning: "剛剛好、恰到好處。",
-          note: "例：辛さが丁度いい（辣度剛剛好）。"
-        }
-      ]
-    },
-    { kind: "heading", text: "可愛・閃耀・甜點比喻" },
-    {
-      kind: "vocab",
-      items: [
-        {
-          word: "キュンとする",
-          reading: "キュンとする",
-          meaning: "心頭一緊、小鹿亂撞。",
-          note: "「キュン」是心揪一下的擬態語。例：その仕草にキュンとした（被那個小動作萌到）。"
-        },
-        {
-          word: "煌めく",
-          reading: "きらめく",
-          meaning: "閃耀、閃爍。",
-          note: "比「光る」更華麗。例：夜空に星が煌めく（星星在夜空閃耀）。"
-        },
-        {
-          word: "飾り付ける",
-          reading: "かざりつける",
-          meaning: "裝飾、佈置。",
-          note: "例：部屋を可愛く飾り付ける（把房間佈置得很可愛）。"
-        },
-        {
-          word: "包み込む",
-          reading: "つつみこむ",
-          meaning: "整個包住、包覆。",
-          note: "例：優しさで包み込む（用溫柔包覆對方）。"
-        },
-        {
-          word: "しゅんわり",
-          reading: "しゅんわり",
-          meaning: "軟綿綿、輕柔蓬鬆的擬態語。",
-          note: "造語感重、很可愛的詞。例：焼きたてのパンがしゅんわり柔らかい（剛烤好的麵包軟綿綿的）。"
-        },
-        {
-          word: "スパイス",
-          reading: "スパイス",
-          meaning: "香料；引申「調味、增添刺激的東西」。",
-          note: "例：適度な緊張はスパイスになる（適度的緊張能成為調味料）。"
-        },
-        {
-          word: "呪文",
-          reading: "じゅもん",
-          meaning: "咒語。",
-          note: "例：呪文を唱える（唸咒語）。歌裡跟南瓜馬車一起用，是童話意象。"
-        },
-        {
-          word: "馬車",
-          reading: "ばしゃ",
-          meaning: "馬車（灰姑娘的南瓜馬車意象）。",
-          note: "例：かぼちゃの馬車に乗る（坐上南瓜馬車）。"
-        },
-        {
-          word: "砂糖",
-          reading: "さとう",
-          meaning: "砂糖。",
-          note: "例：コーヒーに砂糖を入れる（在咖啡裡加糖）。"
-        },
-        {
-          word: "お好み",
-          reading: "おこのみ",
-          meaning: "喜好、偏好。",
-          note: "例：トッピングはお好みでどうぞ（配料請依喜好取用）。「お好み焼き」也是這個詞。"
-        },
-        {
-          word: "フレーバー",
-          reading: "フレーバー",
-          meaning: "口味、風味（flavor）。",
-          note: "例：新しいフレーバーのアイスを試す（試新口味的冰淇淋）。"
-        },
-        {
-          word: "溶け出す",
-          reading: "とけだす",
-          meaning: "開始融化／溶解出來（複合動詞）。",
-          note: "「溶ける＋出す（開始…）」。例：チョコが手の中で溶け出した（巧克力在手裡開始融化）。"
-        }
-      ]
-    },
-    { kind: "heading", text: "口語・程度・其他" },
-    {
-      kind: "vocab",
-      items: [
-        {
-          word: "〜てこ",
-          reading: "〜てこ",
-          meaning: "「〜ていこう」的口語縮約，「（一起）…下去吧」。",
-          note: "很青春的收尾語氣。例：これからも頑張ってこ（今後也一起加油下去吧）。"
-        },
-        {
-          word: "〜ちゃう",
-          reading: "〜ちゃう",
-          meaning: "「〜てしまう」的口語縮約，表「不小心／乾脆就…了」。",
-          note: "例：つい笑っちゃう（忍不住就笑了）。／全部食べちゃった（不小心全吃光了）。"
-        },
-        {
-          word: "ホント・ジブン",
-          reading: "ホント・ジブン",
-          meaning: "本当・自分刻意用「片假名」寫。",
-          note: "把普通漢字詞寫成カタカナ，是歌詞、SNS 常見的「口語、俏皮、強調」語感。例：ホントに嬉しい（真的超開心）。"
-        },
-        {
-          word: "億千万",
-          reading: "おくせんまん",
-          meaning: "億萬——用來誇飾「多到數不清」。",
-          note: "例：億千万の言葉より一つの行動（勝過億萬句話的一個行動）。"
-        },
-        {
-          word: "掻き消す",
-          reading: "かきけす",
-          meaning: "蓋過、抹去（聲音、痕跡等）。",
-          note: "例：波の音が声を掻き消す（浪聲蓋過了說話聲）。"
-        },
-        {
-          word: "まだまだ",
-          reading: "まだまだ",
-          meaning: "還早得很、還不夠、還有得是。",
-          note: "例：まだまだこれから（好戲還在後頭）。"
-        },
-        {
-          word: "もっと",
-          reading: "もっと",
-          meaning: "更多、再多一點。",
-          note: "例：もっと上手くなりたい（想變得更厲害）。"
-        }
-      ]
-    },
-    { kind: "heading", text: "現場口上（開場口白）裡的詞" },
-    {
-      kind: "paragraph",
-      text: "她們現場常有一段元氣滿滿的「口上」（開場口白），裡面也藏了實用日文。挑幾個標準詞來學（一樣，例句原創、不照搬口白）。"
-    },
-    {
-      kind: "vocab",
-      items: [
-        {
-          word: "おっとっと",
-          reading: "おっとっと",
-          meaning: "感嘆詞，快跌倒／失去平衡時的「哎呀、哎喲」。",
-          note: "倒飲料喊停時也用。例：おっとっと、危ない（哎呀、差點跌倒）。"
-        },
-        {
-          word: "つまずく",
-          reading: "つまずく",
-          meaning: "絆倒、跌跤；引申「受挫、卡關」。",
-          note: "漢字「躓く」。例：石につまずく（被石頭絆倒）。／途中でつまずく（中途卡關）。"
-        },
-        {
-          word: "手を取る",
-          reading: "てをとる",
-          meaning: "牽手；「手を取り合う」＝攜手合作。",
-          note: "例：みんなで手を取り合って進む（大家攜手前進）。"
-        },
-        {
-          word: "着実",
-          reading: "ちゃくじつ",
-          meaning: "踏實、穩紮穩打。",
-          note: "常用「着実に」。例：着実に前進する（穩紮穩打地前進）。"
-        },
-        {
-          word: "大輪",
-          reading: "たいりん",
-          meaning: "一大朵（花）。",
-          note: "例：大輪のひまわりが咲く（一大朵向日葵綻放）。"
-        },
-        {
-          word: "種",
-          reading: "たね",
-          meaning: "種子；也指「原因、來源、材料」。",
-          note: "例：花の種をまく（播花的種子）。／悩みの種（煩惱的根源）。"
-        },
-        {
-          word: "花を咲かせる",
-          reading: "はなをさかせる",
-          meaning: "使開花；慣用「開花結果、大放異彩」。",
-          note: "例：努力が実って花を咲かせる（努力終於開花結果）。"
-        }
-      ]
-    },
-    { kind: "heading", text: "小專欄：副歌那串「跳舞」是多國語言接龍" },
-    {
-      kind: "paragraph",
-      text: "副歌前那串聽起來像亂碼的詞，其實全部都是「跳舞」，用不同語言接龍：Dancin’（英語）→ 踊って（日語）→ baila（西班牙語）→ rince（愛爾蘭語）→ ram＝รำ（泰語）→ büjiglekh＝Бүжиглэх（蒙古語）→ šokis（立陶宛語）。知道這個梗，再聽副歌會突然「原來是這樣！」——也是個很好的日文以外的小知識。"
-    },
-    {
-      kind: "paragraph",
-      text: "〈SWEET STEP〉真正可愛的地方，不是假裝一切都很順，而是它老實承認了很多不安——不知道真正的自己是誰、有時候不坦率、有時候硬撐、有時候覺得自己很遜，連甜甜的步伐都會讓人累。但它沒有停在這裡，而是決定：那就繼續跳、繼續喜歡，把那些笨拙、逞強、妄想、反省，全都裝飾起來，包成一份屬於自己的可愛送給你。所以它不只是甜——它是一首把「還在摸索自己的我」也一起肯定下來的歌。把上面這些詞記熟，再去點 MV 邊聽邊對，抒情的副歌會突然好懂不少。"
-    },
-    {
-      kind: "cta",
-      cta: { kind: "challenge", mode: "vocab", label: "把單字練熟：去單字讀音刷一輪 →" }
-    }
-  ],
   "cho-saikyo-tokimeki": [
     {
       kind: "lead",
@@ -357,6 +76,11 @@ const BODIES: Record<string, ReadonlyArray<ArticleBlock>> = {
       kind: "paragraph",
       text: "所以 live 裡那聲「かわいい！」不是硬塞互動，而是在完成這首歌的邏輯。粉絲說偶像可愛，偶像因為被這樣肯定而變得更可愛，再把這份可愛還給粉絲。這裡的 かわいい 不是單方面供給，比較像一個來回循環。聽懂這點，再看歌裡的推し活詞彙，就不會只覺得它是在列周邊和 SNS 行為。"
     },
+    { kind: "heading", text: "為什麼〈超最強〉很強？" },
+    {
+      kind: "paragraph",
+      text: "〈超最強〉真正厲害的地方，是把粉絲平常覺得有點宅、有點不好意思的行為，全都唱成理直氣壯的可愛——設鎖屏、相簿全是她、把小卡夾進手機殼、帶著娃娃出門、留言按讚寫レポ布教。這些不是粉絲單方面沉迷，而是偶像和粉絲一起完成的循環。粉絲喊「かわいい！」，偶像接住這份肯定，變得更可愛，再把可愛還給粉絲。聽懂這個循環，推し、布教、レス、レポ 這些詞就不只是粉絲圈術語，而是這首歌真正運作的文法。"
+    },
     {
       kind: "links",
       label: "官方 MV 與背景資料",
@@ -379,6 +103,7 @@ const BODIES: Record<string, ReadonlyArray<ArticleBlock>> = {
         }
       ]
     },
+    { kind: "divider", label: "日文教學" },
     {
       kind: "callout",
       text: "下面挑的是歌裡值得學的日文「單字與說法」。不整理完整歌詞，也不把它寫成粉絲頁；重點是看這些詞在偶像歌和推し活裡怎麼用。例句都是原創。"
@@ -574,11 +299,6 @@ const BODIES: Record<string, ReadonlyArray<ArticleBlock>> = {
           note: "例：本にしおりを挟む（在書裡夾書籤）。／ケースにトレカを挟む（把小卡夾進手機殼）。"
         }
       ]
-    },
-    { kind: "heading", text: "最後：為什麼〈超最強〉很強？" },
-    {
-      kind: "paragraph",
-      text: "〈超最強〉真正厲害的地方，是把粉絲平常覺得有點宅、有點不好意思的行為，全都唱成理直氣壯的可愛——設鎖屏、相簿全是她、把小卡夾進手機殼、帶著娃娃出門、留言按讚寫レポ布教。這些不是粉絲單方面沉迷，而是偶像和粉絲一起完成的循環。粉絲喊「かわいい！」，偶像接住這份肯定，變得更可愛，再把可愛還給粉絲。聽懂這個循環，推し、布教、レス、レポ 這些詞就不只是粉絲圈術語，而是這首歌真正運作的文法。"
     },
     {
       kind: "cta",

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -216,6 +216,31 @@
   color: var(--ink);
 }
 
+/* Essay / teaching section break: a labelled rule so the 日文教學 half reads
+   as its own zone below the essay. */
+.blog-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin: 1.8rem 0 0.4rem;
+}
+
+.blog-divider::before,
+.blog-divider::after {
+  content: "";
+  flex: 1;
+  border-top: 1px solid var(--rule);
+}
+
+.blog-divider-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.35em;
+  padding-left: 0.35em; /* optically recentre: balances the trailing letter-space */
+  color: var(--muted);
+  white-space: nowrap;
+}
+
 /* Vocab table */
 .blog-vocab {
   background: var(--paper);


### PR DESCRIPTION
#483 follow-up（作者指示的小修：文章架構＋UI）。

## 改動
- **兩篇歌曲文章重排**：敘事（文章）全部移到上半、日文教學（單字表等）全部在下半。超最強的「最後：為什麼〈超最強〉很強？」與 SWEET STEP 的「還在摸索，也可以被肯定」收尾段都移回文章區、不再掉在教學後面（超最強標題去掉「最後：」）。
- **UI：新增 `divider` 區塊**（「日文教學」分節線，label＋左右橫線、`role=separator`），文章區／教學區視覺分開。
- **結構 guard 測試**（TDD 先紅後綠）：每篇 published 文章恰一個 divider、所有 vocab 區塊必在 divider 之後、無「最後：」開頭的標題；BlogArticlePage 渲染測試驗 divider 在首個單字表之前。
- **清死碼**：`articles.ts` 裡舊版 SWEET STEP body（slug alias 導向 override 後不可達，-285 行）。

## 驗證
- typecheck ✅／test **741 passed** ✅（含 2 個新測試，先觀察到紅）／build（pre-push hook）✅
- Preview 實機驗證兩篇 DOM 順序：lead→敘事段→links→**divider 日文教學**→callout→單字表×N→CTA；divider 樣式生效、console 無錯誤。
- 內容僅「搬移既有原創解說區塊」，未新增歌詞內容（維持外連原則）。