### PR TITLE
fix(deploy): CSS cache-bust — 解除 jabiko.app 邊緣快取中毒（全站無樣式事故）

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -245,3 +245,14 @@ rt {
   line-height: 1.1;
   user-select: none;
 }
+
+/* Asset-cache bust (2026-07-06 incident): during the #505/#504 back-to-back
+   deploys, some Cloudflare edge nodes cached the SPA fallback (index.html,
+   served 200 by public/_redirects for a not-yet-propagated asset URL) AS the
+   stylesheet, stamped immutable by the /assets/* rule in public/_headers.
+   Changing this value changes the built CSS hash, moving everyone to a clean,
+   never-poisoned URL (and refreshing the PWA precache manifest). Bump it if
+   an asset URL ever gets edge-poisoned again. */
+:root {
+  --jabiko-css-rev: 20260706;
+}


### PR DESCRIPTION
## 事故（線上全站無樣式）
#505/#504 連續兩次部署的交接空窗，Cloudflare 邊緣對**瀏覽器請求**把 SPA fallback（`_redirects` 對不存在資產回 200 的 index.html）快取成 CSS，並被 `_headers` 的 `/assets/* immutable, max-age=1y` 釘死 → 中毒節點回給瀏覽器的 `index-Dl-86mSG.css` 是 `text/html` → 瀏覽器拒絕套用 → 吉祥物 SVG 以原始尺寸撐爆。

**已重現且排除其他因**：全新無痕 headless Chrome 打 prod → CSS 回 text/html（console: Refused to apply style, MIME text/html）；作者端 Chrome＋無痕＋手機三處同症；同時 curl 抓同一 URL 卻是正確 text/css（origin 沒壞、本機 dev/dist 皆正常）→ 純邊緣快取中毒、非程式碼 bug、revert 無效（碰不到邊緣快取且會再觸發同 race）。

## 修法
一條無視覺影響的 `:root` 變數（附完整事故註解）→ CSS hash 換新（`Dl-86mSG` → `B_FZNXNf`）→ 所有客戶端改抓從未被毒的網址；新 SW precache manifest 同步讓黏住 immutable 舊檔的 PWA 客戶端自癒。

## 併行的即時處置
owner 於 Cloudflare 後台 Purge Everything（清邊緣快取，無痕/手機/新訪客秒恢復）。本 PR 是耐久修復＋救本機已中毒的客戶端。

## 後續
根因（`/assets/*` miss 不該回 200 HTML、immutable 不該蓋到 fallback、部署間隔紀律）另開 issue。

（TDD 豁免：純樣式常數、無行為改動；本機 `pnpm build` 綠、新 hash 已驗。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stylesheet versioning so users are more likely to receive the latest styles after deployment.
  * Reduced the chance of seeing stale cached CSS in the browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->