### PR TITLE
fix(recovery): 客戶端自癒 + /assets 404 守門 — 快取中毒事故根治（#507）

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,21 +1,28 @@
-// Cloudflare Pages Functions middleware: 301 the old shared origin
-// (jabiko.pages.dev) to the canonical custom domain (#jabiko-app-domain).
+// Cloudflare Pages Functions middleware, two jobs:
 //
-// Why a Function and not _redirects: Pages' _redirects only supports
-// path-based sources — Netlify-style absolute-URL/host rules are silently
-// ignored (verified in prod: the host rule never fired). Host logic needs
-// code. _routes.json keeps static assets (hashed chunks, images, sw.js)
-// out of this middleware, so old links' OG previews still resolve and the
-// free Functions quota is only spent on navigations.
+// 1. 301 the old shared origin (jabiko.pages.dev) to the canonical custom
+//    domain (#jabiko-app-domain). Why a Function and not _redirects: Pages'
+//    _redirects only supports path-based sources — Netlify-style
+//    absolute-URL/host rules are silently ignored (verified in prod). Host
+//    logic needs code. The origin-migration bridge is exempt: jabiko.app
+//    iframes it ON the old origin to pull a visitor's localStorage across
+//    (src/domain/originMigration.ts); redirecting would break that pull.
 //
-// The origin-migration bridge is exempt: jabiko.app iframes it ON the old
-// origin to pull a visitor's localStorage across (see
-// src/domain/originMigration.ts). Redirecting it would break that pull —
-// the iframe would land same-origin and the origin check would reject it.
+// 2. Guard /assets/* against the SPA-fallback poison (2026-07-06 outage,
+//    #507): a request for a not-yet-propagated hashed asset used to fall
+//    through to _redirects' `/* /index.html 200` and come back as HTML with
+//    200 — which edges/browsers then cached AS the asset (public/_headers
+//    marks /assets/* immutable for a year), breaking the app until a manual
+//    purge. The guard turns that fallback into an uncacheable 404, so the
+//    poison can never enter a cache. Trade-off: /assets/* now runs through
+//    this Function (see public/_routes.json), which skips Cloudflare's edge
+//    cache for assets — acceptable because browsers still cache them as
+//    immutable; revisit with the Cache API if Function quota ever hurts.
 
 const CANONICAL_ORIGIN = "https://jabiko.app";
 const OLD_HOST = "jabiko.pages.dev";
 const BRIDGE_PREFIX = "/migration-bridge";
+const ASSETS_PREFIX = "/assets/";
 
 /** Pure decision: the 301 target for `url`, or null to serve normally. */
 export function redirectTargetFor(url) {
@@ -26,7 +33,33 @@ export function redirectTargetFor(url) {
   return CANONICAL_ORIGIN + u.pathname + u.search;
 }
 
+/** Pure decision: the uncacheable 404 replacing a poisoned asset response,
+ *  or null to serve the response as-is. Only /assets/* is guarded, and only
+ *  when the "asset" came back as HTML (= the SPA fallback, never a real
+ *  build file). */
+export function guardedAssetResponse(pathname, response) {
+  if (!pathname.startsWith(ASSETS_PREFIX)) return null;
+  const type = response.headers.get("content-type") || "";
+  if (!type.includes("text/html")) return null;
+  return new Response("Not found", {
+    status: 404,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store"
+    }
+  });
+}
+
 export async function onRequest(context) {
+  const { pathname } = new URL(context.request.url);
+
+  // Assets are never host-redirected (old links' OG images on pages.dev must
+  // keep resolving) — they only get the poisoned-fallback guard.
+  if (pathname.startsWith(ASSETS_PREFIX)) {
+    const response = await context.next();
+    return guardedAssetResponse(pathname, response) ?? response;
+  }
+
   const target = redirectTargetFor(context.request.url);
   if (target !== null) return Response.redirect(target, 301);
   return context.next();

--- a/functions/_middleware.test.mjs
+++ b/functions/_middleware.test.mjs
@@ -39,3 +39,64 @@ describe("pages.dev -> jabiko.app middleware", () => {
     expect(await passed.text()).toBe("shell");
   });
 });
+
+// 2026-07-06 outage guard: a missing /assets/* file used to fall through to
+// the _redirects SPA rule and come back as index.html with 200 — which the
+// edge/browser then cached as the asset itself (immutable), breaking the app
+// for everyone who fetched during a deploy transition. The middleware must
+// turn that fallback into an uncacheable 404 so poison can never be cached.
+describe("/assets/* poisoned-fallback guard", () => {
+  const htmlFallback = () =>
+    Promise.resolve(
+      new Response("<!doctype html><title>shell</title>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      })
+    );
+
+  it("turns an HTML fallback on an /assets/ path into an uncacheable 404", async () => {
+    const res = await onRequest({
+      request: new Request("https://jabiko.app/assets/ChallengePanel-XYZ.js"),
+      next: htmlFallback
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    expect(res.headers.get("content-type")).not.toContain("text/html");
+  });
+
+  it("passes real assets through untouched", async () => {
+    const res = await onRequest({
+      request: new Request("https://jabiko.app/assets/index-ABC.js"),
+      next: () =>
+        Promise.resolve(
+          new Response("console.log(1)", {
+            status: 200,
+            headers: { "content-type": "application/javascript" }
+          })
+        )
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("console.log(1)");
+  });
+
+  it("leaves the SPA HTML fallback alone for non-asset routes", async () => {
+    const res = await onRequest({
+      request: new Request("https://jabiko.app/challenge"),
+      next: htmlFallback
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("does not 301 old-origin asset requests (OG images on pages.dev keep resolving)", async () => {
+    const res = await onRequest({
+      request: new Request("https://jabiko.pages.dev/assets/og-XYZ.png"),
+      next: () =>
+        Promise.resolve(
+          new Response("png-bytes", { status: 200, headers: { "content-type": "image/png" } })
+        )
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("png-bytes");
+  });
+});

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,9 +1,8 @@
 {
   "version": 1,
-  "description": "Run the redirect middleware (functions/_middleware.js) only for navigations: static assets are excluded so they serve directly from the CDN (old links' images/scripts keep resolving on pages.dev, and Functions invocations are spent only on page loads).",
+  "description": "Run the middleware (functions/_middleware.js) for navigations AND for /assets/*. Navigations get the pages.dev -> jabiko.app 301; /assets/* gets the poisoned-fallback guard (#507: an asset miss must 404, never be cached as index.html). Other static files stay excluded so they serve straight from the CDN and Functions quota stays small; root *.js/*.css (sw.js etc.) are must-revalidate, so they cannot be pinned by a poisoned cache the way immutable /assets/* files were.",
   "include": ["/*"],
   "exclude": [
-    "/assets/*",
     "/*.png",
     "/*.svg",
     "/*.webp",

--- a/src/components/RouteErrorBoundary.test.tsx
+++ b/src/components/RouteErrorBoundary.test.tsx
@@ -1,9 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RouteErrorBoundary } from "./RouteErrorBoundary";
 
 function Thrower() {
   throw new Error("route failed");
+  return null;
+}
+
+// A poisoned-cache chunk failure, as Chrome reports it (2026-07-06 outage).
+function ChunkThrower() {
+  throw new TypeError(
+    "Failed to fetch dynamically imported module: https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js"
+  );
   return null;
 }
 
@@ -34,6 +43,107 @@ describe("RouteErrorBoundary", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("Page failed");
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
+
+  it("auto-recovers a chunk-load failure once: repair caches, then reload", async () => {
+    sessionStorage.clear();
+    const recover = vi.fn().mockResolvedValue(true);
+    const reload = vi.fn();
+
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        recover={recover}
+        reload={reload}
+      >
+        <ChunkThrower />
+      </RouteErrorBoundary>
+    );
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(recover).toHaveBeenCalledTimes(1);
+    // The auto path repairs silently -- no error screen flash into view.
+    expect(screen.queryByRole("button", { name: "Reload" })).not.toBeInTheDocument();
+  });
+
+  it("stops auto-reloading after the attempt budget and shows the fallback instead", async () => {
+    sessionStorage.clear();
+    const recover = vi.fn().mockResolvedValue(true);
+    const reload = vi.fn();
+
+    const ui = (
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        recover={recover}
+        reload={reload}
+      >
+        <ChunkThrower />
+      </RouteErrorBoundary>
+    );
+
+    const first = render(ui);
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    // Same session, second mount = the post-reload page failing again.
+    render(ui);
+    expect(await screen.findByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(reload).toHaveBeenCalledTimes(1); // no reload loop
+  });
+
+  it("does not auto-reload for ordinary render errors", async () => {
+    sessionStorage.clear();
+    const recover = vi.fn().mockResolvedValue(true);
+    const reload = vi.fn();
+
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        recover={recover}
+        reload={reload}
+      >
+        <Thrower />
+      </RouteErrorBoundary>
+    );
+
+    expect(await screen.findByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("the reload button repairs caches before reloading (never a bare reload)", async () => {
+    sessionStorage.clear();
+    const user = userEvent.setup();
+    const recover = vi.fn().mockResolvedValue(true);
+    const reload = vi.fn();
+
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        recover={recover}
+        reload={reload}
+      >
+        <Thrower />
+      </RouteErrorBoundary>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reload" }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(recover).toHaveBeenCalledTimes(1);
+    // recover must complete before reload fires
+    expect(recover.mock.invocationCallOrder[0]).toBeLessThan(reload.mock.invocationCallOrder[0]);
   });
 
   it("resets after the route key changes", () => {

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -1,4 +1,26 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { isChunkLoadError, recoverPoisonedAssets } from "../lib/assetRecovery";
+
+// One silent self-repair per session: enough to recover a poisoned cache
+// (2026-07-06 outage) without ever looping a genuinely broken deploy.
+const RECOVERY_ATTEMPT_KEY = "jabiko:route-recovery";
+
+function recoveryAttempts(): number {
+  try {
+    return Number(sessionStorage.getItem(RECOVERY_ATTEMPT_KEY)) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function setRecoveryAttempts(count: number) {
+  try {
+    if (count <= 0) sessionStorage.removeItem(RECOVERY_ATTEMPT_KEY);
+    else sessionStorage.setItem(RECOVERY_ATTEMPT_KEY, String(count));
+  } catch {
+    // sessionStorage unavailable: recovery still runs, just unguarded.
+  }
+}
 
 type RouteErrorBoundaryProps = {
   resetKey: string;
@@ -6,42 +28,89 @@ type RouteErrorBoundaryProps = {
   body: string;
   reloadLabel: string;
   children: ReactNode;
+  /** Injectable for tests; defaults to the real cache-repair routine. */
+  recover?: (error: unknown) => Promise<boolean>;
+  /** Injectable for tests; defaults to window.location.reload(). */
+  reload?: () => void;
 };
 
 type RouteErrorBoundaryState = {
   error: Error | null;
+  /** A repair+reload is in flight (button disabled meanwhile). */
+  recovering: boolean;
+  /** The in-flight repair is the automatic one: keep the screen blank. */
+  silent: boolean;
 };
 
 export class RouteErrorBoundary extends Component<
   RouteErrorBoundaryProps,
   RouteErrorBoundaryState
 > {
-  state: RouteErrorBoundaryState = { error: null };
+  state: RouteErrorBoundaryState = { error: null, recovering: false, silent: false };
 
-  static getDerivedStateFromError(error: Error): RouteErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<RouteErrorBoundaryState> {
     return { error };
   }
 
   componentDidUpdate(prevProps: RouteErrorBoundaryProps) {
     if (prevProps.resetKey !== this.props.resetKey && this.state.error) {
-      this.setState({ error: null });
+      this.setState({ error: null, recovering: false, silent: false });
+    }
+    // A healthy render means any earlier repair worked — reopen the budget
+    // so a future incident gets its silent attempt again.
+    if (!this.state.error && recoveryAttempts() > 0) {
+      setRecoveryAttempts(0);
     }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error("[route-error]", error, errorInfo);
+    // Chunk-load failures are almost always a poisoned/stale local cache
+    // (immutable HTTP entry or old SW shell) — a bare reload can't fix those,
+    // so repair the caches and reload once, silently. Ordinary render errors
+    // never auto-reload (that would loop a real bug).
+    if (isChunkLoadError(error) && recoveryAttempts() < 1) {
+      setRecoveryAttempts(recoveryAttempts() + 1);
+      this.setState({ recovering: true, silent: true });
+      this.repairThenReload(error);
+    }
   }
+
+  repairThenReload(error: unknown) {
+    const { recover = recoverPoisonedAssets, reload = () => window.location.reload() } =
+      this.props;
+    recover(error)
+      .catch(() => undefined)
+      .then(() => reload());
+  }
+
+  handleReloadClick = () => {
+    // The button must actually repair, not just reload: for a user pinned by
+    // a poisoned immutable cache entry + stale SW, reload alone is a no-op.
+    this.setState({ recovering: true });
+    this.repairThenReload(this.state.error);
+  };
 
   render() {
     if (!this.state.error) {
       return this.props.children;
+    }
+    // While the silent auto-repair runs, keep the route blank instead of
+    // flashing an error screen the reload is about to replace anyway.
+    if (this.state.silent) {
+      return null;
     }
 
     return (
       <section className="route-error" role="alert" aria-live="assertive">
         <h2>{this.props.title}</h2>
         <p>{this.props.body}</p>
-        <button type="button" className="next-button" onClick={() => window.location.reload()}>
+        <button
+          type="button"
+          className="next-button"
+          disabled={this.state.recovering}
+          onClick={this.handleReloadClick}
+        >
           {this.props.reloadLabel}
         </button>
       </section>

--- a/src/lib/assetRecovery.test.ts
+++ b/src/lib/assetRecovery.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractAssetUrls, isChunkLoadError, recoverPoisonedAssets } from "./assetRecovery";
+
+// 2026-07-06 outage: /assets/* chunks poisoned as text/html got pinned in the
+// browser HTTP cache by the immutable header — a plain reload never refetches
+// them. Recovery must overwrite those cache entries (fetch cache:"reload"),
+// drop any stale service worker, and clear Cache Storage, all without ever
+// throwing (best effort in old browsers).
+
+describe("isChunkLoadError", () => {
+  it("recognises the chunk-load failure shapes of the major engines", () => {
+    // Chrome
+    expect(
+      isChunkLoadError(
+        new TypeError(
+          "Failed to fetch dynamically imported module: https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js"
+        )
+      )
+    ).toBe(true);
+    // Firefox
+    expect(isChunkLoadError(new TypeError("error loading dynamically imported module"))).toBe(true);
+    // Safari
+    expect(isChunkLoadError(new TypeError("Importing a module script failed."))).toBe(true);
+  });
+
+  it("does not fire for ordinary render errors", () => {
+    expect(isChunkLoadError(new Error("Cannot read properties of undefined"))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+  });
+});
+
+describe("extractAssetUrls", () => {
+  it("pulls the /assets/ URL out of a Chrome-style error message", () => {
+    const error = new TypeError(
+      "Failed to fetch dynamically imported module: https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js"
+    );
+    expect(extractAssetUrls(error)).toEqual([
+      "https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js"
+    ]);
+  });
+
+  it("returns [] when the engine gives no URL (Safari/Firefox)", () => {
+    expect(extractAssetUrls(new TypeError("Importing a module script failed."))).toEqual([]);
+    expect(extractAssetUrls(undefined)).toEqual([]);
+  });
+});
+
+describe("recoverPoisonedAssets", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("overwrites the poisoned HTTP-cache entry, unregisters SWs, and clears Cache Storage", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("js"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const unregister = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal("navigator", {
+      ...navigator,
+      serviceWorker: { getRegistrations: vi.fn().mockResolvedValue([{ unregister }]) }
+    });
+
+    const cacheDelete = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal("caches", {
+      keys: vi.fn().mockResolvedValue(["workbox-precache-v2"]),
+      delete: cacheDelete
+    });
+
+    const error = new TypeError(
+      "Failed to fetch dynamically imported module: https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js"
+    );
+    const acted = await recoverPoisonedAssets(error);
+
+    expect(acted).toBe(true);
+    // The one call that can actually evict an immutable poisoned entry:
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://jabiko.app/assets/ChallengePanel-D0s6xzVg.js",
+      expect.objectContaining({ cache: "reload" })
+    );
+    expect(unregister).toHaveBeenCalled();
+    expect(cacheDelete).toHaveBeenCalledWith("workbox-precache-v2");
+  });
+
+  it("never throws when the browser lacks SW/caches APIs", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    vi.stubGlobal("navigator", { ...navigator, serviceWorker: undefined });
+    vi.stubGlobal("caches", undefined);
+
+    await expect(
+      recoverPoisonedAssets(new TypeError("Importing a module script failed."))
+    ).resolves.toBe(true); // SW/caches best-effort still counts as an attempt
+  });
+});

--- a/src/lib/assetRecovery.ts
+++ b/src/lib/assetRecovery.ts
@@ -1,0 +1,71 @@
+// Client-side recovery for poisoned build assets (2026-07-06 outage).
+//
+// During a deploy transition, a request for a not-yet-propagated /assets/*
+// file fell through to the SPA fallback and came back as index.html with 200.
+// public/_headers marks /assets/* as `immutable, max-age=1y`, so browsers
+// pinned that HTML-as-JS/CSS in their HTTP disk cache — after which a plain
+// location.reload() NEVER refetches it: dynamic import() keeps reading the
+// poisoned entry and every challenge route dies with
+// "Failed to fetch dynamically imported module" / a MIME-type refusal.
+//
+// The one call that can evict such an entry from the HTTP cache is
+// `fetch(url, { cache: "reload" })`: it bypasses the cache, hits the network,
+// and REPLACES the stored entry with the fresh response. We also unregister
+// any service worker (a stale precache can keep serving an old app shell)
+// and drop Cache Storage. Everything is best-effort: recovery must never
+// throw, and partial repair + reload is still better than a dead page.
+//
+// This module is imported by RouteErrorBoundary (eager entry chunk) on
+// purpose — recovery code must never live in a lazy chunk that can itself be
+// poisoned.
+
+const ASSET_URL_PATTERN = /https?:\/\/[^\s'"()]+\/assets\/[^\s'"()]+/g;
+
+// Chunk-load failure messages of the major engines:
+//   Chrome:  "Failed to fetch dynamically imported module: <url>"
+//   Firefox: "error loading dynamically imported module"
+//   Safari:  "Importing a module script failed."
+const CHUNK_LOAD_PATTERN = /dynamically imported module|module script|loading chunk/i;
+
+export function isChunkLoadError(error: unknown): boolean {
+  return error instanceof Error && CHUNK_LOAD_PATTERN.test(error.message);
+}
+
+export function extractAssetUrls(error: unknown): string[] {
+  if (!(error instanceof Error)) return [];
+  return Array.from(new Set(error.message.match(ASSET_URL_PATTERN) ?? []));
+}
+
+// Repair the local caches that a plain reload cannot touch. Returns true when
+// a repair attempt ran (callers then reload to pick the fresh assets up).
+export async function recoverPoisonedAssets(error: unknown): Promise<boolean> {
+  // Overwrite each poisoned HTTP-cache entry with the live response.
+  for (const url of extractAssetUrls(error)) {
+    try {
+      await fetch(url, { cache: "reload" });
+    } catch {
+      // Offline / blocked: the reload that follows will surface it anyway.
+    }
+  }
+
+  // A stale service worker can keep serving an old app shell whose chunk
+  // URLs no longer exist; drop it and let the next load register fresh.
+  try {
+    const registrations = (await navigator.serviceWorker?.getRegistrations()) ?? [];
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  } catch {
+    // No SW support / detached — fine.
+  }
+
+  // Workbox precache may hold the poisoned copy too.
+  try {
+    if (typeof caches !== "undefined" && caches) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+    }
+  } catch {
+    // Cache Storage unavailable — fine.
+  }
+
+  return true;
+}


### PR DESCRIPTION
解決 #507 的兩個核心項。TDD（14 個新測試先紅後綠），全套 767 綠、typecheck/build 綠。

## 1. 客戶端自癒（使用者不再需要手動清快取）
中毒機制：部署空窗抓到的 chunk 被 `_headers` 的 immutable 釘進瀏覽器磁碟快取（text/html 假冒 JS），**location.reload() 永遠救不了**（immutable 不重驗）。
- 新 `src/lib/assetRecovery.ts`（eager entry chunk，不能放 lazy）：從錯誤訊息抽出 `/assets/...` URL → `fetch(url, { cache: "reload" })` **強制覆寫中毒的 HTTP 快取條目** → 註銷所有 service worker → 清 Cache Storage；全程 best-effort 永不 throw。
- `RouteErrorBoundary`：偵測 chunk-load 錯誤（Chrome/Firefox/Safari 三種訊息型）→ **自動修復＋自動 reload 一次**（sessionStorage 預算防迴圈；一般 render 錯誤絕不自動 reload）；「重新整理」按鈕也改為**先修復再 reload**（不再是白按的裸 reload）。健康渲染後重置預算。
- 對這次事故已卡死的使用者：部署後下次進站，載到壞 chunk → 自動修復 → 自動恢復，全程無感。

## 2. /assets/* 404 守門（毒進不了任何快取）
- `functions/_middleware.js` 新增 `guardedAssetResponse`：`/assets/*` 回應若是 text/html（＝SPA fallback 假冒資產，真 build 檔不可能是 HTML）→ 改回 **404 + no-store**。
- `public/_routes.json`：`/assets/*` 改進 middleware 範圍；pages.dev 的資產**不做 301**（保留 OG 圖解析行為，有測試鎖）。
- 取捨：assets 改走 Function、略過 CF 邊緣快取（瀏覽器端 immutable 快取不變）；quota 有壓力再上 Cache API（註解已留）。

## 事故背景
2026-07-06：#505/#504 連續部署空窗 → 邊緣把 SPA fallback 當資產快取（immutable）→ 全站無樣式/練習區死路；purge 後邊緣復原，但已中毒的客戶端因 immutable+SW 黏死、reload 無效。本 PR 讓「邊緣不再可能中毒」＋「客戶端中毒可自癒」。