### PR TITLE
fix(deploy): _routes 萬用字元吞掉 /assets 守門 — 逐檔排除 + verify:deploy 部署驗證（#507）

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build:furigana": "node scripts/build-furigana.mjs",
     "optimize-hero": "node scripts/optimize-hero.mjs",
     "pre": "pnpm build",
-    "build:sitemap": "node scripts/build-sitemap.mjs"
+    "build:sitemap": "node scripts/build-sitemap.mjs",
+    "verify:deploy": "node scripts/verify-deploy.mjs"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm build"

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,15 +1,18 @@
 {
   "version": 1,
-  "description": "Run the middleware (functions/_middleware.js) for navigations AND for /assets/*. Navigations get the pages.dev -> jabiko.app 301; /assets/* gets the poisoned-fallback guard (#507: an asset miss must 404, never be cached as index.html). Other static files stay excluded so they serve straight from the CDN and Functions quota stays small; root *.js/*.css (sw.js etc.) are must-revalidate, so they cannot be pinned by a poisoned cache the way immutable /assets/* files were.",
+  "description": "Run the middleware (functions/_middleware.js) for navigations AND for /assets/*: navigations get the pages.dev -> jabiko.app 301, /assets/* gets the poisoned-fallback guard (#507: an asset miss must 404, never be cached as index.html). GOTCHA (2026-07-06): Pages route wildcards span path segments, so a broad exclude like /*.js also swallowed /assets/index-*.js and silently disabled the guard — excludes must therefore name the root-level files explicitly and never use cross-segment extension globs.",
   "include": ["/*"],
   "exclude": [
-    "/*.png",
-    "/*.svg",
-    "/*.webp",
-    "/*.ico",
-    "/*.js",
-    "/*.css",
-    "/*.woff2",
+    "/apple-touch-icon.png",
+    "/hero.webp",
+    "/icon.svg",
+    "/og-image.png",
+    "/pwa-192x192.png",
+    "/pwa-512x512.png",
+    "/pwa-maskable-512x512.png",
+    "/sw.js",
+    "/registerSW.js",
+    "/workbox-*.js",
     "/manifest.webmanifest"
   ]
 }

--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -1,0 +1,76 @@
+// Post-deploy synthetic check (#507, born from the 2026-07-06 cache-poison
+// outage). Run after every production deploy:
+//
+//   pnpm verify:deploy                 # checks https://jabiko.app
+//   DEPLOY_URL=https://... pnpm verify:deploy
+//
+// It asserts the five invariants that, together, would have caught both the
+// original poisoning AND the _routes.json wildcard regression that silently
+// disabled the /assets guard:
+//   1. the entry HTML serves and references hashed assets
+//   2. the referenced CSS really is text/css (not a cached HTML fallback)
+//   3. the referenced JS really is JavaScript
+//   4. a MISSING /assets file returns 404 + no-store (the poison window)
+//   5. an SPA route still serves the app shell with 200
+//
+// Exit code 0 = all green; 1 = any failure (prints each check).
+
+const BASE = (process.env.DEPLOY_URL || "https://jabiko.app").replace(/\/$/, "");
+
+const results = [];
+function record(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? `  (${detail})` : ""}`);
+}
+
+async function main() {
+  // 1. entry HTML + asset references
+  const htmlRes = await fetch(`${BASE}/?verify=${Date.now()}`, {
+    headers: { "cache-control": "no-cache" }
+  });
+  const html = await htmlRes.text();
+  const cssPath = html.match(/\/assets\/index-[\w-]+\.css/)?.[0];
+  const jsPath = html.match(/\/assets\/index-[\w-]+\.js/)?.[0];
+  record("entry HTML 200 + hashed asset refs", htmlRes.status === 200 && !!cssPath && !!jsPath,
+    `status=${htmlRes.status} css=${cssPath ?? "?"} js=${jsPath ?? "?"}`);
+
+  // 2. referenced CSS is really CSS
+  if (cssPath) {
+    const res = await fetch(BASE + cssPath);
+    const type = res.headers.get("content-type") ?? "";
+    record("entry CSS is text/css", res.status === 200 && type.includes("text/css"),
+      `status=${res.status} type=${type}`);
+  }
+
+  // 3. referenced JS is really JavaScript
+  if (jsPath) {
+    const res = await fetch(BASE + jsPath);
+    const type = res.headers.get("content-type") ?? "";
+    record("entry JS is javascript", res.status === 200 && type.includes("javascript"),
+      `status=${res.status} type=${type}`);
+  }
+
+  // 4. THE poison-window check: a missing asset must be an uncacheable 404,
+  //    never the SPA fallback (200 text/html + immutable = the outage).
+  const missing = await fetch(`${BASE}/assets/verify-missing-${Date.now()}.js`);
+  const missType = missing.headers.get("content-type") ?? "";
+  const missCache = missing.headers.get("cache-control") ?? "";
+  record("missing /assets/* -> 404 + no-store",
+    missing.status === 404 && missCache.includes("no-store"),
+    `status=${missing.status} type=${missType} cache=${missCache}`);
+
+  // 5. SPA routes still fall back to the app shell
+  const spa = await fetch(`${BASE}/challenge?verify=${Date.now()}`);
+  const spaType = spa.headers.get("content-type") ?? "";
+  record("SPA route serves app shell", spa.status === 200 && spaType.includes("text/html"),
+    `status=${spa.status} type=${spaType}`);
+
+  const failed = results.filter((r) => !r.ok);
+  console.log(failed.length === 0 ? "\nDEPLOY VERIFIED ✓" : `\nDEPLOY BROKEN ✗ (${failed.length} failed)`);
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error("verify-deploy crashed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## 問題（post-deploy 驗證抓到）
#508 合併部署後實測：**守門沒生效**——不存在的 `/assets/*.js` 仍回 `200 text/html + immutable`（毒源還開著）。根因：Cloudflare Pages 的 `_routes.json` 萬用字元**跨路徑段**，exclude 裡的 `/*.js`、`/*.css` 把 `/assets/index-*.js` 等也排除出 middleware。單元測試測不到平台路由語義，所以全綠仍漏。

## 修法
- `public/_routes.json`：exclude 改為**根層逐檔列舉**（7 個圖檔＋sw.js/registerSW.js/workbox-*.js＋manifest），杜絕跨段吞噬；description 記下這個平台 gotcha。
- 新增 `scripts/verify-deploy.mjs`（`pnpm verify:deploy`，#507 合成監測項）：五項不變量——entry HTML/CSS 真身/JS 真身/**missing asset→404+no-store**/SPA 路由 200。這組檢查能同時抓住「原始中毒」與「本次守門失效」兩類回歸。**之後每次部署後跑一次。**

## 驗證
767 測全綠、build 綠（dist/_routes.json 確認複製）。合併部署後將以 `pnpm verify:deploy` 對 prod 實測守門生效並回報。
（TDD 豁免：純設定檔＋驗證腳本；_routes 平台語義無法單元測試，故以部署後合成檢查取代。）