### PR TITLE
feat(seo): build-time prerender 全站 108 條公開路由（#478 GEO/P0）

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "preview": "vite preview",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && node scripts/prerender.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,59 @@
+// Postbuild prerender (#478, GEO/P0): bake every public route into a real
+// static HTML file under dist/, so crawlers that never execute JavaScript
+// (GPTBot / ClaudeBot / PerplexityBot / Bingbot in practice) can read titles,
+// content and <a> links. Cloudflare Pages serves physical files before the
+// SPA fallback, so this is a pure additive layer — the app itself is
+// untouched and hydration replaces the static body wholesale.
+//
+// Page data comes from src/domain/prerender/staticPages.ts (unit-tested,
+// enumerates routes from the same domain modules the app uses). This script
+// is only the I/O shell: it loads that TS module through Vite's ssrLoadModule
+// (no extra runner dependency), applies each page to the built index.html
+// template, and writes dist/<route>/index.html.
+//
+// Run AFTER `vite build` (see package.json "build"). Ordering note: the PWA
+// precache manifest is generated during the build, so the extra HTML files
+// are NOT precached — correct, since SW navigations use the app shell and
+// these files exist for crawlers/first hits only.
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DIST = path.join(ROOT, "dist");
+
+const template = readFileSync(path.join(DIST, "index.html"), "utf8");
+
+// Vite dev server in middleware mode purely as a TS module loader; closed
+// before exit so the process terminates cleanly.
+const server = await createServer({
+  root: ROOT,
+  logLevel: "error",
+  server: { middlewareMode: true },
+  optimizeDeps: { noDiscovery: true }
+});
+
+try {
+  const { buildStaticPages, applyHead, pageFilePath } = await server.ssrLoadModule(
+    "/src/domain/prerender/staticPages.ts"
+  );
+
+  const pages = buildStaticPages();
+  let written = 0;
+  for (const page of pages) {
+    const filePath = path.join(DIST, pageFilePath(page.path));
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, applyHead(template, page), "utf8");
+    written += 1;
+  }
+  console.log(`[prerender] wrote ${written} static pages into dist/`);
+
+  // Sanity: the root page must have crawlable content now.
+  const home = readFileSync(path.join(DIST, "index.html"), "utf8");
+  if (!home.includes('<div id="root"><header>')) {
+    throw new Error("[prerender] home page has no static body — check applyHead");
+  }
+} finally {
+  await server.close();
+}

--- a/src/domain/prerender/staticPages.test.ts
+++ b/src/domain/prerender/staticPages.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+// Raw imports (typed via vite/client) keep @types/node out of the app build,
+// same trick as sitemap.test.ts.
+import TEMPLATE from "../../../index.html?raw";
+import sitemapXml from "../../../public/sitemap.xml?raw";
+import {
+  applyHead,
+  buildStaticPages,
+  escapeHtml,
+  isSafePathSegment,
+  pageFilePath
+} from "./staticPages";
+import { grammarPatterns } from "../grammarDatabase";
+import { publishedArticleMetas } from "../articlesMeta";
+
+describe("escapeHtml", () => {
+  it("escapes the five HTML-special characters", () => {
+    expect(escapeHtml(`<a href="x" & 'y'>`)).toBe(
+      "&lt;a href=&quot;x&quot; &amp; &#39;y&#39;&gt;"
+    );
+  });
+});
+
+describe("pageFilePath", () => {
+  it("maps the root to index.html", () => {
+    expect(pageFilePath("/")).toBe("index.html");
+  });
+
+  it("maps a static route to a flat .html file (Pages pretty URL, no 308)", () => {
+    expect(pageFilePath("/grammar")).toBe("grammar.html");
+  });
+
+  it("keeps Japanese segments decoded for the filesystem", () => {
+    expect(pageFilePath("/grammar/てもいい")).toBe("grammar/てもいい.html");
+  });
+});
+
+describe("isSafePathSegment", () => {
+  it("accepts Japanese pattern surfaces", () => {
+    expect(isSafePathSegment("〜てもいい")).toBe(true);
+    expect(isSafePathSegment("〜ざるを得ない")).toBe(true);
+  });
+
+  it("rejects segments with filesystem-hostile characters", () => {
+    for (const bad of ["a/b", "a\\b", "a?b", "a*b", "a:b", 'a"b', "a<b", "a|b", ".."]) {
+      expect(isSafePathSegment(bad)).toBe(false);
+    }
+  });
+});
+
+describe("applyHead", () => {
+  const page = {
+    path: "/grammar/〜てもいい",
+    title: "〜てもいい 的意思與用法 · Jabiko",
+    description: "測試用描述文字。",
+    canonical: "https://jabiko.app/grammar/%E3%80%9C%E3%81%A6%E3%82%82%E3%81%84%E3%81%84",
+    bodyHtml: "<main><h1>〜てもいい</h1></main>"
+  };
+
+  it("replaces title, description, canonical and og/twitter tags", () => {
+    const html = applyHead(TEMPLATE, page);
+    expect(html).toContain("<title>〜てもいい 的意思與用法 · Jabiko</title>");
+    expect(html).not.toContain("<title>Jabiko · JLPT 日檢自習室");
+    expect(html).toContain(`<link rel="canonical" href="${page.canonical}" />`);
+    // og + twitter pairs all carry the page title/description now.
+    expect(html.match(/測試用描述文字。/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(html).toContain(`property="og:url" content="${page.canonical}"`);
+  });
+
+  it("injects the static body into #root", () => {
+    const html = applyHead(TEMPLATE, page);
+    expect(html).toContain('<div id="root"><main><h1>〜てもいい</h1></main></div>');
+  });
+
+  it("escapes HTML-special characters in metadata values", () => {
+    const html = applyHead(TEMPLATE, { ...page, title: 'A"B<C>' });
+    expect(html).toContain("<title>A&quot;B&lt;C&gt;</title>");
+  });
+});
+
+describe("buildStaticPages", () => {
+  const pages = buildStaticPages();
+  const byPath = new Map(pages.map((p) => [p.path, p]));
+
+  it("covers every top-level view", () => {
+    for (const route of [
+      "/",
+      "/learn",
+      "/rules",
+      "/kanji",
+      "/challenge",
+      "/mock",
+      "/about",
+      "/grammar",
+      "/blog"
+    ]) {
+      expect(byPath.has(route), route).toBe(true);
+    }
+  });
+
+  it("covers the five JLPT level indexes", () => {
+    for (const level of ["n1", "n2", "n3", "n4", "n5"]) {
+      const page = byPath.get(`/grammar/${level}`);
+      expect(page, level).toBeDefined();
+      expect(page!.title).toContain(level.toUpperCase());
+    }
+  });
+
+  it("covers every grammar point with its content in the body", () => {
+    const grammarPages = pages.filter(
+      (p) => p.path.startsWith("/grammar/") && !/^\/grammar\/n[1-5]$/.test(p.path)
+    );
+    expect(grammarPages.length).toBe(grammarPatterns.length);
+
+    // Route surface strips the leading 〜 (matches app links + sitemap).
+    const temoii = byPath.get("/grammar/てもいい");
+    expect(temoii).toBeDefined();
+    const pattern = grammarPatterns.find((p) => p.pattern === "〜てもいい")!;
+    expect(temoii!.bodyHtml).toContain(escapeHtml(pattern.meaningZh));
+    expect(temoii!.bodyHtml).toContain(escapeHtml(pattern.formation));
+    expect(temoii!.bodyHtml).toContain(escapeHtml(pattern.examples[0].japanese));
+    // Related patterns become real crawlable links.
+    expect(temoii!.bodyHtml).toContain('<a href="/grammar/');
+  });
+
+  it("links every grammar point from the grammar index (crawler discovery)", () => {
+    const index = byPath.get("/grammar")!;
+    const linkCount = index.bodyHtml.match(/<a href="\/grammar\//g)?.length ?? 0;
+    expect(linkCount).toBeGreaterThanOrEqual(grammarPatterns.length);
+  });
+
+  it("covers the blog index and every published article", () => {
+    const blogIndex = byPath.get("/blog")!;
+    for (const meta of publishedArticleMetas) {
+      expect(blogIndex.bodyHtml).toContain(`/blog/${encodeURIComponent(meta.slug)}`);
+      const article = byPath.get(`/blog/${meta.slug}`);
+      expect(article, meta.slug).toBeDefined();
+      expect(article!.title).toContain(meta.title);
+    }
+  });
+
+  it("gives every page a nav, an h1 and an absolute canonical", () => {
+    for (const page of pages) {
+      expect(page.canonical.startsWith("https://jabiko.app"), page.path).toBe(true);
+      expect(page.bodyHtml.includes('<a href="/">'), page.path).toBe(true);
+      expect(page.bodyHtml.includes("<h1>"), page.path).toBe(true);
+    }
+  });
+
+  it("covers every URL in the committed sitemap (drift guard)", () => {
+    const locs = [...sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    expect(locs.length).toBeGreaterThan(0);
+    for (const loc of locs) {
+      const route = decodeURIComponent(new URL(loc).pathname);
+      const normalized = route !== "/" && route.endsWith("/") ? route.slice(0, -1) : route;
+      expect(byPath.has(normalized), loc).toBe(true);
+    }
+  });
+});

--- a/src/domain/prerender/staticPages.ts
+++ b/src/domain/prerender/staticPages.ts
@@ -1,0 +1,275 @@
+// Build-time prerender content (#478, GEO/P0).
+//
+// Non-Google AI crawlers execute ZERO JavaScript (GPTBot / ClaudeBot /
+// PerplexityBot / Bingbot-in-practice), so the SPA's raw HTML shell — one
+// <title> and an empty <div id="root"> — is all they ever see. This module
+// builds, for every public route, the static head metadata plus a plain-HTML
+// body (real text + real <a> links) that the postbuild script bakes into
+// dist/. React's createRoot() replaces the #root children wholesale on
+// hydration, so browsers with JS never see a mismatch — the static body is
+// strictly a crawler/first-paint artifact.
+//
+// Pure data -> strings; no fs, no DOM. The I/O lives in scripts/prerender.mjs.
+// NOT imported by the app (build-time only), so it adds zero bundle weight.
+import { SITE_ORIGIN, VIEW_SEO, seoForView, type SeoView } from "../seo";
+import { grammarPatterns, type GrammarPattern } from "../grammarDatabase";
+import { publishedArticleMetas } from "../articlesMeta";
+import { publishedArticles, type ArticleBlock } from "../articles";
+import type { JlptLevel } from "../types";
+
+export interface StaticPage {
+  /** Decoded URL path, e.g. "/grammar/〜てもいい". */
+  path: string;
+  title: string;
+  description: string;
+  /** Absolute canonical URL (percent-encoded where needed). */
+  canonical: string;
+  /** Static HTML injected into <div id="root"> for non-JS crawlers. */
+  bodyHtml: string;
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Whether a decoded path segment is safe as a directory name on every
+ *  filesystem we build on (NTFS is the strictest: \ / : * ? " < > |). */
+export function isSafePathSegment(segment: string): boolean {
+  if (segment.length === 0 || segment === "." || segment === "..") return false;
+  return !/[\\/:*?"<>|]/.test(segment);
+}
+
+/** Map a decoded route path to its file path under dist/. Flat `<route>.html`
+ *  (not `<route>/index.html`): Cloudflare Pages serves `/about.html` at
+ *  `/about` with no trailing-slash 308, so sitemap URLs stay byte-identical,
+ *  and sirv's extension resolution gives the same behaviour locally. */
+export function pageFilePath(routePath: string): string {
+  if (routePath === "/") return "index.html";
+  return `${routePath.replace(/^\//, "")}.html`;
+}
+
+function replaceMetaContent(html: string, attr: "name" | "property", key: string, value: string): string {
+  const pattern = new RegExp(`(<meta\\s+${attr}="${key}"\\s+content=")[\\s\\S]*?("\\s*\\/>)`);
+  return html.replace(pattern, `$1${escapeHtml(value)}$2`);
+}
+
+/**
+ * Bake a page's metadata + static body into the built index.html template.
+ * Replaces title / description / canonical / og / twitter tags and injects
+ * the crawler-visible body into the (empty) #root container.
+ */
+export function applyHead(template: string, page: StaticPage): string {
+  let html = template;
+  html = html.replace(/<title>[\s\S]*?<\/title>/, `<title>${escapeHtml(page.title)}</title>`);
+  html = replaceMetaContent(html, "name", "description", page.description);
+  html = html.replace(
+    /(<link rel="canonical" href=")[^"]*(" \/>)/,
+    `$1${page.canonical}$2`
+  );
+  html = replaceMetaContent(html, "property", "og:url", page.canonical);
+  html = replaceMetaContent(html, "property", "og:title", page.title);
+  html = replaceMetaContent(html, "property", "og:description", page.description);
+  html = replaceMetaContent(html, "name", "twitter:title", page.title);
+  html = replaceMetaContent(html, "name", "twitter:description", page.description);
+  html = html.replace('<div id="root"></div>', `<div id="root">${page.bodyHtml}</div>`);
+  return html;
+}
+
+// ---------------------------------------------------------------------------
+// Body builders
+// ---------------------------------------------------------------------------
+
+const NAV_LINKS: ReadonlyArray<{ href: string; label: string }> = [
+  { href: "/", label: "首頁" },
+  { href: "/learn", label: "分章學習" },
+  { href: "/rules", label: "規則速查表" },
+  { href: "/kanji", label: "漢字音讀" },
+  { href: "/grammar", label: "文型資料庫" },
+  { href: "/blog", label: "文章" },
+  { href: "/challenge", label: "題庫練習" },
+  { href: "/mock", label: "題型練習" },
+  { href: "/about", label: "關於" }
+];
+
+const LEVELS: JlptLevel[] = ["N5", "N4", "N3", "N2", "N1"];
+
+/** Navigable surface for a pattern: the leading 〜/～ is stripped, matching
+ *  how the app's grammar index links (onOpenPattern) and the sitemap. */
+export function navigableSurface(pattern: string): string {
+  return pattern.replace(/^[〜～]/, "");
+}
+
+function grammarHref(surface: string): string {
+  return `/grammar/${encodeURIComponent(navigableSurface(surface))}`;
+}
+
+function nav(): string {
+  const items = NAV_LINKS.map(
+    (link) => `<a href="${link.href}">${escapeHtml(link.label)}</a>`
+  ).join(" · ");
+  return `<header><nav>${items}</nav></header>`;
+}
+
+function wrap(h1: string, inner: string): string {
+  return `${nav()}<main><h1>${escapeHtml(h1)}</h1>${inner}</main>`;
+}
+
+function paragraph(text: string): string {
+  return `<p>${escapeHtml(text)}</p>`;
+}
+
+function grammarPointBody(pattern: GrammarPattern, byId: Map<string, GrammarPattern>): string {
+  const parts: string[] = [];
+  if (pattern.reading) parts.push(paragraph(`讀音：${pattern.reading}`));
+  parts.push(`<p>JLPT 等級：<a href="/grammar/${pattern.level.toLowerCase()}">${pattern.level}</a></p>`);
+  parts.push(`<h2>意思</h2>${paragraph(pattern.meaningZh)}`);
+  parts.push(`<h2>接續</h2>${paragraph(pattern.formation)}`);
+  if (pattern.examples.length > 0) {
+    const items = pattern.examples
+      .map(
+        (example) =>
+          `<li><span lang="ja">${escapeHtml(example.japanese)}</span> — ${escapeHtml(example.meaningZh)}</li>`
+      )
+      .join("");
+    parts.push(`<h2>例句</h2><ul>${items}</ul>`);
+  }
+  const related = pattern.relatedPatternIds
+    .map((id) => byId.get(id))
+    .filter((entry): entry is GrammarPattern => Boolean(entry));
+  if (related.length > 0) {
+    const items = related
+      .map((entry) => `<li><a href="${grammarHref(entry.pattern)}">${escapeHtml(entry.pattern)}</a> — ${escapeHtml(entry.meaningZh)}</li>`)
+      .join("");
+    parts.push(`<h2>相近文型</h2><ul>${items}</ul>`);
+  }
+  parts.push(`<p><a href="/grammar">回文型資料庫</a> · <a href="/challenge">進題庫練習</a></p>`);
+  return wrap(`${pattern.pattern}（JLPT ${pattern.level} 文法）`, parts.join(""));
+}
+
+function grammarIndexBody(level?: JlptLevel): string {
+  const pool = level ? grammarPatterns.filter((p) => p.level === level) : grammarPatterns;
+  const levelLinks = LEVELS.map(
+    (l) => `<a href="/grammar/${l.toLowerCase()}">JLPT ${l} 文型</a>`
+  ).join(" · ");
+  const items = pool
+    .map(
+      (pattern) =>
+        `<li><a href="${grammarHref(pattern.pattern)}">${escapeHtml(pattern.pattern)}</a>（${pattern.level}）— ${escapeHtml(pattern.meaningZh)}</li>`
+    )
+    .join("");
+  const heading = level ? `JLPT ${level} 文型索引` : "JLPT 文型資料庫（N5–N1）";
+  const intro = level
+    ? `JLPT ${level} 的文型一覽：意思、接續、用法與例句，點進各文型看完整說明。`
+    : VIEW_SEO.grammar.description;
+  return wrap(heading, `${paragraph(intro)}<p>${levelLinks}</p><ul>${items}</ul>`);
+}
+
+function articleText(block: ArticleBlock): string {
+  switch (block.kind) {
+    case "lead":
+    case "paragraph":
+    case "callout":
+      return paragraph(block.text);
+    case "heading":
+      return `<h2>${escapeHtml(block.text)}</h2>`;
+    case "vocab": {
+      const items = block.items
+        .map(
+          (item) =>
+            `<li><span lang="ja">${escapeHtml(item.word)}（${escapeHtml(item.reading)}）</span>：${escapeHtml(item.meaning)}${item.note ? ` — ${escapeHtml(item.note)}` : ""}</li>`
+        )
+        .join("");
+      return `<ul>${items}</ul>`;
+    }
+    case "links": {
+      const items = block.items
+        .map((item) => `<li><a href="${escapeHtml(item.url)}" rel="noopener">${escapeHtml(item.label)}</a></li>`)
+        .join("");
+      return `<ul>${items}</ul>`;
+    }
+    case "lyricPoint":
+      // Deliberately render only the original commentary, never the lyric
+      // fragment — the static HTML must stay clear of reproduced lyrics.
+      return block.points.map((point) => paragraph(point)).join("");
+    case "divider":
+      return `<h2>${escapeHtml(block.label)}</h2>`;
+    case "cta":
+      return "";
+  }
+}
+
+function blogIndexBody(): string {
+  const items = publishedArticleMetas
+    .map(
+      (meta) =>
+        `<li><a href="/blog/${encodeURIComponent(meta.slug)}">${escapeHtml(meta.title)}</a> — ${escapeHtml(meta.description)}</li>`
+    )
+    .join("");
+  return wrap("Jabiko 文章｜課本不教的日文，這裡補", `${paragraph(VIEW_SEO.blog.description)}<ul>${items}</ul>`);
+}
+
+function homeBody(): string {
+  const sections = [
+    `<li><a href="/grammar">JLPT 文型資料庫</a>：${grammarPatterns.length} 個文型的意思、接續與例句</li>`,
+    `<li><a href="/learn">分章學習</a>：動詞變化到常用句型，一章一章打底</li>`,
+    `<li><a href="/challenge">題庫練習</a>：N1〜N5 綜合題庫、備考模式與弱點複習</li>`,
+    `<li><a href="/mock">題型練習</a>：照 JLPT 官方題型分區逐區攻略</li>`,
+    `<li><a href="/kanji">漢字音讀速查</a>、<a href="/rules">規則速查表</a></li>`,
+    `<li><a href="/blog">文章</a>：流行語、推し活、從歌詞學日文</li>`
+  ].join("");
+  const levelLinks = LEVELS.map(
+    (l) => `<a href="/grammar/${l.toLowerCase()}">JLPT ${l} 文法</a>`
+  ).join(" · ");
+  return wrap(
+    "Jabiko · JLPT 日檢自習室",
+    `${paragraph(VIEW_SEO.home.description)}<ul>${sections}</ul><p>${levelLinks}</p>`
+  );
+}
+
+function simpleViewBody(view: SeoView): string {
+  const entry = VIEW_SEO[view];
+  return wrap(entry.title.split(" · ")[0], `${paragraph(entry.description)}<p><a href="/">回 Jabiko 首頁</a></p>`);
+}
+
+// ---------------------------------------------------------------------------
+
+export function buildStaticPages(): StaticPage[] {
+  const pages: StaticPage[] = [];
+  const byId = new Map(grammarPatterns.map((pattern) => [pattern.id, pattern]));
+
+  const push = (view: SeoView, path: string, bodyHtml: string, surface?: string, slug?: string) => {
+    const seo = seoForView(view, surface ?? null, slug ?? null);
+    pages.push({ path, title: seo.title, description: seo.description, canonical: seo.canonical, bodyHtml });
+  };
+
+  push("home", "/", homeBody());
+  for (const view of ["learn", "rules", "kanji", "challenge", "mock", "about"] as const) {
+    push(view, VIEW_SEO[view].path, simpleViewBody(view));
+  }
+  push("grammar", "/grammar", grammarIndexBody());
+  for (const level of LEVELS) {
+    push("grammar", `/grammar/${level.toLowerCase()}`, grammarIndexBody(level), level.toLowerCase());
+  }
+  for (const pattern of grammarPatterns) {
+    const surface = navigableSurface(pattern.pattern);
+    if (!isSafePathSegment(surface)) {
+      // eslint-disable-next-line no-console
+      console.warn(`[prerender] skip unsafe surface: ${surface}`);
+      continue;
+    }
+    push("grammar", `/grammar/${surface}`, grammarPointBody(pattern, byId), surface);
+  }
+  push("blog", "/blog", blogIndexBody());
+  for (const article of publishedArticles) {
+    const inner = article.body.map(articleText).join("");
+    const bodyHtml = wrap(article.title, `${paragraph(article.description)}${inner}<p><a href="/blog">更多文章</a></p>`);
+    push("blog", `/blog/${article.slug}`, bodyHtml, undefined, article.slug);
+  }
+
+  return pages;
+}


### PR DESCRIPTION
Closes #478

## 問題
非 Google AI 爬蟲（GPTBot/ClaudeBot/PerplexityBot、實務上含 Bingbot）不執行 JS——SPA shell 對它們全站只有 ~51 字元、零 <a> 連結。

## 做法（issue 選項 A：build-time SSG，不 SSR）
- **`src/domain/prerender/staticPages.ts`**（純函式、16 tests）：每路由 title/description/canonical/og/twitter 沿用 `seoForView`；`#root` 注入爬蟲可讀 body（真文字＋真 `<a>`）。涵蓋：`/`、6 個簡單視圖、`/grammar`＋n1–n5 索引＋**每個文法點**（意思/接續/例句/相近文型互鏈）、`/blog`＋已發佈文章（lyricPoint 只渲染解說、絕不渲染歌詞片段）。
- **`scripts/prerender.mjs`**：postbuild 經 vite `ssrLoadModule` 載入 domain（零新依賴），接進 `pnpm build`。共寫出 **108 頁**。
- **扁平 `<route>.html`**：Pages 的 pretty URL（`/about.html` → `/about`）無 308，sitemap URL 逐字不變。
- **Drift guard**：`public/sitemap.xml` 每條 `<loc>` 必須有對應頁（test 擋）。

## 驗證
- 16/16 新測試＋全套 784 綠；`vite preview` curl 各路由 title 正確、未知路由照舊 fallback SPA shell。
- **Hydration 實機**（真 Chrome）：React 接手後靜態 body 被整體替換、app 正常掛載、console 零錯誤。
- Bundle 紀律不動：純 postbuild HTML，JS/chunk 零變更；新 HTML 不進 SW precache（manifest 於 build 期生成）＝行為正確。

## Merge 前最後 gate
⚠ 請用本 PR 的 **Cloudflare Pages preview URL** 實測**日文路徑**靜態檔（例 `/grammar/てもいい`）是否由 Pages 正確以 pretty URL 服務（非 ASCII 檔名是唯一部署面風險）。我會在 preview deployment 出來後 curl 驗證並回報。