### PR TITLE
feat(home): persistent target-level control so learners can change level anytime (Closes #526)

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -69,6 +69,43 @@ describe("HomePanel level onboarding (#199)", () => {
   });
 });
 
+describe("HomePanel persistent level control (#526 change level anytime)", () => {
+  it("shows the current target level with a change affordance once a preference exists", () => {
+    renderHome({ targetLevel: "n2n3", progressAttempts: [sampleAttempt] });
+    expect(screen.getByText("目標級別")).toBeInTheDocument();
+    // reflects the chosen band (中級 = n2n3) and offers a change action
+    const chip = screen.getByRole("button", { name: /變更/ });
+    expect(chip).toHaveTextContent("中級");
+  });
+
+  it("is collapsed by default -- the band picker is not shown until 變更 is clicked", () => {
+    renderHome({ targetLevel: "n2n3", progressAttempts: [sampleAttempt] });
+    // 高級 belongs only to the (still-collapsed) picker, so it must be absent
+    expect(screen.queryByRole("button", { name: /高級/ })).not.toBeInTheDocument();
+  });
+
+  it("expands to the band picker and changes the level", () => {
+    const props = renderHome({ targetLevel: "n2n3", progressAttempts: [sampleAttempt] });
+    fireEvent.click(screen.getByRole("button", { name: /變更/ }));
+    fireEvent.click(screen.getByRole("button", { name: /高級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n1n2");
+  });
+
+  it("lets a returning learner with no saved preference set a target level", () => {
+    const props = renderHome({ targetLevel: null, progressAttempts: [sampleAttempt] });
+    expect(screen.getByText("尚未設定")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /變更/ }));
+    fireEvent.click(screen.getByRole("button", { name: /中級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n2n3");
+  });
+
+  it("does NOT show the persistent control for a brand-new learner (big onboarding card instead)", () => {
+    renderHome({ targetLevel: null, progressAttempts: [] });
+    expect(screen.queryByText("目標級別")).not.toBeInTheDocument();
+    expect(screen.getByText("選擇你的程度")).toBeInTheDocument();
+  });
+});
+
 describe("HomePanel guide link", () => {
   it("renders a 使用說明書 link to the blog that opens safely in a new tab", () => {
     renderHome();

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, ArrowRight, BookOpen, Bug, CalendarCheck, Heart, Sparkles, X } from "lucide-react";
+import { AlertTriangle, ArrowRight, BookOpen, Bug, CalendarCheck, ChevronDown, Heart, Sparkles, Target, X } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import type { LevelRange } from "../domain/levelRange";
@@ -181,6 +181,18 @@ export function HomePanel({
   };
   const showHowItWorks = showLevelOnboarding && !howItWorksDismissed;
 
+  // Persistent "目標級別" control (#526): once the first-run card is gone, this
+  // compact chip is the only way to see and re-pick the target level. Shown to
+  // everyone who is NOT a brand-new visitor (i.e. whenever the big card isn't),
+  // so returning learners who set a level -- or older ones who never had the
+  // card -- can still change it. Collapsed by default; 變更 expands the picker.
+  const [levelEditing, setLevelEditing] = useState(false);
+  const currentLevelOption = onboardingOptions.find((option) => option.range === targetLevel);
+  const chooseLevel = (range: LevelRange) => {
+    onChooseLevel(range);
+    setLevelEditing(false);
+  };
+
   return (
     <section className="home-panel" aria-label={t.home}>
       {/* First-time orientation: a single "how it works" line shown only to
@@ -235,6 +247,52 @@ export function HomePanel({
         </span>
         <ArrowRight aria-hidden="true" />
       </button>
+
+      {/* Persistent target-level control (#526): reflects the current band and,
+          when expanded, re-uses the same three-band picker as the first-run
+          card so the level can be changed at any time. Not rendered for a
+          brand-new visitor -- they get the big onboarding card above instead. */}
+      {!showLevelOnboarding ? (
+        <div className="home-level-manage" role="group" aria-label={t.levelOnboarding.manageTitle}>
+          <button
+            type="button"
+            className="home-level-chip"
+            aria-expanded={levelEditing}
+            onClick={() => setLevelEditing((open) => !open)}
+          >
+            <Target aria-hidden="true" />
+            <span className="home-level-chip-label">{t.levelOnboarding.manageTitle}</span>
+            <span className="home-level-chip-value">
+              {currentLevelOption ? (
+                <>
+                  <strong>{currentLevelOption.label}</strong>
+                  <small>{currentLevelOption.hint}</small>
+                </>
+              ) : (
+                <em>{t.levelOnboarding.notSet}</em>
+              )}
+            </span>
+            <span className="home-level-chip-action">{t.levelOnboarding.change}</span>
+            <ChevronDown className="home-level-chip-caret" aria-hidden="true" />
+          </button>
+          {levelEditing ? (
+            <div className="home-level-card-options">
+              {onboardingOptions.map((option) => (
+                <button
+                  key={option.range}
+                  type="button"
+                  className="home-level-option"
+                  aria-pressed={option.range === targetLevel}
+                  onClick={() => chooseLevel(option.range)}
+                >
+                  <strong>{option.label}</strong>
+                  <small>{option.hint}</small>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
 
       <header className="home-hero">
         {/* Decorative hero -- the heading below carries the actual

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -223,6 +223,9 @@ export type Copy = {
     intermediateHint: string;
     advanced: string;
     advancedHint: string;
+    manageTitle: string;
+    change: string;
+    notSet: string;
   };
   sessionLength: string;
   sessionLengthAll: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -239,7 +239,10 @@ export const en: Copy = {
     intermediate: "Intermediate",
     intermediateHint: "N2・N3",
     advanced: "Advanced",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "Target level",
+    change: "Change",
+    notSet: "Not set"
   },
   sessionLength: "Questions per set",
   sessionLengthAll: "All",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -239,7 +239,10 @@ export const id: Copy = {
     intermediate: "Menengah",
     intermediateHint: "N2・N3",
     advanced: "Mahir",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "Level target",
+    change: "Ubah",
+    notSet: "Belum diatur"
   },
   sessionLength: "Soal per set",
   sessionLengthAll: "Semua",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -247,7 +247,10 @@ export const ja: Copy = {
     intermediate: "中級",
     intermediateHint: "N2・N3",
     advanced: "上級",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "目標レベル",
+    change: "変更",
+    notSet: "未設定"
   },
   sessionLength: "1セットの問題数",
   sessionLengthAll: "すべて",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -239,7 +239,10 @@ export const ko: Copy = {
     intermediate: "중급",
     intermediateHint: "N2・N3",
     advanced: "고급",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "목표 레벨",
+    change: "변경",
+    notSet: "미설정"
   },
   sessionLength: "세트당 문제 수",
   sessionLengthAll: "전체",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -239,7 +239,10 @@ export const my: Copy = {
     intermediate: "အလယ်အလတ်",
     intermediateHint: "N2・N3",
     advanced: "အဆင့်မြင့်",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "ပန်းတိုင်အဆင့်",
+    change: "ပြောင်းရန်",
+    notSet: "မသတ်မှတ်ရသေးပါ"
   },
   sessionLength: "တစ်စုလျှင် မေးခွန်းအရေအတွက်",
   sessionLengthAll: "အားလုံး",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -240,7 +240,10 @@ export const th: Copy = {
     intermediate: "ระดับกลาง",
     intermediateHint: "N2・N3",
     advanced: "ระดับสูง",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "ระดับเป้าหมาย",
+    change: "เปลี่ยน",
+    notSet: "ยังไม่ได้ตั้ง"
   },
   sessionLength: "จำนวนข้อต่อชุด",
   sessionLengthAll: "ทั้งหมด",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -239,7 +239,10 @@ export const vi: Copy = {
     intermediate: "Trung cấp",
     intermediateHint: "N2・N3",
     advanced: "Cao cấp",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "Cấp độ mục tiêu",
+    change: "Thay đổi",
+    notSet: "Chưa đặt"
   },
   sessionLength: "Số câu mỗi bộ",
   sessionLengthAll: "Tất cả",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -239,7 +239,10 @@ export const zhHant: Copy = {
     intermediate: "中級",
     intermediateHint: "N2・N3",
     advanced: "高級",
-    advancedHint: "N1・N2"
+    advancedHint: "N1・N2",
+    manageTitle: "目標級別",
+    change: "變更",
+    notSet: "尚未設定"
   },
   sessionLength: "每組題數",
   sessionLengthAll: "全部",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1054,3 +1054,70 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Persistent target-level control (#526): a compact chip that shows the current
+   band and expands to the same three-band picker used at onboarding. */
+.home-level-manage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.home-level-chip {
+  width: 100%;
+  justify-content: flex-start;
+  gap: 0.55rem;
+  padding: 0.7rem 0.9rem;
+  background: var(--paper);
+  text-align: left;
+  flex-wrap: wrap;
+}
+
+.home-level-chip > svg:first-child {
+  color: var(--teal);
+}
+
+.home-level-chip-label {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.home-level-chip-value {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.home-level-chip-value strong {
+  color: var(--ink);
+}
+
+.home-level-chip-value small {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.home-level-chip-value em {
+  color: var(--muted);
+  font-style: normal;
+}
+
+.home-level-chip-action {
+  margin-left: auto;
+  color: var(--teal);
+  font-size: 0.85rem;
+}
+
+.home-level-chip-caret {
+  color: var(--muted);
+  transition: transform 0.16s ease;
+}
+
+.home-level-chip[aria-expanded="true"] .home-level-chip-caret {
+  transform: rotate(180deg);
+}
+
+.home-level-option[aria-pressed="true"] {
+  border-color: var(--teal);
+  box-shadow: inset 0 0 0 1px var(--teal);
+}


### PR DESCRIPTION
## 為什麼

「選擇你的程度」onboarding 卡只對**全新訪客**（無偏好且無答題紀錄）出現；一旦選了程度，卡片就消失、**再也沒有地方可以更改**——即使卡片副標自己寫著「之後隨時可改」。這正是 #526 回報的缺口。

## 做法

在首頁「開始今日練習」banner 下方新增一個常駐的 **目標級別** chip：

- 顯示目前的級別（例：中級 · N2・N3），右側「變更 ⌄」。
- 點擊展開，重用與 onboarding 卡**同一組三段選擇器**（初級/中級/高級 = n4n5/n2n3/n1n2），目前級別以 teal 邊框標示（`aria-pressed`）。
- 選擇後立即透過既有的 `onChooseLevel` → `writeLevelPreference` 路徑持久化並收合。
- 對「有答題紀錄但從未設定偏好」的舊使用者顯示「尚未設定」狀態，讓他們也能在此設定。
- 只在**非**全新訪客時渲染（全新訪客仍看大張 onboarding 卡）；兩者以 `showLevelOnboarding` / `!showLevelOnboarding` 互斥，不會同時出現。

## 範圍

- `HomePanel.tsx`：新增常駐控制 + 展開/收合 state。
- 8 個語系檔 + `Copy` 型別：新增 `manageTitle` / `change` / `notSet`。
- `home.css`：chip 樣式（重用 base `button` 與 `.home-level-option`）。

## 測試 / 驗證

- TDD：先加 `HomePanel.test.tsx` 5 個新測試（RED → GREEN）：顯示現值、預設收合、展開改級別、舊使用者未設定可設定、全新訪客不顯示常駐控制改顯示大卡。
- `pnpm test` 800 綠、`tsc --noEmit` 綠、`pnpm build` 綠（`index` eager chunk 無膨脹）。
- Claude_Preview 實機驗證：桌機/手機/深色三態排版正確、端到端改級別會寫入 localStorage 並收合。
- 內容可見性：未觸碰任何 `*Zh` 欄位，只渲染正規 i18n key（codex review PASS 已確認）。