### PR TITLE
feat(challenge): adjustable TTS speech rate so learners can slow the audio down (Closes #527)

### DIFF
--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -2,11 +2,13 @@ import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import type { LevelRange } from "../domain/levelRange";
 import { usePracticeSession, type SessionInit } from "../hooks/usePracticeSession";
+import { useTtsRate } from "../hooks/useTtsRate";
 import { ModePicker } from "./challenge/ModePicker";
 import { DrillPanel } from "./challenge/DrillPanel";
 import { ScoreReport } from "./challenge/ScoreReport";
 import { ReviewList } from "./challenge/ReviewList";
 import { SessionLengthPicker } from "./challenge/SessionLengthPicker";
+import { TtsRatePicker } from "./challenge/TtsRatePicker";
 
 // The challenge workspace: the three-column practice layout (mode/setup
 // controls, the active drill, and the running mistake list). This is the
@@ -45,6 +47,10 @@ export function ChallengePanel({
 }) {
   const t = copy[language];
   const session = usePracticeSession({ language, init, progressAttempts, recordAttempt, targetLevel });
+  // Global 語速 preference for the 讀出來 buttons (#527); shown in the settings
+  // sidebar. SpeakButton reads the stored value on click, so this applies to
+  // every audio button, not just the ones in this panel.
+  const { rate: ttsRate, setRate: setTtsRate } = useTtsRate();
 
   return (
     <section className="practice-layout" aria-label="Jabiko practice">
@@ -66,6 +72,7 @@ export function ChallengePanel({
             onChange={session.handleSessionLengthChange}
           />
         ) : null}
+        <TtsRatePicker language={language} rate={ttsRate} onChange={setTtsRate} />
         <ScoreReport
           language={language}
           attempts={session.attempts}

--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -1,6 +1,7 @@
 import { Volume2 } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { getJapaneseVoice } from "../lib/speech";
+import { readTtsRate } from "../lib/ttsRate";
 
 // Small inline button that reads its `text` aloud via the browser's
 // built-in SpeechSynthesis API. No external TTS service or audio asset
@@ -29,7 +30,9 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
       const jaVoice = getJapaneseVoice();
       if (jaVoice) utterance.voice = jaVoice;
       utterance.lang = "ja-JP";
-      utterance.rate = 0.95;
+      // Read the rate fresh each click so a change in the 語速 control (#527)
+      // applies immediately; defaults to the long-standing 0.95 when unset.
+      utterance.rate = readTtsRate();
       window.speechSynthesis.speak(utterance);
     } catch {
       // Voice synthesis can throw if the engine is in a bad state; the

--- a/src/components/challenge/TtsRatePicker.test.tsx
+++ b/src/components/challenge/TtsRatePicker.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TtsRatePicker } from "./TtsRatePicker";
+import { TTS_RATE_DEFAULT } from "../../lib/ttsRate";
+
+function renderPicker(overrides: Partial<Parameters<typeof TtsRatePicker>[0]> = {}) {
+  const props = {
+    language: "zh-Hant" as const,
+    rate: TTS_RATE_DEFAULT,
+    onChange: vi.fn(),
+    ...overrides
+  };
+  render(<TtsRatePicker {...props} />);
+  return props;
+}
+
+describe("TtsRatePicker (#527 speech-rate control)", () => {
+  it("marks the preset matching the current rate as pressed", () => {
+    renderPicker({ rate: TTS_RATE_DEFAULT });
+    expect(screen.getByRole("button", { name: "標準" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("calls onChange with a slower rate when a slower preset is chosen", () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    fireEvent.click(screen.getByRole("button", { name: "慢" }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toBeLessThan(TTS_RATE_DEFAULT);
+  });
+
+  it("accepts a custom manual rate via the number input", () => {
+    const props = renderPicker();
+    fireEvent.change(screen.getByLabelText("自訂"), { target: { value: "1.2" } });
+    expect(props.onChange).toHaveBeenCalledWith(1.2);
+  });
+
+  it("lets the user type a sub-1 slow rate digit-by-digit without the leading 0 reverting", () => {
+    const props = renderPicker();
+    const input = screen.getByLabelText("自訂") as HTMLInputElement;
+    // Typing "0" is not yet a committable rate (0 is out of range) -- it must
+    // NOT be reverted, so the user can go on to type "0.8".
+    fireEvent.change(input, { target: { value: "0" } });
+    expect(input.value).toBe("0");
+    expect(props.onChange).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: "0.8" } });
+    expect(props.onChange).toHaveBeenCalledWith(0.8);
+  });
+
+  it("does not commit an out-of-range custom value and reconciles the field on blur", () => {
+    const props = renderPicker({ rate: TTS_RATE_DEFAULT });
+    const input = screen.getByLabelText("自訂") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(props.onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("99"); // draft kept while editing
+    fireEvent.blur(input);
+    expect(input.value).toBe(""); // reverts to the active preset (empty custom field)
+  });
+
+  it("clears the custom draft when a preset is chosen", () => {
+    renderPicker({ rate: 1.25 });
+    const input = screen.getByLabelText("自訂") as HTMLInputElement;
+    expect(input.value).toBe("1.25");
+    fireEvent.click(screen.getByRole("button", { name: "標準" }));
+    expect(input.value).toBe("");
+  });
+
+  it("highlights the custom field when the rate is not one of the presets", () => {
+    renderPicker({ rate: 1.25 });
+    // no preset button is pressed for an off-preset rate
+    expect(screen.getByRole("button", { name: "標準" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "慢" })).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/src/components/challenge/TtsRatePicker.tsx
+++ b/src/components/challenge/TtsRatePicker.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { copy, type Language } from "../../i18n";
+import { TTS_RATE_MAX, TTS_RATE_MIN, TTS_RATE_PRESETS } from "../../lib/ttsRate";
+
+// The 語速 (speech-rate) control for the challenge settings sidebar (#527).
+// Same shape as SessionLengthPicker: a segmented row of presets plus a 自訂
+// number field for a manual rate. Pure presentation over the rate state +
+// handler owned by the parent (via useTtsRate). Affects every 讀出來 button
+// because SpeakButton reads the stored rate on click.
+export function TtsRatePicker({
+  language,
+  rate,
+  onChange
+}: {
+  language: Language;
+  rate: number;
+  onChange: (rate: number) => void;
+}) {
+  const t = copy[language];
+
+  // A rate that isn't one of the presets is a manual choice -- surface it in
+  // the 自訂 field so it stays visible/editable and no preset button lights up.
+  const isCustom = !TTS_RATE_PRESETS.some((preset) => preset.rate === rate);
+
+  // The custom field keeps its own draft string so a user can type intermediate
+  // values ("0", "0.", "0.8") that aren't yet a committable rate -- important
+  // because the point of #527 is slowing DOWN, i.e. entering rates below 1 that
+  // start with "0". We only lift a value up when it parses in range; a preset
+  // click clears the draft. (value bound to `rate` + a `> 0` guard would revert
+  // the leading "0" and make sub-1 rates untypable.)
+  const [draft, setDraft] = useState(isCustom ? String(rate) : "");
+
+  const pickPreset = (presetRate: number) => {
+    setDraft("");
+    onChange(presetRate);
+  };
+
+  const handleCustomInput = (raw: string) => {
+    setDraft(raw);
+    // Only lift a value up when it's genuinely in range, so the field's text
+    // and the effective rate never disagree (an out-of-range number would be
+    // clamped by the parent yet still shown verbatim here). Out-of-range /
+    // half-typed drafts are left uncommitted until they parse in range.
+    const next = Number(raw);
+    if (raw.trim() !== "" && next >= TTS_RATE_MIN && next <= TTS_RATE_MAX) onChange(next);
+  };
+
+  const reconcileDraft = () => {
+    // On blur, drop an empty / out-of-range draft back to the effective rate so
+    // the field never lingers showing a speed that isn't actually in use.
+    setDraft(isCustom ? String(rate) : "");
+  };
+
+  return (
+    <fieldset className="tts-rate-picker">
+      <legend>{t.ttsRate}</legend>
+      <div className="segmented tts-rate-segmented">
+        {TTS_RATE_PRESETS.map((preset) => {
+          const active = rate === preset.rate;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              className={active ? "selected" : ""}
+              aria-pressed={active}
+              onClick={() => pickPreset(preset.rate)}
+            >
+              {t.ttsRatePresets[preset.id]}
+            </button>
+          );
+        })}
+      </div>
+      <label className={`tts-rate-custom${isCustom ? " selected" : ""}`}>
+        <span>{t.ttsRateCustom}</span>
+        <input
+          type="number"
+          min={TTS_RATE_MIN}
+          max={TTS_RATE_MAX}
+          step={0.05}
+          inputMode="decimal"
+          aria-label={t.ttsRateCustom}
+          placeholder={String(TTS_RATE_PRESETS[0].rate)}
+          value={draft}
+          onChange={(event) => handleCustomInput(event.target.value)}
+          onBlur={reconcileDraft}
+        />
+      </label>
+    </fieldset>
+  );
+}

--- a/src/hooks/useTtsRate.test.ts
+++ b/src/hooks/useTtsRate.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useTtsRate } from "./useTtsRate";
+import { TTS_RATE_DEFAULT, TTS_RATE_MAX } from "../lib/ttsRate";
+
+const KEY = "jabiko.ttsRate";
+
+describe("useTtsRate", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("defaults to TTS_RATE_DEFAULT when nothing is stored", () => {
+    const { result } = renderHook(() => useTtsRate());
+    expect(result.current.rate).toBe(TTS_RATE_DEFAULT);
+  });
+
+  it("reads a persisted rate on mount", () => {
+    localStorage.setItem(KEY, "0.7");
+    const { result } = renderHook(() => useTtsRate());
+    expect(result.current.rate).toBe(0.7);
+  });
+
+  it("setRate persists and reflects the new rate", () => {
+    const { result } = renderHook(() => useTtsRate());
+
+    act(() => result.current.setRate(0.5));
+    expect(result.current.rate).toBe(0.5);
+    expect(localStorage.getItem(KEY)).toBe("0.5");
+  });
+
+  it("setRate clamps an out-of-range value in BOTH the state and storage", () => {
+    const { result } = renderHook(() => useTtsRate());
+
+    act(() => result.current.setRate(3));
+    expect(result.current.rate).toBe(TTS_RATE_MAX);
+    expect(localStorage.getItem(KEY)).toBe(String(TTS_RATE_MAX));
+  });
+});

--- a/src/hooks/useTtsRate.ts
+++ b/src/hooks/useTtsRate.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { clampTtsRate, readTtsRate, writeTtsRate } from "../lib/ttsRate";
+
+// Owns the global speech-rate preference (#527): the initial read from storage
+// and the persisted setter. Mirrors useFurigana / useTheme. The consumer (the
+// challenge settings sidebar) renders TtsRatePicker from this state; SpeakButton
+// does NOT subscribe -- it reads the stored rate fresh on each click, so a
+// change here is picked up everywhere audio plays without any context wiring.
+export function useTtsRate() {
+  const [rate, setRateState] = useState<number>(() => readTtsRate());
+
+  const setRate = (next: number) => {
+    writeTtsRate(next);
+    setRateState(clampTtsRate(next));
+  };
+
+  return { rate, setRate };
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -231,6 +231,13 @@ export type Copy = {
   sessionLengthAll: string;
   sessionLengthCustom: string;
   sessionLengthCustomPlaceholder: string;
+  ttsRate: string;
+  ttsRatePresets: {
+    normal: string;
+    slow: string;
+    slower: string;
+  };
+  ttsRateCustom: string;
   practiceFocus: string;
   verbGroup: string;
   targetForm: string;

--- a/src/lib/ttsRate.test.ts
+++ b/src/lib/ttsRate.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  TTS_RATE_DEFAULT,
+  TTS_RATE_MAX,
+  TTS_RATE_MIN,
+  TTS_RATE_PRESETS,
+  clampTtsRate,
+  readTtsRate,
+  writeTtsRate
+} from "./ttsRate";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("clampTtsRate", () => {
+  it("keeps an in-range rate unchanged", () => {
+    expect(clampTtsRate(0.8)).toBe(0.8);
+  });
+
+  it("clamps below the minimum and above the maximum", () => {
+    expect(clampTtsRate(0.1)).toBe(TTS_RATE_MIN);
+    expect(clampTtsRate(9)).toBe(TTS_RATE_MAX);
+  });
+
+  it("falls back to the default for non-finite input", () => {
+    expect(clampTtsRate(Number.NaN)).toBe(TTS_RATE_DEFAULT);
+    expect(clampTtsRate(Number.POSITIVE_INFINITY)).toBe(TTS_RATE_DEFAULT);
+  });
+});
+
+describe("readTtsRate / writeTtsRate", () => {
+  it("defaults to TTS_RATE_DEFAULT when nothing is stored", () => {
+    expect(readTtsRate()).toBe(TTS_RATE_DEFAULT);
+  });
+
+  it("round-trips a written in-range rate", () => {
+    writeTtsRate(0.7);
+    expect(readTtsRate()).toBe(0.7);
+  });
+
+  it("clamps an out-of-range written rate on the way in", () => {
+    writeTtsRate(5);
+    expect(readTtsRate()).toBe(TTS_RATE_MAX);
+  });
+
+  it("falls back to the default when the stored value is not a number", () => {
+    localStorage.setItem("jabiko.ttsRate", "not-a-number");
+    expect(readTtsRate()).toBe(TTS_RATE_DEFAULT);
+  });
+
+  it("falls back to the default (not the minimum) for an empty stored value", () => {
+    localStorage.setItem("jabiko.ttsRate", "");
+    expect(readTtsRate()).toBe(TTS_RATE_DEFAULT);
+    localStorage.setItem("jabiko.ttsRate", "   ");
+    expect(readTtsRate()).toBe(TTS_RATE_DEFAULT);
+  });
+});
+
+describe("TTS_RATE_PRESETS", () => {
+  it("includes a normal preset equal to the default (no change for existing users)", () => {
+    expect(TTS_RATE_PRESETS.some((preset) => preset.rate === TTS_RATE_DEFAULT)).toBe(true);
+  });
+
+  it("offers at least one slower-than-default option (the point of #527)", () => {
+    expect(TTS_RATE_PRESETS.some((preset) => preset.rate < TTS_RATE_DEFAULT)).toBe(true);
+  });
+
+  it("keeps every preset within the clamp range", () => {
+    for (const preset of TTS_RATE_PRESETS) {
+      expect(preset.rate).toBeGreaterThanOrEqual(TTS_RATE_MIN);
+      expect(preset.rate).toBeLessThanOrEqual(TTS_RATE_MAX);
+    }
+  });
+});

--- a/src/lib/ttsRate.ts
+++ b/src/lib/ttsRate.ts
@@ -1,0 +1,53 @@
+// Global speech-rate preference for the "讀出來" (TTS) buttons (#527).
+//
+// A learner asked to be able to slow the Japanese audio down. The rate is a
+// single global preference stored locally (like the furigana toggle), read
+// fresh by SpeakButton on each click so a change in the settings sidebar takes
+// effect immediately everywhere audio plays (drill / exam / kanji panels).
+//
+// Crash-safe like safeStorage: a blocked / garbage store reads back as the
+// default, so persistence can fail without breaking playback.
+import { readStored, writeStored } from "../domain/safeStorage";
+
+const TTS_RATE_KEY = "jabiko.ttsRate";
+
+// SpeechSynthesisUtterance.rate: 1.0 is the engine default. The app has always
+// spoken at 0.95 (a touch under default), so that stays the "標準" preset and
+// the no-preference default -- existing users hear no change.
+export const TTS_RATE_DEFAULT = 0.95;
+// Practical bounds: below ~0.5 the built-in voices slur; above ~1.5 it races.
+export const TTS_RATE_MIN = 0.5;
+export const TTS_RATE_MAX = 1.5;
+
+// Slow-leaning presets (the request was specifically "let me slow it down"),
+// ordered default-first so 標準 reads as the baseline and the rest step down.
+// `rate` is used verbatim as utterance.rate; labels are i18n'd by the picker.
+export const TTS_RATE_PRESETS = [
+  { id: "normal", rate: TTS_RATE_DEFAULT },
+  { id: "slow", rate: 0.7 },
+  { id: "slower", rate: 0.5 }
+] as const;
+
+export type TtsRatePresetId = (typeof TTS_RATE_PRESETS)[number]["id"];
+
+// Coerce any number into the safe range; non-finite input falls back to the
+// default rather than clamping (NaN/Infinity aren't a meaningful speed).
+export function clampTtsRate(rate: number): number {
+  if (!Number.isFinite(rate)) return TTS_RATE_DEFAULT;
+  return Math.min(TTS_RATE_MAX, Math.max(TTS_RATE_MIN, rate));
+}
+
+// The stored rate, or the default when unset / unreadable / non-numeric.
+export function readTtsRate(): number {
+  const raw = readStored(TTS_RATE_KEY);
+  // Treat missing AND empty/whitespace as unset: Number("") is 0, which would
+  // otherwise clamp up to the minimum instead of falling back to the default.
+  if (raw === null || raw.trim() === "") return TTS_RATE_DEFAULT;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? clampTtsRate(parsed) : TTS_RATE_DEFAULT;
+}
+
+// Persist a rate, clamped to the safe range so a bad custom value can't stick.
+export function writeTtsRate(rate: number): void {
+  writeStored(TTS_RATE_KEY, String(clampTtsRate(rate)));
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -248,6 +248,13 @@ export const en: Copy = {
   sessionLengthAll: "All",
   sessionLengthCustom: "Custom",
   sessionLengthCustomPlaceholder: "Count",
+  ttsRate: "Speech rate",
+  ttsRatePresets: {
+    normal: "Normal",
+    slow: "Slow",
+    slower: "Slower"
+  },
+  ttsRateCustom: "Custom",
   practiceFocus: "Practice focus",
   verbGroup: "Verb group",
   targetForm: "Target form",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -248,6 +248,13 @@ export const id: Copy = {
   sessionLengthAll: "Semua",
   sessionLengthCustom: "Atur sendiri",
   sessionLengthCustomPlaceholder: "Jumlah soal",
+  ttsRate: "Kecepatan suara",
+  ttsRatePresets: {
+    normal: "Normal",
+    slow: "Lambat",
+    slower: "Lebih lambat"
+  },
+  ttsRateCustom: "Kustom",
   practiceFocus: "Fokus latihan",
   verbGroup: "Jenis kata kerja",
   targetForm: "Bentuk target",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -256,6 +256,13 @@ export const ja: Copy = {
   sessionLengthAll: "すべて",
   sessionLengthCustom: "カスタム",
   sessionLengthCustomPlaceholder: "問題数",
+  ttsRate: "読み上げ速度",
+  ttsRatePresets: {
+    normal: "標準",
+    slow: "ゆっくり",
+    slower: "もっとゆっくり"
+  },
+  ttsRateCustom: "カスタム",
   practiceFocus: "練習の重点",
   verbGroup: "動詞の種類",
   targetForm: "目標形",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -248,6 +248,13 @@ export const ko: Copy = {
   sessionLengthAll: "전체",
   sessionLengthCustom: "직접 설정",
   sessionLengthCustomPlaceholder: "문제 수",
+  ttsRate: "읽기 속도",
+  ttsRatePresets: {
+    normal: "표준",
+    slow: "느리게",
+    slower: "더 느리게"
+  },
+  ttsRateCustom: "사용자 지정",
   practiceFocus: "연습 초점",
   verbGroup: "동사 그룹",
   targetForm: "목표 활용형",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -248,6 +248,13 @@ export const my: Copy = {
   sessionLengthAll: "အားလုံး",
   sessionLengthCustom: "စိတ်ကြိုက်",
   sessionLengthCustomPlaceholder: "အရေအတွက်",
+  ttsRate: "အသံဖတ်နှုန်း",
+  ttsRatePresets: {
+    normal: "ပုံမှန်",
+    slow: "နှေး",
+    slower: "ပိုနှေး"
+  },
+  ttsRateCustom: "စိတ်ကြိုက်",
   practiceFocus: "လေ့ကျင့်မှု အာရုံစိုက်ရာ",
   verbGroup: "ကြိယာ အုပ်စု",
   targetForm: "ပစ်မှတ် ပုံစံ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -249,6 +249,13 @@ export const th: Copy = {
   sessionLengthAll: "ทั้งหมด",
   sessionLengthCustom: "กำหนดเอง",
   sessionLengthCustomPlaceholder: "จำนวนข้อ",
+  ttsRate: "ความเร็วเสียง",
+  ttsRatePresets: {
+    normal: "ปกติ",
+    slow: "ช้า",
+    slower: "ช้ามาก"
+  },
+  ttsRateCustom: "กำหนดเอง",
   practiceFocus: "จุดเน้นการฝึก",
   verbGroup: "ประเภทคำกริยา",
   targetForm: "รูปเป้าหมาย",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -248,6 +248,13 @@ export const vi: Copy = {
   sessionLengthAll: "Tất cả",
   sessionLengthCustom: "Tùy chỉnh",
   sessionLengthCustomPlaceholder: "Số lượng",
+  ttsRate: "Tốc độ đọc",
+  ttsRatePresets: {
+    normal: "Bình thường",
+    slow: "Chậm",
+    slower: "Chậm hơn"
+  },
+  ttsRateCustom: "Tùy chỉnh",
   practiceFocus: "Trọng tâm luyện tập",
   verbGroup: "Nhóm động từ",
   targetForm: "Thể mục tiêu",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -248,6 +248,13 @@ export const zhHant: Copy = {
   sessionLengthAll: "全部",
   sessionLengthCustom: "自訂",
   sessionLengthCustomPlaceholder: "題數",
+  ttsRate: "語速",
+  ttsRatePresets: {
+    normal: "標準",
+    slow: "慢",
+    slower: "更慢"
+  },
+  ttsRateCustom: "自訂",
   practiceFocus: "練習重點",
   verbGroup: "動詞類別",
   targetForm: "目標形",

--- a/src/styles/challenge.css
+++ b/src/styles/challenge.css
@@ -107,8 +107,15 @@ legend,
   grid-template-columns: repeat(auto-fit, minmax(2.8rem, 1fr));
 }
 
-/* 自訂題數: manual count entry below the session-length presets. */
-.session-length-custom {
+/* 語速 presets are a 3-across row (標準/慢/更慢) instead of the default 2-col
+   grid, which would orphan the third onto its own line (#527). */
+.tts-rate-segmented {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+/* 自訂: manual entry below the session-length / speech-rate presets. */
+.session-length-custom,
+.tts-rate-custom {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -117,7 +124,8 @@ legend,
   color: var(--muted);
 }
 
-.session-length-custom input {
+.session-length-custom input,
+.tts-rate-custom input {
   width: 5rem;
   padding: 0.32rem 0.5rem;
   border: 1px solid var(--field-border);
@@ -127,7 +135,8 @@ legend,
   font: inherit;
 }
 
-.session-length-custom.selected input {
+.session-length-custom.selected input,
+.tts-rate-custom.selected input {
   border-color: var(--matcha-dark);
   background: var(--matcha);
   color: var(--selected-text);


### PR DESCRIPTION
## 為什麼

「讀出來」（SpeakButton）一直以固定 `rate = 0.95` 播放，使用者反映想把日文語音**放慢**。#527。

## 做法

新增全域 **語速** 偏好（`jabiko.ttsRate`）＋挑戰面板設定側欄的控制項——**segmented 三預設（標準/慢/更慢）＋ 自訂手調欄**，正好對應使用者說的「開關按鈕 或 客製化手調」。

- `src/lib/ttsRate.ts`：crash-safe 讀寫（鏡像 safeStorage），clamp 到 `[0.5, 1.5]`，`TTS_RATE_DEFAULT = 0.95`（＝原本寫死值，**未設定＝零行為改變**）。空字串/空白讀回 default 而非 clamp 到最小值。
- `src/hooks/useTtsRate.ts`：持有偏好（鏡像 useFurigana）。
- `src/components/challenge/TtsRatePicker.tsx`：預設 + 自訂欄用 draft string，讓 <1 的慢速（如 0.8）能**逐字輸入**（避免 controlled value 綁 rate 把前導 `0` 還原）；只在 `[MIN,MAX]` 範圍內提交，`onBlur` 把空/超範圍 draft 還原成有效語速。
- `SpeakButton`：每次點擊 `readTtsRate()` 讀最新值，故側欄改語速會**即時套用到所有面板**（drill / exam / 漢字）的播放鈕，無需 context 佈線。
- 8 語系 + `Copy` 型別：`ttsRate` / `ttsRatePresets{normal,slow,slower}` / `ttsRateCustom`。

## 範圍與落點

放在挑戰設定側欄（`SessionLengthPicker` 旁）而非 header——遵循「避免 header 膨脹」的 UI 成長紀律；偏好是全域的，所以漢字面板等也自動吃到。

## 測試 / 驗證

- TDD：`ttsRate`（clamp/read/write/空字串/預設）、`useTtsRate`（default/persist/setRate 雙 clamp）、`TtsRatePicker`（選中態/慢速/自訂/逐字輸入不還原/超範圍不提交+blur 還原/preset 清 draft）皆先紅後綠。
- `pnpm test` 806 綠、`tsc` 綠、`pnpm build` 綠（eager `index` chunk 幾乎無變化；新程式都在 lazy 的 ChallengePanel/SpeakButton chunk）。
- Claude_Preview 實機：picker 渲染正確、預設/自訂寫入 localStorage、**端到端確認 SpeakButton 點擊時 utterance.rate 讀到設定值（0.7）**。
- 雙審（codex + code-reviewer subagent）PASS：codex 三輪修正（逐字輸入、空字串、範圍+blur），subagent 補 `useTtsRate` 直接測試；未觸碰任何 `*Zh` 欄位或 `isZhHant` 閘門。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new speech speed control with preset options and a custom value input.
  * Speech playback now follows the selected speed setting immediately and remembers it between sessions.
  * Added localized labels for the new speech speed controls in multiple languages.

* **Bug Fixes**
  * Improved handling of custom speed entry so partial or out-of-range values no longer cause awkward input behavior.
  * Updated the speak action to use the current saved speed instead of a fixed default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->