### PR TITLE
feat(starter): 基礎詞彙 97 詞 deck＋入門章節＋意思 drill (Part of #533, #531)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -595,6 +595,7 @@ export default function App() {
           onStartKanaDrill={(script) =>
             openChallenge({ mode: "kana", filter: { kanaScript: script } })
           }
+          onStartStarterDrill={() => openChallenge({ mode: "starter" })}
         />
       ) : appView === "rules" ? (
         <RulesPanel language={language} />

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -29,7 +29,8 @@ export function LearningPanel({
   onStartDrill,
   onStartPatternDrill,
   onStartExamSection,
-  onStartKanaDrill
+  onStartKanaDrill,
+  onStartStarterDrill
 }: {
   language: Language;
   progressAttempts: Attempt[];
@@ -41,6 +42,8 @@ export function LearningPanel({
   onStartExamSection: (level: "N1" | "N2" | "N3", promptLabel: string) => void;
   // Launches the kana recognition drill for an 入門 chapter (#533).
   onStartKanaDrill: (script: KanaScript) => void;
+  // Launches the starter-vocab meaning drill (#533).
+  onStartStarterDrill: () => void;
 }) {
   const t = copy[language];
   // Study-chapter translations are heavy and grow per language, so they're
@@ -247,6 +250,19 @@ export function LearningPanel({
                 >
                   <ArrowRight aria-hidden="true" />
                   {drillButtonLabel(active.kanaDrill)}
+                </button>
+              </div>
+            ) : null}
+
+            {active.starterDrill ? (
+              <div className="inline-action-row">
+                <button
+                  className="inline-drill-button"
+                  type="button"
+                  onClick={onStartStarterDrill}
+                >
+                  <ArrowRight aria-hidden="true" />
+                  {drillButtonLabel(active.starterDrill)}
                 </button>
               </div>
             ) : null}

--- a/src/domain/challengeDeepLink.ts
+++ b/src/domain/challengeDeepLink.ts
@@ -11,7 +11,7 @@ import type { LevelRange } from "./levelRange";
 
 export type ChallengeDeepLink = { mode?: PracticeMode; levelRange?: LevelRange };
 
-const MODES: readonly PracticeMode[] = ["basic", "cloze", "daily", "kana", "pattern", "exam", "review", "vocab"];
+const MODES: readonly PracticeMode[] = ["basic", "cloze", "daily", "kana", "starter", "pattern", "exam", "review", "vocab"];
 const RANGES: readonly LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5"];
 
 function asMode(value: string | null): PracticeMode | undefined {

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -122,6 +122,52 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "starter-vocab": {
+    "en": {
+      "category": "Starter",
+      "kicker": "Lesson 0",
+      "title": "Starter Vocabulary",
+      "explanation":
+        "Once you can read kana, stock up on a first batch of immediately useful words: greetings, numbers, time words, the people and things around you, and the most common verbs and adjectives. Every word here is written in kana only -- no kanji needed. The example sentences in the grammar chapters ahead are built almost entirely from these words.",
+      "notes": [
+        "Greetings: your first spoken steps",
+        "Numbers: shopping and telling time both rely on them",
+        "Time words",
+        "People and forms of address",
+        "Everyday nouns",
+        "The most common verbs",
+        "Common adjectives",
+        "Ko-so-a-do: pointing at things, asking where"
+      ],
+      "pitfalls": [
+        "すみません (getting attention / a light apology) and ごめんなさい (owning up and apologizing) are used in different situations",
+        "これ／それ／あれ split by distance: near me → これ, near you → それ, far from both → あれ",
+        "たかい means both \"tall/high\" and \"expensive\" -- judge from context"
+      ]
+    },
+    "ja": {
+      "category": "入門",
+      "kicker": "第0課",
+      "title": "基礎単語",
+      "explanation":
+        "仮名が読めるようになったら、まず「すぐ使える」単語をひとまとめに覚える：あいさつ、数字、時間のことば、身の回りの人と物、いちばんよく使う動詞と形容詞。ここの単語はすべて仮名書きなので、漢字を知らなくても練習できる。この先の文法章の例文は、ほぼこれらの単語でできている。",
+      "notes": [
+        "あいさつ：口に出す第一歩",
+        "数字：買い物にも時間にも必要",
+        "時間のことば",
+        "人と呼び方",
+        "身の回りの名詞",
+        "最頻出の動詞",
+        "よく使う形容詞",
+        "こそあど：物を指す・場所をたずねる"
+      ],
+      "pitfalls": [
+        "すみません（呼びかけ・軽い謝罪）と ごめんなさい（非を認めて謝る）は場面が違う",
+        "これ／それ／あれ は「どちらに近いか」で使い分け：自分の近く→これ、相手の近く→それ、どちらからも遠い→あれ",
+        "たかい には「高い」と「（値段が）高い」の両方の意味がある。文脈で判断"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,20 +59,48 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana (#533) + 11 conjugation + 7 sentence-pattern; only verb-types
-    // stays reference.
-    expect(trackable.length).toBe(20);
+    // 2 kana + 1 starter-vocab (#533) + 11 conjugation + 7 sentence-pattern;
+    // only verb-types stays reference.
+    expect(trackable.length).toBe(21);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });
 });
 
 describe("kana starter chapters (#533)", () => {
-  it("the two 入門 chapters lead the chapter list, ahead of every other category", () => {
+  it("the three 入門 chapters lead the chapter list, ahead of every other category", () => {
     expect(learningBlocks[0].id).toBe("kana-hiragana");
     expect(learningBlocks[1].id).toBe("kana-katakana");
+    expect(learningBlocks[2].id).toBe("starter-vocab");
     expect(learningBlocks[0].category).toBe("入門");
-    expect(learningBlocks[2].category).not.toBe("入門");
+    expect(learningBlocks[2].category).toBe("入門");
+    expect(learningBlocks[3].category).not.toBe("入門");
+  });
+
+  it("the starter-vocab chapter completes via a starter attempt or implicit history", () => {
+    const starter = byId("starter-vocab");
+    expect(isLearningBlockComplete([], starter)).toBe(false);
+    // One correct starter-drill answer (buildQuestionPool ids are "<vocabId>:<form>").
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "meaning", questionId: "starter-mizu:meaning" }],
+        starter
+      )
+    ).toBe(true);
+    // Kana drills alone prove kana literacy, not vocab knowledge.
+    const kanaOnly = Array.from({ length: 10 }, (_, index) => ({
+      isCorrect: true,
+      targetForm: "reading",
+      questionId: `kana-hiragana-read-${index}`
+    }));
+    expect(isLearningBlockComplete(kanaOnly, starter)).toBe(false);
+    // A real (non-入門) practice history implies this floor is behind them.
+    const regular = Array.from({ length: 5 }, (_, index) => ({
+      isCorrect: true,
+      targetForm: "te",
+      questionId: `n3-grammar-item-${index}`
+    }));
+    expect(isLearningBlockComplete(regular, starter)).toBe(true);
   });
 
   it("a kana chapter completes via one correct kana-drill attempt of its script", () => {

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -30,6 +30,10 @@ export type LearningBlockKanaDrill = {
   script: KanaScript;
 };
 
+export type LearningBlockStarterDrill = {
+  labelKey: string;
+};
+
 export type LearningBlockExamDrill = {
   labelKey: string;
   /** JLPT level whose exam pool to drill (matches the 模擬考 section launch). */
@@ -77,6 +81,11 @@ export type LearningBlock = {
    * ("kana-<script>-…"), not by a conjugation form.
    */
   kanaDrill?: LearningBlockKanaDrill;
+  /**
+   * Launches the starter-vocab meaning drill (#533). Completion is judged by
+   * starter question ids ("starter-…"), like the kana chapters.
+   */
+  starterDrill?: LearningBlockStarterDrill;
   /**
    * Launches exam practice filtered to a JLPT level + section (promptLabel),
    * e.g. N3 文法形式選擇. Used by N3+ grammar-lesson chapters whose practice is
@@ -172,6 +181,33 @@ export const learningBlocks: LearningBlock[] = [
       "ク/ワ/フ、コ/ユ、チ/テ 也是常見形近組"
     ],
     kanaDrill: { labelKey: "drillKana", script: "katakana" },
+    recommendedAfter: ["kana-hiragana"]
+  },
+  {
+    id: "starter-vocab",
+    group: "basic",
+    category: "入門",
+    kicker: "第 0 課",
+    title: "基礎詞彙",
+    subtitle: "みず・いぬ・ありがとう",
+    explanation:
+      "會唸假名之後，先背一批「馬上用得到」的詞：招呼語、數字、時間、身邊的人事物、最常用的動詞和形容詞。這批詞全部用假名書寫，不用會漢字也能練。之後每個文法章節的例句，幾乎都由這些詞組成。",
+    examples: [
+      { formula: "ありがとう・すみません・おはよう", note: "招呼語：開口的第一步" },
+      { formula: "いち・に・さん・じゅう・ひゃく", note: "數字：買東西、報時間都靠它" },
+      { formula: "きょう・あした・いま・まいにち", note: "時間詞" },
+      { formula: "わたし・せんせい・ともだち・かぞく", note: "人與稱謂" },
+      { formula: "みず・ごはん・いえ・がっこう", note: "身邊名詞" },
+      { formula: "たべる・のむ・いく・みる", note: "最常用動詞" },
+      { formula: "おおきい・ちいさい・おいしい", note: "常用形容詞" },
+      { formula: "これ・それ・あれ・ここ・どこ", note: "こそあど：指東西問地方" }
+    ],
+    pitfalls: [
+      "すみません（喚起注意／輕道歉）和 ごめんなさい（認錯道歉）場合不同",
+      "これ／それ／あれ 按「離誰近」區分：近自己→これ、近對方→それ、都遠→あれ",
+      "たかい 同時有「高」和「貴」兩個意思，看語境判斷"
+    ],
+    starterDrill: { labelKey: "drillStarterVocab" },
     recommendedAfter: ["kana-hiragana"]
   },
   {
@@ -1214,6 +1250,22 @@ export function isLearningBlockComplete(attempts: CompletionAttempt[], block: Le
       (attempt) => attempt.isCorrect && !attempt.questionId?.startsWith("kana-")
     ).length;
     return literacyEvidence >= KANA_IMPLICIT_LITERACY_THRESHOLD;
+  }
+  // The starter-vocab chapter (#533) mirrors the kana rule: complete via one
+  // correct starter-drill answer, or implicitly for learners whose history
+  // already shows real (non-入門) practice.
+  if (block.starterDrill) {
+    const drilled = attempts.some(
+      (attempt) => attempt.isCorrect && attempt.questionId?.startsWith("starter-")
+    );
+    if (drilled) return true;
+    const evidence = attempts.filter(
+      (attempt) =>
+        attempt.isCorrect &&
+        !attempt.questionId?.startsWith("kana-") &&
+        !attempt.questionId?.startsWith("starter-")
+    ).length;
+    return evidence >= KANA_IMPLICIT_LITERACY_THRESHOLD;
   }
   // Sentence-pattern chapters are completed via their pattern drill -- a
   // correct attempt on any of the chapter's patterns (id "pattern-<id>-…") --

--- a/src/domain/practiceMode.ts
+++ b/src/domain/practiceMode.ts
@@ -8,6 +8,7 @@ export type PracticeMode =
   | "cloze"
   | "daily"
   | "kana"
+  | "starter"
   | "pattern"
   | "exam"
   | "review"

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -30,6 +30,7 @@ function poolParams(overrides: Partial<PracticePoolParams> = {}): PracticePoolPa
     isVocabFocus: false,
     isDailyFocus: false,
     isKanaFocus: false,
+    isStarterFocus: false,
     isBookmarksFocus: false,
     partOfSpeech: "verb",
     verbGroup: "godan",
@@ -71,6 +72,24 @@ describe("buildPracticeQuestions kana branch (#533)", () => {
     const known = buildAllKnownQuestions();
     expect(known.some((question) => question.id.startsWith("kana-hiragana-"))).toBe(true);
     expect(known.some((question) => question.id.startsWith("kana-katakana-match-"))).toBe(true);
+  });
+});
+
+describe("buildPracticeQuestions starter branch (#533)", () => {
+  it("starter focus builds one meaning question per deck word", () => {
+    const pool = buildPracticeQuestions(poolParams({ isStarterFocus: true, sessionLength: null }));
+    expect(pool.length).toBeGreaterThanOrEqual(90);
+    expect(pool.every((question) => question.targetForm === "meaning")).toBe(true);
+    expect(pool.every((question) => question.id.startsWith("starter-"))).toBe(true);
+  });
+
+  it("starter focus honours the session-length cap and resolves in buildAllKnownQuestions", () => {
+    const capped = buildPracticeQuestions(
+      poolParams({ isStarterFocus: true, sessionLength: 10 })
+    );
+    expect(capped).toHaveLength(10);
+    const known = buildAllKnownQuestions();
+    expect(known.some((question) => question.id.startsWith("starter-"))).toBe(true);
   });
 });
 

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -27,6 +27,7 @@ import {
 } from "./practice";
 import type { PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./types";
 import { prioritizeUnattempted } from "./unattempted";
+import { starterVocabulary } from "./starterVocabulary";
 import { vocabulary } from "./vocabulary";
 import { jlptVocabulary } from "./vocabulary-jlpt";
 
@@ -133,11 +134,16 @@ export function buildAllKnownQuestions(): PracticeQuestion[] {
     ...buildExamQuestionPool(["N1", "N2", "N3", "N4", "N5"]),
     ...buildClozeQuestionPool(clozeSentences, vocabulary),
     ...buildSentencePatternPool(),
-    // Both kana scripts (#533): a missed kana question must resolve here or
-    // it silently vanishes from the weak-point queue / 收藏 (same trap as
-    // the N4/N5 exam items above).
+    // Both kana scripts + the starter deck (#533): a missed 入門 question
+    // must resolve here or it silently vanishes from the weak-point queue /
+    // 收藏 (same trap as the N4/N5 exam items above).
     ...buildKanaQuestionPool({ script: "hiragana" }),
     ...buildKanaQuestionPool({ script: "katakana" }),
+    ...buildQuestionPool(starterVocabulary, {
+      partOfSpeech: "mixed",
+      verbGroup: "all",
+      targetForms: ["meaning"]
+    }),
     ...buildQuestionPool(vocabulary, {
       partOfSpeech: "mixed",
       verbGroup: "all",
@@ -178,6 +184,7 @@ export type PracticePoolParams = {
   isVocabFocus: boolean;
   isDailyFocus: boolean;
   isKanaFocus: boolean;
+  isStarterFocus: boolean;
   isBookmarksFocus: boolean;
   examSection?: { level: MockExamLevel; promptLabel: string };
   patternIds?: SentencePatternId[];
@@ -221,6 +228,7 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
     isVocabFocus,
     isDailyFocus,
     isKanaFocus,
+    isStarterFocus,
     isBookmarksFocus,
     examSection,
     patternIds,
@@ -276,6 +284,21 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
   if (isKanaFocus) {
     // Kana recognition drill (#533): the 入門 chapter CTAs pick the script.
     return cap(shuffleQuestions(buildKanaQuestionPool({ script: kanaScript ?? "hiragana" })));
+  }
+
+  if (isStarterFocus) {
+    // Starter-vocab meaning drill (#533): see the kana word, pick its
+    // meaning. Distractors come from the same deck (pool-based), whose
+    // pairwise-distinct meanings are locked by starterVocabulary.test.ts.
+    return cap(
+      shuffleQuestions(
+        buildQuestionPool(starterVocabulary, {
+          partOfSpeech: "mixed",
+          verbGroup: "all",
+          targetForms: ["meaning"]
+        })
+      )
+    );
   }
 
   if (isReviewFocus) {

--- a/src/domain/starterVocabulary.test.ts
+++ b/src/domain/starterVocabulary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { STARTER_CATEGORIES, starterVocabulary } from "./starterVocabulary";
+
+describe("starterVocabulary integrity (#533 starter deck)", () => {
+  it("holds a meaningful deck: 90+ words across the 8 starter categories", () => {
+    expect(starterVocabulary.length).toBeGreaterThanOrEqual(90);
+    for (const category of STARTER_CATEGORIES) {
+      const inCategory = starterVocabulary.filter((word) => word.tags.includes(category));
+      expect(inCategory.length, category).toBeGreaterThanOrEqual(8);
+    }
+  });
+
+  it("every word is starter-shaped: kana-only surface, N5, tagged starter", () => {
+    for (const word of starterVocabulary) {
+      // Surface is pure kana (+ー) -- the deck sits right after the kana
+      // chapters, before any kanji instruction.
+      expect(word.surface, word.id).toMatch(/^[ぁ-んァ-ヶー]+$/);
+      expect(word.reading, word.id).toBe(word.surface);
+      expect(word.level, word.id).toBe("N5");
+      expect(word.tags, word.id).toContain("starter");
+      expect(STARTER_CATEGORIES.some((category) => word.tags.includes(category)), word.id).toBe(
+        true
+      );
+    }
+  });
+
+  it("ids and surfaces are unique; meanings are pairwise distinct (unique-solution guard)", () => {
+    const ids = starterVocabulary.map((word) => word.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    const surfaces = starterVocabulary.map((word) => word.surface);
+    expect(new Set(surfaces).size).toBe(surfaces.length);
+    // The meaning drill draws its distractors from this same deck, so two
+    // words sharing an identical meaning string would be a double solution.
+    const meanings = starterVocabulary.map((word) => word.meaningZh);
+    expect(new Set(meanings).size).toBe(meanings.length);
+  });
+
+  it("every word carries en+ja meaning overlays (data-ready for i18n) and no empty fields", () => {
+    for (const word of starterVocabulary) {
+      expect(word.meaningZh.trim(), word.id).not.toHaveLength(0);
+      expect(word.meaningI18n?.en?.trim(), word.id).toBeTruthy();
+      expect(word.meaningI18n?.ja?.trim(), word.id).toBeTruthy();
+    }
+  });
+
+  it("ids are stable ASCII (SRS/mistake-pool keys)", () => {
+    for (const word of starterVocabulary) {
+      expect(word.id, word.id).toMatch(/^starter-[a-z0-9-]+$/);
+    }
+  });
+});

--- a/src/domain/starterVocabulary.ts
+++ b/src/domain/starterVocabulary.ts
@@ -1,0 +1,219 @@
+// The absolute-beginner starter deck (#533, beginner zone #531): the first
+// ~95 words a zero-base learner meets, drilled kana-only (surface === reading)
+// right after the gojuon chapters and BEFORE any kanji instruction.
+//
+// Deck rules (locked by starterVocabulary.test.ts):
+//   - surface is pure kana (ぁ-ん / ァ-ヶ / ー), reading === surface;
+//   - meanings are PAIRWISE DISTINCT -- the meaning drill draws distractors
+//     from this same deck, so two words sharing a meaning string would be a
+//     double solution (e.g. すみません vs ごめんなさい are deliberately
+//     glossed apart);
+//   - every word carries en+ja meaning overlays so the deck is data-ready
+//     for a localized meaning drill (the answer/option pipeline itself still
+//     compares meaningZh verbatim -- an existing app-wide behaviour);
+//   - ids are stable ASCII (they key SRS / mistake-pool history, #525).
+//
+// This deck is intentionally SEPARATE from vocabulary.ts (the conjugation
+// deck): nothing here feeds the 基礎變化 drills, and only the meaning drill
+// consumes it (via sessionPools' starter branch).
+import type { VocabularyItem } from "./types";
+
+export const STARTER_CATEGORIES = [
+  "greetings",
+  "numbers",
+  "time",
+  "people",
+  "things",
+  "verbs",
+  "adjectives",
+  "kosoado"
+] as const;
+
+export type StarterCategory = (typeof STARTER_CATEGORIES)[number];
+
+type StarterSpec = [
+  id: string,
+  surface: string,
+  meaningZh: string,
+  en: string,
+  ja: string,
+  partOfSpeech: VocabularyItem["partOfSpeech"],
+  group?: VocabularyItem["group"]
+];
+
+const DECK: Record<StarterCategory, StarterSpec[]> = {
+  greetings: [
+    ["starter-ohayou", "おはよう", "早安", "good morning", "朝のあいさつ", "expression"],
+    ["starter-konnichiwa", "こんにちは", "你好（白天）", "hello (daytime)", "昼のあいさつ", "expression"],
+    ["starter-konbanwa", "こんばんは", "你好（晚上）", "good evening", "夜、人に会ったときのあいさつ", "expression"],
+    ["starter-arigatou", "ありがとう", "謝謝", "thank you", "感謝のことば", "expression"],
+    [
+      "starter-sumimasen",
+      "すみません",
+      "不好意思（呼喚／輕道歉）",
+      "excuse me (to get attention); sorry",
+      "謝るときや人を呼ぶときのことば",
+      "expression"
+    ],
+    [
+      "starter-gomennasai",
+      "ごめんなさい",
+      "對不起（認錯）",
+      "I'm sorry (admitting fault)",
+      "自分が悪いと認めて謝ることば",
+      "expression"
+    ],
+    ["starter-sayounara", "さようなら", "再見", "goodbye", "別れのあいさつ", "expression"],
+    ["starter-oyasuminasai", "おやすみなさい", "晚安（睡前）", "good night", "寝る前のあいさつ", "expression"],
+    [
+      "starter-itadakimasu",
+      "いただきます",
+      "開動了（飯前）",
+      "said before eating",
+      "食事の前のあいさつ",
+      "expression"
+    ],
+    [
+      "starter-gochisousama",
+      "ごちそうさま",
+      "吃飽了、多謝款待（飯後）",
+      "said after eating",
+      "食事の後のあいさつ",
+      "expression"
+    ],
+    [
+      "starter-hajimemashite",
+      "はじめまして",
+      "初次見面",
+      "nice to meet you",
+      "初対面のあいさつ",
+      "expression"
+    ],
+    [
+      "starter-onegaishimasu",
+      "おねがいします",
+      "拜託了、麻煩你",
+      "please (requesting)",
+      "人に頼むときのことば",
+      "expression"
+    ],
+    ["starter-hai", "はい", "是、對", "yes", "肯定の返事", "expression"],
+    ["starter-iie", "いいえ", "不、不是", "no", "否定の返事", "expression"]
+  ],
+  numbers: [
+    ["starter-ichi", "いち", "一", "one", "数字の 1", "noun"],
+    ["starter-ni", "に", "二", "two", "数字の 2", "noun"],
+    ["starter-san", "さん", "三", "three", "数字の 3", "noun"],
+    ["starter-yon", "よん", "四", "four", "数字の 4", "noun"],
+    ["starter-go", "ご", "五", "five", "数字の 5", "noun"],
+    ["starter-roku", "ろく", "六", "six", "数字の 6", "noun"],
+    ["starter-nana", "なな", "七", "seven", "数字の 7", "noun"],
+    ["starter-hachi", "はち", "八", "eight", "数字の 8", "noun"],
+    ["starter-kyuu", "きゅう", "九", "nine", "数字の 9", "noun"],
+    ["starter-juu", "じゅう", "十", "ten", "数字の 10", "noun"],
+    ["starter-hyaku", "ひゃく", "百", "hundred", "数字の 100", "noun"]
+  ],
+  time: [
+    ["starter-kyou", "きょう", "今天", "today", "この日", "noun"],
+    ["starter-ashita", "あした", "明天", "tomorrow", "今日の次の日", "noun"],
+    ["starter-kinou", "きのう", "昨天", "yesterday", "今日の前の日", "noun"],
+    ["starter-ima", "いま", "現在", "now", "この瞬間", "noun"],
+    ["starter-asa", "あさ", "早上", "morning", "一日のはじめの時間", "noun"],
+    ["starter-hiru", "ひる", "中午", "noon", "正午ごろ", "noun"],
+    ["starter-yoru", "よる", "晚上", "night", "日が沈んだあとの時間", "noun"],
+    ["starter-mainichi", "まいにち", "每天", "every day", "どの日も", "noun"],
+    ["starter-jikan", "じかん", "時間", "time", "時の長さ", "noun"],
+    ["starter-tokei", "とけい", "時鐘、手錶", "clock; watch", "時刻を知る道具", "noun"]
+  ],
+  people: [
+    ["starter-watashi", "わたし", "我", "I; me", "自分を指すことば", "noun"],
+    ["starter-anata", "あなた", "你", "you", "相手を指すことば", "noun"],
+    ["starter-sensei", "せんせい", "老師", "teacher", "教える人", "noun"],
+    ["starter-tomodachi", "ともだち", "朋友", "friend", "親しい人", "noun"],
+    ["starter-kazoku", "かぞく", "家人", "family", "親や兄弟など", "noun"],
+    ["starter-okaasan", "おかあさん", "媽媽", "mother", "母を呼ぶことば", "noun"],
+    ["starter-otousan", "おとうさん", "爸爸", "father", "父を呼ぶことば", "noun"],
+    ["starter-kodomo", "こども", "小孩", "child", "おさない人", "noun"],
+    ["starter-otoko", "おとこ", "男人", "man", "男性", "noun"],
+    ["starter-onna", "おんな", "女人", "woman", "女性", "noun"],
+    ["starter-hito", "ひと", "人", "person", "人間", "noun"],
+    ["starter-namae", "なまえ", "名字", "name", "人や物の呼び名", "noun"]
+  ],
+  things: [
+    ["starter-mizu", "みず", "水", "water", "飲んだり洗ったりする液体", "noun"],
+    ["starter-gohan", "ごはん", "飯、餐", "rice; meal", "食事・米のめし", "noun"],
+    ["starter-ie", "いえ", "房子", "house", "住む建物", "noun"],
+    ["starter-gakkou", "がっこう", "學校", "school", "勉強する所", "noun"],
+    ["starter-hon", "ほん", "書", "book", "読む物", "noun"],
+    ["starter-kuruma", "くるま", "汽車", "car", "道路を走る乗り物", "noun"],
+    ["starter-densha", "でんしゃ", "電車", "train", "線路を走る乗り物", "noun"],
+    ["starter-inu", "いぬ", "狗", "dog", "ワンとなく動物", "noun"],
+    ["starter-neko", "ねこ", "貓", "cat", "ニャーとなく動物", "noun"],
+    ["starter-kaban", "かばん", "包包", "bag", "物を入れて持ち歩く物", "noun"],
+    ["starter-keitai", "けいたい", "手機", "mobile phone", "持ち歩く電話", "noun"],
+    ["starter-okane", "おかね", "錢", "money", "買い物に使う物", "noun"]
+  ],
+  verbs: [
+    ["starter-taberu", "たべる", "吃", "to eat", "食事をする", "verb", "ichidan"],
+    ["starter-nomu", "のむ", "喝", "to drink", "水などを口に入れる", "verb", "godan"],
+    ["starter-iku", "いく", "去", "to go", "ある場所へ向かう", "verb", "godan"],
+    ["starter-kuru", "くる", "來", "to come", "こちらへ向かう", "verb", "irregular"],
+    ["starter-miru", "みる", "看、觀看", "to see; to watch", "目で物の形や様子を知る", "verb", "ichidan"],
+    ["starter-kiku", "きく", "聽、問", "to listen; to ask", "耳で聞く・たずねる", "verb", "godan"],
+    ["starter-hanasu", "はなす", "說、講", "to speak", "ことばを口に出す", "verb", "godan"],
+    ["starter-yomu", "よむ", "閱讀（文字）", "to read", "文字を目で追う", "verb", "godan"],
+    ["starter-kaku", "かく", "寫", "to write", "文字をしるす", "verb", "godan"],
+    ["starter-kau", "かう", "買", "to buy", "お金を払って手に入れる", "verb", "godan"],
+    ["starter-neru", "ねる", "睡覺", "to sleep", "眠る", "verb", "ichidan"],
+    ["starter-okiru", "おきる", "起床", "to get up", "眠りから覚めて起き上がる", "verb", "ichidan"]
+  ],
+  adjectives: [
+    ["starter-ookii", "おおきい", "大的", "big", "サイズが上", "i_adjective"],
+    ["starter-chiisai", "ちいさい", "小的", "small", "サイズが下", "i_adjective"],
+    ["starter-takai", "たかい", "高的、貴的", "high; expensive", "高さ・値段が上", "i_adjective"],
+    ["starter-yasui", "やすい", "便宜的", "cheap", "値段が下", "i_adjective"],
+    ["starter-atsui", "あつい", "熱的", "hot", "温度が高い", "i_adjective"],
+    ["starter-samui", "さむい", "寒冷的（天氣）", "cold (weather)", "気温が低い", "i_adjective"],
+    ["starter-oishii", "おいしい", "好吃的", "delicious", "味がいい", "i_adjective"],
+    ["starter-tanoshii", "たのしい", "愉快的", "fun; enjoyable", "気分が明るくなる", "i_adjective"],
+    ["starter-ii", "いい", "好的、良好的", "good", "望ましい", "i_adjective"],
+    ["starter-warui", "わるい", "壞的", "bad", "望ましくない", "i_adjective"],
+    ["starter-atarashii", "あたらしい", "新的", "new", "できたばかり", "i_adjective"],
+    ["starter-furui", "ふるい", "舊的", "old (things)", "時間がたっている", "i_adjective"]
+  ],
+  kosoado: [
+    ["starter-kore", "これ", "這個（靠近自己）", "this (near me)", "自分の近くの物", "noun"],
+    ["starter-sore", "それ", "那個（靠近對方）", "that (near you)", "相手の近くの物", "noun"],
+    ["starter-are", "あれ", "那個（在遠處）", "that (over there)", "どちらからも遠い物", "noun"],
+    ["starter-koko", "ここ", "這裡", "here", "自分のいる場所", "noun"],
+    ["starter-doko", "どこ", "哪裡", "where", "場所をたずねることば", "noun"],
+    ["starter-nani", "なに", "什麼", "what", "物事をたずねることば", "noun"],
+    ["starter-dare", "だれ", "誰", "who", "人をたずねることば", "noun"],
+    ["starter-itsu", "いつ", "什麼時候", "when", "時をたずねることば", "noun"],
+    ["starter-ikura", "いくら", "多少錢", "how much", "値段をたずねることば", "noun"],
+    ["starter-dou", "どう", "怎麼樣", "how; what about", "様子をたずねることば", "adverb"],
+    ["starter-dore", "どれ", "哪個", "which one", "いくつかの中から選んでたずねることば", "noun"],
+    ["starter-soko", "そこ", "那裡（靠近對方）", "there (near you)", "相手のいる場所", "noun"]
+  ]
+};
+
+function toItem(spec: StarterSpec, category: StarterCategory): VocabularyItem {
+  const [id, surface, meaningZh, en, ja, partOfSpeech, group] = spec;
+  return {
+    id,
+    surface,
+    reading: surface,
+    meaningZh,
+    meaningI18n: { en, ja },
+    partOfSpeech,
+    group: group ?? null,
+    lesson: null,
+    tags: ["starter", category],
+    examples: [],
+    level: "N5"
+  };
+}
+
+export const starterVocabulary: VocabularyItem[] = STARTER_CATEGORIES.flatMap((category) =>
+  DECK[category].map((spec) => toItem(spec, category))
+);

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,4 +1,8 @@
-export type PartOfSpeech = "verb" | "i_adjective" | "na_adjective" | "noun" | "adverb";
+// "expression" = greetings / set phrases (あいさつ表現, #533 starter deck):
+// they conjugate like nothing else, and labelling them 名詞 would teach a
+// beginner the wrong word class on their very first drill. Additive union
+// member -- every existing consumer stays valid.
+export type PartOfSpeech = "verb" | "i_adjective" | "na_adjective" | "noun" | "adverb" | "expression";
 
 export type VerbGroup = "godan" | "ichidan" | "irregular";
 

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -179,6 +179,7 @@ export function usePracticeSession({
   const isVocabFocus = practiceMode === "vocab";
   const isDailyFocus = practiceMode === "daily";
   const isKanaFocus = practiceMode === "kana";
+  const isStarterFocus = practiceMode === "starter";
   const isBookmarksFocus = practiceMode === "bookmarks";
   const isCuratedFocus =
     isExamFocus ||
@@ -188,6 +189,7 @@ export function usePracticeSession({
     isVocabFocus ||
     isDailyFocus ||
     isKanaFocus ||
+    isStarterFocus ||
     isBookmarksFocus;
   // The session-length picker applies to the endless drill modes (exam /
   // cloze / pattern / vocab / basic). review clears the whole due queue,
@@ -284,6 +286,7 @@ export function usePracticeSession({
         isVocabFocus,
         isDailyFocus,
         isKanaFocus,
+        isStarterFocus,
         isBookmarksFocus,
         examSection: practiceFilter.examSection,
         patternIds: practiceFilter.patternIds,
@@ -319,6 +322,7 @@ export function usePracticeSession({
       isVocabFocus,
       isDailyFocus,
       isKanaFocus,
+      isStarterFocus,
       isBookmarksFocus,
       practiceFilter.patternIds,
       practiceFilter.examSection,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -208,6 +208,7 @@ export type Copy = {
   drillPatternTeAux: string;
   drillN3Grammar: string;
   drillKana: string;
+  drillStarterVocab: string;
   startChallenge: string;
   settingsLabel: string;
   todayPractice: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -225,6 +225,7 @@ export const en: Copy = {
   drillPatternTeAux: "Pattern drill: auxiliary verbs",
   drillN3Grammar: "Go drill N3 grammar",
   drillKana: "Drill kana recognition",
+  drillStarterVocab: "Drill starter vocabulary",
   startChallenge: "Start practice",
   settingsLabel: "Practice settings",
   todayPractice: "Today's practice",
@@ -358,6 +359,7 @@ export const en: Copy = {
   modeOptions: {
     daily: { title: "Today's practice", subtitle: "Review first · mixed round of grammar / word order / kanji readings" },
     kana: { title: "Kana", subtitle: "Hiragana/katakana recognition" },
+    starter: { title: "Starter vocabulary", subtitle: "95 starter words · pick the meaning" },
     basic: { title: "Basic conjugation", subtitle: "Part-of-speech conjugation drills · textbook vocabulary" },
     cloze: { title: "Sentence cloze", subtitle: "N5 patterns · 〜てください / 〜たいです" },
     pattern: { title: "Pattern practice", subtitle: "N5/N4 pattern recognition · perspective / permission / quoting / don't-have-to" },
@@ -421,6 +423,7 @@ export const en: Copy = {
     na_adjective: "な-adjective",
     noun: "Noun",
     adverb: "Adverb",
+    expression: "Expression",
     mixed: "Mixed"
   },
   verbGroups: {

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -225,6 +225,7 @@ export const id: Copy = {
   drillPatternTeAux: "Latih pola: kata kerja bantu",
   drillN3Grammar: "Latih soal tata bahasa N3",
   drillKana: "Latihan pengenalan kana",
+  drillStarterVocab: "Latihan kosakata dasar",
   startChallenge: "Mulai tantangan",
   settingsLabel: "Pengaturan latihan",
   todayPractice: "Latihan hari ini",
@@ -358,6 +359,7 @@ export const id: Copy = {
   modeOptions: {
     daily: { title: "Latihan hari ini", subtitle: "Ulangan diprioritaskan · satu putaran campuran tata bahasa / urutan kata / bacaan kanji" },
     kana: { title: "Kana", subtitle: "Pengenalan hiragana/katakana" },
+    starter: { title: "Kosakata dasar", subtitle: "95 kata pemula · pilih artinya" },
     basic: { title: "Konjugasi dasar", subtitle: "Latihan konjugasi jenis kata · kosakata buku pelajaran" },
     cloze: { title: "Isian dalam kalimat", subtitle: "Pola kalimat N5 · 〜てください / 〜たいです" },
     pattern: { title: "Latihan pola kalimat", subtitle: "Penilaian pola N5/N4 · sudut pandang / izin / kutipan / tidak perlu" },
@@ -421,6 +423,7 @@ export const id: Copy = {
     na_adjective: "Kata sifat-な",
     noun: "Kata benda",
     adverb: "Kata keterangan",
+    expression: "Ungkapan",
     mixed: "Campuran"
   },
   verbGroups: {

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -233,6 +233,7 @@ export const ja: Copy = {
   drillPatternTeAux: "文型を練習：補助動詞",
   drillN3Grammar: "N3 文法の問題を練習する",
   drillKana: "五十音の読みを練習",
+  drillStarterVocab: "基礎単語を練習",
   startChallenge: "チャレンジを始める",
   settingsLabel: "練習設定",
   todayPractice: "今日の練習",
@@ -366,6 +367,7 @@ export const ja: Copy = {
   modeOptions: {
     daily: { title: "今日の練習", subtitle: "復習を優先 · 文法 / 語順 / 漢字読みを混ぜて一巡" },
     kana: { title: "五十音", subtitle: "ひらがな／カタカナの読み当て" },
+    starter: { title: "基礎単語", subtitle: "入門95語 · 単語の意味当て" },
     basic: { title: "基礎活用", subtitle: "品詞の活用練習 · 教科書の語彙" },
     cloze: { title: "文中穴埋め", subtitle: "N5 文型 · 〜てください / 〜たいです" },
     pattern: { title: "文型練習", subtitle: "N5/N4 の文型判別 · 視点 / 許可 / 引用 / 不要" },
@@ -429,6 +431,7 @@ export const ja: Copy = {
     na_adjective: "な形容詞",
     noun: "名詞",
     adverb: "副詞",
+    expression: "あいさつ表現",
     mixed: "混合"
   },
   verbGroups: {

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -225,6 +225,7 @@ export const ko: Copy = {
   drillPatternTeAux: "문형 연습: 보조동사",
   drillN3Grammar: "N3 문법 연습하러 가기",
   drillKana: "오십음 읽기 연습",
+  drillStarterVocab: "기초 단어 연습",
   startChallenge: "연습 시작",
   settingsLabel: "연습 설정",
   todayPractice: "오늘의 연습",
@@ -358,6 +359,7 @@ export const ko: Copy = {
   modeOptions: {
     daily: { title: "오늘의 연습", subtitle: "복습 우선 · 문법 / 어순 / 한자 읽기 혼합 한 바퀴" },
     kana: { title: "오십음", subtitle: "히라가나/가타카나 읽기 인식" },
+    starter: { title: "기초 단어", subtitle: "입문 95단어 · 뜻 고르기" },
     basic: { title: "기초 활용", subtitle: "품사별 활용 연습 · 교과서 어휘" },
     cloze: { title: "문장 빈칸", subtitle: "N5 문형 · 〜てください / 〜たいです" },
     pattern: { title: "문형 연습", subtitle: "N5/N4 문형 판별 · 관점 / 허가 / 인용 / ~하지 않아도 됨" },
@@ -421,6 +423,7 @@ export const ko: Copy = {
     na_adjective: "な형용사",
     noun: "명사",
     adverb: "부사",
+    expression: "인사 표현",
     mixed: "혼합"
   },
   verbGroups: {

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -225,6 +225,7 @@ export const my: Copy = {
   drillPatternTeAux: "ပုံစံ လေ့ကျင့်: အကူကြိယာများ",
   drillN3Grammar: "N3 သဒ္ဒါ လေ့ကျင့်ရန် သွားရန်",
   drillKana: "ကနာ မှတ်သားမှု လေ့ကျင့်ရန်",
+  drillStarterVocab: "အခြေခံ ဝေါဟာရ လေ့ကျင့်ရန်",
   startChallenge: "လေ့ကျင့်ခန်း စတင်ရန်",
   settingsLabel: "လေ့ကျင့်မှု ဆက်တင်များ",
   todayPractice: "ဒီနေ့ လေ့ကျင့်ခန်း",
@@ -358,6 +359,7 @@ export const my: Copy = {
   modeOptions: {
     daily: { title: "ဒီနေ့ လေ့ကျင့်ခန်း", subtitle: "ပြန်လေ့ကျင့်ခြင်း ဦးစား · သဒ္ဒါ / စကားလုံးအစီအစဉ် / ခန်းဂျိအဖတ် ရောစပ်အကြိမ်" },
     kana: { title: "ကနာ", subtitle: "ဟီရာဂနာ/ခတခနာ မှတ်သားခြင်း" },
+    starter: { title: "အခြေခံ ဝေါဟာရ", subtitle: "အစပြု စကားလုံး ၉၅ · အဓိပ္ပာယ် ရွေးပါ" },
     basic: { title: "အခြေခံ ပုံစံပြောင်းခြင်း", subtitle: "ဝေါဟာရအမျိုးအစား ပုံစံပြောင်းခြင်း လေ့ကျင့်ခန်း · ကျောင်းသုံးစာအုပ် ဝေါဟာရ" },
     cloze: { title: "ဝါကျဖြည့်", subtitle: "N5 ပုံစံများ · 〜てください / 〜たいです" },
     pattern: { title: "ပုံစံ လေ့ကျင့်ခြင်း", subtitle: "N5/N4 ပုံစံခွဲခြားခြင်း · ရှုထောင့် / ခွင့်ပြုချက် / ကိုးကား / မလိုအပ်" },
@@ -421,6 +423,7 @@ export const my: Copy = {
     na_adjective: "な-နာမဝိသေသန",
     noun: "နာမ်",
     adverb: "ကြိယာဝိသေသန",
+    expression: "နှုတ်ဆက်စကား",
     mixed: "ရောစပ်"
   },
   verbGroups: {

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -226,6 +226,7 @@ export const th: Copy = {
   drillPatternTeAux: "ฝึกรูปประโยค: คำกริยาเสริม",
   drillN3Grammar: "ไปฝึกโจทย์ไวยากรณ์ N3",
   drillKana: "ฝึกจดจำคานะ",
+  drillStarterVocab: "ฝึกคำศัพท์พื้นฐาน",
   startChallenge: "เริ่มฝึกทำโจทย์",
   settingsLabel: "ตั้งค่าการฝึก",
   todayPractice: "ฝึกประจำวัน",
@@ -359,6 +360,7 @@ export const th: Copy = {
   modeOptions: {
     daily: { title: "ฝึกประจำวัน", subtitle: "ทบทวนก่อน · ผสมไวยากรณ์ / เรียงประโยค / คำอ่านคันจิหนึ่งรอบ" },
     kana: { title: "คานะ", subtitle: "จดจำฮิรางานะ/คาตากานะ" },
+    starter: { title: "คำศัพท์พื้นฐาน", subtitle: "95 คำเริ่มต้น · เลือกความหมาย" },
     basic: { title: "การผันพื้นฐาน", subtitle: "ฝึกผันชนิดคำ · คำศัพท์ในตำรา" },
     cloze: { title: "เติมคำในประโยค", subtitle: "รูปประโยค N5 · 〜てください / 〜たいです" },
     pattern: { title: "ฝึกรูปประโยค", subtitle: "ตัดสินรูปประโยค N5/N4 · มุมมอง / อนุญาต / อ้างอิง / ไม่จำเป็น" },
@@ -422,6 +424,7 @@ export const th: Copy = {
     na_adjective: "คำคุณศัพท์ な",
     noun: "คำนาม",
     adverb: "คำวิเศษณ์",
+    expression: "สำนวนทักทาย",
     mixed: "ผสม"
   },
   verbGroups: {

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -225,6 +225,7 @@ export const vi: Copy = {
   drillPatternTeAux: "Luyện mẫu câu: động từ bổ trợ",
   drillN3Grammar: "Đi luyện ngữ pháp N3",
   drillKana: "Luyện nhận biết kana",
+  drillStarterVocab: "Luyện từ vựng cơ bản",
   startChallenge: "Bắt đầu luyện tập",
   settingsLabel: "Thiết lập luyện tập",
   todayPractice: "Luyện tập hôm nay",
@@ -358,6 +359,7 @@ export const vi: Copy = {
   modeOptions: {
     daily: { title: "Luyện tập hôm nay", subtitle: "Ôn trước · một vòng hỗn hợp ngữ pháp / trật tự từ / cách đọc kanji" },
     kana: { title: "Kana", subtitle: "Nhận biết hiragana/katakana" },
+    starter: { title: "Từ vựng cơ bản", subtitle: "95 từ nhập môn · chọn nghĩa" },
     basic: { title: "Chia động từ cơ bản", subtitle: "Luyện chia theo loại từ · từ vựng trong giáo trình" },
     cloze: { title: "Điền khuyết trong câu", subtitle: "Mẫu câu N5 · 〜てください / 〜たいです" },
     pattern: { title: "Luyện mẫu câu", subtitle: "Nhận diện mẫu câu N5/N4 · góc nhìn / cho phép / trích dẫn / không cần phải" },
@@ -421,6 +423,7 @@ export const vi: Copy = {
     na_adjective: "Tính từ な",
     noun: "Danh từ",
     adverb: "Phó từ",
+    expression: "Cụm chào hỏi",
     mixed: "Hỗn hợp"
   },
   verbGroups: {

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -225,6 +225,7 @@ export const zhHant: Copy = {
   drillPatternTeAux: "練句型：補助動詞",
   drillN3Grammar: "去練 N3 文法題",
   drillKana: "練五十音認讀",
+  drillStarterVocab: "練基礎詞彙",
   startChallenge: "開始挑戰",
   settingsLabel: "練習設定",
   todayPractice: "今日練習",
@@ -358,6 +359,7 @@ export const zhHant: Copy = {
   modeOptions: {
     daily: { title: "今日練習", subtitle: "複習優先 · 文法 / 語順 / 漢字読み混合一輪" },
     kana: { title: "五十音認讀", subtitle: "平／片假名 · 認讀與對應" },
+    starter: { title: "基礎詞彙", subtitle: "入門 95 詞 · 看詞選意思" },
     basic: { title: "基礎變化", subtitle: "詞類變化練習 · 課本詞彙" },
     cloze: { title: "句中填空", subtitle: "N5 文型 · 〜てください / 〜たいです" },
     pattern: { title: "句型練習", subtitle: "N5/N4 句型判斷 · 視角 / 許可 / 引用 / 不必" },
@@ -421,6 +423,7 @@ export const zhHant: Copy = {
     na_adjective: "な形容詞",
     noun: "名詞",
     adverb: "副詞",
+    expression: "寒暄語",
     mixed: "混合"
   },
   verbGroups: {


### PR DESCRIPTION
## 為什麼

新手區第二批內容（接 #537 五十音）：學完假名後「馬上用得到」的第一批詞。全部假名書寫、不需漢字，drill＝看詞選中文意思（四選一）。

## 內容

**Deck（`src/domain/starterVocabulary.ts`，97 詞 × 8 類）**
- 招呼語 14／數字 11／時間 10／人物 12／身邊名詞 12／動詞 12／形容詞 12／こそあど 12
- 意思**兩兩相異**（干擾同 deck 抽，測試鎖死唯一解）；每詞帶 en＋ja 釋義 overlay（未來本地化 meaning drill 的資料已備妥）；動詞連 ichidan/godan/irregular 都標齊
- id 穩定 ASCII（SRS/錯題池 key）

**`PartOfSpeech` 加 `"expression"`（向後相容的 union 擴充）**
- 招呼語是あいさつ表現不是名詞——drill 題面的詞性徽章若顯示「名詞」等於第一課就教錯詞性。8 語系標籤補齊（zh-Hant「寒暄語」/ja「あいさつ表現」…），編譯期強制

**入門第三章「基礎詞彙」**＋接線全套鏡像 kana 模式（mode 不上卡、章節 CTA＋`?mode=starter` 深連結、弱點複習/收藏可解析、8 語系、en/ja 章節 overlay、完成度＝答對一題或既有紀錄隱性完成）

## 內容品質 pipeline（本 PR 重點）

1. **主筆**（Fable）→ 2. **9-agent 對抗驗 Workflow**（逐類駁倒者 ×8＋跨類雙解掃描 ×1）→ **16 項發現全修**，包括：
   - High：車/電車上下位雙解（→汽車）、讀/看語意重疊（→閱讀（文字）/看、觀看）
   - Medium：はい/いいえ 錯放こそあど類（→移招呼語、補回 どれ/そこ 完整 paradigm）、こんばんは「晚上好」台灣語感問題（→你好（晚上），與 你好（白天）平行）、ごめんなさい/すみません 的 zh+en+ja 三語消歧、いえ「家」與「家人」含糊（→房子）
   - Low：たのしい→愉快的、たかい en 補 high、ja 釋義自然度修正等
3. **codex 終審 PASS**（雙解/假名表記/台灣繁中語感/動詞 group 全查）

## 驗證

- TDD；**838 測全綠**、tsc/build 綠；deck +8.8kB 落 lazy ChallengePanel chunk（eager 僅章節文字）
- 實機端到端：章節開啟→drill 啟動（`starter-kau:meaning`，唯一解）→答題記錄→**寒暄語徽章正確顯示**（おはよう 題不再標「名詞」）