### PR TITLE
feat(home): 今日練習程度閘門＋程度卡第四檔「完全新手」＋自動開注音 (Closes #532)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -527,17 +527,78 @@ describe("App", () => {
     expect(screen.queryByText(/やいなや/)).not.toBeInTheDocument();
   });
 
-  it("starts a 今日練習 session from the home entry", async () => {
+  it("gates the home 今日練習 CTA on a level choice, then auto-continues (#532)", async () => {
     const user = userEvent.setup();
     render(<App />);
 
-    // The prominent home CTA launches the mixed daily session.
+    // A brand-new visitor taps the CTA with no level chosen: the session
+    // must NOT start (the old behaviour fell back to the N1/N2-heavy "all"
+    // pool). Instead the level ask appears...
     await user.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    expect(screen.queryByRole("region", { name: "目前題目" })).not.toBeInTheDocument();
+    expect(screen.getByText(/先選擇你的程度/)).toBeInTheDocument();
 
-    // Lands in the challenge view with a question and the 今日練習 mode
-    // card selected.
+    // ...and answering it continues straight into the daily session.
+    await user.click(screen.getByRole("button", { name: /初級/ }));
     await screen.findByRole("region", { name: "目前題目" });
     expect(screen.getByRole("button", { name: /今日練習/ })).toHaveClass("selected");
+  });
+
+  it("starts a 今日練習 session directly when a level is already set", async () => {
+    localStorage.setItem("jabiko:targetLevel", "n2n3");
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: /開始今日練習/ }));
+
+    await screen.findByRole("region", { name: "目前題目" });
+    expect(screen.getByRole("button", { name: /今日練習/ })).toHaveClass("selected");
+  });
+
+  it("完全新手 onboarding: enables furigana and lands on the 入門 chapters (#532)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(localStorage.getItem("jabiko.furigana")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /完全新手/ }));
+
+    // Preference persisted, furigana forced on for the beginner...
+    expect(localStorage.getItem("jabiko:targetLevel")).toBe("starter");
+    expect(localStorage.getItem("jabiko.furigana")).toBe("on");
+    expect(screen.getByRole("button", { name: "隱藏註音" })).toHaveAttribute("aria-pressed", "true");
+    // ...and the app lands on Learn, whose default-active chapter for a
+    // fresh history is 五十音・平假名.
+    expect(screen.getByRole("heading", { name: "一章一章解鎖" })).toBeInTheDocument();
+    expect(screen.getAllByRole("heading", { name: "五十音・平假名" }).length).toBeGreaterThan(0);
+  });
+
+  it("gate -> 完全新手: honours the practice intent (starter daily, furigana on) (#532)", async () => {
+    // Combined path: a brand-new visitor taps the daily CTA FIRST (gated),
+    // THEN answers with 完全新手. The pick must continue into the starter
+    // daily session -- they asked to practise, and the starter daily serves
+    // 入門 questions -- NOT detour to the chapter list. Furigana still
+    // turns on. (The learn-landing applies to the non-gated card path.)
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    await user.click(screen.getByRole("button", { name: /完全新手/ }));
+
+    const panel = await screen.findByRole("region", { name: "目前題目" });
+    expect(panel.getAttribute("data-question-id")).toMatch(/^(kana-|starter-)/);
+    expect(localStorage.getItem("jabiko.furigana")).toBe("on");
+    expect(localStorage.getItem("jabiko:targetLevel")).toBe("starter");
+  });
+
+  it("完全新手 daily session serves 入門 content, not exam items (#532)", async () => {
+    localStorage.setItem("jabiko:targetLevel", "starter");
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    const panel = await screen.findByRole("region", { name: "目前題目" });
+    // Every question in a starter daily comes from the kana / starter pools.
+    expect(panel.getAttribute("data-question-id")).toMatch(/^(kana-|starter-)/);
   });
 
   it("mock exam is a section picker that launches a filtered exam drill", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -277,7 +277,7 @@ export default function App() {
   const { theme, toggleTheme } = useTheme();
   // Global furigana (ruby) preference, default OFF (#134). The hook owns the
   // button state; FuriganaContext broadcasts `enabled` to every <Ruby>.
-  const { enabled: furiganaEnabled, toggle: toggleFurigana } = useFurigana();
+  const { enabled: furiganaEnabled, toggle: toggleFurigana, enable: enableFurigana } = useFurigana();
   const { user, error: authError, signInWithGoogle, signOut } = useAuth();
   // `user` drives cross-device sync: on login the hook merges the remote
   // attempt history into the local store and pushes the local-only delta.
@@ -308,6 +308,25 @@ export default function App() {
     writeLevelPreference(range);
     setTargetLevel(range);
     trackEvent("level_changed", { scope: "global", levelRange: range, locale: language });
+    if (range === "starter") {
+      // 完全新手 (#532): a zero-base learner needs readings everywhere and
+      // won't find the header toggle -- turn furigana on for them (their
+      // choice stays overridable via the toggle; the global default is
+      // untouched for everyone else).
+      enableFurigana();
+      // Land TRUE newcomers on the 入門 chapters (kana is the default-active
+      // chapter for a fresh history). Returning learners switching bands via
+      // the #526 chip keep their current view -- no surprise navigation.
+      // DELIBERATE exception (same-batch override): when this choice answers
+      // the daily-CTA gate, HomePanel's auto-continue fires openChallenge
+      // right after and its setAppView("challenge") wins the batch -- the
+      // learner asked to START PRACTISING, and the starter daily serves 入門
+      // questions, so honouring that intent beats detouring to the chapter
+      // list. Locked by the "gate -> 完全新手" App test.
+      if (progressAttempts.length === 0 && appView === "home") {
+        setAppView("learn");
+      }
+    }
   };
 
   const themeToggleLabel = theme === "dark" ? t.themeLight : t.themeDark;

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -29,7 +29,7 @@ function renderHome(overrides: Partial<Parameters<typeof HomePanel>[0]> = {}) {
     onNavigate: noop,
     onStartReview: noop,
     onStartVocab: noop,
-    onStartDaily: noop,
+    onStartDaily: vi.fn(),
     targetLevel: null,
     onChooseLevel: vi.fn(),
     ...overrides
@@ -66,6 +66,62 @@ describe("HomePanel level onboarding (#199)", () => {
   it("hides the card for a returning learner with attempts (even without a preference)", () => {
     renderHome({ progressAttempts: [sampleAttempt] });
     expect(screen.queryByText("選擇你的程度")).not.toBeInTheDocument();
+  });
+});
+
+describe("HomePanel 完全新手 band (#532)", () => {
+  it("the onboarding card offers 完全新手 first, mapping to the starter range", () => {
+    const props = renderHome();
+    const options = screen.getAllByRole("button", { name: /完全新手|初級|中級|高級/ });
+    expect(options[0]).toHaveTextContent("完全新手");
+    fireEvent.click(screen.getByRole("button", { name: /完全新手/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("starter");
+  });
+
+  it("the #526 chip displays 完全新手 when the starter band is active", () => {
+    renderHome({ targetLevel: "starter", progressAttempts: [sampleAttempt] });
+    const chip = screen.getByRole("button", { name: /變更/ });
+    expect(chip).toHaveTextContent("完全新手");
+  });
+});
+
+describe("HomePanel daily CTA level gate (#532)", () => {
+  it("with a level set, the CTA starts daily immediately (unchanged)", () => {
+    const props = renderHome({ targetLevel: "n4n5", progressAttempts: [sampleAttempt] });
+    fireEvent.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    expect(props.onStartDaily).toHaveBeenCalledTimes(1);
+  });
+
+  it("without a level, the CTA does NOT start daily -- it asks for a level first", () => {
+    const props = renderHome({ targetLevel: null });
+    fireEvent.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    expect(props.onStartDaily).not.toHaveBeenCalled();
+    expect(screen.getByText(/先選擇你的程度/)).toBeInTheDocument();
+  });
+
+  it("after the gated ask, choosing a band from the onboarding card auto-continues into daily", () => {
+    const props = renderHome({ targetLevel: null });
+    fireEvent.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    fireEvent.click(screen.getByRole("button", { name: /初級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n4n5");
+    expect(props.onStartDaily).toHaveBeenCalledTimes(1);
+  });
+
+  it("a returning learner without a preference gets the chip picker expanded by the gate", () => {
+    const props = renderHome({ targetLevel: null, progressAttempts: [sampleAttempt] });
+    fireEvent.click(screen.getByRole("button", { name: /開始今日練習/ }));
+    expect(props.onStartDaily).not.toHaveBeenCalled();
+    // The chip's band picker is now open; picking a band auto-continues.
+    fireEvent.click(screen.getByRole("button", { name: /中級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n2n3");
+    expect(props.onStartDaily).toHaveBeenCalledTimes(1);
+  });
+
+  it("a level choice made WITHOUT the gated ask does not auto-start daily", () => {
+    const props = renderHome({ targetLevel: null });
+    fireEvent.click(screen.getByRole("button", { name: /高級/ }));
+    expect(props.onChooseLevel).toHaveBeenCalledWith("n1n2");
+    expect(props.onStartDaily).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -134,6 +134,9 @@ export function HomePanel({
   // existing LevelRange bands (n4n5 / n2n3 / n1n2); easy → hard order.
   const showLevelOnboarding = targetLevel === null && progressAttempts.length === 0;
   const onboardingOptions: { range: LevelRange; label: string; hint: string }[] = [
+    // 完全新手 first (#532): easy -> hard reading order, and the zero-base
+    // learner is exactly who must not mis-classify themselves.
+    { range: "starter", label: t.levelOnboarding.starter, hint: t.levelOnboarding.starterHint },
     { range: "n4n5", label: t.levelOnboarding.beginner, hint: t.levelOnboarding.beginnerHint },
     { range: "n2n3", label: t.levelOnboarding.intermediate, hint: t.levelOnboarding.intermediateHint },
     { range: "n1n2", label: t.levelOnboarding.advanced, hint: t.levelOnboarding.advancedHint }
@@ -188,9 +191,31 @@ export function HomePanel({
   // card -- can still change it. Collapsed by default; 變更 expands the picker.
   const [levelEditing, setLevelEditing] = useState(false);
   const currentLevelOption = onboardingOptions.find((option) => option.range === targetLevel);
+
+  // Daily CTA level gate (#532): without a target level the daily session
+  // used to fall back to the "all" (N1/N2-heavy) pool -- a brand-new
+  // visitor's first tap served questions they couldn't read. Now the CTA
+  // asks for a level first, and the choice that answers the ask CONTINUES
+  // into the daily session (one flow, no second tap).
+  const [dailyPending, setDailyPending] = useState(false);
+  const handleStartDaily = () => {
+    if (targetLevel !== null) {
+      onStartDaily();
+      return;
+    }
+    setDailyPending(true);
+    // Returning learners without a preference have no onboarding card --
+    // open the #526 chip's band picker for them.
+    if (!showLevelOnboarding) setLevelEditing(true);
+  };
+
   const chooseLevel = (range: LevelRange) => {
     onChooseLevel(range);
     setLevelEditing(false);
+    if (dailyPending) {
+      setDailyPending(false);
+      onStartDaily();
+    }
   };
 
   return (
@@ -225,7 +250,7 @@ export function HomePanel({
                 key={option.range}
                 type="button"
                 className="home-level-option"
-                onClick={() => onChooseLevel(option.range)}
+                onClick={() => chooseLevel(option.range)}
               >
                 <strong>{option.label}</strong>
                 <small>{option.hint}</small>
@@ -239,7 +264,13 @@ export function HomePanel({
           due-reviews-first + mixed-section session. Hoisted above the hero
           art so the one honest primary action is the first thing a visitor
           reaches on the first screen (mobile onboarding). */}
-      <button type="button" className="home-banner home-banner-daily" onClick={onStartDaily}>
+      {dailyPending ? (
+        <p className="home-level-gate-hint" role="alert">
+          {t.levelOnboarding.chooseFirst}
+        </p>
+      ) : null}
+
+      <button type="button" className="home-banner home-banner-daily" onClick={handleStartDaily}>
         <CalendarCheck aria-hidden="true" />
         <span className="home-banner-text">
           <strong>{t.homeDailyMain}</strong>

--- a/src/domain/challengeDeepLink.ts
+++ b/src/domain/challengeDeepLink.ts
@@ -12,7 +12,7 @@ import type { LevelRange } from "./levelRange";
 export type ChallengeDeepLink = { mode?: PracticeMode; levelRange?: LevelRange };
 
 const MODES: readonly PracticeMode[] = ["basic", "cloze", "daily", "kana", "starter", "pattern", "exam", "review", "vocab"];
-const RANGES: readonly LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5"];
+const RANGES: readonly LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5", "starter"];
 
 function asMode(value: string | null): PracticeMode | undefined {
   return value !== null && (MODES as readonly string[]).includes(value) ? (value as PracticeMode) : undefined;

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -11,12 +11,18 @@ describe("levelsForRange", () => {
     expect(levelsForRange("n4n5")).toEqual(["N4", "N5"]);
   });
 
-  it("offers 全部 first, then the target bands high→low", () => {
+  it("offers 全部 first, then the target bands high→low, then the starter band (#532)", () => {
     expect(LEVEL_RANGE_OPTIONS[0]).toBe("all");
-    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n3n4", "n4n5"]);
+    expect(LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3", "n3n4", "n4n5", "starter"]);
   });
 
-  it("excludes n4n5 from the vocab picker (no N4/N5 jlpt words)", () => {
+  it("maps the starter band to the gentlest exam pool (N5 only)", () => {
+    // 完全新手 shouldn't be in exam mode at all, but if they wander in, the
+    // pool must be the shallowest -- never the N1/N2 default.
+    expect(levelsForRange("starter")).toEqual(["N5"]);
+  });
+
+  it("excludes n4n5 and starter from the vocab picker (no N4/N5 jlpt words)", () => {
     expect(VOCAB_LEVEL_RANGE_OPTIONS).toEqual(["all", "n1n2", "n2n3"]);
   });
 });

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -5,10 +5,14 @@ import type { JlptLevel } from "./types";
 // FILTER only -- the level never appears on the question itself (no
 // visible promptLabel); it just narrows which bank items are in play.
 // "all" keeps each pool's own default behaviour (no level narrowing).
-export type LevelRange = "all" | "n1n2" | "n2n3" | "n3n4" | "n4n5";
+//
+// "starter" (#532) is the 完全新手 band from the onboarding card: the daily
+// session serves 入門 content (kana + starter vocab) instead of exam items,
+// and any exam-pool consumer falls back to the gentlest N5-only pool.
+export type LevelRange = "all" | "n1n2" | "n2n3" | "n3n4" | "n4n5" | "starter";
 
 // Order shown in the picker (全部 first, then the target bands high→low).
-export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5"];
+export const LEVEL_RANGE_OPTIONS: LevelRange[] = ["all", "n1n2", "n2n3", "n3n4", "n4n5", "starter"];
 
 // Vocab (単字讀音) only has N1/N2 jlpt entries, so its segmented picker must
 // NOT offer the lower bands (they would filter jlptVocabulary down to an
@@ -20,7 +24,10 @@ const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
   n1n2: ["N1", "N2"],
   n2n3: ["N2", "N3"],
   n3n4: ["N3", "N4"],
-  n4n5: ["N4", "N5"]
+  n4n5: ["N4", "N5"],
+  // 完全新手 shouldn't meet the exam pool at all (daily serves 入門 content
+  // instead), but any consumer that does ask gets the shallowest bank.
+  starter: ["N5"]
 };
 
 // The JLPT levels a range covers, or null for "all" (= no filter; let the

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -3,6 +3,7 @@ import { buildClozeQuestionPool } from "./cloze";
 import { clozeSentences } from "./cloze-data";
 import { ADJECTIVE_FORMS } from "./conjugation";
 import { buildExamQuestionPool } from "./examBlocks";
+import { buildKanaQuestionPool } from "./kanaDrill";
 import { levelsForRange } from "./levelRange";
 import { buildQuestionPool } from "./practice";
 import {
@@ -371,6 +372,43 @@ describe("composeDailySet", () => {
     // The empty vocab slots roll into N4/N5 exam (which carry their own 4
     // baked options), so EVERY item is exam_style -- no short-option 漢字読み.
     expect(set.every((q) => q.vocabulary.tags?.includes("exam_style"))).toBe(true);
+  });
+
+  it("完全新手 starter: the fresh portion is 入門 content only (kana + starter vocab), never exam (#532)", () => {
+    const set = composeDailySet([], "starter");
+    expect(set.length).toBe(20);
+    expect(
+      set.every(
+        (question) => question.id.startsWith("kana-") || question.id.startsWith("starter-")
+      )
+    ).toBe(true);
+    // A real mix, not a single-pool dump.
+    expect(set.some((question) => question.id.startsWith("kana-"))).toBe(true);
+    expect(set.some((question) => question.id.startsWith("starter-"))).toBe(true);
+  });
+
+  it("starter back-fills from words when the kana pool is exhausted (codex review)", () => {
+    // Every kana question is due -> the fresh kana pool filters to empty.
+    // The word half must then expand to fill ALL fresh slots, not leave the
+    // session short.
+    const allKana = [
+      ...buildKanaQuestionPool({ script: "hiragana" }),
+      ...buildKanaQuestionPool({ script: "katakana" })
+    ];
+    const set = composeDailySet(allKana, "starter");
+    expect(set).toHaveLength(20);
+    // 10 due kana lead; the 10 fresh are all starter words.
+    expect(set.slice(10).every((question) => question.id.startsWith("starter-"))).toBe(true);
+  });
+
+  it("starter keeps the reviews-first promise: due 入門 items lead the set (#532)", () => {
+    const due = composeDailySet([], "starter").slice(0, 3);
+    const set = composeDailySet(due, "starter");
+    expect(set.slice(0, due.length).map((question) => question.id)).toEqual(
+      due.map((question) => question.id)
+    );
+    const dueIds = new Set(due.map((question) => question.id));
+    expect(set.slice(due.length).some((question) => dueIds.has(question.id))).toBe(false);
   });
 
   it("defaults to the prior all-levels behaviour when no range is passed (#199)", () => {

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -62,6 +62,44 @@ export function composeDailySet(
   const isFresh = (question: PracticeQuestion) => !dueIds.has(question.id);
   const freshSlots = DAILY_TARGET - dueTake.length;
 
+  // 完全新手 (#532): the fresh portion is 入門 content ONLY -- kana
+  // recognition + starter vocab -- never exam items (kanji-laden JLPT
+  // questions are exactly what a zero-base learner must not meet on day
+  // one). Reviews still lead the set, same as every other band.
+  if (range === "starter") {
+    // Reserved halves (mirroring the vocab-floor pattern below): a naive
+    // shuffle over both pools would often draw kana only -- the kana bank is
+    // ~5x the word deck -- so the session reserves word slots explicitly.
+    // Either pool being short rolls its slots into the other.
+    const kanaAll = shuffleQuestions(
+      [
+        ...buildKanaQuestionPool({ script: "hiragana" }),
+        ...buildKanaQuestionPool({ script: "katakana" })
+      ].filter(isFresh)
+    );
+    const wordsAll = shuffleQuestions(
+      buildQuestionPool(starterVocabulary, {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["meaning"]
+      }).filter(isFresh)
+    );
+    const wordTake = wordsAll.slice(0, Math.ceil(freshSlots / 2));
+    const kanaTake = kanaAll.slice(0, freshSlots - wordTake.length);
+    // Back-fill in BOTH directions (codex review): a short kana pool (e.g.
+    // everything due) rolls its unfilled slots back into words, so the
+    // session never comes up short while either pool still has questions.
+    const wordTopUp = wordsAll.slice(
+      wordTake.length,
+      wordTake.length + (freshSlots - wordTake.length - kanaTake.length)
+    );
+    const starterMix = reduceAdjacentClusters(
+      [...kanaTake, ...wordTake, ...wordTopUp],
+      (question) => question.promptLabel ?? question.targetForm
+    );
+    return [...dueTake, ...starterMix];
+  }
+
   // Narrow the fresh pools to the learner's target band (#199). `null`
   // (range "all") keeps each bank's own default mix -- the prior behaviour,
   // so a learner with no preference is unaffected.

--- a/src/hooks/useFurigana.test.tsx
+++ b/src/hooks/useFurigana.test.tsx
@@ -25,6 +25,20 @@ describe("useFurigana", () => {
     expect(result.current.enabled).toBe(false);
   });
 
+  it("enable() turns furigana ON and persists, and is idempotent (#532 starter onboarding)", () => {
+    const { result } = renderHook(() => useFurigana());
+    expect(result.current.enabled).toBe(false);
+
+    act(() => result.current.enable());
+    expect(result.current.enabled).toBe(true);
+    expect(localStorage.getItem(KEY)).toBe("on");
+
+    // Calling again keeps it on (no accidental toggle).
+    act(() => result.current.enable());
+    expect(result.current.enabled).toBe(true);
+    expect(localStorage.getItem(KEY)).toBe("on");
+  });
+
   it("toggles and persists the new value", () => {
     const { result } = renderHook(() => useFurigana());
 

--- a/src/hooks/useFurigana.ts
+++ b/src/hooks/useFurigana.ts
@@ -23,5 +23,12 @@ export function useFurigana() {
     });
   };
 
-  return { enabled, toggle };
+  // Idempotent ON: used when the learner picks 完全新手 at onboarding (#532)
+  // -- a beginner needs readings everywhere and won't find the toggle.
+  const enable = () => {
+    writeStored(FURIGANA_STORAGE_KEY, "on");
+    setEnabled(true);
+  };
+
+  return { enabled, toggle, enable };
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -215,7 +215,14 @@ export type Copy = {
   practiceType: string;
   practiceMode: string;
   levelRange: string;
-  levelRangeOptions: { all: string; n1n2: string; n2n3: string; n3n4: string; n4n5: string };
+  levelRangeOptions: {
+    all: string;
+    n1n2: string;
+    n2n3: string;
+    n3n4: string;
+    n4n5: string;
+    starter: string;
+  };
   levelOnboarding: {
     title: string;
     subtitle: string;
@@ -225,9 +232,13 @@ export type Copy = {
     intermediateHint: string;
     advanced: string;
     advancedHint: string;
+    starter: string;
+    starterHint: string;
     manageTitle: string;
     change: string;
     notSet: string;
+    /** Daily-CTA gate (#532): shown when 今日練習 is tapped with no level set. */
+    chooseFirst: string;
   };
   sessionLength: string;
   sessionLengthAll: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -232,7 +232,7 @@ export const en: Copy = {
   practiceType: "Practice type",
   practiceMode: "Practice mode",
   levelRange: "Question pool",
-  levelRangeOptions: { all: "All", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "All", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "Starter" },
   levelOnboarding: {
     title: "Choose your level",
     subtitle: "Sets the default difficulty for today's practice and each question pool — change it anytime.",
@@ -242,9 +242,12 @@ export const en: Copy = {
     intermediateHint: "N2・N3",
     advanced: "Advanced",
     advancedHint: "N1・N2",
+    starter: "Complete beginner",
+    starterHint: "From zero",
     manageTitle: "Target level",
     change: "Change",
-    notSet: "Not set"
+    notSet: "Not set",
+    chooseFirst: "Pick your level first — today's practice starts right after."
   },
   sessionLength: "Questions per set",
   sessionLengthAll: "All",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -232,7 +232,7 @@ export const id: Copy = {
   practiceType: "Jenis latihan",
   practiceMode: "Mode latihan",
   levelRange: "Cakupan bank soal",
-  levelRangeOptions: { all: "Semua", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "Semua", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "Pemula total" },
   levelOnboarding: {
     title: "Pilih tingkatmu",
     subtitle: "Atur tingkat kesulitan default untuk latihan hari ini dan tiap bank soal; bisa diubah kapan saja nanti.",
@@ -242,9 +242,12 @@ export const id: Copy = {
     intermediateHint: "N2・N3",
     advanced: "Mahir",
     advancedHint: "N1・N2",
+    starter: "Pemula total",
+    starterHint: "Dari nol",
     manageTitle: "Level target",
     change: "Ubah",
-    notSet: "Belum diatur"
+    notSet: "Belum diatur",
+    chooseFirst: "Pilih levelmu dulu — latihan hari ini langsung dimulai."
   },
   sessionLength: "Soal per set",
   sessionLengthAll: "Semua",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -240,7 +240,7 @@ export const ja: Copy = {
   practiceType: "練習タイプ",
   practiceMode: "練習モード",
   levelRange: "出題範囲",
-  levelRangeOptions: { all: "すべて", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "すべて", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "完全な初心者" },
   levelOnboarding: {
     title: "あなたのレベルを選択",
     subtitle: "今日の練習と各問題集の初期難易度を設定します。あとからいつでも変更できます。",
@@ -250,9 +250,12 @@ export const ja: Copy = {
     intermediateHint: "N2・N3",
     advanced: "上級",
     advancedHint: "N1・N2",
+    starter: "完全な初心者",
+    starterHint: "ゼロから",
     manageTitle: "目標レベル",
     change: "変更",
-    notSet: "未設定"
+    notSet: "未設定",
+    chooseFirst: "まずレベルを選ぶと、すぐに今日の練習が始まります。"
   },
   sessionLength: "1セットの問題数",
   sessionLengthAll: "すべて",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -232,7 +232,7 @@ export const ko: Copy = {
   practiceType: "연습 유형",
   practiceMode: "연습 모드",
   levelRange: "문제 풀(pool)",
-  levelRangeOptions: { all: "전체", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "전체", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "완전 초보" },
   levelOnboarding: {
     title: "레벨을 선택하세요",
     subtitle: "오늘의 연습과 각 문제 풀의 기본 난이도를 정합니다 — 언제든 바꿀 수 있어요.",
@@ -242,9 +242,12 @@ export const ko: Copy = {
     intermediateHint: "N2・N3",
     advanced: "고급",
     advancedHint: "N1・N2",
+    starter: "완전 초보",
+    starterHint: "제로부터",
     manageTitle: "목표 레벨",
     change: "변경",
-    notSet: "미설정"
+    notSet: "미설정",
+    chooseFirst: "먼저 레벨을 고르면 바로 오늘의 연습이 시작돼요."
   },
   sessionLength: "세트당 문제 수",
   sessionLengthAll: "전체",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -232,7 +232,7 @@ export const my: Copy = {
   practiceType: "လေ့ကျင့်မှု အမျိုးအစား",
   practiceMode: "လေ့ကျင့်မှု မုဒ်",
   levelRange: "မေးခွန်း အစုအဝေး",
-  levelRangeOptions: { all: "အားလုံး", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "အားလုံး", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "လုံးဝ အစပြုသူ" },
   levelOnboarding: {
     title: "သင့်အဆင့်ကို ရွေးပါ",
     subtitle: "ဒီနေ့ လေ့ကျင့်ခန်းနှင့် မေးခွန်းအစုအဝေးတစ်ခုစီ၏ မူရင်းအခက်အခဲကို သတ်မှတ်သည် — အချိန်မရွေး ပြောင်းနိုင်သည်။",
@@ -242,9 +242,12 @@ export const my: Copy = {
     intermediateHint: "N2・N3",
     advanced: "အဆင့်မြင့်",
     advancedHint: "N1・N2",
+    starter: "လုံးဝ အစပြုသူ",
+    starterHint: "သုညမှစ",
     manageTitle: "ပန်းတိုင်အဆင့်",
     change: "ပြောင်းရန်",
-    notSet: "မသတ်မှတ်ရသေးပါ"
+    notSet: "မသတ်မှတ်ရသေးပါ",
+    chooseFirst: "အရင် သင့်အဆင့်ကို ရွေးပါ — ဒီနေ့ လေ့ကျင့်ခန်း ချက်ချင်း စတင်ပါမည်။"
   },
   sessionLength: "တစ်စုလျှင် မေးခွန်းအရေအတွက်",
   sessionLengthAll: "အားလုံး",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -233,7 +233,7 @@ export const th: Copy = {
   practiceType: "ประเภทการฝึก",
   practiceMode: "โหมดการฝึก",
   levelRange: "ขอบเขตคลังข้อสอบ",
-  levelRangeOptions: { all: "ทั้งหมด", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "ทั้งหมด", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "มือใหม่สุด ๆ" },
   levelOnboarding: {
     title: "เลือกระดับของคุณ",
     subtitle: "ตั้งค่าความยากเริ่มต้นของการฝึกประจำวันและคลังข้อสอบแต่ละชุด เปลี่ยนทีหลังได้ตลอด",
@@ -243,9 +243,12 @@ export const th: Copy = {
     intermediateHint: "N2・N3",
     advanced: "ระดับสูง",
     advancedHint: "N1・N2",
+    starter: "มือใหม่สุด ๆ",
+    starterHint: "เริ่มจากศูนย์",
     manageTitle: "ระดับเป้าหมาย",
     change: "เปลี่ยน",
-    notSet: "ยังไม่ได้ตั้ง"
+    notSet: "ยังไม่ได้ตั้ง",
+    chooseFirst: "เลือกระดับของคุณก่อน แล้วฝึกประจำวันจะเริ่มทันที"
   },
   sessionLength: "จำนวนข้อต่อชุด",
   sessionLengthAll: "ทั้งหมด",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -232,7 +232,7 @@ export const vi: Copy = {
   practiceType: "Loại luyện tập",
   practiceMode: "Chế độ luyện tập",
   levelRange: "Phạm vi đề",
-  levelRangeOptions: { all: "Tất cả", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "Tất cả", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "Người mới hoàn toàn" },
   levelOnboarding: {
     title: "Chọn cấp độ của bạn",
     subtitle: "Đặt độ khó mặc định cho luyện tập hôm nay và từng kho đề — có thể đổi bất cứ lúc nào.",
@@ -242,9 +242,12 @@ export const vi: Copy = {
     intermediateHint: "N2・N3",
     advanced: "Cao cấp",
     advancedHint: "N1・N2",
+    starter: "Người mới hoàn toàn",
+    starterHint: "Từ con số 0",
     manageTitle: "Cấp độ mục tiêu",
     change: "Thay đổi",
-    notSet: "Chưa đặt"
+    notSet: "Chưa đặt",
+    chooseFirst: "Chọn cấp độ trước — luyện tập hôm nay sẽ bắt đầu ngay."
   },
   sessionLength: "Số câu mỗi bộ",
   sessionLengthAll: "Tất cả",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -232,7 +232,7 @@ export const zhHant: Copy = {
   practiceType: "練習類型",
   practiceMode: "練習模式",
   levelRange: "題庫範圍",
-  levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5" },
+  levelRangeOptions: { all: "全部", n1n2: "N1＋N2", n2n3: "N2＋N3", n3n4: "N3＋N4", n4n5: "N4＋N5", starter: "完全新手" },
   levelOnboarding: {
     title: "選擇你的程度",
     subtitle: "設定今日練習與各題庫的預設難度，之後隨時可改。",
@@ -242,9 +242,12 @@ export const zhHant: Copy = {
     intermediateHint: "N2・N3",
     advanced: "高級",
     advancedHint: "N1・N2",
+    starter: "完全新手",
+    starterHint: "從零開始",
     manageTitle: "目標級別",
     change: "變更",
-    notSet: "尚未設定"
+    notSet: "尚未設定",
+    chooseFirst: "先選擇你的程度，馬上就開始今日練習。"
   },
   sessionLength: "每組題數",
   sessionLengthAll: "全部",

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -1032,8 +1032,22 @@
 
 .home-level-card-options {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  /* 4 bands since #532 (完全新手 leads) -- 2x2 reads better than a squeezed
+     single row. */
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
+}
+
+/* Daily-CTA level gate (#532): one-line ask shown above the CTA when 今日練習
+   is tapped before a level exists. */
+.home-level-gate-hint {
+  margin: 0;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--teal) 45%, var(--panel-border));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--teal) 8%, var(--paper));
+  color: var(--ink);
+  font-size: 0.92rem;
 }
 
 .home-level-option {


### PR DESCRIPTION
## 為什麼（P0 導流陷阱）

`targetLevel === null` 時按首頁「開始今日練習」會 fallback 到 "all"（N1/N2 為主）pool——**全新訪客的第一場是 20 題完全看不懂的高級考題**（#531 盤點的最尖銳發現，直接違背 #199/#526 初衷）。

## 三件事

### 1. CTA 程度閘門
- 未設程度按 CTA → **不開始**，出現一行提示（8 語系）＋選擇器就位（新訪客＝onboarding 卡、老用戶＝#526 chip 自動展開）
- 選完程度 → **自動接續**進今日練習（一氣呵成，不用按第二次）
- 已設程度 → 行為完全不變

### 2. 程度卡第四檔「完全新手」（starter band）
- 四檔由淺到深：**完全新手**／初級／中級／高級（2×2 排版）
- `LevelRange` 加 `"starter"`，所有消費端有定義：
  - **今日練習**：fresh 部分＝入門內容（假名認讀＋基礎詞彙，雙向補位的保留配額），**絕不給 exam 題**；錯題複習照樣領頭
  - exam pool fallback＝最淺的 N5-only；単字讀音沿用既有 clamp 到 "all"；備考 preset 不受影響
  - #526 chip 可顯示/切換完全新手；`?level=starter` 深連結可用
- 純新客直接點卡 → 落地學習 tab（預設章＝五十音）；**閘門路徑選完全新手 → 刻意直接進 starter daily**（他按的是「開始練習」，starter daily 首題就是假名認讀）——已用 App 測試鎖死

### 3. 自動開注音
- 選完全新手 → `useFurigana.enable()`（冪等）寫 `jabiko.furigana=on`；header 開關仍可自由關、全域 default 不動

## 品質把關

- TDD 全程；**854 測全綠**（含 6 個新 App 整合測試：閘門→接續、直通、完全新手落地、starter daily 內容、閘門×完全新手複合路徑、注音持久化）
- **雙審**：codex 抓到 starter session 補位缺口（kana pool 耗盡→session 變短）→ 修＋測試；subagent 抓到閘門×完全新手複合路徑無文件無測試 → 意圖寫明＋測試鎖死；其餘（LevelRange 漣漪/閘門狀態機/React 批次時序/8 語系完整性）雙方確認 clean
- 實機端到端：四檔卡、閘住＋hint、選完全新手一氣呵成進 starter daily（首題 `kana-hiragana-pick-3050`）、`furigana=on`、chip 顯示「完全新手」

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “完全新手 / starter” onboarding option for absolute beginners.
  * Daily practice now guides first-time users to choose a level before starting.
  * Selecting the starter path now turns furigana on automatically and opens beginner-friendly learning content.

* **Bug Fixes**
  * Daily practice now respects an already selected level and skips the extra prompt.
  * Starter sessions now serve beginner-appropriate questions instead of exam-focused items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->