### PR TITLE
feat(starter): 第0課文法首批 — 基本句 AはBです＋助詞入門 (Part of #534, #531)

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 46,
+  patternChecks: 62,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 92

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -168,6 +168,90 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "starter-desu": {
+    "en": {
+      "category": "Starter",
+      "kicker": "Lesson 0",
+      "title": "The Basic Sentence AはBです",
+      "explanation":
+        "Japanese's most basic sentence: 「AはBです」 = \"A is B\". は marks the topic you're talking about (read wa), and です sits at the end. To say \"is not\", swap です for じゃありません; for the past, でした; to ask a question, add か for ですか. Master these four endings and you can start speaking in full sentences.",
+      "notes": [
+        "A is B: I am a student",
+        "Negative: (I'm) not a teacher",
+        "Past: it rained yesterday",
+        "Past negative: it didn't rain yesterday",
+        "Question: is that a dog?",
+        "Introducing yourself"
+      ],
+      "pitfalls": [
+        "The topic は is read wa, not ha — writing は but saying wa is a fixed rule",
+        "\"Tomorrow\" hasn't happened yet but still takes です: あしたは やすみです (no future tense)",
+        "In speech じゃありません often becomes じゃないです — same meaning"
+      ]
+    },
+    "ja": {
+      "category": "入門",
+      "kicker": "第0課",
+      "title": "基本文 AはBです",
+      "explanation":
+        "日本語のいちばん基本の文：「AはBです」。は は話題を示し（wa と読む）、です は文末に置く。「〜ではない」は じゃありません、過去は でした、質問は か を付けて ですか。この四つの文末を身につければ、文で話し始められる。",
+      "notes": [
+        "AはB：わたしは学生です",
+        "否定：先生ではありません",
+        "過去：きのうは雨でした",
+        "過去否定：きのうは雨ではありませんでした",
+        "疑問：あれは犬ですか",
+        "自己紹介"
+      ],
+      "pitfalls": [
+        "主題の は は ha ではなく wa と読む——書くのは は、読むのは wa という決まり",
+        "「あした」のことも です を使う：あしたは休みです（未来形はない）",
+        "話し言葉では じゃありません を じゃないです とも言う。意味は同じ"
+      ]
+    }
+  },
+  "starter-particles": {
+    "en": {
+      "category": "Starter",
+      "kicker": "Lesson 0",
+      "title": "Particle Basics は・を・に・が",
+      "explanation":
+        "Particles are little words glued after nouns that tell you what the noun is doing in the sentence. The first four to know: は = topic (who the sentence is about), を = the object of an action (what you eat or drink), に = destination or point in time (where you're going), が = a newly-introduced subject (there IS something / WHO does it). Add で for where an action happens and と for \"together with\", and everyday sentences all snap together.",
+      "notes": [
+        "は topic + を object: I drink water",
+        "に destination: go to school",
+        "が introduces: there's a dog over there",
+        "A question-word subject can only take が",
+        "で place of action: eat at home",
+        "と together: chat with a friend"
+      ],
+      "pitfalls": [
+        "\"Doing an action somewhere\" takes で; \"existing somewhere / going somewhere\" takes に: いえで たべます vs いえに います",
+        "A question word (だれ・なに) as subject only takes が, never は",
+        "を only marks the object of an action; in modern Japanese it sounds the same as お"
+      ]
+    },
+    "ja": {
+      "category": "入門",
+      "kicker": "第0課",
+      "title": "助詞の基本 は・を・に・が",
+      "explanation":
+        "助詞は名詞の後ろに付く小さな語で、「その名詞が文の中で何をしているか」を示す。まず覚える四つ：は＝主題（この文は誰の話か）、を＝動作の対象（何を食べる・飲む）、に＝行き先や時点（どこへ行く）、が＝初めて登場する主語（何がある・誰がする）。さらに場所の で（どこでする）と一緒の と（誰と）を足せば、日常の文はほぼ組み立てられる。",
+      "notes": [
+        "は主題＋を対象：わたしは水を飲みます",
+        "に行き先：学校に行きます",
+        "が登場：そこに犬がいます",
+        "疑問詞の主語は が だけ",
+        "で動作の場所：家で食べます",
+        "と一緒：友だちと話します"
+      ],
+      "pitfalls": [
+        "「ある場所で動作する」は で、「ある場所に存在する／行く」は に：いえで たべます vs いえに います",
+        "疑問詞（だれ・なに）が主語のときは が だけ。は は使えない",
+        "を は動作の対象だけに付く。現代語では お と同じ発音"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,22 +59,23 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 11 conjugation + 7 sentence-pattern;
-    // only verb-types stays reference.
-    expect(trackable.length).toBe(21);
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 11
+    // conjugation + 7 sentence-pattern; only verb-types stays reference.
+    expect(trackable.length).toBe(23);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });
 });
 
 describe("kana starter chapters (#533)", () => {
-  it("the three 入門 chapters lead the chapter list, ahead of every other category", () => {
+  it("the five 入門 chapters lead the chapter list, ahead of every other category", () => {
     expect(learningBlocks[0].id).toBe("kana-hiragana");
     expect(learningBlocks[1].id).toBe("kana-katakana");
     expect(learningBlocks[2].id).toBe("starter-vocab");
-    expect(learningBlocks[0].category).toBe("入門");
-    expect(learningBlocks[2].category).toBe("入門");
-    expect(learningBlocks[3].category).not.toBe("入門");
+    expect(learningBlocks[3].id).toBe("starter-desu");
+    expect(learningBlocks[4].id).toBe("starter-particles");
+    for (let i = 0; i < 5; i++) expect(learningBlocks[i].category).toBe("入門");
+    expect(learningBlocks[5].category).not.toBe("入門");
   });
 
   it("the starter-vocab chapter completes via a starter attempt or implicit history", () => {

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -102,6 +102,14 @@ export type LearningBlock = {
    */
   drillNote?: string;
   /**
+   * 入門 chapters set this (#533/#534): the chapter ALSO counts as complete
+   * for a learner whose history shows real (non-入門) practice -- these
+   * chapters sit first in array order, and without this rule every existing
+   * learner's home 繼續 banner would be hijacked into Lesson-0 material
+   * they plainly don't need.
+   */
+  implicitCompleteWithHistory?: boolean;
+  /**
    * Block ids the learner is suggested to look at first. Informational
    * only -- access is never blocked. Used to render a soft
    * "建議先看：XX" hint in the chapter list when those prereqs are
@@ -151,7 +159,8 @@ export const learningBlocks: LearningBlock[] = [
       "じ 和 ぢ 都讀 ji、ず 和 づ 都讀 zu（一般用 じ/ず，ぢ/づ 只出現在少數詞）",
       "小さい ゃゅょ 和大的 やゆよ 意思不同：きや kiya ≠ きゃ kya"
     ],
-    kanaDrill: { labelKey: "drillKana", script: "hiragana" }
+    kanaDrill: { labelKey: "drillKana", script: "hiragana" },
+    implicitCompleteWithHistory: true
   },
   {
     id: "kana-katakana",
@@ -181,6 +190,7 @@ export const learningBlocks: LearningBlock[] = [
       "ク/ワ/フ、コ/ユ、チ/テ 也是常見形近組"
     ],
     kanaDrill: { labelKey: "drillKana", script: "katakana" },
+    implicitCompleteWithHistory: true,
     recommendedAfter: ["kana-hiragana"]
   },
   {
@@ -208,7 +218,62 @@ export const learningBlocks: LearningBlock[] = [
       "たかい 同時有「高」和「貴」兩個意思，看語境判斷"
     ],
     starterDrill: { labelKey: "drillStarterVocab" },
+    implicitCompleteWithHistory: true,
     recommendedAfter: ["kana-hiragana"]
+  },
+  {
+    id: "starter-desu",
+    group: "basic",
+    category: "入門",
+    kicker: "第 0 課",
+    title: "基本句 AはBです",
+    subtitle: "です・じゃありません・でした",
+    explanation:
+      "日文最基本的句子：「AはBです」＝「A 是 B」。は 標記你要談論的主題（讀作 wa），です 放在句尾。要說「不是」就把です換成じゃありません；說過去的事換成でした；問問題就在句尾加か變成ですか。這四個結尾練熟，就能開始說完整的句子。",
+    examples: [
+      { formula: "わたしは がくせいです", note: "A是B：我是學生" },
+      { formula: "せんせい じゃありません", note: "否定：不是老師" },
+      { formula: "きのうは あめでした", note: "過去：昨天下雨" },
+      { formula: "いいえ、あめ じゃありませんでした", note: "過去否定：昨天沒下雨" },
+      { formula: "あれは いぬですか", note: "疑問：那是狗嗎？" },
+      { formula: "はじめまして。なまえは たなかです", note: "自我介紹" }
+    ],
+    pitfalls: [
+      "主題的は讀作 wa、不讀 ha——寫は讀 wa 是固定規則",
+      "「明天」還沒發生也用です：あしたは やすみです（不用未來式）",
+      "口語常把じゃありません說成じゃないです，意思相同"
+    ],
+    patternDrills: [{ labelKey: "drillPatternStarterDesu", patternIds: ["starter-desu"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["kana-hiragana", "starter-vocab"]
+  },
+  {
+    id: "starter-particles",
+    group: "basic",
+    category: "入門",
+    kicker: "第 0 課",
+    title: "助詞入門 は・を・に・が",
+    subtitle: "わたしは みずを のみます",
+    explanation:
+      "助詞是黏在名詞後面的小字，負責說明「這個名詞在句子裡做什麼」。最先要認得的四個：は＝主題（這句在談誰）、を＝動作的對象（吃什麼、喝什麼）、に＝目的地或時間點（去哪裡）、が＝第一次登場的主語（有什麼、誰做）。再加上場所的で（在哪裡做）和一起的と（和誰），日常句子就都拼得起來了。",
+    examples: [
+      { formula: "わたしは みずを のみます", note: "は主題＋を對象：我喝水" },
+      { formula: "がっこうに いきます", note: "に目的地：去學校" },
+      { formula: "そこに いぬが います", note: "が登場：那裡有狗" },
+      { formula: "だれが きますか", note: "疑問詞主語只能用が" },
+      { formula: "いえで たべます", note: "で動作場所：在家吃" },
+      { formula: "ともだちと はなします", note: "と一起：和朋友聊" }
+    ],
+    pitfalls: [
+      "「在某處做動作」用で、「存在於某處／去某處」用に：いえで たべます vs いえに います",
+      "疑問詞（だれ・なに）當主語只能接が，不能接は",
+      "を 只用來標動作對象；現代日文裡讀音和 お 相同"
+    ],
+    patternDrills: [
+      { labelKey: "drillPatternStarterParticles", patternIds: ["starter-particles"] }
+    ],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["starter-desu"]
   },
   {
     id: "adverbial",
@@ -1220,11 +1285,25 @@ export const learningBlocks: LearningBlock[] = [
 
 type CompletionAttempt = { isCorrect: boolean; targetForm: string; questionId?: string };
 
-// Correct answers on regular (non-kana) content that count as proof the
-// learner already reads kana; above this the 入門 kana chapters self-complete.
-// Small enough that any real returning learner clears it, large enough that
-// one lucky MCQ guess doesn't.
-const KANA_IMPLICIT_LITERACY_THRESHOLD = 5;
+// Correct answers on regular (non-入門) content that count as proof the
+// learner is already past the Lesson-0 floor; above this any
+// implicitCompleteWithHistory chapter self-completes. Small enough that any
+// real returning learner clears it, large enough that one lucky MCQ guess
+// doesn't.
+const IMPLICIT_HISTORY_THRESHOLD = 5;
+
+// 入門 question-id prefixes: kana drills, the starter vocab deck, and the
+// Lesson-0 pattern drills. These never count as "real practice" evidence --
+// intro content can't prove the intro chapters redundant.
+const INTRO_ID_PREFIXES = ["kana-", "starter-", "pattern-starter-"];
+
+function realPracticeEvidence(attempts: CompletionAttempt[]): number {
+  return attempts.filter(
+    (attempt) =>
+      attempt.isCorrect &&
+      !INTRO_ID_PREFIXES.some((prefix) => attempt.questionId?.startsWith(prefix))
+  ).length;
+}
 
 export function isLearningBlockComplete(attempts: CompletionAttempt[], block: LearningBlock): boolean {
   // Reference chapters are reading material -- treat them as
@@ -1232,40 +1311,29 @@ export function isLearningBlockComplete(attempts: CompletionAttempt[], block: Le
   // park on them, and the UI shows "參考" rather than misleadingly
   // marking them perpetually incomplete.
   if (block.completionMode === "reference") return true;
+  // 入門 chapters (#533/#534) self-complete on real practice history (see
+  // implicitCompleteWithHistory) BEFORE their own drill rules run.
+  if (
+    block.implicitCompleteWithHistory &&
+    realPracticeEvidence(attempts) >= IMPLICIT_HISTORY_THRESHOLD
+  ) {
+    return true;
+  }
   // Kana chapters (#533) are completed via their recognition drill -- one
   // correct attempt on any question of the chapter's script (ids are
-  // "kana-<script>-…") -- mirroring the pattern-chapter rule below. They
-  // ALSO auto-complete on evident kana literacy: the chapters sit first in
-  // array order, so without this rule every existing learner's home 繼續
-  // banner (first incomplete chapter) would be hijacked into 五十音 they
-  // plainly don't need. Answering regular (kana-rendered) content correctly
-  // IS reading kana, so a small body of correct non-kana attempts counts.
+  // "kana-<script>-…") -- mirroring the pattern-chapter rule below.
   if (block.kanaDrill) {
     const prefix = `kana-${block.kanaDrill.script}-`;
-    const drilled = attempts.some(
+    return attempts.some(
       (attempt) => attempt.isCorrect && attempt.questionId?.startsWith(prefix)
     );
-    if (drilled) return true;
-    const literacyEvidence = attempts.filter(
-      (attempt) => attempt.isCorrect && !attempt.questionId?.startsWith("kana-")
-    ).length;
-    return literacyEvidence >= KANA_IMPLICIT_LITERACY_THRESHOLD;
   }
-  // The starter-vocab chapter (#533) mirrors the kana rule: complete via one
-  // correct starter-drill answer, or implicitly for learners whose history
-  // already shows real (non-入門) practice.
+  // The starter-vocab chapter (#533) mirrors the kana rule: one correct
+  // starter-drill answer completes it.
   if (block.starterDrill) {
-    const drilled = attempts.some(
+    return attempts.some(
       (attempt) => attempt.isCorrect && attempt.questionId?.startsWith("starter-")
     );
-    if (drilled) return true;
-    const evidence = attempts.filter(
-      (attempt) =>
-        attempt.isCorrect &&
-        !attempt.questionId?.startsWith("kana-") &&
-        !attempt.questionId?.startsWith("starter-")
-    ).length;
-    return evidence >= KANA_IMPLICIT_LITERACY_THRESHOLD;
   }
   // Sentence-pattern chapters are completed via their pattern drill -- a
   // correct attempt on any of the chapter's patterns (id "pattern-<id>-…") --

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -23,6 +23,230 @@ export const patternInstructionI18n: LocalizedText = {
 };
 
 export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
+  "pattern-starter-desu-001": {
+    "hintI18n": {
+      "en": "Answering a question about what you are.",
+      "ja": "自分の身分についての質問に答える。"
+    },
+    "promptContextI18n": {
+      "en": "\"Are you a student?\" \"Yes, I am a student now.\"",
+      "ja": "「学生ですか。」「はい、わたしは今、学生です。」"
+    },
+    "explanationI18n": {
+      "en": "The question is affirmative (「がくせいですか」), and 「はい」 agrees with it — so present affirmative 「です」; 「じゃありません」 would contradict the 「はい」. 「いま」 (now) rules out the past 「でした」. ※がくせい = student.",
+      "ja": "相手は肯定形で「がくせいですか」と聞いている。「はい」はそれに同意する返事なので、現在肯定の「です」。「じゃありません」は「はい」と矛盾する。「いま」があるので過去の「でした」も合わない。"
+    }
+  },
+  "pattern-starter-desu-002": {
+    "hintI18n": {
+      "en": "Correcting someone's mistaken idea about what you are.",
+      "ja": "相手の勘違いを訂正する。"
+    },
+    "promptContextI18n": {
+      "en": "\"Are you a teacher?\" \"No, I am not a teacher.\"",
+      "ja": "「先生ですか。」「いいえ、わたしは先生じゃありません。」"
+    },
+    "explanationI18n": {
+      "en": "The question is affirmative (「せんせいですか」) and 「いいえ」 denies it → present negative 「じゃありません」. 「です」 contradicts the 「いいえ」; 「じゃありませんでした」 is PAST negative but the question asks about now; 「ですか」 asks a question.",
+      "ja": "相手は肯定形で「せんせいですか」と聞き、「いいえ」でそれを打ち消す → 現在否定の「じゃありません」。「です」は「いいえ」と矛盾。「じゃありませんでした」は過去否定で、現在を聞く質問と合わない。「ですか」は質問の文末。"
+    }
+  },
+  "pattern-starter-desu-003": {
+    "hintI18n": {
+      "en": "Talking about yesterday's weather.",
+      "ja": "きのうの天気について話す。"
+    },
+    "promptContextI18n": {
+      "en": "\"It rained yesterday (yesterday was rainy).\"",
+      "ja": "「きのうは雨でした。」"
+    },
+    "explanationI18n": {
+      "en": "「きのう」 (yesterday) is in the past; the past affirmative of a noun sentence is 「でした」. 「です」 is present, 「じゃありません」 is present negative, 「ですか」 is a question. ※あめ = rain.",
+      "ja": "「きのう」は過去のこと。名詞文の過去肯定は「でした」。「です」は現在、「じゃありません」は現在否定、「ですか」は疑問文。"
+    }
+  },
+  "pattern-starter-desu-004": {
+    "hintI18n": {
+      "en": "Correcting someone's impression of yesterday's weather.",
+      "ja": "きのうの天気についての印象を訂正する。"
+    },
+    "promptContextI18n": {
+      "en": "\"Did it rain yesterday?\" \"No, it didn't rain.\"",
+      "ja": "「きのうは雨でしたか。」「いいえ、雨じゃありませんでした。」"
+    },
+    "explanationI18n": {
+      "en": "The question is affirmative (「あめでしたか」) and 「いいえ」 denies it, AND 「きのう」 is past → past negative 「じゃありませんでした」. 「でした」 would contradict the 「いいえ」; 「じゃありません」 is present negative, clashing with the past-tense question.",
+      "ja": "相手は肯定形で「あめでしたか」と聞き、「いいえ」でそれを打ち消す＋「きのう」は過去 → 過去否定の「じゃありませんでした」。「でした」は「いいえ」と矛盾、「じゃありません」は現在否定で過去の質問と合わない。"
+    }
+  },
+  "pattern-starter-desu-005": {
+    "hintI18n": {
+      "en": "Pointing at an animal in the distance and checking with the listener.",
+      "ja": "遠くの動物を指して、相手に確かめる。"
+    },
+    "promptContextI18n": {
+      "en": "\"Um... is that a dog?\" \"Yes, it is.\"",
+      "ja": "「あのう、あれは犬ですか。」「はい、そうです。」"
+    },
+    "explanationI18n": {
+      "en": "The other person answers 「はい、そうです」 — only a QUESTION gets an answer, so the sentence must end in 「ですか」. With plain 「です」 you'd be telling them, and no 「はい」 would follow.",
+      "ja": "相手が「はい、そうです」と答えている——返事が返ってくるのは質問だから、文末は「ですか」。「です」なら断定になり、「はい」の返事は続かない。"
+    }
+  },
+  "pattern-starter-desu-006": {
+    "hintI18n": {
+      "en": "Talking about tomorrow's schedule.",
+      "ja": "あしたの予定について話す。"
+    },
+    "promptContextI18n": {
+      "en": "\"Tomorrow is a day off.\"",
+      "ja": "「あしたは休みです。」"
+    },
+    "explanationI18n": {
+      "en": "「あした」 (tomorrow) hasn't happened yet; Japanese noun sentences use the present form 「です」 for the future too. 「でした」/「じゃありませんでした」/「でしたか」 all carry past tense, contradicting 「あした」. ※やすみ = day off.",
+      "ja": "「あした」はまだ起きていないこと。日本語の名詞文は未来も現在形「です」で表す。「でした」「じゃありませんでした」「でしたか」はいずれも過去で「あした」と矛盾。"
+    }
+  },
+  "pattern-starter-desu-007": {
+    "hintI18n": {
+      "en": "The opening line when meeting someone for the first time.",
+      "ja": "初対面のあいさつの場面。"
+    },
+    "promptContextI18n": {
+      "en": "\"Nice to meet you. My name is Tanaka.\"",
+      "ja": "「はじめまして。わたしの名前は田中です。」"
+    },
+    "explanationI18n": {
+      "en": "「はじめまして」 is the first-meeting greeting, followed by introducing your own name = present affirmative 「です」. You wouldn't introduce yourself with a negative or a question.",
+      "ja": "「はじめまして」は初対面のあいさつ。続けて自分の名前を紹介する＝現在肯定の「です」。自己紹介で否定や疑問は使わない。"
+    }
+  },
+  "pattern-starter-desu-008": {
+    "hintI18n": {
+      "en": "Explaining which bag is actually yours.",
+      "ja": "どのかばんが自分のものかを説明する。"
+    },
+    "promptContextI18n": {
+      "en": "\"This is not my bag. Mine is that one over there.\"",
+      "ja": "「これはわたしのかばんじゃありません。わたしのはあれです。」"
+    },
+    "explanationI18n": {
+      "en": "The second sentence says \"mine is THAT one (あれ)\", so the first must DENY that this one is yours → 「じゃありません」. With 「です」 the two sentences would contradict each other.",
+      "ja": "二文目で「わたしのはあれです」と言っているので、一文目は「これがわたしのだ」を打ち消しているはず →「じゃありません」。「です」だと二つの文が矛盾する。"
+    }
+  },
+  "pattern-starter-particles-001": {
+    "hintI18n": {
+      "en": "Describing your own daily habit.",
+      "ja": "自分の毎日の習慣について話す。"
+    },
+    "promptContextI18n": {
+      "en": "\"I drink water every day.\"",
+      "ja": "「わたしは毎日水を飲みます。」"
+    },
+    "explanationI18n": {
+      "en": "「わたし」 is the TOPIC of the sentence (what it's about), marked with 「は」. 「を」 marks the object of an action (already there: みずを); 「に」 marks a time or destination; 「で」 marks where an action happens.",
+      "ja": "「わたし」はこの文の主題なので「は」。「を」は動作の対象（すでに「みずを」がある）、「に」は時点や行き先、「で」は動作の場所。"
+    }
+  },
+  "pattern-starter-particles-002": {
+    "hintI18n": {
+      "en": "Saying one thing you do in the morning.",
+      "ja": "朝にすることをひとつ言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"In the morning, (I) drink water.\"",
+      "ja": "「朝、水を飲みます。」"
+    },
+    "explanationI18n": {
+      "en": "「みず」 is the object of 「のみます」 (drink); objects take 「を」. 「が」 marks the doer of the action, and the water isn't doing the drinking; 「に」 marks a time or direction, 「へ」 direction only — none can mark what you drink.",
+      "ja": "「みず」は「のみます」の対象なので「を」。「が」は動作をする側に付くが、水は飲む側ではない。「に」は時点や方向、「へ」は方向だけで、飲む対象には付かない。"
+    }
+  },
+  "pattern-starter-particles-003": {
+    "hintI18n": {
+      "en": "Saying where you'll go tomorrow.",
+      "ja": "あした行く場所を言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"Tomorrow (I'm) going to school.\"",
+      "ja": "「あした、学校に行きます。」"
+    },
+    "explanationI18n": {
+      "en": "The destination of 「いきます」 (go) takes 「に」. 「を」 marks an object; 「で」 marks where an action takes place (doing something AT a place), not where you're heading; 「と」 means \"together with someone\". ※「へ」 also works for direction; this item's options use 「に」.",
+      "ja": "「いきます」の行き先は「に」。「を」は対象、「で」は動作の場所（〜で何かをする）で行き先ではない、「と」は「誰かと一緒に」。※方向は「へ」も使えるが、この問題の選択肢では「に」。"
+    }
+  },
+  "pattern-starter-particles-004": {
+    "hintI18n": {
+      "en": "Asking which person is coming.",
+      "ja": "来る予定の人をたずねる。"
+    },
+    "promptContextI18n": {
+      "en": "\"Who is coming?\"",
+      "ja": "「だれが来ますか。」"
+    },
+    "explanationI18n": {
+      "en": "A question-word subject (だれ, なに) takes 「が」 — and remember: 「は」 can't go here, because 「は」 must attach to something both speakers already know, while \"who\" is exactly the unknown being asked. 「を」 marks an object, 「に」 a time or direction, 「で」 the place of an action — none fits the subject slot.",
+      "ja": "疑問詞（だれ・なに）が主語のときは「が」。ついでに覚えておく：ここに「は」は使えない——「は」の前は双方すでに知っている話題でなければならず、「だれ」はまさに未知だから聞いている。「を」は対象、「に」は時点や方向、「で」は動作の場所で、主語の位置には入らない。"
+    }
+  },
+  "pattern-starter-particles-005": {
+    "hintI18n": {
+      "en": "Telling the listener what you've spotted.",
+      "ja": "見つけたものを相手に伝える。"
+    },
+    "promptContextI18n": {
+      "en": "\"There's a dog over there.\"",
+      "ja": "「そこに犬がいます。」"
+    },
+    "explanationI18n": {
+      "en": "When stating that something EXISTS with 「います／あります」, the newly-introduced thing takes 「が」. 「を」 marks the object of an action, but 「います」 isn't an action; 「へ」 marks direction; 「いぬで います」 isn't a sentence — 「〜でいます」 only works in state expressions like 「元気でいます」.",
+      "ja": "「います／あります」で「何かがある・いる」と初めて言うとき、その物には「が」。「を」は動作の対象だが「います」は動作ではない。「へ」は方向。「いぬで います」は文にならない——「〜でいます」は「元気でいます」のような状態の言い方だけ。"
+    }
+  },
+  "pattern-starter-particles-006": {
+    "hintI18n": {
+      "en": "Talking about an evening activity.",
+      "ja": "夜にすることについて話す。"
+    },
+    "promptContextI18n": {
+      "en": "\"At night, (I) read books.\"",
+      "ja": "「夜、本を読みます。」"
+    },
+    "explanationI18n": {
+      "en": "「ほん」 is the object of 「よみます」 (read) → 「を」. 「が」 marks the doer of the action, and the book isn't doing anything; 「に」/「へ」 mark direction or time.",
+      "ja": "「ほん」は「よみます」の対象なので「を」。「が」は動作をする側に付くが、本は動作しない。「に」「へ」は方向・時点。"
+    }
+  },
+  "pattern-starter-particles-007": {
+    "hintI18n": {
+      "en": "Saying your plan for tomorrow.",
+      "ja": "あした、おしゃべりする相手のことを言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"Tomorrow I'll talk with a friend.\"",
+      "ja": "「あした、わたしは友だちと話します。」"
+    },
+    "explanationI18n": {
+      "en": "The person you talk WITH takes 「と」 — chatting is mutual. The subject slot is already taken by 「わたしは」, so 「が」 can't fit; 「を」 can't mark the person you talk with — it marks what is spoken (にほんごを はなします \"speak Japanese\"); 「へ」 marks direction. ※「ともだちに はなします」 is also possible but feels one-directional (talking TO); this item's options use 「と」.",
+      "ja": "「はなします」の相手は「と」——おしゃべりはお互いにするもの。主語はすでに「わたしは」なので「が」は入らない。「を」は話す相手には付かず、話す内容に付く（にほんごを はなします）。「へ」は方向。※「ともだちに はなします」も言えるが一方向に「話しかける」感じ。この問題の選択肢では「と」。"
+    }
+  },
+  "pattern-starter-particles-008": {
+    "hintI18n": {
+      "en": "Saying where you eat.",
+      "ja": "ごはんを食べる場所を言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"(I) eat meals at home.\"",
+      "ja": "「家でごはんを食べます。」"
+    },
+    "explanationI18n": {
+      "en": "The place where an ACTION happens takes 「で」 — eating at home is an action. 「に」 marks where something exists or a destination (いえに います、いえに かえります); with action verbs the location takes 「で」. This is the key に/で split.",
+      "ja": "「動作をする場所」は「で」——家で「食べる」のは動作。「に」は存在の場所や行き先（いえに います、いえに かえります）。動作動詞の場所は「で」。に／で の一番大事な使い分け。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -2,6 +2,8 @@ import type { PracticeQuestion, VocabularyItem } from "./types";
 import { patternInstructionI18n, sentencePatternI18n } from "./sentencePatterns.i18n";
 
 export type SentencePatternId =
+  | "starter-desu"
+  | "starter-particles"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -29,6 +31,8 @@ export type SentencePatternItem = {
 };
 
 const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
+  "starter-desu": "基本句 〜です",
+  "starter-particles": "助詞入門",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -37,6 +41,203 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "nagara-tari": "並列・同時",
   "te-aux": "補助動詞"
 };
+
+// ===========================================================================
+// Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
+//   Absolute-beginner floor: kana-only sentences built from the starter
+//   vocabulary deck. Unique solutions are locked by IN-SENTENCE anchors
+//   (はい/いいえ for polarity, きのう/あした/いま for tense, はじめまして
+//   for self-introduction) plus option control -- only ONE option ever
+//   satisfies the anchors.
+// ===========================================================================
+const STARTER_DESU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-starter-desu-001",
+    patternId: "starter-desu",
+    promptText: "「がくせいですか。」「はい、わたしは いま がくせい___。」",
+    hintZh: "回答關於自己身分的問題。",
+    promptContextZh: "「你是學生嗎？」「是的，我現在是學生。」",
+    expectedAnswer: "です",
+    options: ["です", "でした", "じゃありません", "ですか"],
+    explanation:
+      "對方用肯定形問「がくせいですか」，回答「はい」＝同意「是學生」，所以接現在肯定的「です」；「じゃありません」和「はい」矛盾。「いま」表示現在，排除過去的「でした」（像昨天那樣已經過去的事）。※がくせい＝學生。"
+  },
+  {
+    id: "pattern-starter-desu-002",
+    patternId: "starter-desu",
+    promptText: "「せんせいですか。」「いいえ、わたしは せんせい___。」",
+    hintZh: "更正對方對自己身分的誤會。",
+    promptContextZh: "「你是老師嗎？」「不，我不是老師。」",
+    expectedAnswer: "じゃありません",
+    options: ["じゃありません", "です", "じゃありませんでした", "ですか"],
+    explanation:
+      "對方用肯定形問「せんせいですか」，回答「いいえ」＝否定「是老師」→ 現在否定「じゃありません」。「です」和「いいえ」矛盾；「じゃありませんでした」是過去否定，但問句問的是現在；「ですか」用來發問。"
+  },
+  {
+    id: "pattern-starter-desu-003",
+    patternId: "starter-desu",
+    promptText: "きのうは あめ___。",
+    hintZh: "說昨天的天氣。",
+    promptContextZh: "「昨天下雨（昨天是雨天）。」",
+    expectedAnswer: "でした",
+    options: ["でした", "です", "ですか", "じゃありません"],
+    explanation:
+      "「きのう（昨天）」是過去的事，名詞句的過去肯定用「でした」。「です」是現在；「じゃありません」是現在否定；「ですか」是問句。※あめ＝雨。"
+  },
+  {
+    id: "pattern-starter-desu-004",
+    patternId: "starter-desu",
+    promptText: "「きのうは あめでしたか。」「いいえ、あめ___。」",
+    hintZh: "更正對方對昨天天氣的印象。",
+    promptContextZh: "「昨天下雨了嗎？」「不，昨天沒有下雨。」",
+    expectedAnswer: "じゃありませんでした",
+    options: ["じゃありませんでした", "でした", "です", "じゃありません"],
+    explanation:
+      "對方用肯定形問「あめでしたか」，回答「いいえ」＝否定它＋「きのう」是過去 → 過去否定「じゃありませんでした」。「でした」跟「いいえ」矛盾；「じゃありません」是現在否定，跟過去的問句對不上。"
+  },
+  {
+    id: "pattern-starter-desu-005",
+    patternId: "starter-desu",
+    promptText: "「あのう、あれは いぬ___。」「はい、そうです。」",
+    hintZh: "指著遠處的動物，向對方確認。",
+    promptContextZh: "「請問……那是狗嗎？」「對，是的。」",
+    expectedAnswer: "ですか",
+    options: ["ですか", "です", "でした", "じゃありません"],
+    explanation:
+      "對方回答了「はい、そうです」——會得到回答的，一定是問句，所以句尾用「ですか」。若用「です」就是告訴對方，後面不會接「はい」的回答。"
+  },
+  {
+    id: "pattern-starter-desu-006",
+    patternId: "starter-desu",
+    promptText: "あしたは やすみ___。",
+    hintZh: "說明天的安排。",
+    promptContextZh: "「明天放假（明天是休息日）。」",
+    expectedAnswer: "です",
+    options: ["です", "でした", "じゃありませんでした", "でしたか"],
+    explanation:
+      "「あした（明天）」還沒發生，日文的名詞句用現在形「です」就能表達未來。「でした」「じゃありませんでした」「でしたか」都帶過去，跟「あした」矛盾。※やすみ＝休假。"
+  },
+  {
+    id: "pattern-starter-desu-007",
+    patternId: "starter-desu",
+    promptText: "はじめまして。わたしの なまえは たなか___。",
+    hintZh: "第一次見面的開場白。",
+    promptContextZh: "「初次見面，我的名字是田中。」",
+    expectedAnswer: "です",
+    options: ["です", "ですか", "じゃありません", "じゃありませんでした"],
+    explanation:
+      "「はじめまして」是初次見面的招呼，接著介紹自己的名字＝現在肯定「です」。介紹自己不會用否定或問句結尾。"
+  },
+  {
+    id: "pattern-starter-desu-008",
+    patternId: "starter-desu",
+    promptText: "これは わたしの かばん___。わたしのは あれです。",
+    hintZh: "說明哪一個包包才是自己的。",
+    promptContextZh: "「這不是我的包包，我的是那個。」",
+    expectedAnswer: "じゃありません",
+    options: ["じゃありません", "です", "でした", "ですか"],
+    explanation:
+      "第二句說「我的是那個（あれ）」，所以第一句一定在否定「這個是我的」→「じゃありません」。若第一句用「です」，兩句就互相矛盾了。"
+  }
+];
+
+// ===========================================================================
+// Lesson-0 pattern B: starter-particles -- は・を・に・が (+で/と) (#534).
+//   Same floor as starter-desu. The double-solution traps here are the
+//   particle system itself: へ/に for direction and は/が for subjects are
+//   NEVER offered head-to-head unless the sentence makes one impossible
+//   (e.g. an interrogative subject だれ can't take は).
+// ===========================================================================
+const STARTER_PARTICLES_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-starter-particles-001",
+    patternId: "starter-particles",
+    promptText: "わたし___ まいにち みずを のみます。",
+    hintZh: "描述自己每天的習慣。",
+    promptContextZh: "「我每天喝水。」",
+    expectedAnswer: "は",
+    options: ["は", "を", "に", "で"],
+    explanation:
+      "「わたし」是這句話的主題（談論的對象），用「は」標記。「を」接動作的對象（這句已經有みずを）；「に」表時間點或目的地；「で」表動作發生的場所。"
+  },
+  {
+    id: "pattern-starter-particles-002",
+    patternId: "starter-particles",
+    promptText: "あさ、みず___ のみます。",
+    hintZh: "說早上做的一件事。",
+    promptContextZh: "「早上喝水。」",
+    expectedAnswer: "を",
+    options: ["を", "に", "へ", "が"],
+    explanation:
+      "「みず」是「のみます（喝）」的對象，動作的對象用「を」。「が」標記做動作的主語，水不是喝東西的一方；「に」表時間點或方向、「へ」只表方向——都接不上「喝」的對象。"
+  },
+  {
+    id: "pattern-starter-particles-003",
+    patternId: "starter-particles",
+    promptText: "あした、がっこう___ いきます。",
+    hintZh: "說明天要去的地方。",
+    promptContextZh: "「明天去學校。」",
+    expectedAnswer: "に",
+    options: ["に", "を", "で", "と"],
+    explanation:
+      "「いきます（去）」的目的地用「に」。「を」是動作對象；「で」是動作發生的場所（在～做某事），不是要去的方向；「と」是「和某人一起」。※方向也可以用「へ」，這題選項中用「に」。"
+  },
+  {
+    id: "pattern-starter-particles-004",
+    patternId: "starter-particles",
+    promptText: "だれ___ きますか。",
+    hintZh: "問會來的人是哪一位。",
+    promptContextZh: "「誰要來？」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "疑問詞（だれ、なに）當主語時用「が」——順帶記住：這裡不能用「は」，因為「は」前面必須是雙方已知的話題，而「誰」正是未知才要問的。「を」接動作對象、「に」表時間或方向、「で」表動作場所，都放不進主語的位置。"
+  },
+  {
+    id: "pattern-starter-particles-005",
+    patternId: "starter-particles",
+    promptText: "そこに いぬ___ います。",
+    hintZh: "告訴對方你發現了什麼。",
+    promptContextZh: "「那裡有一隻狗。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "へ", "で"],
+    explanation:
+      "用「います／あります」說「有什麼東西存在」時，第一次提到的東西用「が」。「を」接動作對象，但「います」不是動作；「へ」表方向；「いぬで います」則不成句——「〜でいます」只接「元気でいます」這種狀態說法。"
+  },
+  {
+    id: "pattern-starter-particles-006",
+    patternId: "starter-particles",
+    promptText: "よる、ほん___ よみます。",
+    hintZh: "說晚上的活動。",
+    promptContextZh: "「晚上讀書（看書）。」",
+    expectedAnswer: "を",
+    options: ["を", "が", "に", "へ"],
+    explanation:
+      "「ほん」是「よみます（閱讀）」的對象 →「を」。「が」標記主語（做動作的人），書不是做動作的一方；「に」表時間點或方向、「へ」只表方向，接不上「讀」的對象。"
+  },
+  {
+    id: "pattern-starter-particles-007",
+    patternId: "starter-particles",
+    promptText: "あした、わたしは ともだち___ はなします。",
+    hintZh: "說自己明天的計畫。",
+    promptContextZh: "「明天我和朋友說話（聊天）。」",
+    expectedAnswer: "と",
+    options: ["と", "を", "が", "へ"],
+    explanation:
+      "「はなします」的交談對象用「と」——聊天是互相進行的。主語已經是「わたしは」，所以「が」放不進去；「を」不能標交談的對象，它標「說出的內容」（如：にほんごを はなします）；「へ」表方向。※「ともだちに はなします」也說得通，但語感是單方向「對朋友說」，這題選項中用「と」。"
+  },
+  {
+    id: "pattern-starter-particles-008",
+    patternId: "starter-particles",
+    promptText: "いえ___ ごはんを たべます。",
+    hintZh: "說吃飯的地點。",
+    promptContextZh: "「在家吃飯。」",
+    expectedAnswer: "で",
+    options: ["で", "に", "を", "へ"],
+    explanation:
+      "「做動作的場所」用「で」——在家「吃」是一個動作。「に」表存在的場所或目的地（いえに います、いえに かえります），配動作動詞的場所要用「で」。這是に／で最重要的分工。"
+  }
+];
 
 // ===========================================================================
 // Pattern 1: te-kudasai -- request / permission / prohibition family
@@ -684,6 +885,8 @@ const TE_AUX_ITEMS: SentencePatternItem[] = [
 ];
 
 export const sentencePatternItems: SentencePatternItem[] = [
+  ...STARTER_DESU_ITEMS,
+  ...STARTER_PARTICLES_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { buildSentencePatternPool } from "./sentencePatterns";
+import { sentencePatternI18n } from "./sentencePatterns.i18n";
+import { isLearningBlockComplete, learningBlocks } from "./learningBlocks";
+
+// The two Lesson-0 grammar drills (#534 batch 1): 基本句 AはBです and
+// 助詞入門 は・を・に・が. Their items must stay at the absolute-beginner
+// floor -- every sentence composable by a learner who knows kana + the
+// 97-word starter deck, no kanji anywhere.
+const desu = buildSentencePatternPool({ patternIds: ["starter-desu"] });
+const particles = buildSentencePatternPool({ patternIds: ["starter-particles"] });
+
+describe("starter sentence patterns (#534)", () => {
+  it("each drill carries 8 items with stable prefixed ids", () => {
+    expect(desu).toHaveLength(8);
+    expect(particles).toHaveLength(8);
+    for (const q of desu) expect(q.id).toMatch(/^pattern-starter-desu-\d+$/);
+    for (const q of particles) expect(q.id).toMatch(/^pattern-starter-particles-\d+$/);
+  });
+
+  it("every item is 4 distinct options with exactly one expected answer", () => {
+    for (const q of [...desu, ...particles]) {
+      expect(q.options, q.id).toHaveLength(4);
+      expect(new Set(q.options).size, q.id).toBe(4);
+      const hits = q.options!.filter((option) => q.expectedAnswers.includes(option));
+      expect(hits, q.id).toHaveLength(1);
+    }
+  });
+
+  it("prompts and options are kanji-free (the Lesson-0 floor: kana only)", () => {
+    for (const q of [...desu, ...particles]) {
+      expect(q.promptText, q.id).not.toMatch(/[一-鿿]/);
+      for (const option of q.options!) {
+        expect(option, q.id).not.toMatch(/[一-鿿]/);
+      }
+    }
+  });
+
+  it("hints never leak the expected answer", () => {
+    for (const q of [...desu, ...particles]) {
+      expect(q.hintZh ?? "", q.id).not.toContain(q.expectedAnswers[0]);
+    }
+  });
+
+  it("every item carries full ja+en overlays (launched-locale rule)", () => {
+    for (const q of [...desu, ...particles]) {
+      const overlay = sentencePatternI18n[q.id];
+      expect(overlay?.hintI18n?.ja, q.id).toBeTruthy();
+      expect(overlay?.hintI18n?.en, q.id).toBeTruthy();
+      expect(overlay?.promptContextI18n?.ja, q.id).toBeTruthy();
+      expect(overlay?.promptContextI18n?.en, q.id).toBeTruthy();
+      expect(overlay?.explanationI18n?.ja, q.id).toBeTruthy();
+      expect(overlay?.explanationI18n?.en, q.id).toBeTruthy();
+    }
+  });
+});
+
+describe("Lesson-0 grammar chapters (#534)", () => {
+  const byId = (id: string) => learningBlocks.find((b) => b.id === id)!;
+
+  it("the two chapters follow starter-vocab inside the 入門 category", () => {
+    expect(learningBlocks[3].id).toBe("starter-desu");
+    expect(learningBlocks[4].id).toBe("starter-particles");
+    expect(learningBlocks[3].category).toBe("入門");
+    expect(learningBlocks[4].category).toBe("入門");
+    expect(learningBlocks[5].category).not.toBe("入門");
+    expect(byId("starter-desu").patternDrills?.[0].patternIds).toEqual(["starter-desu"]);
+    expect(byId("starter-particles").patternDrills?.[0].patternIds).toEqual([
+      "starter-particles"
+    ]);
+  });
+
+  it("completes via one correct attempt on the chapter's own pattern drill", () => {
+    const chapter = byId("starter-desu");
+    expect(isLearningBlockComplete([], chapter)).toBe(false);
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "reading", questionId: "pattern-starter-desu-001" }],
+        chapter
+      )
+    ).toBe(true);
+    // The other Lesson-0 drill does not complete this chapter.
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "reading", questionId: "pattern-starter-particles-001" }],
+        chapter
+      )
+    ).toBe(false);
+  });
+
+  it("auto-completes for learners with real practice history (no 繼續 banner hijack)", () => {
+    const regular = Array.from({ length: 5 }, (_, index) => ({
+      isCorrect: true,
+      targetForm: "te",
+      questionId: `n3-grammar-item-${index}`
+    }));
+    expect(isLearningBlockComplete(regular, byId("starter-desu"))).toBe(true);
+    expect(isLearningBlockComplete(regular, byId("starter-particles"))).toBe(true);
+    // 入門 content itself is NOT evidence -- a kana-only learner still sees
+    // these chapters as待完成.
+    const introOnly = [
+      ...Array.from({ length: 5 }, (_, index) => ({
+        isCorrect: true,
+        targetForm: "reading",
+        questionId: `kana-hiragana-read-${index}`
+      })),
+      ...Array.from({ length: 5 }, (_, index) => ({
+        isCorrect: true,
+        targetForm: "meaning",
+        questionId: `starter-word-${index}:meaning`
+      }))
+    ];
+    expect(isLearningBlockComplete(introOnly, byId("starter-desu"))).toBe(false);
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -199,6 +199,8 @@ export type Copy = {
   drillPassive: string;
   drillCausative: string;
   drillDesiderative: string;
+  drillPatternStarterDesu: string;
+  drillPatternStarterParticles: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -216,6 +216,8 @@ export const en: Copy = {
   drillPassive: "Drill passive form",
   drillCausative: "Drill causative form",
   drillDesiderative: "Drill たい・たがる",
+  drillPatternStarterDesu: "Drill basic 〜です sentences",
+  drillPatternStarterParticles: "Drill particles は・を・に・が",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -216,6 +216,8 @@ export const id: Copy = {
   drillPassive: "Latih bentuk pasif",
   drillCausative: "Latih bentuk kausatif",
   drillDesiderative: "Latih たい・たがる",
+  drillPatternStarterDesu: "Latih kalimat dasar 〜です",
+  drillPatternStarterParticles: "Latih partikel は・を・に・が",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -224,6 +224,8 @@ export const ja: Copy = {
   drillPassive: "受身形を練習",
   drillCausative: "使役形を練習",
   drillDesiderative: "たい・たがるを練習",
+  drillPatternStarterDesu: "基本文 〜です を練習",
+  drillPatternStarterParticles: "助詞 は・を・に・が を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -216,6 +216,8 @@ export const ko: Copy = {
   drillPassive: "수동형 연습",
   drillCausative: "사역형 연습",
   drillDesiderative: "たい・たがる 연습",
+  drillPatternStarterDesu: "기본 문장 〜です 연습",
+  drillPatternStarterParticles: "조사 は・を・に・が 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -216,6 +216,8 @@ export const my: Copy = {
   drillPassive: "ခံရပုံစံ လေ့ကျင့်",
   drillCausative: "စေခိုင်းပုံစံ လေ့ကျင့်",
   drillDesiderative: "たい・たがる လေ့ကျင့်",
+  drillPatternStarterDesu: "အခြေခံဝါကျ 〜です လေ့ကျင့်ရန်",
+  drillPatternStarterParticles: "ဝိဘတ် は・を・に・が လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -217,6 +217,8 @@ export const th: Copy = {
   drillPassive: "ฝึกรูปถูกกระทำ (受身形)",
   drillCausative: "ฝึกรูปใช้ให้ทำ (使役形)",
   drillDesiderative: "ฝึก たい・たがる",
+  drillPatternStarterDesu: "ฝึกประโยคพื้นฐาน 〜です",
+  drillPatternStarterParticles: "ฝึกคำช่วย は・を・に・が",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -216,6 +216,8 @@ export const vi: Copy = {
   drillPassive: "Luyện thể bị động",
   drillCausative: "Luyện thể sai khiến",
   drillDesiderative: "Luyện たい・たがる",
+  drillPatternStarterDesu: "Luyện câu cơ bản 〜です",
+  drillPatternStarterParticles: "Luyện trợ từ は・を・に・が",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -216,6 +216,8 @@ export const zhHant: Copy = {
   drillPassive: "練受身形",
   drillCausative: "練使役形",
   drillDesiderative: "練たい・たがる",
+  drillPatternStarterDesu: "練基本句 〜です",
+  drillPatternStarterParticles: "練助詞 は・を・に・が",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## 為什麼

新手區（#531）的文法起點。#534 拍板「第 0 課群、每批 1–2 章」——首批做最根基的兩章，銜接「會假名＋97 詞」到既有變化章節。

## 內容

**16 題原創 cloze**（全假名、詞彙以 starter deck 為地板）：
- `starter-desu` 8 題：です／じゃありません／でした／じゃありませんでした／ですか，應答題全部帶**顯式問句的迷你對話**
- `starter-particles` 8 題：は・を・に・が（＋で/と），每題唯一解由句內錨鎖死（わたしは 佔位殺が、疑問詞主語、時制錨…）

**兩個入門章**：「基本句 AはBです」「助詞入門 は・を・に・が」——解說白話、pitfalls 含 は讀wa、に/で 分工等新手雷；en/ja 章節 overlay 齊；每題 ja/en 三欄 overlay 齊。

**隱性完成重構**：五個入門章統一 `implicitCompleteWithHistory` 旗標＋共用 `realPracticeEvidence` helper——老用戶的「繼續」banner 永不被入門章劫持。

`patternChecks` 46→62（drift guard 同步）；8 語系 drill labels。

## 內容品質 pipeline（本批最重）

1. 主筆（Fable）→ 2. **三透鏡對抗驗 Workflow**（雙解獵人／文法自然度／i18n 一致性）→ **16 項發現全處置**，最大收穫：
   - **はい/いいえ 只表「同意對方所言」、不鎖極性**（對否定問句回 はい 是初級教材標準用法）→ 應答題全部補顯式問句
   - 「みずで のみます」＝配水吞服（省略受詞是日語預設）→ で 干擾撤換
   - ja hint 洩答案助詞（「誰**が**来るか」「誰**と**会って」）→ 中性化
3. **codex 終審**再抓 2 項（だれは 對比語境可辯、を 說明過度簡化）→ 修 → **codex 複確認 PASS**

## 驗證

- TDD：`starterPatterns.test.ts` 鎖結構（8+8、四選項唯一解、**題面/選項零漢字**、hint 不洩答案、overlay 完整）＋章節位置/完成度/隱性規則
- **862 測全綠**、tsc/build 綠；pattern 資料全在 lazy chunk
- 實機：章節→drill→答對→解析→完成標記全鏈通；混合句型池中 starter 題渲染正確

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new beginner grammar drills for basic 〜です sentences and common particles は・を・に・が.
  * Expanded lesson-0 chapters and pattern overlays with localized content in multiple languages.

* **Bug Fixes**
  * Improved lesson completion tracking so intro chapters can complete based on relevant practice history.
  * Updated completion rules to better reflect the newest trackable learning content.

* **Tests**
  * Updated and added tests to cover the new starter patterns, chapter ordering, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->