### PR TITLE
feat(grammar): N5 首批 — 存在句あります・います＋位置詞/この・その (Closes #543)

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 62,
+  patternChecks: 78,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -252,6 +252,88 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n5-sonzai": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Existence: あります・います",
+      "explanation":
+        "The pattern for saying \"there is / it's at\". Two verbs split the work: things and plants take あります, people and animals take います. The two sentence shapes come as a pair: to introduce that something exists, use 「場所に 〜が あります/います」; to answer where a known thing is, use 「〜は 場所に あります/います」. The place of existence always takes に — で is for where an ACTION happens, the single most important に/で split.",
+      "notes": [
+        "Existence: there's a cat in the room (animal → います)",
+        "Existence: there's a book on the desk (thing → あります)",
+        "Location: answering \"where's the book?\"",
+        "The set phrase for asking directions",
+        "Negatives: isn't there / there's none"
+      ],
+      "pitfalls": [
+        "います is only for living, moving beings (people/animals); plants and things take あります",
+        "Existence takes に, actions take で: にわに います (is in the yard) vs にわで あそびます (plays in the yard)",
+        "First mention uses 〜が あります; a known topic uses 〜は 〜に あります — don't swap が/は"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "存在文 あります・います",
+      "explanation":
+        "「何がある・どこにいる」を言う文型。動詞は二つで分担：物と植物は あります、人と動物は います。文の形はペアで覚える：「何かがある」と紹介するなら「場所に 〜が あります/います」、「どこにあるか」を答えるなら「〜は 場所に あります/います」。存在の場所は必ず に——「ある場所で動作する」なら で。に／で の一番大事な分かれ目。",
+      "notes": [
+        "存在文：部屋に猫がいます（動物→います）",
+        "存在文：机の上に本があります（物→あります）",
+        "所在文：「本はどこ？」に答える",
+        "道をたずねる決まり文句",
+        "否定：いません／ありません"
+      ],
+      "pitfalls": [
+        "います は生きて動くもの（人・動物）だけ。植物と物は あります",
+        "存在は に、動作は で：にわに います vs にわで あそびます",
+        "初めての紹介は「〜が あります」、既知の話題は「〜は 〜に あります」——が/は を入れ替えない"
+      ]
+    }
+  },
+  "n5-ichi": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Position Words + この・その",
+      "explanation":
+        "Positions are said as 「noun + の + position word + に」: かばんの なかに (inside the bag), つくえの うえに (on the desk). The common position words: うえ/した/なか/まえ/うしろ/となり/よこ/ちかく. For demonstratives, this chapter covers the noun-attached forms: この/その/あの + noun (これ/それ/あれ stand alone; この must be followed by a noun). The distance split matches the これ series: near me → この, near you → その, far from both → あの.",
+      "notes": [
+        "なか = inside",
+        "うえ = on/above, した = under",
+        "まえ = in front, うしろ = behind",
+        "となり = next door, よこ = beside, ちかく = nearby",
+        "この + noun: near me",
+        "その + noun: near you"
+      ],
+      "pitfalls": [
+        "この/その/あの must be followed by a noun; standing alone, switch to これ/それ/あれ",
+        "となり = adjacent in a row (next door), よこ = to the side, ちかく = in the vicinity — three different ranges",
+        "\"On the desk\" is つくえの うえ — things on a surface always take うえ, don't drop it"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "位置のことばと この・その",
+      "explanation":
+        "位置は「名詞の＋位置のことば＋に」で言う：かばんの なかに、つくえの うえに。よく使う位置のことば：うえ/した/なか/まえ/うしろ/となり/よこ/ちかく。指示詞はここで「名詞に付く形」を学ぶ：この/その/あの＋名詞（これ/それ/あれ は単独で使う。この の後ろには必ず名詞）。距離の使い分けは これ系と同じ：自分の近く→この、相手の近く→その、どちらからも遠い→あの。",
+      "notes": [
+        "なか＝中",
+        "うえ＝上、した＝下",
+        "まえ＝前、うしろ＝後ろ",
+        "となり＝隣、よこ＝横、ちかく＝近く",
+        "この＋名詞：自分の近く",
+        "その＋名詞：相手の近く"
+      ],
+      "pitfalls": [
+        "この/その/あの の後ろには必ず名詞。単独なら これ/それ/あれ に替える",
+        "となり＝並んで隣接、よこ＝横の方向、ちかく＝近辺——範囲が違う",
+        "「机の上」は つくえの うえ。面の上にある物はいつも うえ を付けて言う"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 2 N5 grammar (#543) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(23);
+    expect(trackable.length).toBe(25);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -275,6 +275,58 @@ export const learningBlocks: LearningBlock[] = [
     implicitCompleteWithHistory: true,
     recommendedAfter: ["starter-desu"]
   },
+  // ---- N5 文法（#542/#543 起的 N5 句型補完系列）----------------------------
+  {
+    id: "n5-sonzai",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "存在句 あります・います",
+    subtitle: "へやに ねこが います",
+    explanation:
+      "說「有什麼、在哪裡」的句型。兩個動詞分工：東西和植物用あります、人和動物用います。兩種句式是一對：介紹「有什麼」用「場所に 〜が あります/います」；回答「在哪裡」用「〜は 場所に あります/います」。存在的場所一定用に——「在某處做動作」才用で，這是に/で最重要的分界。",
+    examples: [
+      { formula: "へやに ねこが います", note: "存在文：房間裡有貓（動物→います）" },
+      { formula: "つくえの うえに ほんが あります", note: "存在文：桌上有書（東西→あります）" },
+      { formula: "ほんは つくえの うえに あります", note: "所在文：回答「書在哪」" },
+      { formula: "トイレは どこに ありますか", note: "問路的固定句" },
+      { formula: "ねこは いません／ほんは ありません", note: "否定：不在/沒有" }
+    ],
+    pitfalls: [
+      "います限「有生命會動的」（人/動物）；植物和東西用あります",
+      "存在用に、動作用で：にわに います（在院子）vs にわで あそびます（在院子玩）",
+      "第一次介紹用「〜が あります」、已知話題用「〜は 〜に あります」——が/は 別互換"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Sonzai", patternIds: ["n5-sonzai"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["starter-particles"]
+  },
+  {
+    id: "n5-ichi",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "位置詞與この・その",
+    subtitle: "かばんの なかに あります",
+    explanation:
+      "位置的說法是「名詞の＋位置詞＋に」：かばんの なかに（包包裡）、つくえの うえに（桌上）。常用位置詞：うえ/した/なか/まえ/うしろ/となり/よこ/ちかく。指示詞這裡學「接名詞」的用法：この/その/あの＋名詞（これ/それ/あれ 單獨用、この 後面一定要接名詞），距離分工跟これ系一樣：近自己→この、近對方→その、都遠→あの。",
+    examples: [
+      { formula: "かばんの なかに けいたいが あります", note: "なか＝裡面" },
+      { formula: "つくえの うえ／した", note: "うえ＝上面、した＝下面" },
+      { formula: "えきの まえ／うしろ", note: "まえ＝前面、うしろ＝後面" },
+      { formula: "へやの となり／よこ／ちかく", note: "となり＝隔壁、よこ＝側邊、ちかく＝附近" },
+      { formula: "この ほんは わたしのです", note: "この＋名詞：近自己" },
+      { formula: "その かさは あなたのですか", note: "その＋名詞：近對方" }
+    ],
+    pitfalls: [
+      "この/その/あの 後面一定接名詞；單獨用要換 これ/それ/あれ",
+      "となり＝並排相鄰（隔壁）、よこ＝側面方向、ちかく＝附近——三個範圍不同",
+      "「桌上」日文說 つくえの うえ，東西放桌面都用うえ、不能省略"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Ichi", patternIds: ["n5-ichi"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-sonzai"]
+  },
   {
     id: "adverbial",
     group: "basic",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -247,6 +247,230 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "「動作をする場所」は「で」——家で「食べる」のは動作。「に」は存在の場所や行き先（いえに います、いえに かえります）。動作動詞の場所は「で」。に／で の一番大事な使い分け。"
     }
   },
+  "pattern-n5-sonzai-001": {
+    "hintI18n": {
+      "en": "Telling the listener what's in the room.",
+      "ja": "部屋に何がいるかを相手に伝える。"
+    },
+    "promptContextI18n": {
+      "en": "\"There's a cat in the room.\"",
+      "ja": "「部屋に猫がいます。」"
+    },
+    "explanationI18n": {
+      "en": "「〜に 〜が います」 is the fixed existence pattern: the newly-introduced thing takes 「が」. 「を」 marks an action's object, but います isn't an action; 「へ」 marks direction; 「で」 marks where an ACTION happens and can't attach to existence. ※へや = room.",
+      "ja": "「〜に 〜が います」は存在文の決まった形：初めて登場するものには「が」。「を」は動作の対象だが います は動作ではない。「へ」は方向。「で」は動作の場所で、存在の います には付かない。"
+    }
+  },
+  "pattern-n5-sonzai-002": {
+    "hintI18n": {
+      "en": "Saying what's on the desk.",
+      "ja": "机の上に何があるかを言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"There's a book on the desk.\"",
+      "ja": "「机の上に本があります。」"
+    },
+    "explanationI18n": {
+      "en": "Existence 「〜に 〜が あります」: the book is newly introduced, so 「が」. 「で」 marks the place of an action and doesn't fit 「あります」 (existence). ※つくえ = desk, うえ = top/on.",
+      "ja": "存在文「〜に 〜が あります」：本は初めて登場するものなので「が」。「で」は動作の場所で、存在の「あります」には合わない。"
+    }
+  },
+  "pattern-n5-sonzai-003": {
+    "hintI18n": {
+      "en": "Answering where the dog is.",
+      "ja": "犬がどこにいるかを答える。"
+    },
+    "promptContextI18n": {
+      "en": "\"The dog is in the yard.\"",
+      "ja": "「犬は庭にいます。」"
+    },
+    "explanationI18n": {
+      "en": "The place where something EXISTS takes 「に」 — the dog IS in the yard, it isn't DOING something there. 「で」 goes with action verbs (にわで あそびます); this is the key に/で split. ※にわ = yard.",
+      "ja": "「存在する場所」は「に」——犬は庭に「いる」のであって、庭で何かを「する」のではない。「で」は動作動詞と使う（にわで あそびます）。に／で の一番大事な使い分け。"
+    }
+  },
+  "pattern-n5-sonzai-004": {
+    "hintI18n": {
+      "en": "Saying who's in the classroom.",
+      "ja": "教室に誰がいるかを言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"There are students in the classroom.\"",
+      "ja": "「教室に学生がいます。」"
+    },
+    "explanationI18n": {
+      "en": "Living, moving beings (people/animals) take 「います」; things and plants take 「あります」. Students are people → 「います」. ※きょうしつ = classroom, がくせい = student.",
+      "ja": "生きて動くもの（人・動物）は「います」、物と植物は「あります」。学生は人 →「います」。"
+    }
+  },
+  "pattern-n5-sonzai-005": {
+    "hintI18n": {
+      "en": "Saying what's inside the bag.",
+      "ja": "かばんの中に何があるかを言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"There's a phone in the bag.\"",
+      "ja": "「かばんの中に携帯があります。」"
+    },
+    "explanationI18n": {
+      "en": "A phone is a thing (not alive), so existence uses 「あります」. 「います」 is reserved for people and animals. ※なか = inside.",
+      "ja": "携帯は物（生きていない）ので、存在は「あります」。「います」は人と動物のためのもの。"
+    }
+  },
+  "pattern-n5-sonzai-006": {
+    "hintI18n": {
+      "en": "Asking where the restroom is.",
+      "ja": "トイレの場所をたずねる。"
+    },
+    "promptContextI18n": {
+      "en": "\"Excuse me, where is the restroom?\"",
+      "ja": "「すみません、トイレはどこにありますか。」"
+    },
+    "explanationI18n": {
+      "en": "Asking \"where\" = asking about the place of existence, and places take 「に」. 「トイレは どこに ありますか」 is the set phrase for asking directions. 「へ」 marks direction, not a static location; 「を」 marks an object; the topic 「は」 already took 「が」's slot. ※トイレ = restroom.",
+      "ja": "「どこにあるか」＝存在の場所を聞いている。場所は「に」。「トイレは どこに ありますか」は道をたずねる決まり文句。「へ」は方向で、静的な存在の場所には使わない。「を」は対象。主題の「は」があるので「が」は入らない。"
+    }
+  },
+  "pattern-n5-sonzai-007": {
+    "hintI18n": {
+      "en": "Saying the cat isn't home right now (it went out).",
+      "ja": "今、猫が家にいないことを言う（外に出ている）。"
+    },
+    "promptContextI18n": {
+      "en": "\"The cat isn't home right now.\"",
+      "ja": "「今、猫は家にいません。」"
+    },
+    "explanationI18n": {
+      "en": "A cat is an animal → the negative of います, 「いません」. 「ありません」 negates things; 「いました」 is past, contradicting 「いま」 (now). The hint says the cat is out, so affirmative 「います」 is wrong too.",
+      "ja": "猫は動物 → います の否定「いません」。「ありません」は物の否定。「いました」は過去で「いま」と矛盾。ヒントで猫はいないと言っているので肯定の「います」も違う。"
+    }
+  },
+  "pattern-n5-sonzai-008": {
+    "hintI18n": {
+      "en": "Answering \"where's the book?\"",
+      "ja": "「本はどこ？」に答える。"
+    },
+    "promptContextI18n": {
+      "en": "\"The book is on the desk.\"",
+      "ja": "「本は机の上にあります。」"
+    },
+    "explanationI18n": {
+      "en": "This is the LOCATION sentence: known thing (ほんは) + place に + あります. A book is a thing → 「あります」. 「〜は 〜に あります」 answers where; 「〜に 〜が あります」 introduces existence — the two shapes are a pair. ※つくえ = desk, うえ = top/on.",
+      "ja": "これは「所在文」：既知のもの（ほんは）＋場所に＋あります。本は物 →「あります」。「〜は 〜に あります」は場所を答える形、「〜に 〜が あります」は存在を紹介する形。二つでペア。"
+    }
+  },
+  "pattern-n5-ichi-001": {
+    "hintI18n": {
+      "en": "Saying where the phone is: INSIDE the bag.",
+      "ja": "携帯の場所を言う：かばんの「中」。"
+    },
+    "promptContextI18n": {
+      "en": "\"The phone is inside the bag.\"",
+      "ja": "「携帯はかばんの中にあります。」"
+    },
+    "explanationI18n": {
+      "en": "Positions are said as 「noun + の + position word + に」: かばんの なかに = inside the bag. なか = inside, うえ = on/above, した = under, まえ = in front.",
+      "ja": "位置は「名詞＋の＋位置のことば＋に」：かばんの なかに＝かばんの中。なか＝中、うえ＝上、した＝下、まえ＝前。"
+    }
+  },
+  "pattern-n5-ichi-002": {
+    "hintI18n": {
+      "en": "Saying where the cat is: UNDER the desk.",
+      "ja": "猫の場所を言う：机の「下」。"
+    },
+    "promptContextI18n": {
+      "en": "\"The cat is under the desk.\"",
+      "ja": "「猫は机の下にいます。」"
+    },
+    "explanationI18n": {
+      "en": "した = under. 「つくえの したに」 = under the desk. 「つくえの なか」 refers to the inside of the desk's storage (drawers, where textbooks go), not the space beneath it; うしろ = behind. ※つくえ = desk.",
+      "ja": "した＝下。「つくえの したに」＝机の下。「つくえの なか」は引き出しなど収納の内部（教科書をしまう所）で、机の下の空間ではない。うしろ＝後ろ。"
+    }
+  },
+  "pattern-n5-ichi-003": {
+    "hintI18n": {
+      "en": "Saying where the book is: ON the desk.",
+      "ja": "本の場所を言う：机の「上」。"
+    },
+    "promptContextI18n": {
+      "en": "\"The book is on the desk.\"",
+      "ja": "「本は机の上にあります。」"
+    },
+    "explanationI18n": {
+      "en": "うえ = on/above. English says \"on the desk\" with a preposition; Japanese uses the structure 「noun + の + position word」: 「つくえの うえに」. Things on a surface always take うえ.",
+      "ja": "うえ＝上。日本語は「名詞＋の＋位置のことば」の形で言う：「つくえの うえに」。面の上にある物はいつも うえ。"
+    }
+  },
+  "pattern-n5-ichi-004": {
+    "hintI18n": {
+      "en": "Saying where the school is: IN FRONT OF the station.",
+      "ja": "学校の場所を言う：駅の「前」。"
+    },
+    "promptContextI18n": {
+      "en": "\"The school is in front of the station.\"",
+      "ja": "「学校は駅の前にあります。」"
+    },
+    "explanationI18n": {
+      "en": "まえ = in front, うしろ = behind. 「えきの まえ」 (in front of the station) is one of the most common ways to describe a location. ※えき = station.",
+      "ja": "まえ＝前、うしろ＝後ろ。「えきの まえ」は場所の説明でいちばんよく使う言い方のひとつ。"
+    }
+  },
+  "pattern-n5-ichi-005": {
+    "hintI18n": {
+      "en": "Saying where the restroom is: NEXT TO the room (adjacent).",
+      "ja": "トイレの場所を言う：部屋の「隣」（すぐ横に並んで）。"
+    },
+    "promptContextI18n": {
+      "en": "\"The restroom is next to the room.\"",
+      "ja": "「トイレは部屋の隣にあります。」"
+    },
+    "explanationI18n": {
+      "en": "となり = next to (adjacent, side by side). Japanese also has 「よこ」 (beside): となり stresses being adjacent in a row (next door), よこ just means to the side. ※トイレ = restroom, へや = room.",
+      "ja": "となり＝隣（並んで隣接）。「よこ」も横の意味だが、となり は並んで隣り合うこと（隣室）、よこ は横の方向だけを言う。"
+    }
+  },
+  "pattern-n5-ichi-006": {
+    "hintI18n": {
+      "en": "Saying where the bank is: BEHIND the supermarket.",
+      "ja": "銀行の場所を言う：スーパーの「後ろ」。"
+    },
+    "promptContextI18n": {
+      "en": "\"The bank is behind the supermarket.\"",
+      "ja": "「銀行はスーパーの後ろにあります。」"
+    },
+    "explanationI18n": {
+      "en": "うしろ = behind. まえ/うしろ come as a pair and are the staple of giving directions. ※ぎんこう = bank, スーパー = supermarket.",
+      "ja": "うしろ＝後ろ。まえ／うしろ はペアで、道案内の定番。"
+    }
+  },
+  "pattern-n5-ichi-007": {
+    "hintI18n": {
+      "en": "Saying the book in your own hand is yours.",
+      "ja": "自分の手にある本が自分のものだと言う。"
+    },
+    "promptContextI18n": {
+      "en": "\"(Looking at the book in my hand) This book is mine.\"",
+      "ja": "「（自分の手にある本を見て）この本はわたしのです。」"
+    },
+    "explanationI18n": {
+      "en": "「この + noun」 = near me. これ stands alone (これは ほんです); この must be followed by a noun (この ほん). In my own hand → この. ※て = hand.",
+      "ja": "「この＋名詞」＝自分の近く。これ は単独で使い（これは ほんです）、この の後ろには必ず名詞（この ほん）。自分の手の中 → この。"
+    }
+  },
+  "pattern-n5-ichi-008": {
+    "hintI18n": {
+      "en": "Asking if the umbrella in the listener's hand is theirs.",
+      "ja": "相手の手にある傘が相手のものかをたずねる。"
+    },
+    "promptContextI18n": {
+      "en": "\"(Looking at the umbrella in your hand) Is that umbrella yours?\"",
+      "ja": "「（相手の手にある傘を見て）その傘はあなたのですか。」"
+    },
+    "explanationI18n": {
+      "en": "「その + noun」 = near the listener. The umbrella is in their hand → その. あの = far from both; どの = which (question). ※かさ = umbrella, あいて = the other person.",
+      "ja": "「その＋名詞」＝相手の近く。傘は相手の手の中 → その。あの＝どちらからも遠い、どの＝疑問。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -4,6 +4,8 @@ import { patternInstructionI18n, sentencePatternI18n } from "./sentencePatterns.
 export type SentencePatternId =
   | "starter-desu"
   | "starter-particles"
+  | "n5-sonzai"
+  | "n5-ichi"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -33,6 +35,8 @@ export type SentencePatternItem = {
 const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "starter-desu": "基本句 〜です",
   "starter-particles": "助詞入門",
+  "n5-sonzai": "存在 あります・います",
+  "n5-ichi": "位置與指示",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -41,6 +45,202 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "nagara-tari": "並列・同時",
   "te-aux": "補助動詞"
 };
+
+// ===========================================================================
+// N5 pattern: n5-sonzai -- あります/います existence sentences (#543).
+//   The biggest single N5 gap from the coverage audit. Kana-first with
+//   starter-deck words; new words get a ※gloss in the explanation.
+//   Unique-solution levers: alive/inanimate subject picks あります vs
+//   います; で (action location) vs に (existence location) is the classic
+//   trap and appears only where the verb makes it dead.
+// ===========================================================================
+const N5_SONZAI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-sonzai-001",
+    patternId: "n5-sonzai",
+    promptText: "へやに ねこ___ います。",
+    hintZh: "告訴對方房間裡有什麼。",
+    promptContextZh: "「房間裡有一隻貓。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "へ", "で"],
+    explanation:
+      "「〜に 〜が います」是存在句的固定形：第一次提到「有什麼」時，那個東西用「が」。「を」接動作對象，但います不是動作；「へ」表方向；「で」是動作發生的場所，跟います（存在）接不上。※へや＝房間。"
+  },
+  {
+    id: "pattern-n5-sonzai-002",
+    patternId: "n5-sonzai",
+    promptText: "つくえの うえに ほん___ あります。",
+    hintZh: "說桌上有什麼東西。",
+    promptContextZh: "「桌上有書。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "で", "へ"],
+    explanation:
+      "存在句「〜に 〜が あります」：書是第一次登場的東西，用「が」。「で」是動作發生的場所，跟「あります（存在）」接不上。※つくえ＝桌子、うえ＝上面。"
+  },
+  {
+    id: "pattern-n5-sonzai-003",
+    patternId: "n5-sonzai",
+    promptText: "いぬは にわ___ います。",
+    hintZh: "回答狗在哪裡。",
+    promptContextZh: "「狗在院子裡。」",
+    expectedAnswer: "に",
+    options: ["に", "で", "を", "へ"],
+    explanation:
+      "「存在的場所」用「に」——狗「在」院子，不是在院子「做」什麼。「で」配動作動詞（にわで あそびます）；這是 に／で 最重要的分工。※にわ＝院子。"
+  },
+  {
+    id: "pattern-n5-sonzai-004",
+    patternId: "n5-sonzai",
+    promptText: "きょうしつに がくせいが ___。",
+    hintZh: "說教室裡有誰。",
+    promptContextZh: "「教室裡有學生。」",
+    expectedAnswer: "います",
+    options: ["います", "あります", "です", "でした"],
+    explanation:
+      "人和動物這些「有生命、會動的」用「います」；東西和植物用「あります」。學生是人 →「います」。※きょうしつ＝教室、がくせい＝學生。"
+  },
+  {
+    id: "pattern-n5-sonzai-005",
+    patternId: "n5-sonzai",
+    promptText: "かばんの なかに けいたいが ___。",
+    hintZh: "說包包裡有什麼東西。",
+    promptContextZh: "「包包裡有手機。」",
+    expectedAnswer: "あります",
+    options: ["あります", "います", "ですか", "じゃありません"],
+    explanation:
+      "手機是東西（沒有生命），存在用「あります」。「います」留給人和動物。※なか＝裡面。"
+  },
+  {
+    id: "pattern-n5-sonzai-006",
+    patternId: "n5-sonzai",
+    promptText: "すみません、トイレは どこ___ ありますか。",
+    hintZh: "問廁所的位置。",
+    promptContextZh: "「不好意思，廁所在哪裡？」",
+    expectedAnswer: "に",
+    options: ["に", "へ", "を", "が"],
+    explanation:
+      "問「在哪裡」＝問存在的場所，場所用「に」。「トイレは どこに ありますか」是問路的固定句。「へ」表方向，不表靜態存在的位置；「を」接動作對象；「が」的位置已被主題「は」佔走。※トイレ＝廁所。"
+  },
+  {
+    id: "pattern-n5-sonzai-007",
+    patternId: "n5-sonzai",
+    promptText: "いま、いえに ねこは ___。",
+    hintZh: "說現在家裡沒有貓（貓出門了）。",
+    promptContextZh: "「現在貓不在家。」",
+    expectedAnswer: "いません",
+    options: ["いません", "ありません", "います", "いました"],
+    explanation:
+      "貓是動物 → 用います的否定「いません」。「ありません」是東西的否定；「いました」是過去，跟「いま（現在）」矛盾。提示說了貓不在，所以肯定的「います」也不對。"
+  },
+  {
+    id: "pattern-n5-sonzai-008",
+    patternId: "n5-sonzai",
+    promptText: "ほんは つくえの うえに ___。",
+    hintZh: "回答「書在哪裡」。",
+    promptContextZh: "「書在桌子上。」",
+    expectedAnswer: "あります",
+    options: ["あります", "います", "です", "でしたか"],
+    explanation:
+      "這是「所在句」：已知的東西（ほんは）＋場所に＋あります。書是東西 →「あります」。「〜は 〜に あります」回答位置、「〜に 〜が あります」介紹存在，兩個句型是一對。※つくえ＝桌子、うえ＝上面。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-ichi -- position words + この/その demonstratives (#543).
+//   Position-word cloze items are locked by the hint's Chinese description
+//   of the spatial relation (the established pattern-item lever) plus
+//   option control; この/その items anchor on who is holding the object.
+// ===========================================================================
+const N5_ICHI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-ichi-001",
+    patternId: "n5-ichi",
+    promptText: "けいたいは かばんの ___に あります。",
+    hintZh: "說手機的位置：在包包「裡面」。",
+    promptContextZh: "「手機在包包裡面。」",
+    expectedAnswer: "なか",
+    options: ["なか", "うえ", "した", "まえ"],
+    explanation:
+      "位置的說法是「名詞＋の＋位置詞＋に」：かばんの なかに＝在包包裡面。なか＝裡面、うえ＝上面、した＝下面、まえ＝前面。"
+  },
+  {
+    id: "pattern-n5-ichi-002",
+    patternId: "n5-ichi",
+    promptText: "ねこは つくえの ___に います。",
+    hintZh: "說貓的位置：在桌子「下面」。",
+    promptContextZh: "「貓在桌子下面。」",
+    expectedAnswer: "した",
+    options: ["した", "うえ", "なか", "うしろ"],
+    explanation:
+      "した＝下面。「つくえの したに」＝在桌子下面。「つくえの なか」指的是抽屜等收納空間的內部（放課本的地方），不是桌子底下；うしろ＝後面。※つくえ＝桌子。"
+  },
+  {
+    id: "pattern-n5-ichi-003",
+    patternId: "n5-ichi",
+    promptText: "ほんは つくえの ___に あります。",
+    hintZh: "說書的位置：在桌子「上面」。",
+    promptContextZh: "「書在桌子上面。」",
+    expectedAnswer: "うえ",
+    options: ["うえ", "した", "まえ", "となり"],
+    explanation:
+      "うえ＝上面。中文說「桌上」，日文要用「名詞＋の＋位置詞」的結構：「つくえの うえに」。東西放在桌面上都用 うえ。"
+  },
+  {
+    id: "pattern-n5-ichi-004",
+    patternId: "n5-ichi",
+    promptText: "がっこうは えきの ___に あります。",
+    hintZh: "說學校的位置：在車站「前面」。",
+    promptContextZh: "「學校在車站前面。」",
+    expectedAnswer: "まえ",
+    options: ["まえ", "うしろ", "なか", "うえ"],
+    explanation:
+      "まえ＝前面、うしろ＝後面。「えきの まえ」（車站前）是描述地點最常用的說法之一。※えき＝車站。"
+  },
+  {
+    id: "pattern-n5-ichi-005",
+    patternId: "n5-ichi",
+    promptText: "トイレは へやの ___に あります。",
+    hintZh: "說廁所的位置：在房間「旁邊」（緊鄰的隔壁）。",
+    promptContextZh: "「廁所在房間旁邊。」",
+    expectedAnswer: "となり",
+    options: ["となり", "うえ", "なか", "まえ"],
+    explanation:
+      "となり＝旁邊（緊鄰、同類並排）。日文還有「よこ」也是旁邊，差別：となり 強調並排相鄰（隔壁），よこ 只說在側面方向。※トイレ＝廁所、へや＝房間。"
+  },
+  {
+    id: "pattern-n5-ichi-006",
+    patternId: "n5-ichi",
+    promptText: "ぎんこうは スーパーの ___に あります。",
+    hintZh: "說銀行的位置：在超市「後面」。",
+    promptContextZh: "「銀行在超市後面。」",
+    expectedAnswer: "うしろ",
+    options: ["うしろ", "まえ", "した", "となり"],
+    explanation:
+      "うしろ＝後面。まえ／うしろ 是一對，配路標描述最常用。※ぎんこう＝銀行、スーパー＝超市。"
+  },
+  {
+    id: "pattern-n5-ichi-007",
+    patternId: "n5-ichi",
+    promptText: "（じぶんの てに ある ほんを みて）___ ほんは わたしのです。",
+    hintZh: "說自己手上拿著的這本書是自己的。",
+    promptContextZh: "「（看著自己手上的書）這本書是我的。」",
+    expectedAnswer: "この",
+    options: ["この", "その", "あの", "どの"],
+    explanation:
+      "「この＋名詞」＝靠近自己的。これ 單獨用（これは ほんです）、この 後面一定接名詞（この ほん）。在自己手上 → この。※て＝手。"
+  },
+  {
+    id: "pattern-n5-ichi-008",
+    patternId: "n5-ichi",
+    promptText: "（あいての てに ある かさを みて）___ かさは あなたのですか。",
+    hintZh: "問對方手上拿著的那把傘是不是對方的。",
+    promptContextZh: "「（看著對方手上的傘）那把傘是你的嗎？」",
+    expectedAnswer: "その",
+    options: ["その", "この", "あの", "どの"],
+    explanation:
+      "「その＋名詞」＝靠近對方的。傘在對方手上 → その。あの＝離雙方都遠；どの＝哪一個（疑問）。※かさ＝傘、あいて＝對方。"
+  }
+];
 
 // ===========================================================================
 // Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
@@ -887,6 +1087,8 @@ const TE_AUX_ITEMS: SentencePatternItem[] = [
 export const sentencePatternItems: SentencePatternItem[] = [
   ...STARTER_DESU_ITEMS,
   ...STARTER_PARTICLES_ITEMS,
+  ...N5_SONZAI_ITEMS,
+  ...N5_ICHI_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -55,6 +55,48 @@ describe("starter sentence patterns (#534)", () => {
   });
 });
 
+describe("N5 grammar patterns (#543: sonzai + ichi)", () => {
+  const sonzai = buildSentencePatternPool({ patternIds: ["n5-sonzai"] });
+  const ichi = buildSentencePatternPool({ patternIds: ["n5-ichi"] });
+
+  it("each drill carries 8 kana-only items with unique solutions and full overlays", () => {
+    expect(sonzai).toHaveLength(8);
+    expect(ichi).toHaveLength(8);
+    for (const q of [...sonzai, ...ichi]) {
+      expect(q.options, q.id).toHaveLength(4);
+      expect(new Set(q.options).size, q.id).toBe(4);
+      expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);
+      expect(q.promptText, q.id).not.toMatch(/[一-鿿]/);
+      expect(q.hintZh ?? "", q.id).not.toContain(q.expectedAnswers[0]);
+      const overlay = sentencePatternI18n[q.id];
+      expect(overlay?.hintI18n?.ja && overlay?.hintI18n?.en, q.id).toBeTruthy();
+      expect(
+        overlay?.explanationI18n?.ja && overlay?.explanationI18n?.en,
+        q.id
+      ).toBeTruthy();
+    }
+  });
+
+  it("the two N5 chapters sit in the N5 文法 category with pattern completion", () => {
+    const byId = (id: string) => learningBlocks.find((b) => b.id === id)!;
+    expect(byId("n5-sonzai").category).toBe("N5 文法");
+    expect(byId("n5-ichi").category).toBe("N5 文法");
+    expect(
+      isLearningBlockComplete(
+        [{ isCorrect: true, targetForm: "reading", questionId: "pattern-n5-sonzai-001" }],
+        byId("n5-sonzai")
+      )
+    ).toBe(true);
+    // Real-history implicit completion applies here too (no banner hijack).
+    const regular = Array.from({ length: 5 }, (_, index) => ({
+      isCorrect: true,
+      targetForm: "te",
+      questionId: `n2-item-${index}`
+    }));
+    expect(isLearningBlockComplete(regular, byId("n5-ichi"))).toBe(true);
+  });
+});
+
 describe("Lesson-0 grammar chapters (#534)", () => {
   const byId = (id: string) => learningBlocks.find((b) => b.id === id)!;
 
@@ -63,7 +105,7 @@ describe("Lesson-0 grammar chapters (#534)", () => {
     expect(learningBlocks[4].id).toBe("starter-particles");
     expect(learningBlocks[3].category).toBe("入門");
     expect(learningBlocks[4].category).toBe("入門");
-    expect(learningBlocks[5].category).not.toBe("入門");
+    expect(learningBlocks[5].category).toBe("N5 文法"); // #543 chapters follow the 入門 block
     expect(byId("starter-desu").patternDrills?.[0].patternIds).toEqual(["starter-desu"]);
     expect(byId("starter-particles").patternDrills?.[0].patternIds).toEqual([
       "starter-particles"

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -201,6 +201,8 @@ export type Copy = {
   drillDesiderative: string;
   drillPatternStarterDesu: string;
   drillPatternStarterParticles: string;
+  drillPatternN5Sonzai: string;
+  drillPatternN5Ichi: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -218,6 +218,8 @@ export const en: Copy = {
   drillDesiderative: "Drill たい・たがる",
   drillPatternStarterDesu: "Drill basic 〜です sentences",
   drillPatternStarterParticles: "Drill particles は・を・に・が",
+  drillPatternN5Sonzai: "Drill あります・います",
+  drillPatternN5Ichi: "Drill position words + この・その",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -218,6 +218,8 @@ export const id: Copy = {
   drillDesiderative: "Latih たい・たがる",
   drillPatternStarterDesu: "Latih kalimat dasar 〜です",
   drillPatternStarterParticles: "Latih partikel は・を・に・が",
+  drillPatternN5Sonzai: "Latih あります・います",
+  drillPatternN5Ichi: "Latih kata posisi + この・その",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -226,6 +226,8 @@ export const ja: Copy = {
   drillDesiderative: "たい・たがるを練習",
   drillPatternStarterDesu: "基本文 〜です を練習",
   drillPatternStarterParticles: "助詞 は・を・に・が を練習",
+  drillPatternN5Sonzai: "あります・います を練習",
+  drillPatternN5Ichi: "位置詞と この・その を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -218,6 +218,8 @@ export const ko: Copy = {
   drillDesiderative: "たい・たがる 연습",
   drillPatternStarterDesu: "기본 문장 〜です 연습",
   drillPatternStarterParticles: "조사 は・を・に・が 연습",
+  drillPatternN5Sonzai: "あります・います 연습",
+  drillPatternN5Ichi: "위치어와 この・その 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -218,6 +218,8 @@ export const my: Copy = {
   drillDesiderative: "たい・たがる လေ့ကျင့်",
   drillPatternStarterDesu: "အခြေခံဝါကျ 〜です လေ့ကျင့်ရန်",
   drillPatternStarterParticles: "ဝိဘတ် は・を・に・が လေ့ကျင့်ရန်",
+  drillPatternN5Sonzai: "あります・います လေ့ကျင့်ရန်",
+  drillPatternN5Ichi: "တည်နေရာစကားလုံး + この・その လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -219,6 +219,8 @@ export const th: Copy = {
   drillDesiderative: "ฝึก たい・たがる",
   drillPatternStarterDesu: "ฝึกประโยคพื้นฐาน 〜です",
   drillPatternStarterParticles: "ฝึกคำช่วย は・を・に・が",
+  drillPatternN5Sonzai: "ฝึก あります・います",
+  drillPatternN5Ichi: "ฝึกคำบอกตำแหน่ง + この・その",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -218,6 +218,8 @@ export const vi: Copy = {
   drillDesiderative: "Luyện たい・たがる",
   drillPatternStarterDesu: "Luyện câu cơ bản 〜です",
   drillPatternStarterParticles: "Luyện trợ từ は・を・に・が",
+  drillPatternN5Sonzai: "Luyện あります・います",
+  drillPatternN5Ichi: "Luyện từ chỉ vị trí + この・その",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -218,6 +218,8 @@ export const zhHant: Copy = {
   drillDesiderative: "練たい・たがる",
   drillPatternStarterDesu: "練基本句 〜です",
   drillPatternStarterParticles: "練助詞 は・を・に・が",
+  drillPatternN5Sonzai: "練あります・います",
+  drillPatternN5Ichi: "練位置詞與この・その",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## 為什麼
#542 盤點的 N5 最大單一缺口：「有什麼、在哪裡」整個表達系統沒有教學章。#543 首批補上。

## 內容
- **兩章**（新分類「N5 文法」接在入門之後）：「存在句 あります・います」（存在文/所在文、生命規則、に/で 分工、否定）＋「位置詞與この・その」（うえ/した/なか/まえ/うしろ/となり＋連體指示詞）
- **16 題原創 cloze**（假名為主、新詞附※gloss、每題 ja/en overlay 三欄全配）
- patternChecks 62→78；8 語系 drill labels；章節 en/ja overlay

## 品質 pipeline
主筆 → 雙透鏡對抗驗（**6 項全處置**：「へやに ねこと います」省略主語真雙解→で、「机の中通常不說」教學錯誤修正、跨題 gloss 補齊）→ codex 終審（再抓 1 項：「どこで ありますか」可讀作文語 であります 判斷句→換へ）→ 乾淨。
878 測全綠、build 綠、實機驗證（分類/章/drill 全通）。