### PR TITLE
feat: N5 文法章 比較＋好惡能力（#545）

### DIFF
--- a/src/domain/contentGuard.test.ts
+++ b/src/domain/contentGuard.test.ts
@@ -260,7 +260,9 @@ const PATTERN_HINT_BANLIST: Record<string, string[]> = {
   "nagara-tari": ["一邊", "同時", "一面", "列舉", "並列"],
   "te-aux": ["試試", "看看", "事先", "預先", "不小心", "已經", "正在", "結果", "補助"],
   "n5-joshi2": ["方向", "舉例", "工具", "手段", "合計", "總共"],
-  "n5-joshi3": ["也", "只有", "只", "或", "從", "代替"]
+  "n5-joshi3": ["也", "只有", "只", "或", "從", "代替"],
+  "n5-hikaku": ["比", "哪個", "哪一個"],
+  "n5-suki-dekiru": ["擅長", "也", "喜歡", "討厭"]
 };
 
 describe("sentence-pattern content guard", () => {

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 94,
+  patternChecks: 110,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -420,6 +420,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n5-hikaku": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Comparison: より・ほうが・いちばん",
+      "explanation":
+        "The comparison trio. (1) 「AはBより〜」 = A is more ~ than B (より follows the standard of comparison). (2) 「〜のほうが〜」 = ~ is more ~; it's also how you answer 「AとBと、どちらが〜」. (3) The superlative 「(range)で 〜が いちばん〜」 = the most ~ within ~. Two iron rules: the pick-one-of-two question word is どちら (not なに), and a question-word subject only takes が.",
+      "notes": [
+        "A is more ~ than B",
+        "Pick-one-of-two question",
+        "Answering: ~ is more ~",
+        "Superlative: range + で",
+        "ほど + negative: not as ~ as"
+      ],
+      "pitfalls": [
+        "ほど also follows a comparison standard, but demands a negative (〜ほど〜ない)",
+        "\"Which (of two)\" is どちら; どれ/なに are for three or more",
+        "The superlative range takes で: クラスで, 日本で, スポーツのなかで"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "比較 より・ほうが・いちばん",
+      "explanation":
+        "比較の三点セット。①「AはBより〜」＝AはBより〜（より は比較の基準の後ろ）。②「〜のほうが〜」——「AとBと、どちらが〜」への答え方でもある。③最上級「（範囲）で 〜が いちばん〜」。鉄則二つ：二択の疑問詞は どちら（なに ではない）、疑問詞が主語なら助詞は が だけ。",
+      "notes": [
+        "AはBより〜",
+        "二択の質問",
+        "答え方：〜のほうが〜",
+        "最上級：範囲＋で",
+        "ほど＋否定：〜ほど〜ない"
+      ],
+      "pitfalls": [
+        "ほど も比較の基準に付くが、必ず否定とセット（〜ほど〜ない）",
+        "「どちら」は二択。三つ以上は どれ/なに",
+        "最上級の範囲は で：クラスで、日本で、スポーツのなかで"
+      ]
+    }
+  },
+  "n5-suki-dekiru": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Likes & Ability: 〜が すき・できる",
+      "explanation":
+        "The family of patterns for \"I like ~ / I can ~\", united by one thing: the object takes 「が」. すき/きらい (like/dislike), じょうず/へた (good at/bad at), わかる (understand), できる (can). Chinese and English instincts reach for を (like \"the cat\"), but this family fixes on が — one of N5's most important switches. To say you can DO something, nominalize the verb with 「こと」 first: およぐ ことが できます.",
+      "notes": [
+        "Like: object takes が",
+        "Good at",
+        "Understand",
+        "Can (noun)",
+        "Can do ~: verb + ことが できる"
+      ],
+      "pitfalls": [
+        "This family's object takes が, not を: ×にほんごを わかります",
+        "Colloquial 「〜をすき」 exists, but tests and writing use が",
+        "きらい looks like an い-adjective but is a な-adjective (きらいな 人)"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "好き・できる 〜が の仲間",
+      "explanation":
+        "「好き・できる」を言う文型ファミリー。共通点は対象が「が」になること：すき/きらい、じょうず/へた、わかる、できる。中国語や英語の感覚では を を使いたくなるが、この仲間は が で固定——N5 でいちばん大事な切り替えのひとつ。動詞で「〜できる」と言うなら、まず「こと」で名詞化：およぐ ことが できます。",
+      "notes": [
+        "好き：対象は が",
+        "上手",
+        "わかる",
+        "できる（名詞）",
+        "〜できる：動詞＋ことが できる"
+      ],
+      "pitfalls": [
+        "この仲間の対象は が。×にほんごを わかります",
+        "話し言葉の「〜をすき」はあるが、試験と書き言葉は が",
+        "きらい は い形容詞に見えるが な形容詞（きらいな 人）"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 4 N5 grammar (#543/#544) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 6 N5 grammar (#543/#544/#545) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(27);
+    expect(trackable.length).toBe(29);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -381,6 +381,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n5-joshi2"]
   },
   {
+    id: "n5-hikaku",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "比較 より・ほうが・いちばん",
+    subtitle: "バスは でんしゃより やすいです",
+    explanation:
+      "比較的三件組。①「AはBより〜」＝A比B更〜（より 接在比較基準後面）；②「〜のほうが〜」＝〜比較〜，問「AとBと、どちらが〜」時就用它回答；③最高級「（範圍）で 〜が いちばん〜」＝在～之中最～。記住兩個鐵則：二選一的疑問詞是どちら（不是なに）、疑問詞當主語只能接が。",
+    examples: [
+      { formula: "バスは でんしゃより やすいです", note: "A比B～" },
+      { formula: "AとBと、どちらが すきですか", note: "二選一疑問" },
+      { formula: "おちゃの ほうが すきです", note: "回答：～比較～" },
+      { formula: "スポーツの なかで サッカーが いちばん すきです", note: "最高級：範圍＋で" },
+      { formula: "きのうほど さむくないです", note: "ほど＋否定：沒～那麼～" }
+    ],
+    pitfalls: [
+      "ほど 也接比較基準，但後面必須是否定（〜ほど〜ない）",
+      "「哪個（二選一）」用どちら；三個以上才用どれ/なに",
+      "最高級的範圍用で：クラスで、日本で、スポーツのなかで"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Hikaku", patternIds: ["n5-hikaku"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["starter-particles"]
+  },
+  {
+    id: "n5-suki-dekiru",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "好惡與能力 〜が すき・できる",
+    subtitle: "ねこが すきです／およぐことが できます",
+    explanation:
+      "說「喜歡什麼、會什麼」的句型家族，共同點是對象全用「が」：すき/きらい（喜歡/討厭）、じょうず/へた（擅長/不擅長）、わかる（懂）、できる（會）。中文語感容易想用を（喜歡「貓」、懂「日語」），但這一家族固定用が——N5 最重要的轉換之一。動詞要說「會做～」時，先用「こと」把動詞變名詞：およぐ ことが できます。",
+    examples: [
+      { formula: "ねこが すきです", note: "喜歡：對象用が" },
+      { formula: "サッカーが じょうずです", note: "擅長" },
+      { formula: "にほんごが わかります", note: "懂" },
+      { formula: "りょうりが できます", note: "會（名詞）" },
+      { formula: "およぐ ことが できます", note: "會做～：動詞＋ことが できる" }
+    ],
+    pitfalls: [
+      "這家族的對象用が不用を：×にほんごを わかります",
+      "口語裡聽得到「〜をすき」，但考試和書面以が為準",
+      "きらい 長得像い形容詞，其實是な形容詞（きらいな 人）"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5SukiDekiru", patternIds: ["n5-suki-dekiru"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-hikaku"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -599,6 +599,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "「〜だけ」：ひとりだけ。「ひとりも」は否定とセット（ひとりも いません）なので、肯定の「います」と矛盾する。"
     }
   },
+  "pattern-n5-hikaku-001": {
+    "hintI18n": { "en": "Talking about the price difference between the bus and the train.", "ja": "バスと電車の値段の違いの話。" },
+    "promptContextI18n": { "en": "\"The bus is cheaper than the train.\"", "ja": "「バスは電車より安いです。」" },
+    "explanationI18n": {
+      "en": "「AはBより〜」 = A is more ~ than B: the standard of comparison (the train) takes 「より」. 「が」 and 「を」 mark subjects/objects and 「の」 is possessive — none of them build a comparison. ※バス = bus.",
+      "ja": "「AはBより〜」：比較の基準（電車）の後ろに「より」。「が」「を」は主語・対象のマーカー、「の」は所有で、どれも比較の文は作れない。"
+    }
+  },
+  "pattern-n5-hikaku-002": {
+    "hintI18n": { "en": "Saying the train is the faster of the two.", "ja": "二つの乗り物のうち、速いのは電車だと言う。" },
+    "promptContextI18n": { "en": "\"The train is faster.\"", "ja": "「電車のほうが速いです。」" },
+    "explanationI18n": {
+      "en": "「〜のほうが〜」 = ~ is more ~: 「ほう」 (that side / one of two) is always followed by 「が」. 「を」「に」「で」 can't attach to this pattern. ※はやい = fast.",
+      "ja": "「〜のほうが〜」：「ほう（一方）」の後ろは「が」で固定。「を」「に」「で」はこの文型につながらない。"
+    }
+  },
+  "pattern-n5-hikaku-003": {
+    "hintI18n": { "en": "Asking about the listener's drink preference.", "ja": "相手に飲み物の好みを尋ねる。" },
+    "promptContextI18n": { "en": "\"Coffee or tea — which do you like better?\"", "ja": "「コーヒーとお茶と、どちらが好きですか。」" },
+    "explanationI18n": {
+      "en": "A question word (どちら, だれ, なに) as subject takes 「が」 — 「は」 marks an already-known topic, and \"which one\" is exactly the unknown being asked, so this neutral question doesn't use 「は」. The object of すき is also fixed as が. 「で」 and 「の」 make no sentence here.",
+      "ja": "疑問詞（どちら、だれ、なに）が主語のときは「が」。「は」の前は既知の話題が来るもので、「どちら」はまさに尋ねたい未知——だからこの中立の質問に「は」は使わない。すき の対象も が で固定。「で」「の」はここでは文にならない。"
+    }
+  },
+  "pattern-n5-hikaku-004": {
+    "hintI18n": { "en": "Answering which of the two you prefer.", "ja": "二つから自分の好みを答える。" },
+    "promptContextI18n": { "en": "\"Which do you like better?\" \"I prefer tea.\"", "ja": "「どちらが好きですか。」「お茶のほうが好きです。」" },
+    "explanationI18n": {
+      "en": "Answering with 「〜のほうが」: the noun links to 「ほう」 with 「の」 — おちゃの ほうが. 「が」 only appears after ほう; putting 「を」 or 「と」 here breaks the sentence.",
+      "ja": "「〜のほうが」で答える：名詞と「ほう」は「の」でつなぐ——おちゃの ほうが。「が」は ほう の後ろに来るもので、「を」「と」をここに置くと文が壊れる。"
+    }
+  },
+  "pattern-n5-hikaku-005": {
+    "hintI18n": { "en": "Naming your favorite among all sports.", "ja": "いちばん好きなスポーツを言う。" },
+    "promptContextI18n": { "en": "\"Among sports, I like soccer the best.\"", "ja": "「スポーツの中でサッカーがいちばん好きです。」" },
+    "explanationI18n": {
+      "en": "The superlative's range takes 「で」: 「〜のなかで 〜が いちばん〜」 = the most ~ within ~. 「に」 marks time/place and 「を」 marks objects; 「が」 already sits after サッカー. ※スポーツ = sports, サッカー = soccer.",
+      "ja": "最上級の範囲は「で」：「〜のなかで 〜が いちばん〜」。「に」は時間・場所、「を」は対象。「が」はもう サッカー の後ろにある。"
+    }
+  },
+  "pattern-n5-hikaku-006": {
+    "hintI18n": { "en": "Saying who is the tallest in the class.", "ja": "いちばん背が高い人はだれかを言う。" },
+    "promptContextI18n": { "en": "\"Tanaka is the tallest in the class.\"", "ja": "「クラスで田中さんがいちばん背が高いです。」" },
+    "explanationI18n": {
+      "en": "「(range)で いちばん〜」: クラスで = within the class. 「に」 and 「へ」 mark location/direction, 「を」 marks objects — none of them mean \"comparing within a range\". ※クラス = class, せ = height.",
+      "ja": "「（範囲）で いちばん〜」：クラスで＝クラスという範囲の中で。「に」「へ」は場所・方向、「を」は対象で、「範囲の中での比較」の意味にならない。"
+    }
+  },
+  "pattern-n5-hikaku-007": {
+    "hintI18n": { "en": "Talking about the temperature difference between today and yesterday.", "ja": "今日と昨日の気温の違いの話。" },
+    "promptContextI18n": { "en": "\"Today is colder than yesterday.\"", "ja": "「今日は昨日より寒いです。」" },
+    "explanationI18n": {
+      "en": "The standard of comparison takes 「より」: きのうより = than yesterday. 「ほど」 also follows a standard but demands a negative (きのうほど さむくない = not as cold as yesterday), contradicting the affirmative さむいです.",
+      "ja": "比較の基準には「より」：きのうより。「ほど」も基準に付くが必ず否定とセット（きのうほど さむくない）なので、文末の肯定「さむいです」と矛盾する。"
+    }
+  },
+  "pattern-n5-hikaku-008": {
+    "hintI18n": { "en": "Offering two fruits and asking the listener to pick one.", "ja": "二つの果物から一つ選んでもらう。" },
+    "promptContextI18n": { "en": "\"An apple or a mandarin — which do you like?\"", "ja": "「りんごとみかんと、どちらが好きですか。」" },
+    "explanationI18n": {
+      "en": "「AとBと」 lays out exactly two options, so the pick-one-of-two question word is 「どちら」. 「なに」 (what) is open-ended, contradicting the two listed choices; だれ asks about people, どこ about places. ※みかん = mandarin orange.",
+      "ja": "「AとBと」は選択肢が二つだと明示しているので、二択の疑問詞は「どちら」。「なに」はオープンな聞き方で、挙げた二つと矛盾。だれ は人、どこ は場所。"
+    }
+  },
+  "pattern-n5-suki-dekiru-001": {
+    "hintI18n": { "en": "Saying how you feel about cats.", "ja": "猫への気持ちを言う。" },
+    "promptContextI18n": { "en": "\"I like cats.\"", "ja": "「私は猫が好きです。」" },
+    "explanationI18n": {
+      "en": "The object of 「すき／きらい」 takes 「が」: ねこが すきです. Instinct from English or Chinese reaches for a direct object (を), but Japanese marks what you like with が — one of N5's most important switches. 「に」「へ」「と」 don't attach here.",
+      "ja": "「すき／きらい」の対象は「が」：ねこが すきです。中国語や英語の感覚では を を使いたくなるが、日本語では好きな対象を が で標示する——N5 でいちばん大事な切り替えのひとつ。「に」「へ」「と」はつながらない。"
+    }
+  },
+  "pattern-n5-suki-dekiru-002": {
+    "hintI18n": { "en": "Saying your little brother plays soccer very well.", "ja": "弟はサッカーがうまいと言う。" },
+    "promptContextI18n": { "en": "\"My little brother is good at soccer.\"", "ja": "「弟はサッカーが上手です。」" },
+    "explanationI18n": {
+      "en": "\"Good at\" is 「じょうず」: サッカーが じょうずです. 「へた」 = bad at and 「きらい」 = dislike — the hint says he plays well, so both point the wrong way; 「たかい」 (tall/expensive) doesn't fit. ※じょうず = good at, へた = bad at.",
+      "ja": "「上手」は じょうず：サッカーが じょうずです。「へた」は不得意、「きらい」は嫌い——ヒントは「うまい」と言っているので方向が逆。「たかい」は高いでつながらない。"
+    }
+  },
+  "pattern-n5-suki-dekiru-003": {
+    "hintI18n": { "en": "Asking whether the listener understands Japanese.", "ja": "相手の日本語の理解を尋ねる。" },
+    "promptContextI18n": { "en": "\"Do you understand Japanese?\"", "ja": "「日本語がわかりますか。」" },
+    "explanationI18n": {
+      "en": "The object of 「わかる」 (understand) takes 「が」: にほんごが わかります. \"Understand Japanese\" tempts you toward 「を」, but わかる is fixed with 「が」 — same family as すき and できる. ※にほんご = Japanese (the language).",
+      "ja": "「わかる」の対象は「が」：にほんごが わかります。「日本語を」と言いたくなるが、わかる は が で固定——すき、できる と同じ仲間。"
+    }
+  },
+  "pattern-n5-suki-dekiru-004": {
+    "hintI18n": { "en": "Saying Tanaka can cook.", "ja": "田中さんの料理の腕の話。" },
+    "promptContextI18n": { "en": "\"Tanaka can cook.\"", "ja": "「田中さんは料理ができます。」" },
+    "explanationI18n": {
+      "en": "The object of 「できる」 (can) also takes 「が」: りょうりが できます. 「を」 marks the object of an action verb, but できる states an ability — the family rule is が. ※りょうり = cooking.",
+      "ja": "「できる」の対象も「が」：りょうりが できます。「を」は動作動詞の対象マーカーだが、できる は能力の叙述なので、この仲間のルールどおり が。"
+    }
+  },
+  "pattern-n5-suki-dekiru-005": {
+    "hintI18n": { "en": "Saying you can swim.", "ja": "泳げると言う。" },
+    "promptContextI18n": { "en": "\"I can swim.\"", "ja": "「私は泳ぐことができます。」" },
+    "explanationI18n": {
+      "en": "\"Can do ~\" = dictionary form + 「ことが できる」: およぐ ことが できます. The verb is first turned into a noun with 「こと」, then takes 「が できる」. ※およぐ = to swim.",
+      "ja": "「辞書形＋ことが できる」＝〜できる：およぐ ことが できます。動詞をまず「こと」で名詞化してから「が できる」につなぐ。"
+    }
+  },
+  "pattern-n5-suki-dekiru-006": {
+    "hintI18n": { "en": "Saying your big brother isn't much of a singer.", "ja": "兄の歌はうまくないと言う。" },
+    "promptContextI18n": { "en": "\"My big brother is bad at singing.\"", "ja": "「兄は歌が下手です。」" },
+    "explanationI18n": {
+      "en": "「へた」 (bad at), like じょうず, takes 「が」 for its object: うたが へたです. 「の」 is possessive; 「へ」 and 「と」 mark direction/accompaniment — none attach here. ※あに = (my) older brother, うた = song.",
+      "ja": "「へた」も じょうず と同じく対象は「が」：うたが へたです。「の」は所有、「へ」「と」は方向・同伴で、どれもつながらない。"
+    }
+  },
+  "pattern-n5-suki-dekiru-007": {
+    "hintI18n": { "en": "Asking whether Kenji can read kanji.", "ja": "健二さんの漢字力を尋ねる。" },
+    "promptContextI18n": { "en": "\"Can Kenji read kanji?\"", "ja": "「健二さんは漢字を読むことができますか。」" },
+    "explanationI18n": {
+      "en": "The whole action 「かんじを よむ こと」 (the act of reading kanji) is the object of できる → takes 「が」. The 「かんじを」 inside belongs to よむ — a different slot; each does its own job. ※かんじ = kanji.",
+      "ja": "「かんじを よむ こと（漢字を読むという行為）」全体が できる の対象 →「が」。文中の「かんじを」は よむ の対象で、置き場所が違う——それぞれ別の仕事。"
+    }
+  },
+  "pattern-n5-suki-dekiru-008": {
+    "hintI18n": { "en": "Adding that you feel the same about cats as about dogs.", "ja": "犬と同じ気持ちを、続けて猫について言う。" },
+    "promptContextI18n": { "en": "\"I like dogs. I like cats too.\"", "ja": "「私は犬が好きです。猫も好きです。」" },
+    "explanationI18n": {
+      "en": "The previous sentence says you like dogs, and you \"also\" like cats → 「も」 takes over the が slot: ねこも すきです. This is the も from Particles III, revisited in a likes sentence.",
+      "ja": "前の文で犬が好きだと言い、猫「も」好き →「も」が が の位置をそのまま引き継ぐ：ねこも すきです。助詞IIIで学んだ も を、好きの文で復習。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -8,6 +8,8 @@ export type SentencePatternId =
   | "n5-ichi"
   | "n5-joshi2"
   | "n5-joshi3"
+  | "n5-hikaku"
+  | "n5-suki-dekiru"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -41,6 +43,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n5-ichi": "位置與指示",
   "n5-joshi2": "助詞II へ・で・と・や",
   "n5-joshi3": "助詞III の・も・か・から",
+  "n5-hikaku": "比較 より・ほうが・いちばん",
+  "n5-suki-dekiru": "好惡與能力",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -437,6 +441,201 @@ const N5_JOSHI3_ITEMS: SentencePatternItem[] = [
     options: ["だけ", "も", "を", "へ"],
     explanation:
       "「只、只有」用「だけ」：ひとりだけ＝只有一個人。「ひとりも」要接否定（ひとりも いません＝一個人都沒有），跟句尾肯定的「います」矛盾。※ひとり＝一個人。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-hikaku -- comparison より/ほうが/いちばん (#545).
+//   Topicalized は readings are grammatical almost everywhere, so は never
+//   competes with が/で answers (except the interrogative-subject item where
+//   は is a DEAD foil by rule); ほど appears only as a dead foil with an
+//   affirmative predicate (ほど demands a negative -- itself a lesson).
+// ===========================================================================
+const N5_HIKAKU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-hikaku-001",
+    patternId: "n5-hikaku",
+    promptText: "バスは でんしゃ___ やすいです。",
+    hintZh: "聊公車跟電車的票價差別。",
+    promptContextZh: "「公車比電車便宜。」",
+    expectedAnswer: "より",
+    options: ["より", "が", "を", "の"],
+    explanation:
+      "「AはBより〜」＝A比B更〜：比較的基準（電車）後面接「より」。「が」「を」是主語/對象標記；「の」是「的」，都搭不出比較句。※バス＝公車。"
+  },
+  {
+    id: "pattern-n5-hikaku-002",
+    patternId: "n5-hikaku",
+    promptText: "でんしゃの ほう___ はやいです。",
+    hintZh: "說兩個交通工具裡電車快。",
+    promptContextZh: "「電車（那邊）比較快。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "「〜のほうが〜」＝〜比較〜：「ほう（一方）」後面固定接「が」。「を」「に」「で」都接不上這個句型。※はやい＝快。"
+  },
+  {
+    id: "pattern-n5-hikaku-003",
+    patternId: "n5-hikaku",
+    promptText: "コーヒーと おちゃと、どちら___ すきですか。",
+    hintZh: "問對方兩種飲料的偏好。",
+    promptContextZh: "「咖啡和茶，你比較喜歡哪個？」",
+    expectedAnswer: "が",
+    options: ["が", "は", "で", "の"],
+    explanation:
+      "疑問詞（どちら、だれ、なに）當主語時用「が」——「は」前面要放已知的話題，而「哪個」正是要問的未知，所以這種中立的提問不用「は」。すき 的對象也固定用が；「で」「の」放這裡都不成句。"
+  },
+  {
+    id: "pattern-n5-hikaku-004",
+    patternId: "n5-hikaku",
+    promptText: "「どちらが すきですか。」「おちゃ___ ほうが すきです。」",
+    hintZh: "從兩個選項裡回答自己的偏好。",
+    promptContextZh: "「你比較喜歡哪個？」「我比較喜歡茶。」",
+    expectedAnswer: "の",
+    options: ["の", "が", "を", "と"],
+    explanation:
+      "回答「〜のほうが」：名詞和「ほう」之間用「の」連接——おちゃの ほうが。「が」在ほう後面才出現；「を」「と」放這裡句子就斷了。"
+  },
+  {
+    id: "pattern-n5-hikaku-005",
+    patternId: "n5-hikaku",
+    promptText: "スポーツの なか___ サッカーが いちばん すきです。",
+    hintZh: "說所有運動裡最喜歡的一種。",
+    promptContextZh: "「運動之中我最喜歡足球。」",
+    expectedAnswer: "で",
+    options: ["で", "に", "を", "が"],
+    explanation:
+      "最高級的範圍用「で」：「〜のなかで 〜が いちばん〜」＝在～之中最～。「に」表時間或地點、「を」接對象；「が」已經在サッカー後面了。※スポーツ＝運動、サッカー＝足球。"
+  },
+  {
+    id: "pattern-n5-hikaku-006",
+    patternId: "n5-hikaku",
+    promptText: "クラス___ たなかさんが いちばん せが たかいです。",
+    hintZh: "說班上個子最高的人。",
+    promptContextZh: "「班上田中個子最高。」",
+    expectedAnswer: "で",
+    options: ["で", "に", "を", "へ"],
+    explanation:
+      "「（範圍）で いちばん〜」：クラスで＝在班上（這個範圍裡）。「に」「へ」表地點方向、「を」接對象，都不是「範圍內比較」的用法。※クラス＝班級、せ＝身高。"
+  },
+  {
+    id: "pattern-n5-hikaku-007",
+    patternId: "n5-hikaku",
+    promptText: "きょうは きのう___ さむいです。",
+    hintZh: "聊今天跟昨天的氣溫差別。",
+    promptContextZh: "「今天比昨天冷。」",
+    expectedAnswer: "より",
+    options: ["より", "ほど", "から", "まで"],
+    explanation:
+      "比較的基準用「より」：きのうより＝比昨天。「ほど」也接比較基準，但後面必須是否定（きのうほど さむくない＝沒昨天那麼冷），跟句尾肯定的「さむいです」矛盾。"
+  },
+  {
+    id: "pattern-n5-hikaku-008",
+    patternId: "n5-hikaku",
+    promptText: "りんごと みかんと、___が すきですか。",
+    hintZh: "兩種水果請對方挑一種。",
+    promptContextZh: "「蘋果和橘子，你喜歡哪個？」",
+    expectedAnswer: "どちら",
+    options: ["どちら", "なに", "だれ", "どこ"],
+    explanation:
+      "「AとBと」擺明只有兩個選項，二選一的疑問詞用「どちら」。「なに（什麼）」是開放式問法，跟已列出的兩選項矛盾；だれ 問人、どこ 問地方。※みかん＝橘子。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-suki-dekiru -- likes/dislikes + ability, all with が (#545).
+//   Colloquial を-marking of すき (ねこを すき) is real modern usage, so
+//   を never competes where すき's が is the answer; topicalized は/も
+//   readings keep は out of subject-slot items.
+// ===========================================================================
+const N5_SUKI_DEKIRU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-suki-dekiru-001",
+    patternId: "n5-suki-dekiru",
+    promptText: "わたしは ねこ___ すきです。",
+    hintZh: "說自己對貓的感覺。",
+    promptContextZh: "「我喜歡貓。」",
+    expectedAnswer: "が",
+    options: ["が", "に", "へ", "と"],
+    explanation:
+      "「すき／きらい」的對象用「が」：ねこが すきです。中文語感會想用「を」（喜歡『貓』），但日文把喜歡的對象當「が」標記——這是 N5 最重要的轉換之一。「に」「へ」「と」都接不上。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-002",
+    patternId: "n5-suki-dekiru",
+    promptText: "おとうとは サッカーが ___です。",
+    hintZh: "說弟弟足球踢得很好。",
+    promptContextZh: "「弟弟足球踢得很好（擅長足球）。」",
+    expectedAnswer: "じょうず",
+    options: ["じょうず", "へた", "きらい", "たかい"],
+    explanation:
+      "「擅長」用「じょうず」：サッカーが じょうずです。「へた」是不擅長、「きらい」是討厭——提示說踢得好，方向相反；「たかい」是高/貴，接不上。※じょうず＝擅長、へた＝不擅長。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-003",
+    patternId: "n5-suki-dekiru",
+    promptText: "にほんご___ わかりますか。",
+    hintZh: "問對方懂不懂日語。",
+    promptContextZh: "「你懂日語嗎？」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "へ"],
+    explanation:
+      "「わかる（懂）」的對象用「が」：にほんごが わかります。中文的「懂『日語』」讓人想選「を」，但わかる 固定搭配「が」——跟すき、できる 同一家族。※にほんご＝日語。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-004",
+    patternId: "n5-suki-dekiru",
+    promptText: "たなかさんは りょうり___ できます。",
+    hintZh: "說田中會做菜。",
+    promptContextZh: "「田中會做菜。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "「できる（會、能）」的對象也用「が」：りょうりが できます。「を」是動作動詞的對象標記，但できる 是能力敘述，家族規則＝用が。※りょうり＝料理、做菜。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-005",
+    patternId: "n5-suki-dekiru",
+    promptText: "わたしは およぐ こと___ できます。",
+    hintZh: "說自己會游泳。",
+    promptContextZh: "「我會游泳。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "「動詞辞書形＋ことが できる」＝會做～：およぐ ことが できます。動詞先用「こと」變成名詞，再接「が できる」。※およぐ＝游泳。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-006",
+    patternId: "n5-suki-dekiru",
+    promptText: "あには うた___ へたです。",
+    hintZh: "說哥哥唱歌不太行。",
+    promptContextZh: "「哥哥不擅長唱歌。」",
+    expectedAnswer: "が",
+    options: ["が", "の", "へ", "と"],
+    explanation:
+      "「へた（不擅長）」跟じょうず 一樣，對象用「が」：うたが へたです。「の」是「的」；「へ」「と」表方向、一起，都接不上。※あに＝哥哥、うた＝歌。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-007",
+    patternId: "n5-suki-dekiru",
+    promptText: "けんじさんは かんじを よむ こと___ できますか。",
+    hintZh: "問健二會不會唸漢字。",
+    promptContextZh: "「健二會唸漢字嗎？」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "整個動作「かんじを よむ こと（唸漢字這件事）」是できる 的對象 → 接「が」。句子裡的「かんじを」是よむ 的對象，位置不同、各管各的。※かんじ＝漢字。"
+  },
+  {
+    id: "pattern-n5-suki-dekiru-008",
+    patternId: "n5-suki-dekiru",
+    promptText: "わたしは いぬが すきです。ねこ___ すきです。",
+    hintZh: "接著說對貓的感覺跟狗一樣。",
+    promptContextZh: "「我喜歡狗。也喜歡貓。」",
+    expectedAnswer: "も",
+    options: ["も", "と", "に", "へ"],
+    explanation:
+      "前一句已說喜歡狗，貓「也」喜歡 → 「も」直接取代「が」的位置：ねこも すきです。這是助詞III學過的も，配上好惡句複習。"
   }
 ];
 
@@ -1289,6 +1488,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N5_ICHI_ITEMS,
   ...N5_JOSHI2_ITEMS,
   ...N5_JOSHI3_ITEMS,
+  ...N5_HIKAKU_ITEMS,
+  ...N5_SUKI_DEKIRU_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -60,13 +60,17 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
   const ichi = buildSentencePatternPool({ patternIds: ["n5-ichi"] });
   const joshi2 = buildSentencePatternPool({ patternIds: ["n5-joshi2"] });
   const joshi3 = buildSentencePatternPool({ patternIds: ["n5-joshi3"] });
+  const hikaku = buildSentencePatternPool({ patternIds: ["n5-hikaku"] });
+  const sukiDekiru = buildSentencePatternPool({ patternIds: ["n5-suki-dekiru"] });
 
   it("each drill carries 8 kana-only items with unique solutions and full overlays", () => {
     expect(sonzai).toHaveLength(8);
     expect(ichi).toHaveLength(8);
     expect(joshi2).toHaveLength(8);
     expect(joshi3).toHaveLength(8);
-    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3]) {
+    expect(hikaku).toHaveLength(8);
+    expect(sukiDekiru).toHaveLength(8);
+    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3, ...hikaku, ...sukiDekiru]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -205,6 +205,8 @@ export type Copy = {
   drillPatternN5Ichi: string;
   drillPatternN5Joshi2: string;
   drillPatternN5Joshi3: string;
+  drillPatternN5Hikaku: string;
+  drillPatternN5SukiDekiru: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -222,6 +222,8 @@ export const en: Copy = {
   drillPatternN5Ichi: "Drill position words + この・その",
   drillPatternN5Joshi2: "Drill particles へ・で・と・や",
   drillPatternN5Joshi3: "Drill particles の・も・か・から",
+  drillPatternN5Hikaku: "Drill comparison patterns",
+  drillPatternN5SukiDekiru: "Drill likes + ability",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -222,6 +222,8 @@ export const id: Copy = {
   drillPatternN5Ichi: "Latih kata posisi + この・その",
   drillPatternN5Joshi2: "Latih partikel へ・で・と・や",
   drillPatternN5Joshi3: "Latih partikel の・も・か・から",
+  drillPatternN5Hikaku: "Latih pola perbandingan",
+  drillPatternN5SukiDekiru: "Latih suka + kemampuan",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -230,6 +230,8 @@ export const ja: Copy = {
   drillPatternN5Ichi: "位置詞と この・その を練習",
   drillPatternN5Joshi2: "助詞II へ・で・と・や を練習",
   drillPatternN5Joshi3: "助詞III の・も・か・から を練習",
+  drillPatternN5Hikaku: "比較の文型を練習",
+  drillPatternN5SukiDekiru: "好き・できる を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -222,6 +222,8 @@ export const ko: Copy = {
   drillPatternN5Ichi: "위치어와 この・その 연습",
   drillPatternN5Joshi2: "조사 へ・で・と・や 연습",
   drillPatternN5Joshi3: "조사 の・も・か・から 연습",
+  drillPatternN5Hikaku: "비교 문형 연습",
+  drillPatternN5SukiDekiru: "호불호와 능력 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -222,6 +222,8 @@ export const my: Copy = {
   drillPatternN5Ichi: "တည်နေရာစကားလုံး + この・その လေ့ကျင့်ရန်",
   drillPatternN5Joshi2: "ဝိဘတ် へ・で・と・や လေ့ကျင့်ရန်",
   drillPatternN5Joshi3: "ဝိဘတ် の・も・か・から လေ့ကျင့်ရန်",
+  drillPatternN5Hikaku: "နှိုင်းယှဉ်ပုံစံ လေ့ကျင့်ရန်",
+  drillPatternN5SukiDekiru: "ကြိုက်/မကြိုက်နှင့် စွမ်းရည် လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -223,6 +223,8 @@ export const th: Copy = {
   drillPatternN5Ichi: "ฝึกคำบอกตำแหน่ง + この・その",
   drillPatternN5Joshi2: "ฝึกคำช่วย へ・で・と・や",
   drillPatternN5Joshi3: "ฝึกคำช่วย の・も・か・から",
+  drillPatternN5Hikaku: "ฝึกรูปประโยคเปรียบเทียบ",
+  drillPatternN5SukiDekiru: "ฝึกชอบ/ไม่ชอบ + ความสามารถ",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -222,6 +222,8 @@ export const vi: Copy = {
   drillPatternN5Ichi: "Luyện từ chỉ vị trí + この・その",
   drillPatternN5Joshi2: "Luyện trợ từ へ・で・と・や",
   drillPatternN5Joshi3: "Luyện trợ từ の・も・か・から",
+  drillPatternN5Hikaku: "Luyện mẫu câu so sánh",
+  drillPatternN5SukiDekiru: "Luyện thích/ghét + năng lực",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -222,6 +222,8 @@ export const zhHant: Copy = {
   drillPatternN5Ichi: "練位置詞與この・その",
   drillPatternN5Joshi2: "練助詞II へ・で・と・や",
   drillPatternN5Joshi3: "練助詞III の・も・か・から",
+  drillPatternN5Hikaku: "練比較句型",
+  drillPatternN5SukiDekiru: "練好惡與能力",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- 新 pattern deck **n5-hikaku**（より／のほうが／いちばん＋範圍で／どちら，8 題）與 **n5-suki-dekiru**（〜が すき・じょうず・わかる・できる・ことができる，8 題），句型總數 94→110
- 學習 tab「N5 文法」分類新增兩章（implicitCompleteWithHistory），含 en/ja 章節 overlay 與 16 題逐題 i18n overlay、8 語系 drill 標籤
- contentGuard `PATTERN_HINT_BANLIST` 增兩 pattern 的洩漏字表

## 品質閘
- 兩鏡頭對抗審（雙解獵人＋文法自然度）：5 findings 全採納 —— すき句を干擾換死干擾（口語「をすき」雙解）、hint 去「比」洩漏 ×2、にほんご 補※gloss、も題を干擾換と
- codex 終審：1 finding（疑問詞＋が規則措辭過度絕對）已軟化
- `pnpm test` 878 全綠；build 綠、examBlocks 仍為獨立 lazy chunk
- Preview 實機驗證：新章出現在學習 tab、drill 啟動、答題判定與解說正常

Closes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new N5 grammar practice sets for comparison expressions and liking/ability patterns.
  * Expanded practice questions, hints, explanations, and localized labels across supported languages.
  * Updated learning content so these new drills appear in the course flow and progress tracking.

* **Bug Fixes**
  * Aligned content stats and tracking totals with the newly added practice material.
  * Updated validation checks to cover the added items and keep content safety rules accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->