### PR TITLE
feat: N5 文法章 邀約提議＋請求建議（#546）

### DIFF
--- a/src/domain/contentGuard.test.ts
+++ b/src/domain/contentGuard.test.ts
@@ -262,7 +262,9 @@ const PATTERN_HINT_BANLIST: Record<string, string[]> = {
   "n5-joshi2": ["方向", "舉例", "工具", "手段", "合計", "總共"],
   "n5-joshi3": ["也", "只有", "只", "或", "從", "代替"],
   "n5-hikaku": ["比", "哪個", "哪一個"],
-  "n5-suki-dekiru": ["擅長", "也", "喜歡", "討厭"]
+  "n5-suki-dekiru": ["擅長", "也", "喜歡", "討厭"],
+  "n5-sasoi": ["邀請", "邀約", "要不要", "我來"],
+  "n5-onegai": ["最好", "不必", "請勿", "別"]
 };
 
 describe("sentence-pattern content guard", () => {

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 110,
+  patternChecks: 126,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -500,6 +500,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n5-sasoi": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Invitations & Offers: ませんか・ましょう",
+      "explanation":
+        "The trio for reaching out: 「ませんか」 = won't you ~? (a question — the decision stays with the listener); 「ましょう」 = let's ~ (a proposal, or the way to accept an invitation); 「ましょうか」 = shall I ~? (offering to help). Alongside them: ます-stem + 「に いきます/きます」 = go/come to do something (かいに いきます = go to buy), and the suggestion 「〜は どうですか」 = how about ~?",
+      "notes": [
+        "Invite: won't you ~?",
+        "Accept: let's ~",
+        "Offer to help: shall I ~?",
+        "Purpose of movement: stem + に",
+        "Suggest: how about ~?"
+      ],
+      "pitfalls": [
+        "ませんか asks the listener; ましょう is your side proposing/accepting — don't flip the direction",
+        "「に いきます」 attaches to the ます-stem (かい, たべ), not the dictionary or て form",
+        "Answering an invitation: yes → 「ましょう」; declining → 「ちょっと……」 (not a blunt いいえ)"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "誘い・申し出 ませんか・ましょう",
+      "explanation":
+        "誘いの三点セット：「ませんか」＝〜しない？（疑問文。決定権は相手に）；「ましょう」＝〜しよう（提案、または誘いを受けるときの返事）；「ましょうか」＝〜しようか？（手伝いの申し出）。あわせて：ます形の語幹＋「に いきます/きます」＝〜しに行く/来る（かいに いきます）、提案の「〜は どうですか」。",
+      "notes": [
+        "誘う：〜ませんか",
+        "受ける：〜ましょう",
+        "申し出：〜ましょうか",
+        "移動の目的：語幹＋に",
+        "提案：〜は どうですか"
+      ],
+      "pitfalls": [
+        "ませんか は相手に聞く形、ましょう は自分側の提案/受諾——方向を逆にしない",
+        "「に いきます」に付くのは ます形の語幹（かい、たべ）。辞書形・て形は不可",
+        "誘いへの返事：OK →「ましょう」、断る →「ちょっと……」（いいえ と直言しない）"
+      ]
+    }
+  },
+  "n5-onegai": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Requests & Advice: ください・ほうがいい",
+      "explanation":
+        "The set for asking and advising. Shopping/ordering: 「Nを (quantity) ください」 — the counter goes right before ください with no particle. Wanting things: 「〜が ほしいです」 (object takes が, same family as すき). Advice: た-form + 「ほうがいいです」 = you'd better ~, ない-form + 「ほうがいいです」 = you'd better not ~. Asking someone not to do: ない-form + 「でください」.",
+      "notes": [
+        "Please give me ~: no particle on the counter",
+        "Want: object takes が",
+        "Advice to do: た-form + ほうがいい",
+        "Advice not to: ない-form",
+        "Please don't ~"
+      ],
+      "pitfalls": [
+        "ほうがいい: the \"do it\" direction takes the た-form (ねた), the \"don't\" direction the ない-form (はいらない)",
+        "The object of ほしい takes が, not を — the same colloquial trap as をすき",
+        "ないでください (please don't) ≠ なくてもいいです (you don't have to)"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "依頼とアドバイス ください・ほうがいい",
+      "explanation":
+        "頼む・勧めるための文型セット。買い物・注文：「Nを（数量）ください」——数量詞は助詞なしで ください の直前。ほしい物：「〜が ほしいです」（対象は が。すき と同じ仲間）。アドバイス：た形＋「ほうがいいです」＝〜したほうがいい、ない形＋「ほうがいいです」＝〜しないほうがいい。してほしくないこと：ない形＋「でください」。",
+      "notes": [
+        "〜をください：数量に助詞なし",
+        "ほしい：対象は が",
+        "した方がいい：た形",
+        "しない方がいい：ない形",
+        "〜ないでください"
+      ],
+      "pitfalls": [
+        "ほうがいい：「する」方向は た形（ねた）、「しない」方向は ない形（はいらない）",
+        "ほしい の対象は が。を は をすき と同じ話し言葉の罠",
+        "ないでください（しないで）≠ なくてもいいです（しなくていい）"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 6 N5 grammar (#543/#544/#545) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 8 N5 grammar (#543/#544/#545/#546) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(29);
+    expect(trackable.length).toBe(31);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -431,6 +431,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n5-hikaku"]
   },
   {
+    id: "n5-sasoi",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "邀約與提議 ませんか・ましょう",
+    subtitle: "いっしょに たべませんか／たべましょう",
+    explanation:
+      "開口約人的三件組：「ませんか」＝要不要〜？（問句，把決定權交給對方）；「ましょう」＝（我們）〜吧（提議，或接受邀約時回答）；「ましょうか」＝我來〜吧？（主動提出幫忙）。配套的還有：ます形語幹＋「に いきます/きます」＝去/來做某事（かいに いきます＝去買），以及提案的「〜は どうですか」＝〜怎麼樣？",
+    examples: [
+      { formula: "いっしょに たべませんか", note: "邀約：要不要～？" },
+      { formula: "いいですね。たべましょう", note: "接受：～吧" },
+      { formula: "にもつを もちましょうか", note: "主動幫忙：我來～吧？" },
+      { formula: "かばんを かいに いきます", note: "移動目的：語幹＋に" },
+      { formula: "どようびは どうですか", note: "提案：～怎麼樣？" }
+    ],
+    pitfalls: [
+      "ませんか 是問對方；ましょう 是自己這邊的提議/接受——別搞反方向",
+      "接「に いきます」的是ます形語幹（かい、たべ），不是辭書形或て形",
+      "回答邀約：好→「ましょう」；婉拒→「ちょっと……」（不直說いいえ）"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Sasoi", patternIds: ["n5-sasoi"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-suki-dekiru"]
+  },
+  {
+    id: "n5-onegai",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "請求與建議 ください・ほうがいい",
+    subtitle: "りんごを みっつ ください",
+    explanation:
+      "開口要東西、給建議的句型組。購物點餐：「Nを（數量）ください」——數量詞直接放ください前面、不加助詞；想要的東西：「〜が ほしいです」（對象用が，跟すき同家族）；建議：「た形＋ほうがいいです」＝最好〜、「ない形＋ほうがいいです」＝最好別〜；請人別做：「ない形＋でください」。",
+    examples: [
+      { formula: "りんごを みっつ ください", note: "請給我～：數量不加助詞" },
+      { formula: "くつが ほしいです", note: "想要：對象用が" },
+      { formula: "ねた ほうがいいです", note: "建議做：た形＋ほうがいい" },
+      { formula: "はいらない ほうがいいです", note: "建議別做：ない形" },
+      { formula: "はなさないで ください", note: "請勿～" }
+    ],
+    pitfalls: [
+      "ほうがいい 的「做」方向接た形（ねた），「別做」方向接ない形（はいらない）",
+      "ほしい 的對象用が不用を——跟をすき同一個口語陷阱",
+      "ないでください（請別做）≠ なくてもいいです（不必做）"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Onegai", patternIds: ["n5-onegai"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-sasoi"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -727,6 +727,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "前の文で犬が好きだと言い、猫「も」好き →「も」が が の位置をそのまま引き継ぐ：ねこも すきです。助詞IIIで学んだ も を、好きの文で復習。"
     }
   },
+  "pattern-n5-sasoi-001": {
+    "hintI18n": { "en": "Reaching out about lunch together.", "ja": "一緒に昼ご飯をと、相手に声をかける。" },
+    "promptContextI18n": { "en": "\"Won't you have lunch together?\" \"Sounds good — let's eat.\"", "ja": "「一緒に昼ご飯を食べませんか。」「いいですね。食べましょう。」" },
+    "explanationI18n": {
+      "en": "Inviting with a question uses 「ませんか」 = won't you ~? — it leaves the decision with the listener, who accepts with 「ましょう」 (that's exactly the reply 「いいですね。たべましょう」). 「ました」「ません」「ませんでした」 are plain past/negative statements — none fit an invitation dialogue. ※いっしょに = together, ひるごはん = lunch.",
+      "ja": "疑問で誘うのが「ませんか」——決定権を相手に渡し、相手は「ましょう」で受ける（返事の「いいですね。たべましょう」がまさにそれ）。「ました」「ません」「ませんでした」は過去/否定のただの叙述で、誘いの対話につながらない。"
+    }
+  },
+  "pattern-n5-sasoi-002": {
+    "hintI18n": { "en": "You've been invited — say yes.", "ja": "誘われた側。OKの返事をする。" },
+    "promptContextI18n": { "en": "\"Want to see a movie tomorrow?\" \"Sounds good — let's watch it.\"", "ja": "「明日映画を見ませんか。」「いいですね。見ましょう。」" },
+    "explanationI18n": {
+      "en": "Accepting an invitation uses 「ましょう」: いいですね、みましょう. 「ませんか」 is how the inviter asks — the accepter doesn't ask back; 「みません」 is a refusal, contradicting 「いいですね」; 「みました」 is past. ※えいが = movie.",
+      "ja": "誘いを受けるときは「ましょう」：いいですね、みましょう。「ませんか」は誘う側の聞き方で、受ける側は聞き返さない。「みません」は断りで「いいですね」と矛盾、「みました」は過去形。"
+    }
+  },
+  "pattern-n5-sasoi-003": {
+    "hintI18n": { "en": "Their bag looks heavy — offer to help.", "ja": "相手の荷物が重そう。こちらから手を貸すと言い出す。" },
+    "promptContextI18n": { "en": "\"That luggage looks heavy — shall I carry half?\"", "ja": "「荷物が重いですね。私が半分持ちましょうか。」" },
+    "explanationI18n": {
+      "en": "Offering to help uses 「ましょうか」 = shall I ~?: わたしが はんぶん もちましょうか. 「ませんか」 would invite the OTHER person to do it, clashing with わたしが (I'll do it) in the sentence; 「ました」「ません」 are past/negative — not offers. ※にもつ = luggage, おもい = heavy, はんぶん = half, もちます = to carry.",
+      "ja": "手伝いの申し出は「ましょうか」：わたしが はんぶん もちましょうか。「ませんか」は相手にやってもらう誘い方で、文中の わたしが と衝突する。「ました」「ません」は過去/否定で、申し出にならない。"
+    }
+  },
+  "pattern-n5-sasoi-004": {
+    "hintI18n": { "en": "Saying what you're going to the department store for.", "ja": "デパートへ行って何をするかを言う。" },
+    "promptContextI18n": { "en": "\"I'm going to the department store to buy a bag.\"", "ja": "「デパートへかばんを買いに行きます。」" },
+    "explanationI18n": {
+      "en": "ます-stem + 「に いきます」 = go to do something: かいます → かい + に いきます = go to buy. 「を」 is already used in かばんを; 「で」 and 「へ」 can't follow a verb stem. ※デパート = department store.",
+      "ja": "ます形の語幹＋「に いきます」＝〜しに行く：かいます→かい＋に いきます。「を」はすでに かばんを で使っている。「で」「へ」は動詞の語幹には付かない。"
+    }
+  },
+  "pattern-n5-sasoi-005": {
+    "hintI18n": { "en": "Saying what tonight's restaurant trip is for.", "ja": "レストランへ行って何をするかを言う。" },
+    "promptContextI18n": { "en": "\"I'm going to a restaurant to eat dinner.\"", "ja": "「レストランへ晩ご飯を食べに行きます。」" },
+    "explanationI18n": {
+      "en": "What attaches to 「に いきます」 is the ます-stem: たべます → たべ + に. 「たべるに」「たべたに」「たべてに」 are all wrong attachments — the dictionary, た, and て forms can't take the purpose に directly. ※レストラン = restaurant, ばんごはん = dinner.",
+      "ja": "「に いきます」に付くのは ます形の語幹：たべます→たべ＋に。「たべるに」「たべたに」「たべてに」はどれも誤り——辞書形・た形・て形は目的の に に直接つながらない。"
+    }
+  },
+  "pattern-n5-sasoi-006": {
+    "hintI18n": { "en": "Tomorrow doesn't work for them — float another day.", "ja": "明日はだめそうなので、別の日を出してみる。" },
+    "promptContextI18n": { "en": "\"Tomorrow's a bit...\" \"Then how about Saturday?\"", "ja": "「明日はちょっと……。」「じゃあ、土曜日はどうですか。」" },
+    "explanationI18n": {
+      "en": "Suggesting and asking an opinion uses 「〜は どうですか」 = how about ~?: じゃあ、どようびは どうですか. 「を」「へ」「の」 don't connect to どうですか. ※どようび = Saturday; 「〜は ちょっと……」 is the set phrase for a soft refusal.",
+      "ja": "提案して意見を聞くのは「〜は どうですか」：じゃあ、どようびは どうですか。「を」「へ」「の」は どうですか につながらない。「〜は ちょっと……」はやんわり断る定型表現。"
+    }
+  },
+  "pattern-n5-sasoi-007": {
+    "hintI18n": { "en": "Saying what your friend came over to do yesterday.", "ja": "昨日、友だちが家に来て何をしたかを言う。" },
+    "promptContextI18n": { "en": "\"Yesterday a friend came over to hang out.\"", "ja": "「昨日、友だちがうちへ遊びに来ました。」" },
+    "explanationI18n": {
+      "en": "「Vに きます」 = come to do something: あそびに きました = came over to hang out. Same pattern as 「かいに いきます」 — go and come both take ます-stem + に. 「を」「と」「へ」 can't follow the stem. ※あそびます = to play / hang out, うち = home (colloquial).",
+      "ja": "「Vに きます」＝〜しに来る：あそびに きました。「かいに いきます」と同じ文型で、行く/来る どちらも ます形の語幹＋に。「を」「と」「へ」は語幹につながらない。"
+    }
+  },
+  "pattern-n5-sasoi-008": {
+    "hintI18n": { "en": "The room is stuffy — offer to get some air moving.", "ja": "部屋の空気がこもっているので、風を通そうと言い出す。" },
+    "promptContextI18n": { "en": "\"The air in here is stale. Shall I open the window?\"", "ja": "「部屋の空気が悪いですね。窓を開けましょうか。」" },
+    "explanationI18n": {
+      "en": "Offering to act uses 「ましょうか」: stale air means you'd OPEN the window → あけましょうか. 「しめましょうか」 (shall I close it?) would only make it stuffier; 「あけません」 = won't open; 「しめました」 is past and the wrong direction too. ※へや = room, くうき = air, まど = window, あけます = to open, しめます = to close.",
+      "ja": "自分から動く申し出は「ましょうか」：空気がこもっているなら窓を「開ける」→あけましょうか。「しめましょうか」はもっとこもる逆方向、「あけません」は「開けない」、「しめました」は過去のうえ逆方向。"
+    }
+  },
+  "pattern-n5-onegai-001": {
+    "hintI18n": { "en": "At the fruit shop, asking for three apples.", "ja": "果物屋で、りんごを三つ買うと店の人に言う。" },
+    "promptContextI18n": { "en": "\"Excuse me, three of these apples, please.\"", "ja": "「すみません、このりんごを三つください。」" },
+    "explanationI18n": {
+      "en": "Shopping and ordering use 「Nを (quantity) ください」 = please give me ~: りんごを みっつ ください. The counter (みっつ) goes right before ください with no particle. 「あります」「います」 are incompatible with 「を」 (you'd say りんごが あります); 「でした」 is a past-tense statement — not how you ask for something. ※みっつ = three (things).",
+      "ja": "買い物・注文は「Nを（数量）ください」：りんごを みっつ ください。数量詞（みっつ）は助詞なしで ください の直前。「あります」「います」は「を」と両立しない（りんごが あります）。「でした」は過去の断定で、買い物の頼み方にならない。"
+    }
+  },
+  "pattern-n5-onegai-002": {
+    "hintI18n": { "en": "Saying you want new shoes.", "ja": "新しい靴を手に入れたい、という気持ちを言う。" },
+    "promptContextI18n": { "en": "\"I want new shoes.\"", "ja": "「新しい靴がほしいです。」" },
+    "explanationI18n": {
+      "en": "「〜が ほしい」 = to want ~: the object takes 「が」 — くつが ほしいです. Same が-family as すき, じょうず, and できる. 「の」「に」「へ」 don't attach. ※くつ = shoes.",
+      "ja": "「〜が ほしい」：対象は「が」——くつが ほしいです。すき、じょうず、できる と同じ が の仲間。「の」「に」「へ」はつながらない。"
+    }
+  },
+  "pattern-n5-onegai-003": {
+    "hintI18n": { "en": "Telling someone with a fever to get to bed early.", "ja": "熱がある人に、今日は早く休むよう言い聞かせる。" },
+    "promptContextI18n": { "en": "\"You have a fever — you'd better go to bed early today.\"", "ja": "「熱がありますから、今日は早く寝たほうがいいです。」" },
+    "explanationI18n": {
+      "en": "Advice uses た-form + 「ほうがいいです」 = you'd better ~: ねた ほうがいいです. 「ないほうがいい」 advises against and 「てはいけません」 forbids — banning sleep with a fever points entirely the wrong way; 「なくてもいい」 waives necessity, also clashing with urging someone to rest. ※ねつ = fever.",
+      "ja": "アドバイスは た形＋「ほうがいいです」：ねた ほうがいいです。「ないほうがいい」は「するな」方向、「てはいけません」は禁止——熱があるのに寝かせないのは真逆。「なくてもいい」は不要の意味で、休むよう勧める場面と矛盾する。"
+    }
+  },
+  "pattern-n5-onegai-004": {
+    "hintI18n": { "en": "Someone with a cold wants a bath — the family steps in.", "ja": "風邪の人がお風呂に入りたがり、家族が止めに入る。" },
+    "promptContextI18n": { "en": "\"You have a cold — better not take a bath today.\"", "ja": "「風邪ですから、今日はお風呂に入らないほうがいいです。」" },
+    "explanationI18n": {
+      "en": "Advising against uses ない-form + 「ほうがいいです」 = better not ~: はいらない ほうがいいです. 「はいったほうがいい」 goes the opposite way; 「てもいい」 is permission; 「ましょうか」 is an offer — none fit stopping someone. ※かぜ = a cold, おふろに はいります = to take a bath.",
+      "ja": "「しないほうがいい」は ない形＋「ほうがいいです」：はいらない ほうがいいです。「はいったほうがいい」は逆方向、「てもいい」は許可、「ましょうか」は申し出で、止める場面に合わない。"
+    }
+  },
+  "pattern-n5-onegai-005": {
+    "hintI18n": { "en": "The librarian wants everyone quiet.", "ja": "図書館員が静かにしてほしいと注意する。" },
+    "promptContextI18n": { "en": "\"This is a library — please don't talk loudly.\"", "ja": "「図書館ですから、大きい声で話さないでください。」" },
+    "explanationI18n": {
+      "en": "ない-form + 「でください」 = please don't ~: はなさないで ください. A library needs quiet — 「はなしてください」 (please talk) points the wrong way; 「てもいい」 and 「ましょう」 contradict the request for quiet. ※こえ = voice, はなします = to talk.",
+      "ja": "ない形＋「でください」：はなさないで ください。図書館は静かにする場所——「はなしてください」は逆方向、「てもいい」「ましょう」は静かにという要求と矛盾する。"
+    }
+  },
+  "pattern-n5-onegai-006": {
+    "hintI18n": { "en": "Buying stamps and specifying how many.", "ja": "切手を買うとき、枚数を伝える。" },
+    "promptContextI18n": { "en": "\"Excuse me, five of these stamps, please.\"", "ja": "「すみません、この切手を五枚ください。」" },
+    "explanationI18n": {
+      "en": "The object of 「Nを (quantity) ください」 takes 「を」: きってを ごまい ください. The quantity (ごまい) goes after を and before ください. 「が ください」 isn't a sentence; 「へ」「の」 don't attach either. ※きって = stamp, 〜まい = counter for flat things.",
+      "ja": "「Nを（数量）ください」の対象は「を」：きってを ごまい ください。数量（ごまい）は を の後、ください の前。「が ください」は文にならない。「へ」「の」もつながらない。"
+    }
+  },
+  "pattern-n5-onegai-007": {
+    "hintI18n": { "en": "Asking what they'd like for their birthday.", "ja": "誕生日プレゼントの希望を聞く。" },
+    "promptContextI18n": { "en": "\"What do you want for your birthday?\"", "ja": "「誕生日に何がほしいですか。」" },
+    "explanationI18n": {
+      "en": "The object of 「ほしい」 takes 「が」, question words included: なにが ほしいですか. 「は」 marks an already-known topic, and \"what\" is exactly the unknown being asked — this neutral question doesn't use 「は」; 「も」 would make なにも, which demands a negative; 「の」 doesn't attach. ※たんじょうび = birthday.",
+      "ja": "「ほしい」の対象は「が」。疑問詞でも同じ：なにが ほしいですか。「は」の前は既知の話題が来るもので、「なに」はまさに尋ねたい未知——この中立の質問に「は」は使わない。「も」だと「なにも」＝否定とセット。「の」はつながらない。"
+    }
+  },
+  "pattern-n5-onegai-008": {
+    "hintI18n": { "en": "A warning sign about this stretch of water.", "ja": "この水辺についての注意書き。" },
+    "promptContextI18n": { "en": "\"This spot is dangerous — no swimming, please.\"", "ja": "「ここは危ないですから、泳がないでください。」" },
+    "explanationI18n": {
+      "en": "A danger warning uses 「ないでください」 = please don't ~: およがないで ください. The topic already declares THIS spot dangerous, so 「およいでください」「ましょう」「ませんか」 — all urging people into the water — contradict 「あぶない」. ※あぶない = dangerous, およぎます = to swim.",
+      "ja": "危険の警告は「ないでください」：およがないで ください。主題が「ここは危ない」と明言しているので、「およいでください」「ましょう」「ませんか」はどれも泳がせる方向で「あぶない」と矛盾する。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -10,6 +10,8 @@ export type SentencePatternId =
   | "n5-joshi3"
   | "n5-hikaku"
   | "n5-suki-dekiru"
+  | "n5-sasoi"
+  | "n5-onegai"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -45,6 +47,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n5-joshi3": "助詞III の・も・か・から",
   "n5-hikaku": "比較 より・ほうが・いちばん",
   "n5-suki-dekiru": "好惡與能力",
+  "n5-sasoi": "邀約與提議 ませんか・ましょう",
+  "n5-onegai": "請求與建議 ください・ほうがいい",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -636,6 +640,203 @@ const N5_SUKI_DEKIRU_ITEMS: SentencePatternItem[] = [
     options: ["も", "と", "に", "へ"],
     explanation:
       "前一句已說喜歡狗，貓「也」喜歡 → 「も」直接取代「が」的位置：ねこも すきです。這是助詞III學過的も，配上好惡句複習。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-sasoi -- invitations and proposals (#546).
+//   ませんか/ましょう are pragmatically adjacent: every item locks the role
+//   with a dialogue anchor (the reply reveals which side speaks) plus a
+//   question-vs-statement hint. たいです and plain ます never appear as
+//   foils in offer items (both have real volunteering readings); ました is
+//   excluded wherever a past-report reading would survive the context.
+// ===========================================================================
+const N5_SASOI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-sasoi-001",
+    patternId: "n5-sasoi",
+    promptText: "「いっしょに ひるごはんを たべ___。」「いいですね。たべましょう。」",
+    hintZh: "開口約對方一起吃午餐。",
+    promptContextZh: "「要不要一起吃午餐？」「好啊，一起吃吧。」",
+    expectedAnswer: "ませんか",
+    options: ["ませんか", "ました", "ません", "ませんでした"],
+    explanation:
+      "邀人用問句「ませんか」＝要不要〜？——把決定權交給對方，對方接受時用「ましょう」回答（後句的「いいですね。たべましょう」就是）。「ました」「ません」「ませんでした」是過去/否定的直述，都接不上邀約的對話。※いっしょに＝一起、ひるごはん＝午餐。"
+  },
+  {
+    id: "pattern-n5-sasoi-002",
+    patternId: "n5-sasoi",
+    promptText: "「あした えいがを みませんか。」「いいですね。み___。」",
+    hintZh: "對方開口約了，你這邊要答應。",
+    promptContextZh: "「明天要不要看電影？」「好啊，一起看吧。」",
+    expectedAnswer: "ましょう",
+    options: ["ましょう", "ませんか", "ません", "ました"],
+    explanation:
+      "接受邀約用「ましょう」＝（我們）〜吧：いいですね、みましょう。「ませんか」是發出邀約的問法，接受方不再回問；「みません」是拒絕，跟「いいですね」矛盾；「みました」是過去式。※えいが＝電影。",
+  },
+  {
+    id: "pattern-n5-sasoi-003",
+    patternId: "n5-sasoi",
+    promptText: "にもつが おもいですね。わたしが はんぶん もち___。",
+    hintZh: "看對方東西重，主動開口幫忙。",
+    promptContextZh: "「行李很重吧，我來幫你拿一半吧？」",
+    expectedAnswer: "ましょうか",
+    options: ["ましょうか", "ませんか", "ました", "ません"],
+    explanation:
+      "主動提出幫忙用「ましょうか」＝我來〜吧？：わたしが はんぶん もちましょうか。「ませんか」是約「對方」做，跟句中的わたしが（我來）衝突；「ました」「ません」是過去/否定，都不是開口幫忙的說法。※にもつ＝行李、おもい＝重、はんぶん＝一半、もちます＝拿。"
+  },
+  {
+    id: "pattern-n5-sasoi-004",
+    patternId: "n5-sasoi",
+    promptText: "デパートへ かばんを かい___ いきます。",
+    hintZh: "說要去百貨公司做什麼。",
+    promptContextZh: "「我要去百貨公司買包包。」",
+    expectedAnswer: "に",
+    options: ["に", "を", "で", "へ"],
+    explanation:
+      "ます形語幹＋「に いきます」＝去做某事：かいます→かい＋に いきます＝去買。「を」已經用在かばんを；「で」「へ」不能接在動詞語幹後面。※デパート＝百貨公司。"
+  },
+  {
+    id: "pattern-n5-sasoi-005",
+    patternId: "n5-sasoi",
+    promptText: "レストランへ ばんごはんを ___ いきます。",
+    hintZh: "說晚上要去餐廳做什麼。",
+    promptContextZh: "「我要去餐廳吃晚餐。」",
+    expectedAnswer: "たべに",
+    options: ["たべに", "たべてに", "たべるに", "たべたに"],
+    explanation:
+      "接「に いきます」的是ます形語幹：たべます→たべ＋に。「たべるに」「たべたに」「たべてに」都不是正確接法——辭書形、た形、て形都不能直接接目的的に。※レストラン＝餐廳、ばんごはん＝晚餐。"
+  },
+  {
+    id: "pattern-n5-sasoi-006",
+    patternId: "n5-sasoi",
+    promptText: "「あしたは ちょっと……。」「じゃあ、どようび___ どうですか。」",
+    hintZh: "對方明天不行，改提別的日子。",
+    promptContextZh: "「明天有點……。」「那，星期六怎麼樣？」",
+    expectedAnswer: "は",
+    options: ["は", "を", "へ", "の"],
+    explanation:
+      "提案、問對方意見用「〜は どうですか」＝〜怎麼樣？：じゃあ、どようびは どうですか。「を」「へ」「の」都接不上どうですか。※どようび＝星期六、「〜は ちょっと……」＝委婉拒絕的固定說法。"
+  },
+  {
+    id: "pattern-n5-sasoi-007",
+    patternId: "n5-sasoi",
+    promptText: "きのう、ともだちが うちへ あそび___ きました。",
+    hintZh: "說朋友昨天來家裡做什麼。",
+    promptContextZh: "「昨天朋友來家裡玩。」",
+    expectedAnswer: "に",
+    options: ["に", "を", "と", "へ"],
+    explanation:
+      "「Vに きます」＝來做某事：あそびに きました＝來玩。跟「かいに いきます」同一個句型——來/去都是ます形語幹＋に。「を」「と」「へ」都接不上語幹。※あそびます＝玩、うち＝家（口語說法）。"
+  },
+  {
+    id: "pattern-n5-sasoi-008",
+    patternId: "n5-sasoi",
+    promptText: "へやの くうきが わるいですね。まどを ___。",
+    hintZh: "房間空氣悶，主動說要讓空氣流通。",
+    promptContextZh: "「房間空氣好悶喔。我來開窗吧？」",
+    expectedAnswer: "あけましょうか",
+    options: ["あけましょうか", "しめましょうか", "あけません", "しめました"],
+    explanation:
+      "主動提議動手用「ましょうか」：空氣悶就要「開」窗通風→あけましょうか。「しめましょうか（我來關吧？）」只會更悶、方向相反；「あけません」是「不開」；「しめました」是過去式又方向相反。※へや＝房間、くうき＝空氣、まど＝窗戶、あけます＝打開、しめます＝關上。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-onegai -- requests and advice (#546).
+//   を never competes where ほしい's が is the answer (colloquial をほしい,
+//   same family as をすき); topicalized は is kept out of shop-request
+//   particle blanks; advice items use full predicates so attachment alone
+//   can never kill a foil -- the context has to do it.
+// ===========================================================================
+const N5_ONEGAI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-onegai-001",
+    patternId: "n5-onegai",
+    promptText: "すみません、この りんごを みっつ ___。",
+    hintZh: "在水果店開口買三顆蘋果。",
+    promptContextZh: "「不好意思，請給我三顆這種蘋果。」",
+    expectedAnswer: "ください",
+    options: ["ください", "あります", "います", "でした"],
+    explanation:
+      "購物點餐用「Nを（數量）ください」＝請給我〜：りんごを みっつ ください。數量詞（みっつ）直接放ください前面、不加助詞。「あります」「います」跟「を」不相容（要說 りんごが あります）；「でした」是過去的斷定，接不上開口買東西的場面。※みっつ＝三個。"
+  },
+  {
+    id: "pattern-n5-onegai-002",
+    patternId: "n5-onegai",
+    promptText: "あたらしい くつ___ ほしいです。",
+    hintZh: "說自己想要新鞋。",
+    promptContextZh: "「我想要新鞋子。」",
+    expectedAnswer: "が",
+    options: ["が", "の", "に", "へ"],
+    explanation:
+      "「〜が ほしい」＝想要〜：對象用「が」——くつが ほしいです。跟すき、じょうず、できる 同一個が家族。「の」「に」「へ」都接不上。※くつ＝鞋子。"
+  },
+  {
+    id: "pattern-n5-onegai-003",
+    patternId: "n5-onegai",
+    promptText: "ねつが ありますから、きょうは はやく ___。",
+    hintZh: "叮囑發燒的人早點休息。",
+    promptContextZh: "「你發燒了，今天最好早點睡。」",
+    expectedAnswer: "ねたほうがいいです",
+    options: ["ねたほうがいいです", "ねないほうがいいです", "ねてはいけません", "ねなくてもいいです"],
+    explanation:
+      "給建議用「た形＋ほうがいいです」＝最好〜：ねた ほうがいいです。「ないほうがいい」是勸別做、「てはいけません」是禁止——發燒了還不讓睡，方向全反；「なくてもいい」是不必，也跟勸人休息的情境矛盾。※ねつ＝發燒。"
+  },
+  {
+    id: "pattern-n5-onegai-004",
+    patternId: "n5-onegai",
+    promptText: "かぜですから、きょうは おふろに ___。",
+    hintZh: "感冒的人想去泡澡，被家人攔了下來。",
+    promptContextZh: "「你感冒了，今天最好別泡澡。」",
+    expectedAnswer: "はいらないほうがいいです",
+    options: ["はいらないほうがいいです", "はいったほうがいいです", "はいってもいいです", "はいりましょうか"],
+    explanation:
+      "勸別做某事用「ない形＋ほうがいいです」＝最好別〜：はいらない ほうがいいです。「はいったほうがいい」方向相反；「てもいい」是允許；「ましょうか」是提議一起/幫忙，跟叮囑的情境不合。※かぜ＝感冒、おふろに はいります＝泡澡。"
+  },
+  {
+    id: "pattern-n5-onegai-005",
+    patternId: "n5-onegai",
+    promptText: "としょかんですから、おおきい こえで ___。",
+    hintZh: "圖書館員要大家安靜。",
+    promptContextZh: "「這裡是圖書館，請不要大聲說話。」",
+    expectedAnswer: "はなさないでください",
+    options: ["はなさないでください", "はなしてください", "はなしてもいいです", "はなしましょう"],
+    explanation:
+      "「ない形＋でください」＝請別〜：はなさないで ください。圖書館要安靜，「はなしてください（請說）」方向相反；「てもいい」「ましょう」都跟安靜的要求矛盾。※こえ＝聲音、はなします＝說話。"
+  },
+  {
+    id: "pattern-n5-onegai-006",
+    patternId: "n5-onegai",
+    promptText: "すみません、この きって___ ごまい ください。",
+    hintZh: "買郵票時指定張數。",
+    promptContextZh: "「不好意思，這種郵票請給我五張。」",
+    expectedAnswer: "を",
+    options: ["を", "が", "へ", "の"],
+    explanation:
+      "「Nを（數量）ください」的對象用「を」：きってを ごまい ください。數量（ごまい）放を後面、ください前面。「が ください」不成句；「へ」「の」也接不上。※きって＝郵票、〜まい＝〜張（扁平物）。"
+  },
+  {
+    id: "pattern-n5-onegai-007",
+    patternId: "n5-onegai",
+    promptText: "たんじょうびに なに___ ほしいですか。",
+    hintZh: "問對方生日禮物的願望。",
+    promptContextZh: "「生日想要什麼？」",
+    expectedAnswer: "が",
+    options: ["が", "は", "も", "の"],
+    explanation:
+      "「ほしい」的對象用「が」，疑問詞當對象也一樣：なにが ほしいですか。「は」前面要放已知的話題，而「什麼」正是要問的未知，這種中立提問不用「は」；「も」變成「なにも」就要配否定；「の」接不上。※たんじょうび＝生日。"
+  },
+  {
+    id: "pattern-n5-onegai-008",
+    patternId: "n5-onegai",
+    promptText: "ここは あぶないですから、___。",
+    hintZh: "告示牌警告這片水域。",
+    promptContextZh: "「這裡很危險，請勿游泳。」",
+    expectedAnswer: "およがないでください",
+    options: ["およがないでください", "およいでください", "およぎましょう", "およぎませんか"],
+    explanation:
+      "危險警告用「ないでください」＝請勿〜：およがないで ください。主題已點明「這裡危險」，「およいでください」「ましょう」「ませんか」都是要人下水，全跟「あぶない」矛盾。※あぶない＝危險、およぎます＝游泳。"
   }
 ];
 
@@ -1490,6 +1691,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N5_JOSHI3_ITEMS,
   ...N5_HIKAKU_ITEMS,
   ...N5_SUKI_DEKIRU_ITEMS,
+  ...N5_SASOI_ITEMS,
+  ...N5_ONEGAI_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -62,6 +62,8 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
   const joshi3 = buildSentencePatternPool({ patternIds: ["n5-joshi3"] });
   const hikaku = buildSentencePatternPool({ patternIds: ["n5-hikaku"] });
   const sukiDekiru = buildSentencePatternPool({ patternIds: ["n5-suki-dekiru"] });
+  const sasoi = buildSentencePatternPool({ patternIds: ["n5-sasoi"] });
+  const onegai = buildSentencePatternPool({ patternIds: ["n5-onegai"] });
 
   it("each drill carries 8 kana-only items with unique solutions and full overlays", () => {
     expect(sonzai).toHaveLength(8);
@@ -70,7 +72,9 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     expect(joshi3).toHaveLength(8);
     expect(hikaku).toHaveLength(8);
     expect(sukiDekiru).toHaveLength(8);
-    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3, ...hikaku, ...sukiDekiru]) {
+    expect(sasoi).toHaveLength(8);
+    expect(onegai).toHaveLength(8);
+    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3, ...hikaku, ...sukiDekiru, ...sasoi, ...onegai]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -207,6 +207,8 @@ export type Copy = {
   drillPatternN5Joshi3: string;
   drillPatternN5Hikaku: string;
   drillPatternN5SukiDekiru: string;
+  drillPatternN5Sasoi: string;
+  drillPatternN5Onegai: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -224,6 +224,8 @@ export const en: Copy = {
   drillPatternN5Joshi3: "Drill particles の・も・か・から",
   drillPatternN5Hikaku: "Drill comparison patterns",
   drillPatternN5SukiDekiru: "Drill likes + ability",
+  drillPatternN5Sasoi: "Drill invitations + offers",
+  drillPatternN5Onegai: "Drill requests + advice",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -224,6 +224,8 @@ export const id: Copy = {
   drillPatternN5Joshi3: "Latih partikel の・も・か・から",
   drillPatternN5Hikaku: "Latih pola perbandingan",
   drillPatternN5SukiDekiru: "Latih suka + kemampuan",
+  drillPatternN5Sasoi: "Latih ajakan + tawaran",
+  drillPatternN5Onegai: "Latih permintaan + saran",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -232,6 +232,8 @@ export const ja: Copy = {
   drillPatternN5Joshi3: "助詞III の・も・か・から を練習",
   drillPatternN5Hikaku: "比較の文型を練習",
   drillPatternN5SukiDekiru: "好き・できる を練習",
+  drillPatternN5Sasoi: "誘い・申し出を練習",
+  drillPatternN5Onegai: "依頼とアドバイスを練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -224,6 +224,8 @@ export const ko: Copy = {
   drillPatternN5Joshi3: "조사 の・も・か・から 연습",
   drillPatternN5Hikaku: "비교 문형 연습",
   drillPatternN5SukiDekiru: "호불호와 능력 연습",
+  drillPatternN5Sasoi: "권유와 제안 연습",
+  drillPatternN5Onegai: "요청과 조언 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -224,6 +224,8 @@ export const my: Copy = {
   drillPatternN5Joshi3: "ဝိဘတ် の・も・か・から လေ့ကျင့်ရန်",
   drillPatternN5Hikaku: "နှိုင်းယှဉ်ပုံစံ လေ့ကျင့်ရန်",
   drillPatternN5SukiDekiru: "ကြိုက်/မကြိုက်နှင့် စွမ်းရည် လေ့ကျင့်ရန်",
+  drillPatternN5Sasoi: "ဖိတ်ခေါ်မှုနှင့် အဆိုပြုမှု လေ့ကျင့်ရန်",
+  drillPatternN5Onegai: "တောင်းဆိုမှုနှင့် အကြံပြုမှု လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -225,6 +225,8 @@ export const th: Copy = {
   drillPatternN5Joshi3: "ฝึกคำช่วย の・も・か・から",
   drillPatternN5Hikaku: "ฝึกรูปประโยคเปรียบเทียบ",
   drillPatternN5SukiDekiru: "ฝึกชอบ/ไม่ชอบ + ความสามารถ",
+  drillPatternN5Sasoi: "ฝึกชักชวนและเสนอ",
+  drillPatternN5Onegai: "ฝึกขอร้องและให้คำแนะนำ",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -224,6 +224,8 @@ export const vi: Copy = {
   drillPatternN5Joshi3: "Luyện trợ từ の・も・か・から",
   drillPatternN5Hikaku: "Luyện mẫu câu so sánh",
   drillPatternN5SukiDekiru: "Luyện thích/ghét + năng lực",
+  drillPatternN5Sasoi: "Luyện mời và đề nghị",
+  drillPatternN5Onegai: "Luyện yêu cầu và lời khuyên",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -224,6 +224,8 @@ export const zhHant: Copy = {
   drillPatternN5Joshi3: "練助詞III の・も・か・から",
   drillPatternN5Hikaku: "練比較句型",
   drillPatternN5SukiDekiru: "練好惡與能力",
+  drillPatternN5Sasoi: "練邀約與提議",
+  drillPatternN5Onegai: "練請求與建議",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- 新 pattern deck **n5-sasoi**（ませんか／ましょう(か)／Vにいく・くる／はどうですか，8 題）與 **n5-onegai**（Nを〜ください／がほしい／た・ないほうがいい／ないでください，8 題），句型總數 110→126
- 學習 tab「N5 文法」新增兩章（implicitCompleteWithHistory），含 en/ja 章節 overlay、16 題逐題 i18n overlay、8 語系 drill 標籤
- contentGuard `PATTERN_HINT_BANLIST` 增兩 pattern 的洩漏字表

## 品質閘
- 兩鏡頭對抗審：9 findings 全採納 —— 「どようびに どうですか」「あそびで きました」兩個真雙解干擾換死項、hint 去「要不要」gloss 洩漏、補 5 個生字※gloss
- codex 終審：7 findings 全採納 —— ませんか題撤掉 ましょう 活干擾、幫忙題加「わたしが」鎖說話者、開窗題改「空氣悶」單向語境、購物題撤 でしたか（店員確認讀法）、建議題 てもいい→てはいけません、警告題改「ここは〜から」、疑問詞＋は 措辭軟化
- `pnpm test` 878 全綠；build 綠、examBlocks 仍為獨立 lazy chunk
- Preview 實機驗證：兩章顯示於學習 tab（順序在好惡與能力後）、drill 啟動、答題判定與 gloss 正常、句型池 126

Closes #546