### PR TITLE
feat: N5 文法章 理由逆接＋時間經驗（#547）

### DIFF
--- a/src/domain/contentGuard.test.ts
+++ b/src/domain/contentGuard.test.ts
@@ -264,7 +264,9 @@ const PATTERN_HINT_BANLIST: Record<string, string[]> = {
   "n5-hikaku": ["比", "哪個", "哪一個"],
   "n5-suki-dekiru": ["擅長", "也", "喜歡", "討厭"],
   "n5-sasoi": ["邀請", "邀約", "要不要", "我來"],
-  "n5-onegai": ["最好", "不必", "請勿", "別"]
+  "n5-onegai": ["最好", "不必", "請勿", "別"],
+  "n5-riyuu": ["因為", "所以", "但是", "可是", "理由", "為什麼"],
+  "n5-toki": ["時候", "已經", "還沒", "大概", "可能"]
 };
 
 describe("sentence-pattern content guard", () => {

--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 126,
+  patternChecks: 142,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -580,6 +580,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n5-riyuu": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Reasons & Contrast: から・ので・が",
+      "explanation":
+        "The basics of joining two clauses. Reasons: 「〜から」 (the answer to どうして is always 「〜からです」); 「〜ので」 sounds more objective and soft — nouns and な-adjectives take な before ので (やすみなので) but だ before から (やすみだから). Contrast: sentence-medial 「〜が」 = although ~, but ~; it also softens openers (すみませんが、〜). Sentence-initial connectors come as a set of four: だから (so), でも (but), そして (and), それから (and then).",
+      "notes": [
+        "Answering どうして: 〜からです",
+        "Noun attachment: なので vs だから",
+        "Contrast: although ~, but ~",
+        "Prefacing が",
+        "The four connectors"
+      ],
+      "pitfalls": [
+        "から and ので mean nearly the same (ので is more objective), but nouns attach differently: だから / なので",
+        "「〜のでです」 is not a sentence — answer どうして with 「〜からです」",
+        "Medial が and initial でも both mark contrast, but they can't swap positions"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "理由と逆接 から・ので・が",
+      "explanation":
+        "二つの文をつなぐ基本。理由：「〜から」（どうして への答えは「〜からです」で固定）；「〜ので」はより客観的で柔らかい——名詞・な形容詞は な＋ので（やすみなので）、から なら だ＋から（やすみだから）。逆接：文中の「〜が」＝〜だが。前置きの「すみませんが、〜」もこの が。文頭の接続詞は四点セット：だから、でも、そして、それから。",
+      "notes": [
+        "どうして の答え：〜からです",
+        "名詞の接続：なので vs だから",
+        "逆接：〜が",
+        "前置きの が",
+        "接続詞四点セット"
+      ],
+      "pitfalls": [
+        "から と ので はほぼ同義（ので はやや客観的）だが、名詞への付き方が違う：だから／なので",
+        "「〜のでです」は文にならない——どうして には「〜からです」",
+        "文中の が と文頭の でも は同じ逆接でも位置を交換できない"
+      ]
+    }
+  },
+  "n5-toki": {
+    "en": {
+      "category": "N5 Grammar",
+      "kicker": "N5 Patterns",
+      "title": "Time & Experience: とき・もう・でしょう",
+      "explanation":
+        "Patterns for time, state, and experience. 「〜とき」 = when ~: the tense before とき shows whether the action is complete — ごはんを たべる とき (before eating) vs たべた とき (after). The done/not-done pair: 「もう〜ました」 = already did, 「まだ〜ていません」 = not yet. Conjecture: 「〜でしょう」 = probably ~ (how every weather forecast ends). Experience: た-form + 「ことが あります」 = have done ~; the negative reply pairs with 「いちども〜ません」 = not even once.",
+      "notes": [
+        "When ~",
+        "Tense before とき = action complete or not",
+        "Already ~ / not yet ~",
+        "Conjecture: probably ~",
+        "Experience: have done ~"
+      ],
+      "pitfalls": [
+        "The negative of まだ is 「まだ〜ていません」, not 「まだ〜ませんでした」",
+        "でしょう follows the plain form (ふるでしょう); 「ふるですか」 is not a sentence",
+        "いちども, だれも, なにも — the whole も family demands a negative"
+      ]
+    },
+    "ja": {
+      "category": "N5文法",
+      "kicker": "N5文型",
+      "title": "時間と経験 とき・もう・でしょう",
+      "explanation":
+        "時間・状態・経験の文型セット。「〜とき」：とき の前の時制は動作が完了したかどうかで決まる——ごはんを たべる とき（食べる前）vs たべた とき（食べた後）。完了/未完了のペア：「もう〜ました」／「まだ〜ていません」。推量：「〜でしょう」（天気予報の定番の結び）。経験：た形＋「ことが あります」＝〜したことがある。否定の返事は「いちども〜ません」。",
+      "notes": [
+        "〜とき",
+        "とき の前の時制＝完了かどうか",
+        "もう〜ました／まだ〜ていません",
+        "推量：〜でしょう",
+        "経験：〜たことがある"
+      ],
+      "pitfalls": [
+        "まだ の否定は「まだ〜ていません」。「まだ〜ませんでした」ではない",
+        "でしょう は普通形に付く（ふるでしょう）。「ふるですか」は文にならない",
+        "いちども・だれも・なにも——「も」の仲間は否定とセット"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 8 N5 grammar (#543/#544/#545/#546) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 10 N5 grammar (#543-#547) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(31);
+    expect(trackable.length).toBe(33);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -481,6 +481,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n5-sasoi"]
   },
   {
+    id: "n5-riyuu",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "理由與逆接 から・ので・が",
+    subtitle: "ねつが ありますから／むずかしいですが",
+    explanation:
+      "把兩句話連起來的基本盤。理由：「〜から」（どうして的回答固定用「〜からです」）；「〜ので」語氣較客觀委婉——名詞和な形容詞接ので要先加な（やすみなので）、接から則用だ（やすみだから）。轉折：句中的「〜が」＝雖然〜但是〜；它還有一個開場緩衝用法「すみませんが、〜」。句子開頭的接續詞一組四個：だから（所以）、でも（可是）、そして（而且）、それから（然後）。",
+    examples: [
+      { formula: "ねつが あったからです", note: "どうして的回答：〜からです" },
+      { formula: "やすみなので／やすみだから", note: "名詞接續：なので vs だから" },
+      { formula: "むずかしいですが、おもしろいです", note: "轉折：雖然〜但是〜" },
+      { formula: "すみませんが、えきは どこですか", note: "開場緩衝的が" },
+      { formula: "だから／でも／そして／それから", note: "句頭接續詞四件組" }
+    ],
+    pitfalls: [
+      "から和ので意思幾乎相同（ので較客觀委婉），但接名詞時形不同：だから／なので",
+      "「〜のでです」不成句——どうして的回答用「〜からです」",
+      "句中的が（轉折）和句頭的でも（可是）方向相同，但位置不能互換"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Riyuu", patternIds: ["n5-riyuu"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-onegai"]
+  },
+  {
+    id: "n5-toki",
+    group: "basic",
+    category: "N5 文法",
+    kicker: "N5 句型",
+    title: "時間與經驗 とき・もう・でしょう",
+    subtitle: "たべる とき／のぼった ことが あります",
+    explanation:
+      "時間、狀態與經驗的句型組。「〜とき」＝〜的時候，前面的時態看動作完成了沒：ごはんを たべる とき（吃之前）vs たべた とき（吃完）。完成/未完成一對：「もう〜ました」＝已經〜了、「まだ〜ていません」＝還沒〜。推測：「〜でしょう」＝大概〜吧（天氣預報的標準結尾）。經驗：「た形＋ことが あります」＝〜過；否定回答配「いちども〜ません」＝一次也沒有。",
+    examples: [
+      { formula: "ひまな とき、おんがくを ききます", note: "〜的時候" },
+      { formula: "たべる とき／たべた とき", note: "とき前的時態＝動作完成與否" },
+      { formula: "もう たべました／まだ たべていません", note: "已經〜／還沒〜" },
+      { formula: "あしたは あめが ふるでしょう", note: "推測：大概〜吧" },
+      { formula: "のぼった ことが あります", note: "經驗：〜過" }
+    ],
+    pitfalls: [
+      "まだ的否定是「まだ〜ていません」，不是「まだ〜ませんでした」",
+      "でしょう接普通形（ふるでしょう）；「ふるですか」不成句",
+      "いちども、だれも、なにも——「も」系全家都要配否定"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN5Toki", patternIds: ["n5-toki"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-riyuu"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -855,6 +855,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "危険の警告は「ないでください」：およがないで ください。主題が「ここは危ない」と明言しているので、「およいでください」「ましょう」「ませんか」はどれも泳がせる方向で「あぶない」と矛盾する。"
     }
   },
+  "pattern-n5-riyuu-001": {
+    "hintI18n": { "en": "Explaining why you missed school.", "ja": "学校を休んだわけを説明する。" },
+    "promptContextI18n": { "en": "\"Why did you miss school?\" \"Because I had a fever.\"", "ja": "「どうして学校を休みましたか。」「熱があったからです。」" },
+    "explanationI18n": {
+      "en": "Answering 「どうして」 (why) uses the fixed shape 「〜からです」: ねつが あったからです. 「ので」 can't attach directly to です (×のでです); 「が」 and 「まで」 don't connect either. ※やすみます = to take a day off.",
+      "ja": "「どうして」への答えは「〜からです」で固定：ねつが あったからです。「ので」は です に直接つながらない（×のでです）。「が」「まで」も接続できない。"
+    }
+  },
+  "pattern-n5-riyuu-002": {
+    "hintI18n": { "en": "Tomorrow's a day off — suggest going somewhere.", "ja": "明日は休み。それを踏まえてどこかへ誘う。" },
+    "promptContextI18n": { "en": "\"Tomorrow's a day off, so shall we go somewhere?\"", "ja": "「明日は休みなので、どこかへ行きませんか。」" },
+    "explanationI18n": {
+      "en": "A noun needs な before 「ので」: やすみ + な + ので = やすみなので. 「だので」 is a wrong attachment (だ and ので don't combine); a bare noun + ので (×やすみので) fails too; and から takes だ after a noun (やすみだから) — 「なから」 doesn't exist. ※どこか = somewhere.",
+      "ja": "名詞に「ので」を付けるときは な を挟む：やすみ＋な＋ので。「だので」は誤接続（だ と ので は連結できない）。名詞に直接 ので（×やすみので）も不可。から なら やすみだから——「なから」という形はない。"
+    }
+  },
+  "pattern-n5-riyuu-003": {
+    "hintI18n": { "en": "Japanese is hard — and fun all the same.", "ja": "日本語は難しい。それでも面白い、という話。" },
+    "promptContextI18n": { "en": "\"Japanese is difficult, but it's interesting.\"", "ja": "「日本語は難しいですが、面白いです。」" },
+    "explanationI18n": {
+      "en": "Sentence-medial 「が」 marks contrast = although ~, but ~: むずかしいですが、おもしろいです — used when the two halves point in opposite directions. 「を」「の」「に」 can't follow です. ※むずかしい = difficult, おもしろい = interesting.",
+      "ja": "文中の「が」は逆接＝〜だが：むずかしいですが、おもしろいです——前後が逆方向のときのつなぎ。「を」「の」「に」は です の後ろに付かない。"
+    }
+  },
+  "pattern-n5-riyuu-004": {
+    "hintI18n": { "en": "Stopping a passerby to ask the way.", "ja": "道で人に声をかけて場所を聞く。" },
+    "promptContextI18n": { "en": "\"Excuse me, where is the station?\"", "ja": "「すみませんが、駅はどこですか。」" },
+    "explanationI18n": {
+      "en": "The buffer before a request is 「が」: すみませんが、〜 = excuse me, (but) ~. This が isn't contrast — it just eases the topic in. 「から」「ので」 give reasons, and 「すみません」 isn't a reason; 「でも」 works at the head of a sentence, not after ません. ※えき = station.",
+      "ja": "切り出しのクッションは「が」：すみませんが、〜。この が は逆接ではなく、話をやわらかく持ち出すためのもの。「から」「ので」は理由——「すみません」は理由ではない。「でも」は文頭に置く語で、ません の後ろには付かない。"
+    }
+  },
+  "pattern-n5-riyuu-005": {
+    "hintI18n": { "en": "Rain or no rain, you're heading out.", "ja": "雨は降っている。それでも出かける。" },
+    "promptContextI18n": { "en": "\"It's raining. But I'm going out anyway.\"", "ja": "「雨が降っています。でも、出かけます。」" },
+    "explanationI18n": {
+      "en": "When the two sentences pull in opposite directions (raining → going out anyway), use 「でも」 = but. 「だから」 (so) follows the causal grain — wrong direction; 「そして」 (and) and 「それから」 (and then) just line events up and can't express \"anyway\". ※あめ = rain, ふります = to fall (rain/snow), でかけます = to go out.",
+      "ja": "前後が逆方向（雨→それでも出かける）なら「でも」。「だから」は因果に沿う語で方向が逆。「そして」「それから」は並列・順接で、「それでも」の逆接は表せない。"
+    }
+  },
+  "pattern-n5-riyuu-006": {
+    "hintI18n": { "en": "Test tomorrow — tonight is for studying, no way around it.", "ja": "明日は試験。今晩は勉強するしかない。" },
+    "promptContextI18n": { "en": "\"There's a test tomorrow. So I'll study tonight.\"", "ja": "「明日テストがあります。だから、今晩勉強します。」" },
+    "explanationI18n": {
+      "en": "Cause followed by its natural consequence takes 「だから」 = so. 「でも」「しかし」 mark contrast (a test, \"but\" studying? — wrong direction); 「まだ」 (still/yet) is an adverb and can't sit at the head of a sentence as a connector. ※テスト = test, こんばん = tonight.",
+      "ja": "前件が原因、後件が当然の結果なら「だから」。「でも」「しかし」は逆接（テストがあるのに「でも」勉強？方向が逆）。「まだ」は副詞で、文頭に置いて接続詞のようには使えない。"
+    }
+  },
+  "pattern-n5-riyuu-007": {
+    "hintI18n": { "en": "Short on time — settling how to get there.", "ja": "時間がない。移動手段を決める。" },
+    "promptContextI18n": { "en": "\"We have no time, so let's take a taxi.\"", "ja": "「時間がありませんから、タクシーで行きましょう。」" },
+    "explanationI18n": {
+      "en": "A mid-sentence reason takes 「から」: じかんが ありませんから = because there's no time, (so) let's taxi. 「まで」「を」「へ」 simply can't attach after ません — the sentence breaks. ※タクシー = taxi.",
+      "ja": "文中の理由は「から」：じかんが ありませんから、タクシーで行きましょう。「まで」「を」「へ」は ません の後ろに付けず、文がそこで壊れる。"
+    }
+  },
+  "pattern-n5-riyuu-008": {
+    "hintI18n": { "en": "Curious what drives their Japanese study.", "ja": "日本語を勉強している動機を知りたい。" },
+    "promptContextI18n": { "en": "\"Why are you studying Japanese?\" \"Because I want to go to Japan.\"", "ja": "「どうして日本語を勉強していますか。」「日本へ行きたいですから。」" },
+    "explanationI18n": {
+      "en": "The reply is 「〜ですから」 (because ~), so the question must ask for a reason: 「どうして」 = why. 「いつ」 (when) and 「どこ」 (where) don't match an answer about motivation; 「なに」 asks for a thing — the sentence already has the object にほんごを. ※べんきょうします = to study, 〜たいです = want to ~.",
+      "ja": "答えが「〜ですから」なので、質問は理由を聞く「どうして」しかない。「いつ」「どこ」は時間・場所で、「日本へ行きたいから」という答えと噛み合わない。「なに」は物を聞く語だが、文にはもう にほんごを がある。"
+    }
+  },
+  "pattern-n5-toki-001": {
+    "hintI18n": { "en": "What you do when you're free.", "ja": "手が空いたらすることの話。" },
+    "promptContextI18n": { "en": "\"When I'm free, I listen to music.\"", "ja": "「暇なとき、音楽を聞きます。」" },
+    "explanationI18n": {
+      "en": "「〜とき」 = when ~: ひまな とき = when I'm free. 「ところ」 mostly means a place (「ひまなところ」 is unnatural here); 「こと」 (a matter) and 「もの」 (a thing) leave the phrase stranded at the head of the sentence, unconnected to \"listen to music\". ※ひま（な） = free (time), おんがく = music.",
+      "ja": "「〜とき」：ひまな とき。「ところ」は主に場所（ここでの「ひまなところ」は不自然）。「こと」「もの」は入れると文頭に浮いてしまい、後ろの「音楽を聞きます」につながらない。"
+    }
+  },
+  "pattern-n5-toki-002": {
+    "hintI18n": { "en": "The set phrase said before a meal.", "ja": "食事の前に言うあの一言。" },
+    "promptContextI18n": { "en": "\"When (about) to eat, you say いただきます.\"", "ja": "「ご飯を食べるとき、『いただきます』と言います。」" },
+    "explanationI18n": {
+      "en": "The tense before とき shows whether the action is done: いただきます is said BEFORE eating — action not yet complete → dictionary form たべる とき. 「たべた とき」 is after finishing — that's when you say 「ごちそうさま」; て/ます forms can't attach to とき.",
+      "ja": "とき の前の時制は動作が完了したかどうか：「いただきます」は食べる「前」——未完了なので辞書形 たべる とき。「たべた とき」は食べ終わった後で、そのときの挨拶は「ごちそうさま」。て形・ます形は とき に付かない。"
+    }
+  },
+  "pattern-n5-toki-003": {
+    "hintI18n": { "en": "Lunch is taken care of, you reply.", "ja": "昼はもう済ませた、と返事する。" },
+    "promptContextI18n": { "en": "\"Did you eat lunch?\" \"Yes, I already ate.\"", "ja": "「昼ご飯を食べましたか。」「はい、もう食べました。」" },
+    "explanationI18n": {
+      "en": "Completion uses 「もう〜ました」 = already did: もう たべました. 「まだ」 pairs with the incomplete (まだ たべていません) and clashes with ました; 「いつ」 is a question word; 「とても」 (very) modifies degree, not completion.",
+      "ja": "完了は「もう〜ました」：もう たべました。「まだ」は未完了（まだ たべていません）とセットで、ました と矛盾。「いつ」は疑問詞、「とても」は程度の語で完了に合わない。"
+    }
+  },
+  "pattern-n5-toki-004": {
+    "hintI18n": { "en": "A progress report on that assignment.", "ja": "レポートの進み具合を答える。" },
+    "promptContextI18n": { "en": "\"Is the report done?\" \"No, not yet.\"", "ja": "「レポートはできましたか。」「いいえ、まだできていません。」" },
+    "explanationI18n": {
+      "en": "Not-yet uses 「まだ〜ていません」: まだ できていません. 「まだ できました」 contradicts itself; 「できます」 is ability or future; and dropping another question 「できましたか」 into an answer doesn't work. ※レポート = report.",
+      "ja": "未完了は「まだ〜ていません」：まだ できていません。「まだ できました」は自己矛盾。「できます」は能力か未来。答えの中に質問形「できましたか」を入れても文にならない。"
+    }
+  },
+  "pattern-n5-toki-005": {
+    "hintI18n": { "en": "The forecast's take on tomorrow.", "ja": "天気予報が伝える明日の天気。" },
+    "promptContextI18n": { "en": "\"According to the forecast, it will probably rain tomorrow.\"", "ja": "「天気予報によると、明日は雨が降るでしょう。」" },
+    "explanationI18n": {
+      "en": "Conjecture uses 「でしょう」 = probably ~: あめが ふるでしょう. The dictionary form ふる can't take 「ですか」 directly (you'd say ふりますか); 「ましょう」 proposes, 「でした」 is past — neither attaches. ※てんきよほう = weather forecast, 〜によると = according to ~, ふります = to fall (rain/snow).",
+      "ja": "推量は「でしょう」：あめが ふるでしょう。辞書形 ふる に「ですか」は直接付かない（ふりますか と言う）。「ましょう」は提案、「でした」は過去で、どちらも接続できない。"
+    }
+  },
+  "pattern-n5-toki-006": {
+    "hintI18n": { "en": "Going along with their guess about tomorrow's cold.", "ja": "明日も寒そうだね、という相手に同調する。" },
+    "promptContextI18n": { "en": "\"Will tomorrow be cold too?\" \"Yeah, probably.\"", "ja": "「明日も寒いでしょうか。」「ええ、寒いでしょう。」" },
+    "explanationI18n": {
+      "en": "Answering a guess with your own guess: ええ、さむいでしょう = yeah, probably cold. 「ですか」 dies on the leading 「ええ」 — you don't commit and then ask back; 「ましたか」「ませんか」 don't even attach — an い-adjective's past is 「さむかったです」 and its negative question 「さむくありませんか」. ※さむい = cold.",
+      "ja": "推量には推量で答える：ええ、さむいでしょう。「ですか」は頭の「ええ」と矛盾——同意してから聞き返さない。「ましたか」「ませんか」はそもそも接続不可——い形容詞の過去は「さむかったです」、否定疑問は「さむくありませんか」。"
+    }
+  },
+  "pattern-n5-toki-007": {
+    "hintI18n": { "en": "You've climbed Mt. Fuji before.", "ja": "富士山に登った経験がある、という話。" },
+    "promptContextI18n": { "en": "\"I have climbed Mt. Fuji.\"", "ja": "「私は富士山に登ったことがあります。」" },
+    "explanationI18n": {
+      "en": "Experience uses た-form + 「ことが あります」 = have done ~: のぼった ことが あります. This pattern takes 「が」 — 「を」「に」「で」 make no sentence here. ※ふじさん = Mt. Fuji, のぼります = to climb.",
+      "ja": "経験は た形＋「ことが あります」：のぼった ことが あります。この文型は「が」——「を」「に」「で」をここに置くと文にならない。"
+    }
+  },
+  "pattern-n5-toki-008": {
+    "hintI18n": { "en": "Asked about sushi experience, you shake your head.", "ja": "すしの経験を聞かれて、首を横に振る。" },
+    "promptContextI18n": { "en": "\"Have you ever eaten sushi?\" \"No, not even once.\"", "ja": "「すしを食べたことがありますか。」「いいえ、一度もありません。」" },
+    "explanationI18n": {
+      "en": "「いちども」 (not even once) demands a negative: いちども ありません. 「あります」「ありました」「たべました」 are all affirmative and clash with いちども — the same rule as だれも/なにも + negative. ※すし = sushi, いちども = (not) even once.",
+      "ja": "「いちども」は否定とセット：いちども ありません。「あります」「ありました」「たべました」は肯定で いちども と矛盾——だれも/なにも＋否定と同じルール。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -12,6 +12,8 @@ export type SentencePatternId =
   | "n5-suki-dekiru"
   | "n5-sasoi"
   | "n5-onegai"
+  | "n5-riyuu"
+  | "n5-toki"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -49,6 +51,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n5-suki-dekiru": "好惡與能力",
   "n5-sasoi": "邀約與提議 ませんか・ましょう",
   "n5-onegai": "請求與建議 ください・ほうがいい",
+  "n5-riyuu": "理由與逆接 から・ので・が",
+  "n5-toki": "時間與經驗 とき・もう・でしょう",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -837,6 +841,205 @@ const N5_ONEGAI_ITEMS: SentencePatternItem[] = [
     options: ["およがないでください", "およいでください", "およぎましょう", "およぎませんか"],
     explanation:
       "危險警告用「ないでください」＝請勿〜：およがないで ください。主題已點明「這裡危險」，「およいでください」「ましょう」「ませんか」都是要人下水，全跟「あぶない」矛盾。※あぶない＝危險、およぎます＝游泳。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-riyuu -- reasons and contrast: から・ので・が (#547).
+//   から and ので are near-interchangeable as reason markers, so they NEVER
+//   compete on meaning: the どうして item kills ので by form (〜のでです is
+//   not a sentence), the ので item tests noun attachment (なので vs だので
+//   vs なから -- pure form), and every other から/ので appearance is a dead
+//   foil by attachment or by contradiction, never a live semantic rival.
+// ===========================================================================
+const N5_RIYUU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-riyuu-001",
+    patternId: "n5-riyuu",
+    promptText: "「どうして がっこうを やすみましたか。」「ねつが あった___です。」",
+    hintZh: "解釋沒去學校的原因。",
+    promptContextZh: "「為什麼沒來學校？」「因為發燒了。」",
+    expectedAnswer: "から",
+    options: ["から", "ので", "が", "まで"],
+    explanation:
+      "回答「どうして（為什麼）」用固定句式「〜からです」：ねつが あったからです。「ので」不能直接接です（×のでです）；「が」「まで」也接不上。※やすみます＝請假・休息。"
+  },
+  {
+    id: "pattern-n5-riyuu-002",
+    patternId: "n5-riyuu",
+    promptText: "あしたは やすみ___、どこかへ いきませんか。",
+    hintZh: "說明天放假，順便約出門。",
+    promptContextZh: "「明天放假，要不要去哪走走？」",
+    expectedAnswer: "なので",
+    options: ["なので", "だので", "ので", "なから"],
+    explanation:
+      "名詞接「ので」要先加な：やすみ＋な＋ので＝やすみなので。「だので」是錯接（だ和ので不能連用）；名詞直接接ので（×やすみので）也不行；「から」接名詞用だ（やすみだから），沒有「なから」這種形。※どこか＝某個地方。"
+  },
+  {
+    id: "pattern-n5-riyuu-003",
+    patternId: "n5-riyuu",
+    promptText: "にほんごは むずかしいです___、おもしろいです。",
+    hintZh: "說日語難歸難、學起來有樂趣。",
+    promptContextZh: "「日語雖然難，但是很有趣。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "の", "に"],
+    explanation:
+      "句中的「が」表示轉折＝雖然〜但是〜：むずかしいですが、おもしろいです——前後兩件事方向相反時用它連接。「を」「の」「に」都不能接在です後面。※むずかしい＝難、おもしろい＝有趣。"
+  },
+  {
+    id: "pattern-n5-riyuu-004",
+    patternId: "n5-riyuu",
+    promptText: "すみません___、えきは どこですか。",
+    hintZh: "向路人開口問路。",
+    promptContextZh: "「不好意思，請問車站在哪裡？」",
+    expectedAnswer: "が",
+    options: ["が", "から", "ので", "でも"],
+    explanation:
+      "開口前的緩衝用「が」：すみませんが、〜＝不好意思，（請問）〜。這個が不是轉折，只是把話題輕輕帶入。「から」「ので」是理由——「すみません」不是理由；「でも」接在句頭當「可是」，不能接在ません後面。"
+  },
+  {
+    id: "pattern-n5-riyuu-005",
+    patternId: "n5-riyuu",
+    promptText: "あめが ふって います。___、でかけます。",
+    hintZh: "雨照下，人照出門。",
+    promptContextZh: "「正在下雨。可是，還是要出門。」",
+    expectedAnswer: "でも",
+    options: ["でも", "だから", "そして", "それから"],
+    explanation:
+      "前後方向相反（下雨→照樣出門）用「でも」＝可是。「だから（所以）」是順著因果，方向不對；「そして（而且）」「それから（然後）」是並列/接續，都表達不出「照樣」的轉折。※あめ＝雨、ふります＝（雨雪）下、でかけます＝出門。"
+  },
+  {
+    id: "pattern-n5-riyuu-006",
+    patternId: "n5-riyuu",
+    promptText: "あした テストが あります。___、こんばん べんきょうします。",
+    hintZh: "明天要考試，今晚不唸不行。",
+    promptContextZh: "「明天有考試。所以，今晚要唸書。」",
+    expectedAnswer: "だから",
+    options: ["だから", "でも", "しかし", "まだ"],
+    explanation:
+      "前句是原因、後句是順理成章的結果，用「だから」＝所以。「でも」「しかし」是轉折（有考試「可是」唸書？方向不對）；「まだ（還）」是副詞，不能放在句頭當連接詞。※テスト＝考試、こんばん＝今晚。"
+  },
+  {
+    id: "pattern-n5-riyuu-007",
+    patternId: "n5-riyuu",
+    promptText: "じかんが ありません___、タクシーで いきましょう。",
+    hintZh: "趕時間，決定搭車方式。",
+    promptContextZh: "「沒時間了，搭計程車去吧。」",
+    expectedAnswer: "から",
+    options: ["から", "まで", "を", "へ"],
+    explanation:
+      "句中的理由用「から」：じかんが ありませんから＝因為沒時間，（所以）搭計程車吧。「まで」「を」「へ」都接不到ません後面，句子直接斷掉。※タクシー＝計程車。"
+  },
+  {
+    id: "pattern-n5-riyuu-008",
+    patternId: "n5-riyuu",
+    promptText: "「___ にほんごを べんきょうして いますか。」「にほんへ いきたいですから。」",
+    hintZh: "想知道對方學日語的動機。",
+    promptContextZh: "「你為什麼在學日語？」「因為想去日本。」",
+    expectedAnswer: "どうして",
+    options: ["どうして", "なに", "どこ", "いつ"],
+    explanation:
+      "回答是「〜ですから（因為〜）」，所以問句一定是問理由的「どうして」＝為什麼。「いつ（什麼時候）」「どこ（哪裡）」問時間地點，跟「因為想去日本」的回答對不上；「なに」問東西——句子已經有受詞にほんごを了。※べんきょうします＝學習、〜たいです＝想〜。"
+  }
+];
+
+// ===========================================================================
+// N5 pattern: n5-toki -- time and experience: とき・もう/まだ・でしょう・
+//   たことがある (#547). でしょう vs ですか is the known double-solution
+//   trap: the forecast item kills ですか by form (dictionary form + ですか
+//   is ungrammatical), and the agreement item kills all question foils
+//   with a leading ええ. The とき tense item uses a culture-locked anchor
+//   (いただきます is said BEFORE eating). は stays out of the ことがある
+//   particle blank (topicalized 〜ことはあります is real).
+// ===========================================================================
+const N5_TOKI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n5-toki-001",
+    patternId: "n5-toki",
+    promptText: "ひまな ___、おんがくを ききます。",
+    hintZh: "說自己閒下來會做的事。",
+    promptContextZh: "「有空的時候，我會聽音樂。」",
+    expectedAnswer: "とき",
+    options: ["とき", "ところ", "こと", "もの"],
+    explanation:
+      "「〜とき」＝〜的時候：ひまな とき＝有空的時候。「ところ」多指地方（「ひまなところ」在這裡不自然）；「こと」是事情、「もの」是東西——放進去孤懸在句首，跟後句「聽音樂」接不起來。※ひま（な）＝空閒、おんがく＝音樂。"
+  },
+  {
+    id: "pattern-n5-toki-002",
+    patternId: "n5-toki",
+    promptText: "ごはんを ___ とき、「いただきます」と いいます。",
+    hintZh: "說吃飯前的那句話。",
+    promptContextZh: "「吃飯（前）的時候，要說『いただきます（開動）』。」",
+    expectedAnswer: "たべる",
+    options: ["たべる", "たべた", "たべて", "たべます"],
+    explanation:
+      "とき前面的時態看動作完成了沒：說「いただきます」是在吃「之前」，動作還沒完成→辭書形たべる とき。「たべた とき」是吃完的時候——吃完說的是「ごちそうさま」；「て形」「ます形」不能直接接とき。"
+  },
+  {
+    id: "pattern-n5-toki-003",
+    patternId: "n5-toki",
+    promptText: "「ひるごはんを たべましたか。」「はい、___ たべました。」",
+    hintZh: "答說午餐解決了。",
+    promptContextZh: "「午餐吃了嗎？」「嗯，已經吃了。」",
+    expectedAnswer: "もう",
+    options: ["もう", "まだ", "いつ", "とても"],
+    explanation:
+      "完成用「もう〜ました」＝已經〜了：もう たべました。「まだ」配未完成（まだ たべていません），跟ました矛盾；「いつ（什麼時候）」是疑問詞；「とても（非常）」修飾程度，不搭完成。"
+  },
+  {
+    id: "pattern-n5-toki-004",
+    patternId: "n5-toki",
+    promptText: "「レポートは できましたか。」「いいえ、まだ ___。」",
+    hintZh: "報告進度的回答。",
+    promptContextZh: "「報告寫好了嗎？」「還沒，還沒寫好。」",
+    expectedAnswer: "できていません",
+    options: ["できていません", "できました", "できます", "できましたか"],
+    explanation:
+      "未完成用「まだ〜ていません」＝還沒〜：まだ できていません。「まだ できました」自相矛盾；「できます」是能力或未來；答句裡再放問句「できましたか」也不通。※レポート＝報告。"
+  },
+  {
+    id: "pattern-n5-toki-005",
+    patternId: "n5-toki",
+    promptText: "てんきよほうに よると、あしたは あめが ふる___。",
+    hintZh: "氣象預報說明天的天氣。",
+    promptContextZh: "「根據氣象預報，明天大概會下雨。」",
+    expectedAnswer: "でしょう",
+    options: ["でしょう", "ですか", "ましょう", "でした"],
+    explanation:
+      "推測用「でしょう」＝大概〜吧：あめが ふるでしょう。辭書形ふる後面不能直接接「ですか」（要說ふりますか）；「ましょう」是提議、「でした」是過去，都接不上。※てんきよほう＝氣象預報、〜によると＝根據〜、ふります＝（雨雪）下。"
+  },
+  {
+    id: "pattern-n5-toki-006",
+    patternId: "n5-toki",
+    promptText: "「あしたも さむいでしょうか。」「ええ、さむい___。」",
+    hintZh: "順著對方的話也覺得明天冷。",
+    promptContextZh: "「明天也會冷吧？」「嗯，大概會冷吧。」",
+    expectedAnswer: "でしょう",
+    options: ["でしょう", "ですか", "ましたか", "ませんか"],
+    explanation:
+      "回答別人的推測、自己也用推測：ええ、さむいでしょう＝嗯，大概會冷吧。「ですか」被開頭的「ええ（嗯）」駁倒——表態之後不會再反問；「ましたか」「ませんか」則連形都接不上——い形容詞的過去是「さむかったです」、否定問句是「さむくありませんか」。※さむい＝冷。"
+  },
+  {
+    id: "pattern-n5-toki-007",
+    patternId: "n5-toki",
+    promptText: "わたしは ふじさんに のぼった こと___ あります。",
+    hintZh: "說爬過富士山。",
+    promptContextZh: "「我爬過富士山。」",
+    expectedAnswer: "が",
+    options: ["が", "を", "に", "で"],
+    explanation:
+      "經驗用「た形＋ことが あります」＝〜過：のぼった ことが あります。這個句型用「が」——「を」「に」「で」放這裡都不成句。※ふじさん＝富士山、のぼります＝爬・登。"
+  },
+  {
+    id: "pattern-n5-toki-008",
+    patternId: "n5-toki",
+    promptText: "「すしを たべた ことが ありますか。」「いいえ、いちども ___。」",
+    hintZh: "被問吃壽司的經驗，搖搖頭。",
+    promptContextZh: "「你吃過壽司嗎？」「沒有，一次也沒有。」",
+    expectedAnswer: "ありません",
+    options: ["ありません", "あります", "ありました", "たべました"],
+    explanation:
+      "「いちども（一次也）」後面必須接否定：いちども ありません＝一次也沒有。「あります」「ありました」「たべました」都是肯定，跟いちども矛盾——這跟だれも/なにも＋否定是同一條規則。※すし＝壽司、いちども＝一次也（沒）。"
   }
 ];
 
@@ -1693,6 +1896,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N5_SUKI_DEKIRU_ITEMS,
   ...N5_SASOI_ITEMS,
   ...N5_ONEGAI_ITEMS,
+  ...N5_RIYUU_ITEMS,
+  ...N5_TOKI_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -64,6 +64,8 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
   const sukiDekiru = buildSentencePatternPool({ patternIds: ["n5-suki-dekiru"] });
   const sasoi = buildSentencePatternPool({ patternIds: ["n5-sasoi"] });
   const onegai = buildSentencePatternPool({ patternIds: ["n5-onegai"] });
+  const riyuu = buildSentencePatternPool({ patternIds: ["n5-riyuu"] });
+  const toki = buildSentencePatternPool({ patternIds: ["n5-toki"] });
 
   it("each drill carries 8 kana-only items with unique solutions and full overlays", () => {
     expect(sonzai).toHaveLength(8);
@@ -74,7 +76,9 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     expect(sukiDekiru).toHaveLength(8);
     expect(sasoi).toHaveLength(8);
     expect(onegai).toHaveLength(8);
-    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3, ...hikaku, ...sukiDekiru, ...sasoi, ...onegai]) {
+    expect(riyuu).toHaveLength(8);
+    expect(toki).toHaveLength(8);
+    for (const q of [...sonzai, ...ichi, ...joshi2, ...joshi3, ...hikaku, ...sukiDekiru, ...sasoi, ...onegai, ...riyuu, ...toki]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -209,6 +209,8 @@ export type Copy = {
   drillPatternN5SukiDekiru: string;
   drillPatternN5Sasoi: string;
   drillPatternN5Onegai: string;
+  drillPatternN5Riyuu: string;
+  drillPatternN5Toki: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -226,6 +226,8 @@ export const en: Copy = {
   drillPatternN5SukiDekiru: "Drill likes + ability",
   drillPatternN5Sasoi: "Drill invitations + offers",
   drillPatternN5Onegai: "Drill requests + advice",
+  drillPatternN5Riyuu: "Drill reasons + contrast",
+  drillPatternN5Toki: "Drill time + experience",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -226,6 +226,8 @@ export const id: Copy = {
   drillPatternN5SukiDekiru: "Latih suka + kemampuan",
   drillPatternN5Sasoi: "Latih ajakan + tawaran",
   drillPatternN5Onegai: "Latih permintaan + saran",
+  drillPatternN5Riyuu: "Latih alasan + kontras",
+  drillPatternN5Toki: "Latih waktu + pengalaman",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -234,6 +234,8 @@ export const ja: Copy = {
   drillPatternN5SukiDekiru: "好き・できる を練習",
   drillPatternN5Sasoi: "誘い・申し出を練習",
   drillPatternN5Onegai: "依頼とアドバイスを練習",
+  drillPatternN5Riyuu: "理由と逆接を練習",
+  drillPatternN5Toki: "時間と経験を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -226,6 +226,8 @@ export const ko: Copy = {
   drillPatternN5SukiDekiru: "호불호와 능력 연습",
   drillPatternN5Sasoi: "권유와 제안 연습",
   drillPatternN5Onegai: "요청과 조언 연습",
+  drillPatternN5Riyuu: "이유와 역접 연습",
+  drillPatternN5Toki: "시간과 경험 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -226,6 +226,8 @@ export const my: Copy = {
   drillPatternN5SukiDekiru: "ကြိုက်/မကြိုက်နှင့် စွမ်းရည် လေ့ကျင့်ရန်",
   drillPatternN5Sasoi: "ဖိတ်ခေါ်မှုနှင့် အဆိုပြုမှု လေ့ကျင့်ရန်",
   drillPatternN5Onegai: "တောင်းဆိုမှုနှင့် အကြံပြုမှု လေ့ကျင့်ရန်",
+  drillPatternN5Riyuu: "အကြောင်းပြချက်နှင့် ဆန့်ကျင်မှု လေ့ကျင့်ရန်",
+  drillPatternN5Toki: "အချိန်နှင့် အတွေ့အကြုံ လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -227,6 +227,8 @@ export const th: Copy = {
   drillPatternN5SukiDekiru: "ฝึกชอบ/ไม่ชอบ + ความสามารถ",
   drillPatternN5Sasoi: "ฝึกชักชวนและเสนอ",
   drillPatternN5Onegai: "ฝึกขอร้องและให้คำแนะนำ",
+  drillPatternN5Riyuu: "ฝึกเหตุผลและการขัดแย้ง",
+  drillPatternN5Toki: "ฝึกเวลาและประสบการณ์",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -226,6 +226,8 @@ export const vi: Copy = {
   drillPatternN5SukiDekiru: "Luyện thích/ghét + năng lực",
   drillPatternN5Sasoi: "Luyện mời và đề nghị",
   drillPatternN5Onegai: "Luyện yêu cầu và lời khuyên",
+  drillPatternN5Riyuu: "Luyện lý do và tương phản",
+  drillPatternN5Toki: "Luyện thời gian và kinh nghiệm",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -226,6 +226,8 @@ export const zhHant: Copy = {
   drillPatternN5SukiDekiru: "練好惡與能力",
   drillPatternN5Sasoi: "練邀約與提議",
   drillPatternN5Onegai: "練請求與建議",
+  drillPatternN5Riyuu: "練理由與逆接",
+  drillPatternN5Toki: "練時間與經驗",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- 新 pattern deck **n5-riyuu**（〜からです／なので接續／逆接與前置きが／だから・でも 接續詞／どうして，8 題）與 **n5-toki**（とき前時態／もう・まだ／でしょう／たことがあります，8 題），句型總數 126→142
- 學習 tab「N5 文法」新增兩章，含 en/ja 章節 overlay、16 題逐題 i18n overlay、8 語系 drill 標籤
- contentGuard `PATTERN_HINT_BANLIST` 增兩 pattern 洩漏字表

## 設計要點
- **から/ので 互換雷**：兩者永不同場語意競爭——どうして題用「〜のでです不成句」形態殺、ので 題考名詞接續（なので/だので/なから 純形態）
- **でしょう/ですか 雙解雷**：預報題用辭書形+ですか 接續殺、附和題用句首「ええ」殺全部問句形
- とき 時態題用文化錨（いただきます＝飯前語）

## 品質閘
- 兩鏡頭對抗審：8 findings 全採納 —— 前置きが 真雙解（兩鏡頭 CONFIRMED）撤換死項、でも「負擔→決心」讀法 hint 鎖死、もう 題幹逐字洩漏修掉、い形容詞接續解說補強、あめ/ふります gloss 補
- codex 終審：3 findings 全採納 —— どうして題加「にほんへ いきたいですから」回答鎖（殺 いつ 活干擾）、それから 補充讀法撤換為 まだ、ところ 解說去絕對化
- `pnpm test` 878 全綠；build 綠、examBlocks 仍獨立 lazy chunk
- Preview 實機驗證：兩章顯示、順序正確、drill 啟動、修正後選項與 gloss 上線、句型池 142

Closes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new N5 grammar lessons covering reasons/contrast and time/experience.
  * Added matching sentence-pattern drills, hints, examples, and explanations for both topics.
  * Expanded translations so the new lessons appear correctly in all supported languages.
* **Bug Fixes**
  * Updated content checks and counts so the dashboard and validation rules stay in sync with the added material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->