### PR TITLE
feat: N4 文法章 說明語氣んです＋推量原因（#549）

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 166,
+  patternChecks: 182,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -780,6 +780,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n4-ndesu": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "The Explanatory 〜んです",
+      "explanation":
+        "N4's highest-frequency tone system. 「〜んです」 is not a plain です — it carries an explaining stance: pressing about something unusual you see (どうしたんですか), giving the background of your own actions (誕生日なんです), or cushioning a request (質問があるんですが…). Attachment: verbs and い-adjectives take the plain form directly (行くんです, 痛いんです); nouns and な-adjectives in the present take な (引っ越しなんです); past だった attaches bare (病気だったんです). Question and answer pair up: 〜んですか is answered with 〜んです.",
+      "notes": [
+        "Pressing for an explanation",
+        "Answering: giving the reason",
+        "Noun + な + んです; が = cushion",
+        "Past だった attaches bare",
+        "The request cushion んですが"
+      ],
+      "pitfalls": [
+        "Plain form + です/ます is no sentence: ×行くです — either 行きます or 行くんです",
+        "Nouns/な-adjectives take な: 学生なんです — but past だったんです drops it",
+        "んですか needs a visible trigger; without one it sounds like an interrogation — neutral questions use ますか"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "説明の「んです」",
+      "explanation":
+        "N4 で最も頻度が高いモダリティ。「〜んです」はただの です ではなく「説明」の態度を帯びる：目の前の様子への追及（どうしたんですか）、自分の行動の背景説明（誕生日なんです）、依頼の前置き（質問があるんですが…）。接続：動詞・い形容詞は普通形に直接（行くんです）；名詞・な形容詞の現在肯定は な を挟む（引っ越しなんです）；過去 だった には直接（病気だったんです）。問いと答えはセット：〜んですか には 〜んです で返す。",
+      "notes": [
+        "様子への追及",
+        "答え：理由の説明",
+        "名詞＋な＋んです。が は前置き",
+        "だった には直接",
+        "依頼の前置き んですが"
+      ],
+      "pitfalls": [
+        "普通形＋です/ます は文にならない：×行くです——行きます か 行くんです",
+        "名詞・な形容詞は な：学生なんです。ただし過去は だったんです",
+        "んですか はきっかけがあってこそ。なければ詰問に聞こえる——中立の質問は ますか"
+      ]
+    }
+  },
+  "n4-suiryou": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Conjecture & Causes: かもしれない・て",
+      "explanation":
+        "The certainty ladder: 〜かもしれない (might — 50% or less) < 〜だろう/でしょう (probably). だろう is the plain-form counterpart of でしょう. Shared attachment rule: nouns and な-adjectives attach BARE, dropping だ — 学生かもしれない, 休みだろう, 元気でしょう (contrast んです, which wants な). The other half is causal て: reasons for feelings and states use て/なくて — 知らせを聞いて安心した, 宿題が終わらなくて困っている. Negative formula: drop the い of ない, add くて.",
+      "notes": [
+        "Might: かもしれない",
+        "だろう = plain でしょう",
+        "Nouns attach bare, だ drops",
+        "て = cause of a feeling",
+        "Negative cause: なくて"
+      ],
+      "pitfalls": [
+        "Before かも/だろう/でしょう, だ always drops: ×学生だかもしれない",
+        "But んです wants な: 学生なんです — keep the two rule-sets apart",
+        "Negative causes take なくて (states/feelings); ないで is \"doing B without doing A\""
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "推量と原因 かもしれない・て",
+      "explanation":
+        "確信度のはしご：〜かもしれない（五分以下）＜〜だろう/でしょう（たぶん）。だろう は でしょう の普通体。共通の接続ルール：名詞・な形容詞は裸で付き、だ は落とす——学生かもしれない、休みだろう、元気でしょう（んです は な が要るのと対照的）。もう一つの柱は「て形の原因用法」：感情・状態の理由は て/なくて——知らせを聞いて安心した、終わらなくて困っている。否定の公式：ない の い を取って くて。",
+      "notes": [
+        "かもしれない",
+        "だろう＝でしょう の普通体",
+        "名詞は裸接続、だ は落とす",
+        "て＝感情の原因",
+        "否定の原因：なくて"
+      ],
+      "pitfalls": [
+        "かも/だろう/でしょう の前で だ は必ず落ちる：×学生だかもしれない",
+        "んです は な が要る：学生なんです——二つのルールを混ぜない",
+        "原因の否定は なくて（状態・感情）。ないで は「Aしないで B する」の付帯状況"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 2 N4 grammar (#549) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(36);
+    expect(trackable.length).toBe(38);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -606,6 +606,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n5-josuushi"]
   },
   {
+    id: "n4-ndesu",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "說明語氣 〜んです",
+    subtitle: "どうしたんですか／引っ越しなんです",
+    explanation:
+      "N4 最高頻的語氣系統。「〜んです」不是單純的です——它帶著「說明、解釋」的態度：看到不尋常的狀況追問（どうしたんですか）、說明自己行為的緣由（誕生日なんです）、拜託人之前先鋪墊（質問があるんですが…）。接續整理：動詞・い形容詞普通形直接接（行くんです、痛いんです）；名詞・な形容詞現在肯定要加な（引っ越しなんです）；過去だった直接接（病気だったんです）。問答成組：〜んですか 的回答用 〜んです。",
+    examples: [
+      { formula: "どうしたんですか", note: "求說明的追問" },
+      { formula: "電車が止まったんです", note: "回答：說明緣由" },
+      { formula: "引っ越しなんですが、…", note: "名詞＋な＋んです；が＝鋪墊" },
+      { formula: "病気だったんです", note: "過去だった直接接" },
+      { formula: "質問があるんですが、今いいですか", note: "開口前的前置き" }
+    ],
+    pitfalls: [
+      "普通形＋です/ます 不成句：×行くです——要嘛 行きます、要嘛 行くんです",
+      "名詞・な形容詞加な：学生なんです；但過去 だったんです 不再加な",
+      "看到情況才用んですか；沒有前提就用會顯得質問——單純問句用ますか"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Ndesu", patternIds: ["n4-ndesu"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n5-teido"]
+  },
+  {
+    id: "n4-suiryou",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "推量與原因 かもしれない・て",
+    subtitle: "雨が降るかもしれません／終わらなくて",
+    explanation:
+      "把握度的階梯：〜かもしれない（說不定，五成以下）＜〜だろう/でしょう（大概吧）。だろう是でしょう的普通體。接續共同鐵則：名詞・な形容詞一律裸接、だ要去掉——学生かもしれない、休みだろう、元気でしょう（對照：んです才要な）。另一塊是「て形表原因」：感情或狀態的緣由用て/なくて——知らせを聞いて安心した、宿題が終わらなくて困っている。否定公式：ない去い＋くて。",
+    examples: [
+      { formula: "雨が降るかもしれません", note: "說不定：可能性" },
+      { formula: "明日は晴れるだろう", note: "だろう＝でしょう的普通體" },
+      { formula: "学生かもしれない／休みだろう", note: "名詞裸接、だ去掉" },
+      { formula: "知らせを聞いて、安心しました", note: "て＝感情的原因" },
+      { formula: "終わらなくて、困っています", note: "原因的否定：なくて" }
+    ],
+    pitfalls: [
+      "かも/だろう/でしょう 前面 だ 全部去掉：×学生だかもしれない",
+      "但んです要な：学生なんです——兩家規則別互相污染",
+      "原因的否定用なくて（狀態・感情）；ないで是「不做A而做B」的付帶狀況"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Suiryou", patternIds: ["n4-suiryou"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-ndesu"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -1175,6 +1175,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "頻度は「期間＋に＋回数」：１しゅうかんに ２かい。この に は期間への割り当てを表す。「を」「へ」「と」は期間の語に付かない。"
     }
   },
+  "pattern-n4-ndesu-001": {
+    "hintI18n": { "en": "Your friend looks pale — check on them.", "ja": "相手の様子がおかしいので声をかける。" },
+    "promptContextI18n": { "en": "\"You look pale — what's wrong?\"", "ja": "「顔色が悪いですね。どうしたんですか。」" },
+    "explanationI18n": {
+      "en": "Pressing for an explanation of something you see uses 「〜んですか」: どうしたんですか = what's wrong? The preceding した is a plain form, so 「ですか」「ますか」「でしたか」 can't attach — among these four options only んですか parses. ※顔色 = complexion.",
+      "ja": "目の前の様子について説明を求めるのが「〜んですか」：どうしたんですか。直前の「した」は普通形なので、「ですか」「ますか」「でしたか」は接続できない——この四択で文になるのは んですか だけ。"
+    }
+  },
+  "pattern-n4-ndesu-002": {
+    "hintI18n": { "en": "Explaining why you were late.", "ja": "遅れた事情を説明する。" },
+    "promptContextI18n": { "en": "\"Why were you late?\" \"The train stopped.\"", "ja": "「どうして遅れたんですか。」「電車が止まったんです。」" },
+    "explanationI18n": {
+      "en": "Answering a 「どうして〜んですか」 probe uses 「〜んです」 to explain: 電車が止まったんです. 止まった is plain, so 「です」「ます」「ましょう」 can't attach. The pair: んですか ⇄ んです. ※遅れる = to be late.",
+      "ja": "「どうして〜んですか」への答えは「〜んです」で事情を説明：電車が止まったんです。「止まった」は普通形なので「です」「ます」「ましょう」は接続不可。問いと答えはセット：んですか⇄んです。"
+    }
+  },
+  "pattern-n4-ndesu-003": {
+    "hintI18n": { "en": "Setting the scene before asking for moving help.", "ja": "手伝いを頼む前に事情を切り出す。" },
+    "promptContextI18n": { "en": "\"I'm moving tomorrow — could you give me a hand?\"", "ja": "「明日引っ越しなんですが、手伝ってくれませんか。」" },
+    "explanationI18n": {
+      "en": "Cushioning a request uses 「〜んですが」; a noun needs な before んです: 引っ越し + な + んですが. 「引っ越しんですが」 is missing the な; 「だんですが」「のんですが」 are attachments that don't exist — this is the same な as in なので. ※引っ越し = moving house, 手伝う = to help.",
+      "ja": "頼みごとの前置きは「〜んですが」。名詞は な を挟む：引っ越し＋な＋んですが。「引っ越しんですが」は な 抜け。「だんですが」「のんですが」は存在しない接続——なので と同じ な。"
+    }
+  },
+  "pattern-n4-ndesu-004": {
+    "hintI18n": { "en": "Explaining why you bought a cake.", "ja": "ケーキを買った理由を説明する。" },
+    "promptContextI18n": { "en": "\"It's my birthday today — that's why I bought a cake.\"", "ja": "「今日は誕生日なんです。だからケーキを買いました。」" },
+    "explanationI18n": {
+      "en": "Explaining the background of your own action uses 「〜んです」: 誕生日なんです = (you see,) it's my birthday. The な is already in the prompt; the other three options can't follow な — this な is the same family as なので and なのに.",
+      "ja": "自分の行動の背景説明は「〜んです」：誕生日なんです。空欄の前にもう な がある——ほかの三つは な の後ろにつながらない。この な は なので・なのに と同じ仲間。"
+    }
+  },
+  "pattern-n4-ndesu-005": {
+    "hintI18n": { "en": "Your friend's carrying a big bag — ask where to.", "ja": "大きいかばんを持つ友だちに聞いてみる。" },
+    "promptContextI18n": { "en": "\"(Seeing the big bag) Where are you off to?\"", "ja": "「（大きいかばんを見て）どこへ行くんですか。」" },
+    "explanationI18n": {
+      "en": "Asking with interest about what you see uses 「〜んですか」: どこへ行くんですか. 行く is the dictionary form — 「ですか」「ましたか」「でしたか」 can't attach; a neutral question would be 行きますか.",
+      "ja": "目にした様子への関心をこめて聞くのが「〜んですか」：どこへ行くんですか。「行く」は辞書形で、「ですか」「ましたか」「でしたか」は接続できない——中立に聞くなら 行きますか。"
+    }
+  },
+  "pattern-n4-ndesu-006": {
+    "hintI18n": { "en": "Explaining why you were absent.", "ja": "休んだ事情を説明する。" },
+    "promptContextI18n": { "en": "\"Why were you off?\" \"I was sick.\"", "ja": "「どうして休んだんですか。」「病気だったんです。」" },
+    "explanationI18n": {
+      "en": "A noun's past form attaches to んです with no な: 病気だった + んです. 「病気だったなんです」 has a superfluous な; 「だったです」「だったでした」 aren't sentences. Summary: present = 病気なんです, past = 病気だったんです.",
+      "ja": "名詞の過去形は な なしで んです に接続：病気だった＋んです。「病気だったなんです」は な が余計。「だったです」「だったでした」は文にならない。整理：現在＝病気なんです、過去＝病気だったんです。"
+    }
+  },
+  "pattern-n4-ndesu-007": {
+    "hintI18n": { "en": "Opening a question to your teacher.", "ja": "先生に質問を切り出す。" },
+    "promptContextI18n": { "en": "\"Sensei, I have a question — is now a good time?\"", "ja": "「先生、質問があるんですが、今いいですか。」" },
+    "explanationI18n": {
+      "en": "The cushion before speaking up: a verb's plain form attaches directly to 「んですが」 — 質問があるんですが. 「あるですが」 isn't a sentence (you'd say ありますが); 「あるなんですが」 adds a な that belongs only to nouns and な-adjectives; 「あるました」 isn't a form.",
+      "ja": "切り出しの前置き：動詞の普通形は「んですが」に直接——質問があるんですが。「あるですが」は文にならない（ありますが と言う）。「あるなんですが」の な は名詞・な形容詞専用。「あるました」は形として存在しない。"
+    }
+  },
+  "pattern-n4-ndesu-008": {
+    "hintI18n": { "en": "Confirming your friend's study-abroad plan.", "ja": "留学の予定を確かめられて答える。" },
+    "promptContextI18n": { "en": "\"You're studying abroad in Japan?\" \"Yes — I leave next year.\"", "ja": "「日本へ留学するんですか。」「はい、来年行くんです。」" },
+    "explanationI18n": {
+      "en": "Asked with 「〜んですか」, you answer in kind with 「〜んです」: 来年行くんです. 「行くです」「行くます」「行くでした」 are all non-sentences — after the dictionary form, only んです among these four parses. ※留学 = studying abroad.",
+      "ja": "「〜んですか」と聞かれたら「〜んです」で受ける：来年行くんです。「行くです」「行くます」「行くでした」はどれも文にならない——辞書形の後ろでこの四択なら んです だけ。"
+    }
+  },
+  "pattern-n4-suiryou-001": {
+    "hintI18n": { "en": "Reading the sky.", "ja": "空模様を見て一言。" },
+    "promptContextI18n": { "en": "\"The sky's dark — it might rain.\"", "ja": "「空が暗いですね。雨が降るかもしれません。」" },
+    "explanationI18n": {
+      "en": "Possibility uses 「〜かもしれません」 = might ~: 雨が降るかもしれません. 「かしれません」 lost the も; 「かもしりません」 garbles しれ into しり; 「かもしれました」 — no such past form exists. Memorize it as one fixed chunk. ※暗い = dark.",
+      "ja": "可能性は「〜かもしれません」：雨が降るかもしれません。「かしれません」は も 抜け。「かもしりません」は しれ→しり の崩れ。「かもしれました」という過去形はない——固定形としてまるごと覚える。"
+    }
+  },
+  "pattern-n4-suiryou-002": {
+    "hintI18n": { "en": "Chatting about tomorrow's weather in plain style.", "ja": "普通体で明日の天気の話。" },
+    "promptContextI18n": { "en": "\"It'll probably clear up tomorrow.\"", "ja": "「明日はたぶん晴れるだろう。」" },
+    "explanationI18n": {
+      "en": "「だろう」 is the plain-style counterpart of でしょう = probably: 晴れるだろう. Attaching 「だ」「だった」「ではない」 directly to the dictionary form makes no sentence — of the だ family, only だろう follows a plain verb. ※晴れる = to clear up.",
+      "ja": "「だろう」は でしょう の普通体：晴れるだろう。辞書形に「だ」「だった」「ではない」を直接付けても文にならない——だ 系で動詞普通形に付くのは だろう だけ。"
+    }
+  },
+  "pattern-n4-suiryou-003": {
+    "hintI18n": { "en": "Homework troubles.", "ja": "宿題の悩みをこぼす。" },
+    "promptContextI18n": { "en": "\"My homework won't get done and I'm stuck.\"", "ja": "「宿題が終わらなくて、困っています。」" },
+    "explanationI18n": {
+      "en": "A negative cause uses 「〜なくて」: 終わらない → 終わらなくて = because it won't finish (I'm stuck). 「終わるなくて」 bolts ない onto the dictionary form; 「終わらなくで」 is misspelled; 「終わないで」 dropped the ら. When the result is a feeling or state (困る), the cause takes なくて. ※宿題 = homework.",
+      "ja": "原因の否定は「〜なくて」：終わらない→終わらなくて。「終わるなくて」は辞書形に ない 系を無理付け。「終わらなくで」は綴りの崩れ。「終わないで」は ら 抜け。後件が感情・状態（困る）のとき、原因は なくて。"
+    }
+  },
+  "pattern-n4-suiryou-004": {
+    "hintI18n": { "en": "Explaining what put you at ease.", "ja": "安心した理由を言う。" },
+    "promptContextI18n": { "en": "\"I heard I passed, and felt relieved.\"", "ja": "「合格の知らせを聞いて、安心しました。」" },
+    "explanationI18n": {
+      "en": "The cause of a feeling (安心, びっくり, うれしい…) uses the て form: 知らせを聞いて、安心しました. 「聞くて」「聞きて」 are wrong sound changes; 「聞いで」 uses the いで that belongs to ぐ-verbs (泳ぐ→泳いで) — く-verbs take いて (聞く→聞いて). ※合格 = passing, 知らせ = news/notice, 安心する = to feel relieved.",
+      "ja": "感情（安心・びっくり・うれしい…）の原因は て形：知らせを聞いて、安心しました。「聞くて」「聞きて」は誤った音便。「聞いで」の いで は ぐ 動詞用（泳ぐ→泳いで）——く 動詞は いて（聞く→聞いて）。"
+    }
+  },
+  "pattern-n4-suiryou-005": {
+    "hintI18n": { "en": "Guessing who that person is.", "ja": "あの人の身分を推測する。" },
+    "promptContextI18n": { "en": "\"That person might be a student.\"", "ja": "「あの人は学生かもしれません。」" },
+    "explanationI18n": {
+      "en": "A noun attaches to かもしれない bare — だ drops: 学生かもしれません. 「学生だかもしれません」 keeps the だ and is wrong; 「なかもしれません」 imports んです's な; 「のかもしれません」 straight after a noun has a stray の (学生なのかもしれません is a different, valid shape). Contrast: んです wants な, かも attaches bare.",
+      "ja": "名詞は かもしれない に裸で付く——だ は落とす：学生かもしれません。「学生だかもしれません」は だ が残った誤り。「なかもしれません」は んです の な の混入。「のかもしれません」は名詞直後だと の が余計（「学生なのかもしれません」なら別の正しい形）。対照：んです は な、かも は裸。"
+    }
+  },
+  "pattern-n4-suiryou-006": {
+    "hintI18n": { "en": "Guessing whether the shop is open, plain style.", "ja": "店が開いているか普通体で推測。" },
+    "promptContextI18n": { "en": "\"That shop's probably closed today.\"", "ja": "「たぶんあの店は休みだろう。」" },
+    "explanationI18n": {
+      "en": "Nouns also attach to だろう bare: 休みだろう. 「なだろう」 imports んです's な; 「休みのだろう」 has a stray の (休みなのだろう is a different valid shape); 「いだろう」 is no form. Before かも, だろう, でしょう: present-tense だ always drops (past だった stays: 休みだっただろう).",
+      "ja": "名詞は だろう にも裸で付く：休みだろう。「なだろう」は んです の な の混入。「休みのだろう」は の が余計（「休みなのだろう」なら別の形）。「いだろう」は形にならない。かも・だろう・でしょう の前では現在形の だ は必ず落とす（過去の だった は残る：休みだっただろう）。"
+    }
+  },
+  "pattern-n4-suiryou-007": {
+    "hintI18n": { "en": "Guessing how an old friend is doing.", "ja": "しばらく会っていない友だちの近況を推測。" },
+    "promptContextI18n": { "en": "\"She's probably doing fine.\"", "ja": "「彼女はたぶん元気でしょう。」" },
+    "explanationI18n": {
+      "en": "な-adjectives attach to でしょう bare — no だ, no な: 元気でしょう. 「なでしょう」「だでしょう」 overdo it; 「元気のでしょう」 has a stray の. The family rule: かもしれない, だろう, でしょう — present-tense nouns and な-adjectives attach bare (past だった stays: 元気だったでしょう).",
+      "ja": "な形容詞は でしょう に裸で付く——だ も な も不要：元気でしょう。「なでしょう」「だでしょう」は蛇足。「元気のでしょう」は の が余計。この一家のルール：かもしれない・だろう・でしょう——名詞・な形容詞の現在形は裸接続（過去の だった は残る：元気だったでしょう）。"
+    }
+  },
+  "pattern-n4-suiryou-008": {
+    "hintI18n": { "en": "Why your stomach is growling.", "ja": "おなかがすいたわけを言う。" },
+    "promptContextI18n": { "en": "\"I skipped breakfast and now I'm hungry.\"", "ja": "「朝ごはんを食べなくて、おなかがすきました。」" },
+    "explanationI18n": {
+      "en": "The negative cause once more: 食べない → 食べなくて = because I didn't eat (I'm hungry). 「食べなくで」「食べずて」「食べないくて」 are all nonexistent forms — formula: drop the い of ない, add くて.",
+      "ja": "原因の否定をもう一度：食べない→食べなくて。「食べなくで」「食べずて」「食べないくて」はどれも存在しない形——公式は「ない の い を取って くて」。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -17,6 +17,8 @@ export type SentencePatternId =
   | "n5-keiyoushi"
   | "n5-josuushi"
   | "n5-teido"
+  | "n4-ndesu"
+  | "n4-suiryou"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -59,6 +61,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n5-keiyoushi": "形容詞的連接與變化",
   "n5-josuushi": "助数詞 數量的說法",
   "n5-teido": "程度與頻度 あまり・よく",
+  "n4-ndesu": "說明語氣 〜んです",
+  "n4-suiryou": "推量與原因 かもしれない・て",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -1349,6 +1353,206 @@ const N5_TEIDO_ITEMS: SentencePatternItem[] = [
 ];
 
 // ===========================================================================
+// N4 pattern: n4-ndesu -- the explanatory んです system (#549).
+//   んです vs です is interchangeable almost everywhere on the surface, so
+//   です NEVER competes semantically: every item is built so the blank
+//   follows a PLAIN form (した/行く/ある/だった/な), where です・ます・
+//   でした are attachment-dead and only んです(か/が) parses. The four
+//   attachment shapes (verb plain, noun+な, noun+だった, い-adj) each get
+//   dedicated items.
+// ===========================================================================
+const N4_NDESU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-ndesu-001",
+    patternId: "n4-ndesu",
+    promptText: "顔色が悪いですね。どうした___。",
+    hintZh: "看對方臉色不對，開口關心。",
+    promptContextZh: "「你臉色不太好耶，怎麼了嗎？」",
+    expectedAnswer: "んですか",
+    options: ["んですか", "ですか", "ますか", "でしたか"],
+    explanation:
+      "看到不尋常的狀況、想「求說明」時用「〜んですか」：どうしたんですか＝怎麼了嗎？前面的「した」是普通形，後面直接接「ですか」「ますか」「でしたか」都不成句——這四個選項裡只有んですか接得上。※顔色＝臉色、氣色。"
+  },
+  {
+    id: "pattern-n4-ndesu-002",
+    patternId: "n4-ndesu",
+    promptText: "「どうして遅れたんですか。」「電車が止まった___。」",
+    hintZh: "說出遲到的緣由。",
+    promptContextZh: "「為什麼遲到了？」「因為電車停駛了。」",
+    expectedAnswer: "んです",
+    options: ["んです", "です", "ます", "ましょう"],
+    explanation:
+      "回答「どうして〜んですか」的追問，用「〜んです」說明緣由：電車が止まったんです。「止まった」是普通形，後面直接接「です」「ます」「ましょう」都不成句。問答一組：んですか⇄んです。※遅れる＝遲到。"
+  },
+  {
+    id: "pattern-n4-ndesu-003",
+    patternId: "n4-ndesu",
+    promptText: "明日引っ越し___、手伝ってくれませんか。",
+    hintZh: "開口請人幫忙搬家前先交代狀況。",
+    promptContextZh: "「明天我要搬家，能幫我個忙嗎？」",
+    expectedAnswer: "なんですが",
+    options: ["なんですが", "んですが", "だんですが", "のんですが"],
+    explanation:
+      "拜託人之前先鋪墊狀況用「〜んですが」；名詞接んです要加な：引っ越し＋な＋んですが。「引っ越しんですが」少了な；「だんですが」「のんですが」都不是存在的接法——跟「なので」同一個な。※引っ越し＝搬家、手伝う＝幫忙。"
+  },
+  {
+    id: "pattern-n4-ndesu-004",
+    patternId: "n4-ndesu",
+    promptText: "今日は誕生日な___。だからケーキを買いました。",
+    hintZh: "解釋自己為什麼買蛋糕。",
+    promptContextZh: "「今天是我生日，所以買了蛋糕。」",
+    expectedAnswer: "んです",
+    options: ["んです", "です", "でした", "だんです"],
+    explanation:
+      "說明自己行為的背景用「〜んです」：誕生日なんです＝（其實）今天是我生日。空格前已經有な，其餘三個選項接在な後面都不成句——這個な跟なので、なのに 是同一家。"
+  },
+  {
+    id: "pattern-n4-ndesu-005",
+    patternId: "n4-ndesu",
+    promptText: "（友だちが大きいかばんを持っている）どこへ行く___。",
+    hintZh: "看到朋友拿著大包包，好奇追問。",
+    promptContextZh: "「（看到朋友拿著大包包）你要去哪裡呀？」",
+    expectedAnswer: "んですか",
+    options: ["んですか", "ですか", "ましたか", "でしたか"],
+    explanation:
+      "看到眼前的情況、帶著關心追問用「〜んですか」：どこへ行くんですか。「行く」是辭書形，直接接「ですか」「ましたか」「でしたか」都不成句——要單純地問就得說「行きますか」。"
+  },
+  {
+    id: "pattern-n4-ndesu-006",
+    patternId: "n4-ndesu",
+    promptText: "「どうして休んだんですか。」「病気だった___。」",
+    hintZh: "說出請假的緣由。",
+    promptContextZh: "「為什麼請假了？」「因為（那時）生病了。」",
+    expectedAnswer: "んです",
+    options: ["んです", "なんです", "です", "でした"],
+    explanation:
+      "名詞的過去形接んです不再加な：病気だった＋んです。「病気だったなんです」多了な；「だったです」「だったでした」都不成句。整理：現在＝病気なんです、過去＝病気だったんです。"
+  },
+  {
+    id: "pattern-n4-ndesu-007",
+    patternId: "n4-ndesu",
+    promptText: "先生、質問がある___、今いいですか。",
+    hintZh: "找老師發問前先開個頭。",
+    promptContextZh: "「老師，我有個問題想請教，現在方便嗎？」",
+    expectedAnswer: "んですが",
+    options: ["んですが", "ですが", "なんですが", "ました"],
+    explanation:
+      "開口前的鋪墊：動詞普通形直接接「んですが」——質問があるんですが。「あるですが」不成句（要說ありますが）；「あるなんですが」多了な（な只給名詞和な形容詞用）；「あるました」不成句。"
+  },
+  {
+    id: "pattern-n4-ndesu-008",
+    patternId: "n4-ndesu",
+    promptText: "「日本へ留学するんですか。」「はい、来年行く___。」",
+    hintZh: "確認對方留學的計畫。",
+    promptContextZh: "「你要去日本留學嗎？」「對，明年要去。」",
+    expectedAnswer: "んです",
+    options: ["んです", "です", "ます", "でした"],
+    explanation:
+      "被「〜んですか」問到，回答也用「〜んです」呼應：来年行くんです。「行くです」「行くます」「行くでした」都不成句——辭書形後面這四個選項只有んです接得上。※留学＝留學。"
+  }
+];
+
+// ===========================================================================
+// N4 pattern: n4-suiryou -- conjecture + causal て (#549).
+//   かもしれない and でしょう/だろう are certainty-adjacent, so they never
+//   compete in one item. The chapter's spine is attachment: かも/だろう/
+//   でしょう all take nouns and な-adjectives BARE (だ drops) -- contrast
+//   with んです's な. て-cause items are pure form kills; ないで never
+//   appears as a foil where なくて is the answer (colloquial ないで+state
+//   readings survive).
+// ===========================================================================
+const N4_SUIRYOU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-suiryou-001",
+    patternId: "n4-suiryou",
+    promptText: "空が暗いですね。雨が降る___。",
+    hintZh: "看天色說話。",
+    promptContextZh: "「天色好暗，說不定會下雨。」",
+    expectedAnswer: "かもしれません",
+    options: ["かもしれません", "かしれません", "かもしりません", "かもしれました"],
+    explanation:
+      "可能性用「〜かもしれません」＝說不定〜：雨が降るかもしれません。「かしれません」少了も；「かもしりません」把しれ誤作しり；「かもしれました」沒有這種過去形——整組當固定形背下來。※暗い＝暗。"
+  },
+  {
+    id: "pattern-n4-suiryou-002",
+    patternId: "n4-suiryou",
+    promptText: "明日はたぶん晴れる___。",
+    hintZh: "用普通體聊明天的天氣。",
+    promptContextZh: "「明天大概會放晴吧。」",
+    expectedAnswer: "だろう",
+    options: ["だろう", "だ", "だった", "ではない"],
+    explanation:
+      "「だろう」是「でしょう」的普通體＝大概〜吧：晴れるだろう。辭書形後面直接接「だ」「だった」「ではない」都不成句——動詞普通形之後だ系只有だろう接得上。※晴れる＝放晴。"
+  },
+  {
+    id: "pattern-n4-suiryou-003",
+    patternId: "n4-suiryou",
+    promptText: "宿題が___、困っています。",
+    hintZh: "說功課卡住的煩惱。",
+    promptContextZh: "「功課寫不完，正傷腦筋。」",
+    expectedAnswer: "終わらなくて",
+    options: ["終わらなくて", "終わるなくて", "終わらなくで", "終わないで"],
+    explanation:
+      "原因的否定用「〜なくて」：終わらない→終わらなくて＝因為寫不完（所以困擾）。「終わるなくて」把辭書形硬接ない系；「終わらなくで」拼錯；「終わないで」少了ら。後件是感情、狀態（困る）時，原因用なくて。※宿題＝功課。"
+  },
+  {
+    id: "pattern-n4-suiryou-004",
+    patternId: "n4-suiryou",
+    promptText: "合格の知らせを___、安心しました。",
+    hintZh: "說明安心的原因。",
+    promptContextZh: "「聽到合格的通知，放心了。」",
+    expectedAnswer: "聞いて",
+    options: ["聞いて", "聞くて", "聞きて", "聞いで"],
+    explanation:
+      "感情（安心、びっくり、うれしい…）的原因用て形：知らせを聞いて、安心しました＝聽到通知而放心。「聞くて」「聞きて」都是錯誤音便；「聞いで」的いで是ぐ結尾動詞用的（泳ぐ→泳いで）——く結尾是いて（聞く→聞いて）。※合格＝合格、知らせ＝通知、安心する＝放心。"
+  },
+  {
+    id: "pattern-n4-suiryou-005",
+    patternId: "n4-suiryou",
+    promptText: "あの人は学生___。",
+    hintZh: "猜測那個人的身分。",
+    promptContextZh: "「那個人說不定是學生。」",
+    expectedAnswer: "かもしれません",
+    options: ["かもしれません", "だかもしれません", "なかもしれません", "のかもしれません"],
+    explanation:
+      "名詞接「かもしれない」直接接、だ要去掉：学生かもしれません。「学生だかもしれません」留著だ是錯的；「なかもしれません」把んです的な錯搬過來；「のかもしれません」直接接名詞多了の（要說「学生なのかもしれません」另當別論）。對照：んです要な（学生なんです）、かも直接接。"
+  },
+  {
+    id: "pattern-n4-suiryou-006",
+    patternId: "n4-suiryou",
+    promptText: "たぶんあの店は休み___。",
+    hintZh: "用普通體猜店家今天的狀態。",
+    promptContextZh: "「那家店今天大概沒開吧。」",
+    expectedAnswer: "だろう",
+    options: ["だろう", "なだろう", "のだろう", "いだろう"],
+    explanation:
+      "名詞接「だろう」也是直接接：休みだろう。「なだろう」把んです的な錯搬；「休みのだろう」多了の（要說「休みなのだろう」另當別論）；「いだろう」不成形。かも、だろう、でしょう前面：現在形的だ全部去掉（過去的だった要保留：休みだっただろう）。"
+  },
+  {
+    id: "pattern-n4-suiryou-007",
+    patternId: "n4-suiryou",
+    promptText: "彼女はたぶん元気___。",
+    hintZh: "猜久沒聯絡的朋友的近況。",
+    promptContextZh: "「她大概過得很好吧。」",
+    expectedAnswer: "でしょう",
+    options: ["でしょう", "なでしょう", "だでしょう", "のでしょう"],
+    explanation:
+      "な形容詞接「でしょう」直接接、だ・な都不要：元気でしょう。「なでしょう」「だでしょう」都畫蛇添足；「元気のでしょう」多了の。整理這一家：〜かもしれない、〜だろう、〜でしょう——名詞/な形容詞的現在形一律裸接（過去的だった保留：元気だったでしょう）。"
+  },
+  {
+    id: "pattern-n4-suiryou-008",
+    patternId: "n4-suiryou",
+    promptText: "朝ごはんを___、おなかがすきました。",
+    hintZh: "說肚子餓的來由。",
+    promptContextZh: "「沒吃早餐，肚子餓了。」",
+    expectedAnswer: "食べなくて",
+    options: ["食べなくて", "食べなくで", "食べずて", "食べないくて"],
+    explanation:
+      "原因的否定再練一次：食べない→食べなくて＝因為沒吃（所以餓了）。「食べなくで」「食べずて」「食べないくて」都不是存在的形——公式：ない形去い＋くて。"
+  }
+];
+
+// ===========================================================================
 // Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
 //   Absolute-beginner floor: kana-only sentences built from the starter
 //   vocabulary deck. Unique solutions are locked by IN-SENTENCE anchors
@@ -2206,6 +2410,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N5_KEIYOUSHI_ITEMS,
   ...N5_JOSUUSHI_ITEMS,
   ...N5_TEIDO_ITEMS,
+  ...N4_NDESU_ITEMS,
+  ...N4_SUIRYOU_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -99,6 +99,26 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     }
   });
 
+  it("N4 drills (#549) carry 8 items with unique solutions and full overlays", () => {
+    // N4 decks use kanji-mixed orthography, so no kana-only assertion here.
+    const ndesu = buildSentencePatternPool({ patternIds: ["n4-ndesu"] });
+    const suiryou = buildSentencePatternPool({ patternIds: ["n4-suiryou"] });
+    expect(ndesu).toHaveLength(8);
+    expect(suiryou).toHaveLength(8);
+    for (const q of [...ndesu, ...suiryou]) {
+      expect(q.options, q.id).toHaveLength(4);
+      expect(new Set(q.options).size, q.id).toBe(4);
+      expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);
+      expect(q.hintZh ?? "", q.id).not.toContain(q.expectedAnswers[0]);
+      const overlay = sentencePatternI18n[q.id];
+      expect(overlay?.hintI18n?.ja && overlay?.hintI18n?.en, q.id).toBeTruthy();
+      expect(
+        overlay?.explanationI18n?.ja && overlay?.explanationI18n?.en,
+        q.id
+      ).toBeTruthy();
+    }
+  });
+
   it("the two N5 chapters sit in the N5 文法 category with pattern completion", () => {
     const byId = (id: string) => learningBlocks.find((b) => b.id === id)!;
     expect(byId("n5-sonzai").category).toBe("N5 文法");

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -214,6 +214,8 @@ export type Copy = {
   drillPatternN5Keiyoushi: string;
   drillPatternN5Josuushi: string;
   drillPatternN5Teido: string;
+  drillPatternN4Ndesu: string;
+  drillPatternN4Suiryou: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -231,6 +231,8 @@ export const en: Copy = {
   drillPatternN5Keiyoushi: "Drill adjective linking",
   drillPatternN5Josuushi: "Drill counters",
   drillPatternN5Teido: "Drill degree + frequency",
+  drillPatternN4Ndesu: "Drill explanatory んです",
+  drillPatternN4Suiryou: "Drill conjecture + causal て",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -231,6 +231,8 @@ export const id: Copy = {
   drillPatternN5Keiyoushi: "Latih penghubungan adjektiva",
   drillPatternN5Josuushi: "Latih kata bantu bilangan",
   drillPatternN5Teido: "Latih derajat + frekuensi",
+  drillPatternN4Ndesu: "Latih nada penjelasan んです",
+  drillPatternN4Suiryou: "Latih dugaan + sebab",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -239,6 +239,8 @@ export const ja: Copy = {
   drillPatternN5Keiyoushi: "形容詞の接続と変化を練習",
   drillPatternN5Josuushi: "助数詞を練習",
   drillPatternN5Teido: "程度と頻度を練習",
+  drillPatternN4Ndesu: "説明の「んです」を練習",
+  drillPatternN4Suiryou: "推量と理由の て を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -231,6 +231,8 @@ export const ko: Copy = {
   drillPatternN5Keiyoushi: "형용사 연결과 변화 연습",
   drillPatternN5Josuushi: "조수사 연습",
   drillPatternN5Teido: "정도와 빈도 연습",
+  drillPatternN4Ndesu: "설명의 んです 연습",
+  drillPatternN4Suiryou: "추량과 원인 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -231,6 +231,8 @@ export const my: Copy = {
   drillPatternN5Keiyoushi: "နာမဝိသေသန ဆက်စပ်မှု လေ့ကျင့်ရန်",
   drillPatternN5Josuushi: "အရေအတွက်စကားလုံး လေ့ကျင့်ရန်",
   drillPatternN5Teido: "အတိုင်းအတာနှင့် ကြိမ်နှုန်း လေ့ကျင့်ရန်",
+  drillPatternN4Ndesu: "ရှင်းလင်းချက် んです လေ့ကျင့်ရန်",
+  drillPatternN4Suiryou: "ခန့်မှန်းမှုနှင့် အကြောင်းရင်း လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -232,6 +232,8 @@ export const th: Copy = {
   drillPatternN5Keiyoushi: "ฝึกการเชื่อมคำคุณศัพท์",
   drillPatternN5Josuushi: "ฝึกลักษณนาม",
   drillPatternN5Teido: "ฝึกระดับและความถี่",
+  drillPatternN4Ndesu: "ฝึกน้ำเสียงอธิบาย んです",
+  drillPatternN4Suiryou: "ฝึกการคาดคะเนและเหตุผล",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -231,6 +231,8 @@ export const vi: Copy = {
   drillPatternN5Keiyoushi: "Luyện nối tính từ",
   drillPatternN5Josuushi: "Luyện trợ số từ",
   drillPatternN5Teido: "Luyện mức độ và tần suất",
+  drillPatternN4Ndesu: "Luyện ngữ khí giải thích んです",
+  drillPatternN4Suiryou: "Luyện suy đoán và nguyên nhân",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -231,6 +231,8 @@ export const zhHant: Copy = {
   drillPatternN5Keiyoushi: "練形容詞連接與變化",
   drillPatternN5Josuushi: "練助数詞",
   drillPatternN5Teido: "練程度與頻度",
+  drillPatternN4Ndesu: "練說明語氣 〜んです",
+  drillPatternN4Suiryou: "練推量與原因",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- **N4 系列開篇**，句型總數 166→182：
  - **n4-ndesu** 說明語氣：どうしたんですか（求說明）／〜んです（答緣由）／なんですが（鋪墊）——動詞普通形・名詞な・過去だった・辭書形四種接續各有專題
  - **n4-suiryou** 推量與原因：かもしれない／だろう／でしょう 裸接三連發（だ 全去掉、對照んです要な）＋て/なくて 原因
- 學習 tab 新分類「**N4 文法**」（38 章 total）；N4 deck 起改用漢字表記
- starterPatterns.test 新增 N4 斷言組（8 題/唯一解/overlay 齊全；不驗 kana-only）

## 設計要點
- **んです/です 處處可換的雷**：所有題目讓空格跟在普通形（した/行く/ある/だった/な）之後——です・ます・でした 接續必死，唯一能接的就是んです
- **かも/でしょう 確信度雙解雷**：兩者永不同場競爭；かも 題用純形誤干擾（かしれません 等）
- ないで 不進 なくて 題（口語 ないで＋狀態讀法存活）

## 品質閘
- 兩鏡頭對抗審：11 findings 全採納 —— だろう 接續存活（高）、終わりなくて「沒完沒了」讀法（中）、「只有〜接得上」三處絕對化（被推量章自打臉）、だった 保留但書、6 個 N4 新詞 gloss、正字法統一
- codex 終審：1 finding 採納 —— 聞かなくて 靠 hint 鎖 → 換「聞いで」純形誤（順帶教 く/ぐ 音便）
- `pnpm test` 879 全綠；build 綠；preview 實機驗證（N4 分類、兩章、drill、gloss）

Closes #549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new N4 grammar study blocks and drill sets for explanatory “んです” and conjecture/reasoning patterns.
  * Expanded multilingual guidance and prompts for these new practice items across supported languages.
* **Bug Fixes**
  * Updated block and content counts to reflect the newly added learning materials.
* **Tests**
  * Adjusted and added tests to validate the new N4 drills and updated totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->