### PR TITLE
feat: N4 文法章 打算決定＋命令禁止（#550）

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 182,
+  patternChecks: 198,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -860,6 +860,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n4-ishi": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Intention & Decision: つもり・ことにする",
+      "explanation":
+        "Three ways to say \"I plan to\", differing in strength and setting: volitional + と思っています = declaring an intention right now (やめようと思っています); 「〜つもりだ」 = a plan you hold — its negative goes on the verb (買わないつもり), and someone else's plan is reported as つもりらしい; 「〜予定だ」 = a schedule — inanimate things (planes, meetings) can only take 予定, since つもり needs a willful agent. The decision pair: you decide = 「〜ことにする」, someone/something else decides = 「〜ことになる」; a decision you keep observing = 「〜ことにしている」.",
+      "notes": [
+        "Intention: volitional + と思う",
+        "つもり and its negative",
+        "Schedules: inanimate → 予定",
+        "ことにする vs ことになる",
+        "ことにしている = standing rule"
+      ],
+      "pitfalls": [
+        "Group-2 volitional = stem + よう (やめよう); ろう belongs to group-1 る-verbs (帰ろう)",
+        "つもり is a noun and never conjugates; someone else's plan = つもりらしい (volitionals can't take らしい)",
+        "ことにする (you) / ことになる (the outside) — ask who made the call"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "意志と決定 つもり・ことにする",
+      "explanation":
+        "「〜するつもり」の言い分け三つ：意向形＋と思っています＝いまの意志表明（やめようと思っています）；「〜つもりだ」＝抱えている予定で、否定は前の動詞に付く（買わないつもり）。他人の予定は つもりらしい で伝える。「〜予定だ」＝スケジュール——無生物（飛行機・会議）は 予定 しか使えない（つもり は意志の主体が要る）。決定のペア：自分で決める＝「〜ことにする」、外から決まる＝「〜ことになる」；決めて続けている＝「〜ことにしている」。",
+      "notes": [
+        "意志：意向形＋と思う",
+        "つもり とその否定",
+        "スケジュール：無生物は 予定",
+        "ことにする vs ことになる",
+        "ことにしている＝自分ルール"
+      ],
+      "pitfalls": [
+        "二類の意向形＝語幹＋よう（やめよう）。ろう は一類る動詞のもの（帰ろう）",
+        "つもり は名詞で活用しない。他人の予定＝つもりらしい（意向形に らしい は付かない）",
+        "ことにする（自分）／ことになる（外部）——決めたのは誰か"
+      ]
+    }
+  },
+  "n4-meirei": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Commands & Prohibition: しろ・するな",
+      "explanation":
+        "The command ladder, blunt to soft: the imperative (group 1 = final vowel to え: 走れ; group 2 = stem + ろ: 逃げろ; する→しろ, 来る→こい) → 「〜なさい」 (ます-stem + なさい, the parent/teacher register) → て-form requests (from N5). Prohibition = dictionary form + な (捨てるな). Colloquial obligation contractions: 「〜なきゃ」 (= なければ) and 「〜なくちゃ」 (= なくては). Relayed orders use 「〜ように言う」. You rarely bark imperatives yourself, but signs (止まれ), emergencies (逃げろ), and quotations (しろと言われた) all run on them.",
+      "notes": [
+        "Imperative: group-2 ろ, group-1 え row",
+        "Prohibition: dictionary form + な",
+        "Soft command: ます-stem + なさい",
+        "なきゃ / なくちゃ contractions",
+        "Relayed order: ように言う"
+      ],
+      "pitfalls": [
+        "なさい takes the ます-stem (しなさい); dictionary form + なさい (×するなさい) is no sentence",
+        "な has two faces: dictionary form + な = don't (行くな); ます-stem + な = go on (行きな) — opposites",
+        "する's imperative is しろ (written tests use the literary せよ)"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "命令と禁止 しろ・するな",
+      "explanation":
+        "命令のはしご（強→柔）：命令形（一類＝語尾え段：走れ；二類＝語幹＋ろ：逃げろ；する→しろ、来る→こい）→「〜なさい」（ます形の語幹＋なさい。親や先生の口調）→ て形の依頼（N5）。禁止＝辞書形＋な（捨てるな）。口語の義務の縮約：「〜なきゃ」（＝なければ）と「〜なくちゃ」（＝なくては）。指示の伝達は「〜ように言う」。命令形を自分で使う場面は少ないが、標識（止まれ）・緊急（逃げろ）・引用（しろと言われた）はみなこれ。",
+      "notes": [
+        "命令形：二類ろ・一類え段",
+        "禁止：辞書形＋な",
+        "柔らかい命令：〜なさい",
+        "なきゃ／なくちゃ",
+        "伝達：ように言う"
+      ],
+      "pitfalls": [
+        "なさい は ます形の語幹に付く（しなさい）。辞書形＋なさい（×するなさい）は文にならない",
+        "な の二つの顔：辞書形＋な＝禁止（行くな）、ます語幹＋な＝促し（行きな）——正反対",
+        "する の命令形は しろ（書面の指示では文語の せよ）"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 2 N4 grammar (#549) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 4 N4 grammar (#549/#550) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(38);
+    expect(trackable.length).toBe(40);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -656,6 +656,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n4-ndesu"]
   },
   {
+    id: "n4-ishi",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "打算與決定 つもり・ことにする",
+    subtitle: "行こうと思っています／行くことにしました",
+    explanation:
+      "「打算」的三個說法，強度與場合不同：「意向形＋と思っています」＝當下的意志表明（やめようと思っています）；「〜つもりだ」＝抱著的打算，否定放前面（買わないつもり），轉述別人用つもりらしい；「〜予定だ」＝排程——無生物（飛機、會議）只能用予定，つもり要有意志的人。決定一對：自己拍板＝「〜ことにする」、別人／組織拍板＝「〜ことになる」；決定後持續遵守＝「〜ことにしている」。",
+    examples: [
+      { formula: "たばこをやめようと思っています", note: "意志：意向形＋と思う" },
+      { formula: "日本で働くつもりです／買わないつもりです", note: "打算與其否定" },
+      { formula: "飛行機は出発する予定です", note: "排程：無生物用予定" },
+      { formula: "走ることにしました／転勤することになりました", note: "自己決定 vs 外部決定" },
+      { formula: "食べないことにしています", note: "決定並持續" }
+    ],
+    pitfalls: [
+      "二類動詞的意向形＝語幹＋よう（やめよう）；ろう是一類る動詞的（帰ろう）",
+      "つもり是名詞不會活用；別人的打算＝つもりらしい（意向形不能接らしい）",
+      "ことにする（自己）／ことになる（外部）——主語是誰拍的板"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Ishi", patternIds: ["n4-ishi"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-suiryou"]
+  },
+  {
+    id: "n4-meirei",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "命令與禁止 しろ・するな",
+    subtitle: "早く逃げろ！／ここに捨てるな",
+    explanation:
+      "命令的階梯，從粗到軟：命令形（一類＝語尾え段：走れ；二類＝語幹＋ろ：逃げろ；する→しろ、来る→こい）→「〜なさい」（ます形語幹＋なさい，家長老師的口吻）→ て形請求（N5 教過）。禁止＝辭書形＋な（捨てるな）。口語義務縮約：「〜なきゃ」（＝なければ）與「〜なくちゃ」（＝なくては）。轉述指示用「〜ように言う」（医者にやめるように言われた）。命令形本人少用，但告示（止まれ）、緊急（逃げろ）、引用（しろと言われた）都靠它。",
+    examples: [
+      { formula: "早く逃げろ！／もっと速く走れ！", note: "命令形：二類ろ、一類え段" },
+      { formula: "ここにごみを捨てるな", note: "禁止：辭書形＋な" },
+      { formula: "早く宿題をしなさい", note: "溫和命令：ます形語幹＋なさい" },
+      { formula: "帰らなきゃ／帰らなくちゃ", note: "口語義務縮約" },
+      { formula: "やめるように言いました", note: "間接命令：ように言う" }
+    ],
+    pitfalls: [
+      "なさい接ます形語幹（しなさい）；接辭書形（×するなさい）不成句",
+      "な兩張臉：辭書形＋な＝禁止（行くな）；ます語幹＋な＝催促（行きな）——完全相反",
+      "する的命令形＝しろ（書面測驗會看到文語せよ）"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Meirei", patternIds: ["n4-meirei"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-ishi"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -1303,6 +1303,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "原因の否定をもう一度：食べない→食べなくて。「食べなくで」「食べずて」「食べないくて」はどれも存在しない形——公式は「ない の い を取って くて」。"
     }
   },
+  "pattern-n4-ishi-001": {
+    "hintI18n": { "en": "This is the year you quit smoking.", "ja": "今年こそ禁煙、という決意。" },
+    "promptContextI18n": { "en": "\"This year I'm going to quit smoking (that's my intention).\"", "ja": "「今年こそ、たばこをやめようと思っています。」" },
+    "explanationI18n": {
+      "en": "Declaring an intention uses the volitional + と思っています: やめようと思っています. やめる is group 2, so the volitional is stem + よう (やめよう); 「やめろう」 wrongly imports the group-1 る-verb pattern (帰る→帰ろう) — group 1 shifts the final vowel to the お row + う; 「やめしょう」「やめるう」 don't exist. ※たばこをやめる = to quit smoking.",
+      "ja": "意志の表明は意向形＋と思っています：やめようと思っています。やめる は二類なので意向形は語幹＋よう。「やめろう」は一類る動詞（帰る→帰ろう）のやり方の誤用——一類は語尾をお段＋う。「やめしょう」「やめるう」は存在しない。"
+    }
+  },
+  "pattern-n4-ishi-002": {
+    "hintI18n": { "en": "Next year's work plans.", "ja": "来年の仕事の予定を語る。" },
+    "promptContextI18n": { "en": "\"I plan to work in Japan next year.\"", "ja": "「来年、日本で働くつもりです。」" },
+    "explanationI18n": {
+      "en": "Plans use dictionary form + 「つもりだ」: 働くつもりです. つもり is a noun and never conjugates — 「つもる (積もる)」 is a different verb (snow piles up), and 「つもれ」「つもら」 treat it as a verb; none makes a sentence here. ※働く = to work.",
+      "ja": "つもりは「辞書形＋つもりだ」：働くつもりです。つもり は名詞で活用しない——「つもる（積もる）」は別の動詞、「つもれ」「つもら」は動詞扱いした崩れ形で、どれも文にならない。"
+    }
+  },
+  "pattern-n4-ishi-003": {
+    "hintI18n": { "en": "No car purchase this year — that's the plan.", "ja": "今年は車を買わない、という自分の予定。" },
+    "promptContextI18n": { "en": "\"I don't plan to buy a car this year.\"", "ja": "「今年は車を買わないつもりです。」" },
+    "explanationI18n": {
+      "en": "\"Plan NOT to\" = ない form + つもり: 買わないつもりです — the negation rides on the verb. 「もり」 is no word; 「ためです」 states a purpose and 「ほうです」 a general tendency — neither matches stating this year's plan. Only つもり fits.",
+      "ja": "「しないつもり」＝ない形＋つもり：買わないつもりです——否定は前の動詞に付ける。「もり」は語にならない。「ためです」は目的、「ほうです」は普段の傾向で、「今年の自分の予定を述べる」場面に合わない——ここは つもり だけ。"
+    }
+  },
+  "pattern-n4-ishi-004": {
+    "hintI18n": { "en": "A new habit you committed to.", "ja": "自分で決めた新しい習慣。" },
+    "promptContextI18n": { "en": "\"For my health, I decided to run every morning.\"", "ja": "「健康のために、毎朝走ることにしました。」" },
+    "explanationI18n": {
+      "en": "A decision you make yourself uses 「〜ことにする」: 走ることにしました. 「ものに」「ところに」「ぶりに」 can't express a decision. Note: 「ようにする」 (make an effort to) is a different pattern. ※健康 = health.",
+      "ja": "自分の決定は「〜ことにする」：走ることにしました。「ものに」「ところに」「ぶりに」では決定の意味が出ない。なお「ようにする」（努力する）は別の文型。"
+    }
+  },
+  "pattern-n4-ishi-005": {
+    "hintI18n": { "en": "The company's staffing announcement.", "ja": "会社が発表した人事。" },
+    "promptContextI18n": { "en": "\"(The company decided) I'm transferring to Osaka next month.\"", "ja": "「来月から、大阪に転勤することになりました。」" },
+    "explanationI18n": {
+      "en": "Decisions made by the outside (company, rules, others) use 「〜ことになる」: 転勤することになりました — I'm not choosing to transfer; it was arranged. Contrast with 004: you decide = ことにする, they decide = ことになる. 「ものに」「ままに」「とおりに」 don't attach. ※転勤 = job transfer.",
+      "ja": "外部（会社・規則・他人）の決定は「〜ことになる」：転勤することになりました——自分の意志ではなく決められた。004 と対照：自分＝ことにする、外部＝ことになる。「ものに」「ままに」「とおりに」はつながらない。"
+    }
+  },
+  "pattern-n4-ishi-006": {
+    "hintI18n": { "en": "Reading out the flight information.", "ja": "フライト情報を読み上げる。" },
+    "promptContextI18n": { "en": "\"The plane is scheduled to depart at 3 p.m.\"", "ja": "「飛行機は午後3時に出発する予定です。」" },
+    "explanationI18n": {
+      "en": "Schedules use 「〜予定だ」: 出発する予定です. 「つもり」 needs a willful agent — a plane doesn't \"intend\" to depart; 「気持ち」「考え」 are likewise human notions and don't fit a flight announcement. ※飛行機 = airplane, 予定 = schedule, 出発 = departure.",
+      "ja": "スケジュールは「〜予定だ」：出発する予定です。「つもり」は意志の主体が要る——飛行機は自分で「つもり」を持たない。「気持ち」「考え」も人間のもので、フライト案内の場面に合わない。"
+    }
+  },
+  "pattern-n4-ishi-007": {
+    "hintI18n": { "en": "Passing along office gossip.", "ja": "聞いた人事のうわさを伝える。" },
+    "promptContextI18n": { "en": "\"I hear Tanaka intends to quit the company.\"", "ja": "「田中さんは会社をやめるつもりらしいです。」" },
+    "explanationI18n": {
+      "en": "Reporting someone ELSE's intention uses 「つもりらしい」: やめるつもりらしいです. 「よう」「ましょう」 are volitional/polite-hortative and 「なさい」 is a command — none can precede らしい; to relay another person's plan you nominalize it as つもり. ※会社をやめる = to quit one's job.",
+      "ja": "他人の意志の伝聞は「つもりらしい」：やめるつもりらしいです。「よう」「ましょう」は意向形/勧誘、「なさい」は命令で、どれも らしい には接続できない——他人の予定は つもり に名詞化してから伝える。"
+    }
+  },
+  "pattern-n4-ishi-008": {
+    "hintI18n": { "en": "A standing rule you keep for yourself.", "ja": "守り続けている自分ルール。" },
+    "promptContextI18n": { "en": "\"I've made it a rule not to eat sweets.\"", "ja": "「甘いものは食べないことにしています。」" },
+    "explanationI18n": {
+      "en": "「〜ことにしている」 = a decision you keep observing: 食べないことにしています — the idiom for personal rules. 「ことへ」「ことか」「ことの」 can't attach to している. ※甘いもの = sweets.",
+      "ja": "「〜ことにしている」＝決めてからずっと続けている：食べないことにしています——自分ルールの定番表現。「ことへ」「ことか」「ことの」は している につながらない。"
+    }
+  },
+  "pattern-n4-meirei-001": {
+    "hintI18n": { "en": "A fire — shout at everyone to get out.", "ja": "火事の現場、外へ走れと叫ぶ。" },
+    "promptContextI18n": { "en": "\"Fire! Run!\"", "ja": "「火事だ！早く逃げろ！」" },
+    "explanationI18n": {
+      "en": "The emergency imperative: group-2 verbs = stem + ろ — 逃げろ! 「逃げるな」 is a prohibition (don't run) — exactly backwards in a fire; 「逃げず」 is written \"without fleeing\" and 「逃げまい」 means \"won't / probably won't flee\" — neither is a command. ※火事 = fire, 逃げる = to flee.",
+      "ja": "緊急時の命令形：二類＝語幹＋ろ——逃げろ！「逃げるな」は禁止で火事の場面では正反対。「逃げず」は書き言葉の「逃げないで」、「逃げまい」は「逃げないつもり/逃げないだろう」——どちらも命令ではない。"
+    }
+  },
+  "pattern-n4-meirei-002": {
+    "hintI18n": { "en": "The coach barking at the team.", "ja": "コーチが選手に飛ばす一声。" },
+    "promptContextI18n": { "en": "Coach: \"Run faster!\"", "ja": "コーチ：「もっと速く走れ！」" },
+    "explanationI18n": {
+      "en": "Group-1 (godan) imperative = final vowel to the え row: 走る → 走れ. 「走りろ」 wrongly imports the group-2 ろ; 「走るれ」「走りれ」 don't exist. Contrast: only group 2 takes ろ (逃げろ, 食べろ). ※コーチ = coach.",
+      "ja": "一類（五段）の命令形＝語尾をえ段に：走る→走れ。「走りろ」は二類の ろ の誤用。「走るれ」「走りれ」は存在しない。対照：ろ を使うのは二類だけ（逃げろ、食べろ）。"
+    }
+  },
+  "pattern-n4-meirei-003": {
+    "hintI18n": { "en": "The rule on the park signboard.", "ja": "公園の看板の決まり文句。" },
+    "promptContextI18n": { "en": "(Park sign) \"No dumping.\"", "ja": "（公園の看板）「ここにごみを捨てるな。」" },
+    "explanationI18n": {
+      "en": "Prohibition = dictionary form + な: 捨てるな = don't dump. 「捨てるれ」「捨てりれ」 don't exist; 「なさい」 takes the ます-stem (捨てなさい) — dictionary form + なさい (捨てるなさい) is no sentence. ※看板 = signboard, 捨てる = to throw away.",
+      "ja": "禁止形＝辞書形＋な：捨てるな。「捨てるれ」「捨てりれ」は存在しない。「なさい」は ます形の語幹に付く（捨てなさい）——辞書形＋なさい（捨てるなさい）は文にならない。"
+    }
+  },
+  "pattern-n4-meirei-004": {
+    "hintI18n": { "en": "Mom hurrying the kid along.", "ja": "母親が子どもをせかす。" },
+    "promptContextI18n": { "en": "Mom: \"Go do your homework.\"", "ja": "お母さん：「早く宿題をしなさい。」" },
+    "explanationI18n": {
+      "en": "The gentle command is ます-stem + なさい: します → し + なさい = しなさい. 「するなさい」「しるなさい」「したなさい」 all attach wrongly — only the ます-stem goes before なさい. The standard parent-to-child / teacher-to-student register.",
+      "ja": "柔らかい命令は「ます形の語幹＋なさい」：します→し＋なさい。「するなさい」「しるなさい」「したなさい」はどれも接続が誤り——なさい の前は ます形の語幹だけ。親→子、先生→生徒の定番の口調。"
+    }
+  },
+  "pattern-n4-meirei-005": {
+    "hintI18n": { "en": "Late-night self-talk: time to go.", "ja": "夜遅く、そろそろ帰らないと、という独り言。" },
+    "promptContextI18n": { "en": "\"It's late — I've got to get home.\"", "ja": "「もう遅い。早く帰らなきゃ。」" },
+    "explanationI18n": {
+      "en": "The colloquial obligation contraction 「〜なきゃ」 = なければ(ならない): 帰らなきゃ = gotta go home. 「ないきゃ」「なちゃ」「なけば」 are all broken forms. Its sibling is 「なくちゃ」 (= なくては) — both are common; learn them as a pair.",
+      "ja": "口語の義務の縮約「〜なきゃ」＝なければ（ならない）：帰らなきゃ。「ないきゃ」「なちゃ」「なけば」は崩れた偽形。相方は「なくちゃ」（＝なくては）——どちらもよく使うのでペアで覚える。"
+    }
+  },
+  "pattern-n4-meirei-006": {
+    "hintI18n": { "en": "The doctor's instruction to your father.", "ja": "医者が父に出した指示。" },
+    "promptContextI18n": { "en": "\"The doctor told my father to quit drinking.\"", "ja": "「医者は父にお酒をやめるように言いました。」" },
+    "explanationI18n": {
+      "en": "Relaying an order or instruction uses 「〜ように言う」: やめるように言いました = (the doctor) told (him) to quit. 「ままに」「とおりに」「ばかりに」 can't express an instruction. ※医者 = doctor.",
+      "ja": "指示の伝達は「〜ように言う」：やめるように言いました。「ままに」「とおりに」「ばかりに」では指示の意味が出ない。"
+    }
+  },
+  "pattern-n4-meirei-007": {
+    "hintI18n": { "en": "What your senpai snapped at you.", "ja": "先輩に言われた一言。" },
+    "promptContextI18n": { "en": "\"My senpai told me: 'Practice more!'\"", "ja": "「先輩に『もっと練習しろ』と言われました。」" },
+    "explanationI18n": {
+      "en": "する's imperative is しろ: 練習しろ! 「しりろ」「すろ」「さろ」 don't exist — する is irregular, so its imperative is memorized (spoken しろ; written test instructions use the literary せよ; some dialects have せえ). ※先輩 = senior.",
+      "ja": "する の命令形は しろ：練習しろ！「しりろ」「すろ」「さろ」は存在しない——する は不規則動詞で、命令形は暗記（口語 しろ、書面の指示は文語 せよ、方言には せえ も）。"
+    }
+  },
+  "pattern-n4-meirei-008": {
+    "hintI18n": { "en": "The red inverted-triangle sign at the intersection.", "ja": "交差点の赤い逆三角形の標識の文字。" },
+    "promptContextI18n": { "en": "(Road sign) \"Stop.\"", "ja": "（道路標識）「止まれ。」" },
+    "explanationI18n": {
+      "en": "Road signs use the imperative: 止まれ = stop (group 1, final vowel to え). Japan's stop sign is a red inverted triangle whose Japanese text reads 止まれ (newer signs add STOP in English). 「止まるな」 prohibits stopping — no intersection sign says that; 「止まりろ」「止まるれ」 don't exist. ※道路標識 = road sign.",
+      "ja": "道路標識は命令形：止まれ（一類・語尾え段）。日本の一時停止標識は赤い逆三角形で、日本語表記は「止まれ」（新しい標識には STOP が併記される）。「止まるな」は停止の禁止で、交差点の標識にはあり得ない。「止まりろ」「止まるれ」は存在しない。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -19,6 +19,8 @@ export type SentencePatternId =
   | "n5-teido"
   | "n4-ndesu"
   | "n4-suiryou"
+  | "n4-ishi"
+  | "n4-meirei"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -63,6 +65,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n5-teido": "程度與頻度 あまり・よく",
   "n4-ndesu": "說明語氣 〜んです",
   "n4-suiryou": "推量與原因 かもしれない・て",
+  "n4-ishi": "打算與決定 つもり・ことにする",
+  "n4-meirei": "命令與禁止 しろ・するな",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -1553,6 +1557,206 @@ const N4_SUIRYOU_ITEMS: SentencePatternItem[] = [
 ];
 
 // ===========================================================================
+// N4 pattern: n4-ishi -- intention and decision (#550).
+//   つもり / 予定 / （よ）うと思う are meaning-adjacent, so they never
+//   compete: the 予定 item uses an inanimate subject (planes have schedules,
+//   not intentions), the third-person item locks via らしい attachment
+//   (volitional+らしい is dead), and the volitional item uses junk
+//   conjugations only. ようにする/ようになる never appear as foils where
+//   ことにする/ことになる is the answer (both are real patterns); plain
+//   行く/たい never compete with 行こう before と思う (both parse).
+// ===========================================================================
+const N4_ISHI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-ishi-001",
+    patternId: "n4-ishi",
+    promptText: "今年こそ、たばこを___と思っています。",
+    hintZh: "下定決心戒菸。",
+    promptContextZh: "「今年一定要戒菸（我是這麼打算的）。」",
+    expectedAnswer: "やめよう",
+    options: ["やめよう", "やめろう", "やめしょう", "やめるう"],
+    explanation:
+      "意志的表明用「意向形＋と思っています」：やめようと思っています＝打算戒。やめる是二類動詞，意向形＝語幹＋よう（やめよう）；「やめろう」是把一類る動詞的變法（帰る→帰ろう）錯搬到二類——一類的意向形是語尾變お段＋う；「やめしょう」「やめるう」都不存在。※たばこをやめる＝戒菸。"
+  },
+  {
+    id: "pattern-n4-ishi-002",
+    patternId: "n4-ishi",
+    promptText: "来年、日本で働く___です。",
+    hintZh: "說明年的工作打算。",
+    promptContextZh: "「我打算明年在日本工作。」",
+    expectedAnswer: "つもり",
+    options: ["つもり", "つもる", "つもれ", "つもら"],
+    explanation:
+      "打算用「辭書形＋つもりだ」：働くつもりです。つもり是名詞、不會活用——「つもる（積もる）」是另一個動詞（雪が積もる），「つもれ」「つもら」是把它當動詞硬變出來的形，放這裡都不成句。※働く＝工作。"
+  },
+  {
+    id: "pattern-n4-ishi-003",
+    patternId: "n4-ishi",
+    promptText: "今年は車を買わない___です。",
+    hintZh: "說自己今年不買車的打算。",
+    promptContextZh: "「今年我打算不買車。」",
+    expectedAnswer: "つもり",
+    options: ["つもり", "もり", "ため", "ほう"],
+    explanation:
+      "「不做〜的打算」＝ない形＋つもり：買わないつもりです——打算的否定放在前面的動詞上。「もり」不成詞；「ためです」是說目的、「ほうです」是說平常的傾向，都跟「陳述自己今年的打算」對不上——這裡只有つもり成立。"
+  },
+  {
+    id: "pattern-n4-ishi-004",
+    patternId: "n4-ishi",
+    promptText: "健康のために、毎朝走る___しました。",
+    hintZh: "自己拍板的新習慣。",
+    promptContextZh: "「為了健康，我決定每天早上跑步。」",
+    expectedAnswer: "ことに",
+    options: ["ことに", "ものに", "ところに", "ぶりに"],
+    explanation:
+      "自己決定用「〜ことにする」：走ることにしました＝我決定要跑。「ものに」「ところに」「ぶりに」都接不出決定的意思。順帶一提：「ようにする」是「努力做到」，是另一個句型。※健康＝健康。"
+  },
+  {
+    id: "pattern-n4-ishi-005",
+    patternId: "n4-ishi",
+    promptText: "来月から、大阪に転勤する___なりました。",
+    hintZh: "公司宣布的人事安排。",
+    promptContextZh: "「（公司決定）下個月起我調職到大阪。」",
+    expectedAnswer: "ことに",
+    options: ["ことに", "ものに", "ままに", "とおりに"],
+    explanation:
+      "外部決定（公司、規定、別人）用「〜ことになる」：転勤することになりました——不是我要調，是被安排調。跟004對照：自己拍板＝ことにする、別人拍板＝ことになる。「ものに」「ままに」「とおりに」都接不上。※転勤＝調職。"
+  },
+  {
+    id: "pattern-n4-ishi-006",
+    patternId: "n4-ishi",
+    promptText: "飛行機は午後3時に出発する___です。",
+    hintZh: "唸出航班資訊。",
+    promptContextZh: "「飛機預定下午三點起飛。」",
+    expectedAnswer: "予定",
+    options: ["予定", "つもり", "気持ち", "考え"],
+    explanation:
+      "排程用「〜予定だ」：出発する予定です。「つもり」需要有意志的主體——飛機自己不會「打算」起飛；「気持ち」「考え」同樣是人才有的，都跟航班播報的語境對不上。※飛行機＝飛機、予定＝預定、出発＝出發。"
+  },
+  {
+    id: "pattern-n4-ishi-007",
+    patternId: "n4-ishi",
+    promptText: "田中さんは会社をやめる___らしいです。",
+    hintZh: "轉述聽來的人事消息。",
+    promptContextZh: "「聽說田中打算辭職。」",
+    expectedAnswer: "つもり",
+    options: ["つもり", "よう", "ましょう", "なさい"],
+    explanation:
+      "轉述「別人的打算」用「つもりらしい」：やめるつもりらしいです。「よう」「ましょう」是意向形/敬體勸誘、「なさい」是命令——三者都不能直接接らしい；要轉述別人的打算，得先名詞化成つもり。※会社をやめる＝辭職。"
+  },
+  {
+    id: "pattern-n4-ishi-008",
+    patternId: "n4-ishi",
+    promptText: "甘いものは食べない___しています。",
+    hintZh: "說一條持續遵守的自我規定。",
+    promptContextZh: "「我（決定並持續）不吃甜食。」",
+    expectedAnswer: "ことに",
+    options: ["ことに", "ことへ", "ことか", "ことの"],
+    explanation:
+      "「〜ことにしている」＝決定之後一直維持著：食べないことにしています——自我規定的慣用說法。「ことへ」「ことか」「ことの」都接不上している。※甘いもの＝甜食。"
+  }
+];
+
+// ===========================================================================
+// N4 pattern: n4-meirei -- commands and prohibitions (#550).
+//   Command items never offer て-form or the な-contraction (帰りな) as
+//   foils -- both are real softened commands; ないと/なくちゃ never compete
+//   with なきゃ (all real). Foils are junk conjugations (走りろ, しれ) or
+//   direction-killed by an explicit scene (STOP sign, fire escape). せよ
+//   (literary する command) stays out of options; explanations mention it.
+// ===========================================================================
+const N4_MEIREI_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-meirei-001",
+    patternId: "n4-meirei",
+    promptText: "火事だ！早く___！",
+    hintZh: "火警現場的呼喊，要大家往外跑。",
+    promptContextZh: "「失火了！快逃！」",
+    expectedAnswer: "逃げろ",
+    options: ["逃げろ", "逃げるな", "逃げず", "逃げまい"],
+    explanation:
+      "緊急時的命令形：二類動詞＝語幹＋ろ——逃げろ！「逃げるな」是禁止（別逃），火場裡方向完全相反；「逃げず」是書面的「不逃（而）」、「逃げまい」是「不打算逃/大概不會逃」——都不是命令。※火事＝火災、逃げる＝逃跑。"
+  },
+  {
+    id: "pattern-n4-meirei-002",
+    patternId: "n4-meirei",
+    promptText: "コーチ：「もっと速く___！」",
+    hintZh: "教練對隊員吼的一聲。",
+    promptContextZh: "教練：「跑快一點！」",
+    expectedAnswer: "走れ",
+    options: ["走れ", "走りろ", "走るれ", "走りれ"],
+    explanation:
+      "一類（五段）動詞的命令形＝語尾變え段：走る→走れ。「走りろ」是把二類的ろ錯搬到一類；「走るれ」「走りれ」都不是存在的形。對照：二類才用ろ（逃げろ、食べろ）。※コーチ＝教練。"
+  },
+  {
+    id: "pattern-n4-meirei-003",
+    patternId: "n4-meirei",
+    promptText: "（公園の看板）ここにごみを___。",
+    hintZh: "公園告示牌上的規定。",
+    promptContextZh: "（公園告示）「請勿在此丟垃圾。」",
+    expectedAnswer: "捨てるな",
+    options: ["捨てるな", "捨てるれ", "捨てりれ", "捨てるなさい"],
+    explanation:
+      "禁止形＝辭書形＋な：捨てるな＝不准丟。「捨てるれ」「捨てりれ」都不是存在的形；「なさい」要接ます形語幹（捨てなさい），接辭書形的「捨てるなさい」不成句。※看板＝告示牌、捨てる＝丟棄。"
+  },
+  {
+    id: "pattern-n4-meirei-004",
+    patternId: "n4-meirei",
+    promptText: "お母さん：「早く宿題を___。」",
+    hintZh: "媽媽催小孩做功課。",
+    promptContextZh: "媽媽：「快去寫功課。」",
+    expectedAnswer: "しなさい",
+    options: ["しなさい", "するなさい", "しるなさい", "したなさい"],
+    explanation:
+      "溫和的命令用「ます形語幹＋なさい」：します→し＋なさい＝しなさい。「するなさい」「しるなさい」「したなさい」都接錯了——なさい前面只能放ます形語幹。家長對小孩、老師對學生的標準口吻。"
+  },
+  {
+    id: "pattern-n4-meirei-005",
+    patternId: "n4-meirei",
+    promptText: "もう遅い。早く帰ら___。",
+    hintZh: "深夜自言自語，該走了。",
+    promptContextZh: "「好晚了，（我）得快點回家。」",
+    expectedAnswer: "なきゃ",
+    options: ["なきゃ", "ないきゃ", "なちゃ", "なけば"],
+    explanation:
+      "口語的義務縮約「〜なきゃ」＝なければ（ならない）：帰らなきゃ＝不回不行。「ないきゃ」「なちゃ」「なけば」都是拼壞的形。同義的還有「なくちゃ」（＝なくては）——兩個都常用，成對記。"
+  },
+  {
+    id: "pattern-n4-meirei-006",
+    patternId: "n4-meirei",
+    promptText: "医者は父にお酒をやめる___言いました。",
+    hintZh: "醫生交代父親的事。",
+    promptContextZh: "「醫生要父親戒酒。」",
+    expectedAnswer: "ように",
+    options: ["ように", "ままに", "とおりに", "ばかりに"],
+    explanation:
+      "間接命令、轉述指示用「〜ように言う」：やめるように言いました＝（醫生）要（父親）戒。「ままに」「とおりに」「ばかりに」都接不出指示的意思。※医者＝醫生。"
+  },
+  {
+    id: "pattern-n4-meirei-007",
+    patternId: "n4-meirei",
+    promptText: "先輩に「もっと練習___」と言われました。",
+    hintZh: "被學長訓了一句。",
+    promptContextZh: "「被學長說『多練習！』。」",
+    expectedAnswer: "しろ",
+    options: ["しろ", "しりろ", "すろ", "さろ"],
+    explanation:
+      "する的命令形＝しろ：練習しろ！「しりろ」「すろ」「さろ」都不是存在的形——する是不規則動詞，命令形只能背（口語しろ；書面測驗指示會看到文語的せよ；部分方言另有せえ）。※先輩＝學長姐。"
+  },
+  {
+    id: "pattern-n4-meirei-008",
+    patternId: "n4-meirei",
+    promptText: "（道路標識）___。",
+    hintZh: "路口要求一時停止的紅色倒三角形標誌上寫的字。",
+    promptContextZh: "（道路標誌）「停。」",
+    expectedAnswer: "止まれ",
+    options: ["止まれ", "止まるな", "止まりろ", "止まるれ"],
+    explanation:
+      "道路標誌用命令形：止まれ＝停（一類動詞、語尾え段）。日本的一時停止標誌是紅色倒三角形、日文寫「止まれ」（新版會併記英文STOP）。「止まるな」是禁止——叫車不准停，路口標誌不會這樣寫；「止まりろ」「止まるれ」都不是存在的形。※道路標識＝道路標誌。"
+  }
+];
+
+// ===========================================================================
 // Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
 //   Absolute-beginner floor: kana-only sentences built from the starter
 //   vocabulary deck. Unique solutions are locked by IN-SENTENCE anchors
@@ -2412,6 +2616,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N5_TEIDO_ITEMS,
   ...N4_NDESU_ITEMS,
   ...N4_SUIRYOU_ITEMS,
+  ...N4_ISHI_ITEMS,
+  ...N4_MEIREI_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -103,9 +103,13 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     // N4 decks use kanji-mixed orthography, so no kana-only assertion here.
     const ndesu = buildSentencePatternPool({ patternIds: ["n4-ndesu"] });
     const suiryou = buildSentencePatternPool({ patternIds: ["n4-suiryou"] });
+    const ishi = buildSentencePatternPool({ patternIds: ["n4-ishi"] });
+    const meirei = buildSentencePatternPool({ patternIds: ["n4-meirei"] });
     expect(ndesu).toHaveLength(8);
     expect(suiryou).toHaveLength(8);
-    for (const q of [...ndesu, ...suiryou]) {
+    expect(ishi).toHaveLength(8);
+    expect(meirei).toHaveLength(8);
+    for (const q of [...ndesu, ...suiryou, ...ishi, ...meirei]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -216,6 +216,8 @@ export type Copy = {
   drillPatternN5Teido: string;
   drillPatternN4Ndesu: string;
   drillPatternN4Suiryou: string;
+  drillPatternN4Ishi: string;
+  drillPatternN4Meirei: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -233,6 +233,8 @@ export const en: Copy = {
   drillPatternN5Teido: "Drill degree + frequency",
   drillPatternN4Ndesu: "Drill explanatory んです",
   drillPatternN4Suiryou: "Drill conjecture + causal て",
+  drillPatternN4Ishi: "Drill intention + decision",
+  drillPatternN4Meirei: "Drill commands + prohibition",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -233,6 +233,8 @@ export const id: Copy = {
   drillPatternN5Teido: "Latih derajat + frekuensi",
   drillPatternN4Ndesu: "Latih nada penjelasan んです",
   drillPatternN4Suiryou: "Latih dugaan + sebab",
+  drillPatternN4Ishi: "Latih niat + keputusan",
+  drillPatternN4Meirei: "Latih perintah + larangan",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -241,6 +241,8 @@ export const ja: Copy = {
   drillPatternN5Teido: "程度と頻度を練習",
   drillPatternN4Ndesu: "説明の「んです」を練習",
   drillPatternN4Suiryou: "推量と理由の て を練習",
+  drillPatternN4Ishi: "意志と決定を練習",
+  drillPatternN4Meirei: "命令と禁止を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -233,6 +233,8 @@ export const ko: Copy = {
   drillPatternN5Teido: "정도와 빈도 연습",
   drillPatternN4Ndesu: "설명의 んです 연습",
   drillPatternN4Suiryou: "추량과 원인 연습",
+  drillPatternN4Ishi: "의지와 결정 연습",
+  drillPatternN4Meirei: "명령과 금지 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -233,6 +233,8 @@ export const my: Copy = {
   drillPatternN5Teido: "အတိုင်းအတာနှင့် ကြိမ်နှုန်း လေ့ကျင့်ရန်",
   drillPatternN4Ndesu: "ရှင်းလင်းချက် んです လေ့ကျင့်ရန်",
   drillPatternN4Suiryou: "ခန့်မှန်းမှုနှင့် အကြောင်းရင်း လေ့ကျင့်ရန်",
+  drillPatternN4Ishi: "ရည်ရွယ်ချက်နှင့် ဆုံးဖြတ်ချက် လေ့ကျင့်ရန်",
+  drillPatternN4Meirei: "အမိန့်နှင့် တားမြစ်ချက် လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -234,6 +234,8 @@ export const th: Copy = {
   drillPatternN5Teido: "ฝึกระดับและความถี่",
   drillPatternN4Ndesu: "ฝึกน้ำเสียงอธิบาย んです",
   drillPatternN4Suiryou: "ฝึกการคาดคะเนและเหตุผล",
+  drillPatternN4Ishi: "ฝึกความตั้งใจและการตัดสินใจ",
+  drillPatternN4Meirei: "ฝึกคำสั่งและการห้าม",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -233,6 +233,8 @@ export const vi: Copy = {
   drillPatternN5Teido: "Luyện mức độ và tần suất",
   drillPatternN4Ndesu: "Luyện ngữ khí giải thích んです",
   drillPatternN4Suiryou: "Luyện suy đoán và nguyên nhân",
+  drillPatternN4Ishi: "Luyện dự định và quyết định",
+  drillPatternN4Meirei: "Luyện mệnh lệnh và cấm chỉ",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -233,6 +233,8 @@ export const zhHant: Copy = {
   drillPatternN5Teido: "練程度與頻度",
   drillPatternN4Ndesu: "練說明語氣 〜んです",
   drillPatternN4Suiryou: "練推量與原因",
+  drillPatternN4Ishi: "練打算與決定",
+  drillPatternN4Meirei: "練命令與禁止",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- **n4-ishi** 打算與決定：意向形＋と思う／つもり（含ない形）／予定／ことにする・ことになる・ことにしている，8 題
- **n4-meirei** 命令與禁止：命令形（一類え段/二類ろ/しろ）／禁止形（辭書形＋な）／なさい／なきゃ／ように言う，8 題
- 句型總數 182→198；「N4 文法」達 4 章（40 章 total）

## 設計要點
- **つもり/予定/うと思う 三近義雷**：永不同場競爭——予定題用無生物主語（飛機不會「打算」）、第三人稱題用 らしい 接續殺意向形、意志題全 junk 形態
- **命令題**：て形請求與 な縮約命令（行きな）都是真實軟化命令，一律不進干擾；ないと/なくちゃ 不與 なきゃ 同場

## 品質閘
- 兩鏡頭對抗審：9 findings 全採納 —— 「〜(ない)ことです」忠告句型雙解×2（高）、「しれ」れ足す方言命令（高）、やめましょう 古風引用讀法、「〜するばかりにする」慣用、捨てりな/れな 方言基底、**日本停止標誌形狀教錯（八角→紅色倒三角）**、意向形規則措辭、gloss
- codex 終審：3 措辭 findings 全採納（無生物斷言收窄、逃げまい＝否定意志非書面否定、標誌併記 STOP）
- `pnpm test` 883 全綠；build 綠；preview 實機驗證（兩章順序、drill、修正後選項）

Closes #550