### PR TITLE
feat: N4 文法章 名詞修飾節＋間接疑問（#551）

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 198,
+  patternChecks: 214,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -940,6 +940,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n4-shushoku": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Noun-Modifying Clauses: 〜した＋noun",
+      "explanation":
+        "N4's biggest syntactic leap: parking a whole sentence in front of a noun as its modifier — きのう買った本 (the book I bought yesterday), 大阪に住んでいる友だち (a friend living in Osaka). Three iron rules: (1) inside the clause use plain forms — polite ます/です can't enter; (2) the clause's tense tracks whether ITS OWN event happened, not the main clause — 来週泊まるホテルは、もう予約しました (the stay hasn't happened → dictionary form, even though the booking is past); (3) the clause's subject takes が (母が作った料理), interchangeable with の (母の作った料理). Introduce names with 「〜という＋noun」 (さくらという店); define terms with 「〜というのは」.",
+      "notes": [
+        "Plain forms inside the clause",
+        "Clause tense = the event's own tense",
+        "Clause subject: が (or の)",
+        "Introducing: 〜という + noun",
+        "Defining: 〜というのは"
+      ],
+      "pitfalls": [
+        "Polite forms can't modify: ×歌っています人 → 歌っている人",
+        "は can't enter a modifier clause — its subject takes が (or の)",
+        "Clause tense is independent: bought yesterday = 買った, staying next week = 泊まる"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "名詞修飾節 〜した＋名詞",
+      "explanation":
+        "N4 最大の構文ジャンプ：文をまるごと名詞の前に置いて修飾する——きのう買った本、大阪に住んでいる友だち。鉄則三つ：①節の中は普通形。ます/です は入れない。②節の時制は「その出来事」が起きたかどうかで決まり、主文に引きずられない——来週泊まるホテルは、もう予約しました。③節内の主語は が（母が作った料理）で、の と交替できる（母の作った料理）。名前の紹介は「〜という＋名詞」、定義は「〜というのは」。",
+      "notes": [
+        "節の中は普通形",
+        "節の時制は出来事基準",
+        "節内主語は が（／の）",
+        "紹介：〜という＋名詞",
+        "定義：〜というのは"
+      ],
+      "pitfalls": [
+        "敬体は修飾節に入れない：×歌っています人→歌っている人",
+        "は は修飾節に入れない——節内主語は が（または の）",
+        "節の時制は独立：昨日買った＝買った、来週泊まる＝泊まる"
+      ]
+    }
+  },
+  "n4-kansetsu": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Indirect Questions: かどうか・〜か",
+      "explanation":
+        "Embedding a question inside a sentence = an indirect question, and the split is a single line: if the clause HAS a question word (いつ, どこ, だれ, どうして…) use 「〜か」 — いつ始まるか知っていますか; a yes/no clause WITHOUT one uses 「〜かどうか」 — 行くかどうか、まだ決めていません (expanded form: 行くか行かないか). Attachment follows the conjecture family: nouns and な-adjectives attach bare, だ drops (本当かどうか); the inside stays plain — polite forms can't enter (×来るですか → 来るか); politeness lives at the end of the sentence.",
+      "notes": [
+        "No question word → かどうか",
+        "Question word → か",
+        "Nouns attach bare, だ drops",
+        "Plain forms inside",
+        "Expanded: 〜か〜ないか"
+      ],
+      "pitfalls": [
+        "Question word + かどうか is wrong: ×いつ来るかどうか → いつ来るか",
+        "Polite forms inside fail: ×来ますか教えて → 来るか教えて",
+        "Nouns drop だ before かどうか: ×本当だかどうか"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "間接疑問 かどうか・〜か",
+      "explanation":
+        "質問を文の中に埋め込むのが間接疑問。線引きは一本だけ：節内に疑問詞（いつ・どこ・だれ・どうして…）が「ある」なら「〜か」——いつ始まるか知っていますか；疑問詞の「ない」Yes/No 型は「〜かどうか」——行くかどうか、まだ決めていません（展開形＝行くか行かないか）。接続は推量の仲間と同じ：名詞・な形容詞は裸接続で だ を落とす（本当かどうか）；中身は普通形——敬体は入れない（×来るですか→来るか）。丁寧さは文末に置けば足りる。",
+      "notes": [
+        "疑問詞なし→かどうか",
+        "疑問詞あり→か",
+        "名詞は裸接続、だ を落とす",
+        "中身は普通形",
+        "展開形：〜か〜ないか"
+      ],
+      "pitfalls": [
+        "疑問詞＋かどうか は誤り：×いつ来るかどうか→いつ来るか",
+        "中の敬体は文にならない：×来ますか教えて→来るか教えて",
+        "名詞は だ を落とす：×本当だかどうか"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 4 N4 grammar (#549/#550) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 6 N4 grammar (#549-#551) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(40);
+    expect(trackable.length).toBe(42);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -706,6 +706,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n4-ishi"]
   },
   {
+    id: "n4-shushoku",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "名詞修飾節 〜した＋名詞",
+    subtitle: "きのう買った本／大阪に住んでいる友だち",
+    explanation:
+      "N4 句法最大的一跳：把整個句子塞到名詞前面當形容詞用——きのう買った本（昨天買的書）、大阪に住んでいる友だち（住大阪的朋友）。三條鐵則：①修飾節內用普通形，敬體（ます/です）進不去；②修飾節的時態看「事件本身」發生了沒，不看主句——来週泊まるホテルは、もう予約しました（住宿未發生用辭書形、即使主句是過去）；③修飾節內的主語用が（母が作った料理），且可換成の（母の作った料理）。引介名字用「〜という＋名詞」（さくらという店）；下定義用「〜というのは」。",
+    examples: [
+      { formula: "きのう買った本", note: "修飾節＝普通形" },
+      { formula: "来週泊まるホテルは、もう予約しました", note: "時態看事件不看主句" },
+      { formula: "母が作った料理（＝母の作った料理）", note: "節內主語が、可換の" },
+      { formula: "「さくら」という店", note: "引介：〜という＋名詞" },
+      { formula: "「さくら」というのは、花の名前です", note: "定義：〜というのは" }
+    ],
+    pitfalls: [
+      "敬體不進修飾節：×歌っています人→歌っている人",
+      "は進不了修飾節——節內主語只能が（或換の）",
+      "修飾節時態獨立：昨天買的＝買った、下週住的＝泊まる"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Shushoku", patternIds: ["n4-shushoku"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-meirei"]
+  },
+  {
+    id: "n4-kansetsu",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "間接疑問 かどうか・〜か",
+    subtitle: "行くかどうか／いつ始まるか",
+    explanation:
+      "把問句塞進句子裡＝間接疑問，分工只有一條線：句子裡「有疑問詞」（いつ、どこ、だれ、どうして…）就用「〜か」——いつ始まるか知っていますか；「沒有疑問詞」的是否句用「〜かどうか」——行くかどうか、まだ決めていません（展開形＝行くか行かないか）。接續規則跟推量家族一樣：名詞・な形容詞裸接、だ去掉（本当かどうか）；內部一律普通形，敬體不進去（×来るですか→来るか），禮貌放在句尾就好。",
+    examples: [
+      { formula: "行くかどうか、まだ決めていません", note: "無疑問詞→かどうか" },
+      { formula: "いつ始まるか、知っていますか", note: "有疑問詞→か" },
+      { formula: "本当かどうか、分かりません", note: "名詞裸接、だ去掉" },
+      { formula: "何時に来るか教えてください", note: "內部用普通形" },
+      { formula: "行くか行かないか", note: "かどうか的展開形" }
+    ],
+    pitfalls: [
+      "疑問詞＋かどうか是錯的：×いつ来るかどうか→いつ来るか",
+      "內部敬體不成句：×来ますか教えて→来るか教えて",
+      "名詞接かどうか要去だ：×本当だかどうか"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Kansetsu", patternIds: ["n4-kansetsu"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-shushoku"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -1431,6 +1431,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "道路標識は命令形：止まれ（一類・語尾え段）。日本の一時停止標識は赤い逆三角形で、日本語表記は「止まれ」（新しい標識には STOP が併記される）。「止まるな」は停止の禁止で、交差点の標識にはあり得ない。「止まりろ」「止まるれ」は存在しない。"
     }
   },
+  "pattern-n4-shushoku-001": {
+    "hintI18n": { "en": "This book joined your shelf yesterday.", "ja": "この本を手に入れたのは昨日。" },
+    "promptContextI18n": { "en": "\"This is the book I bought yesterday.\"", "ja": "「これはきのう買った本です。」" },
+    "explanationI18n": {
+      "en": "Parking a sentence before a noun = a noun-modifying clause, and its verb is plain: きのう買った本 = the book I bought yesterday. 「買う本」 is a book you WILL buy — clashing with きのう; 「買います」 is polite, and polite forms generally can't enter a modifier clause (always wrong on tests); 「買って本」 is no sentence.",
+      "ja": "名詞の前に文をまるごと置く＝名詞修飾節。動詞は普通形：きのう買った本。「買う本」は「これから買う本」で きのう と矛盾。「買います」は敬体で、修飾節には原則入らない（試験では常に誤り）。「買って本」は文にならない。"
+    }
+  },
+  "pattern-n4-shushoku-002": {
+    "hintI18n": { "en": "Pointing out who's singing over there.", "ja": "あそこで歌っているのが誰かを言う。" },
+    "promptContextI18n": { "en": "\"The person singing over there is Tanaka.\"", "ja": "「あそこで歌っている人は田中さんです。」" },
+    "explanationI18n": {
+      "en": "Inside the clause, plain forms only: 歌っている人 = the person singing. 「歌っています人」 shoves a polite form into the clause — generally no sentence, always wrong on tests (ultra-formal letters are another world); 「歌いますの」「歌ってる人の」 are scrambles. ※歌う = to sing.",
+      "ja": "節の中は普通形：歌っている人。「歌っています人」は敬体を修飾節に入れた形——原則文にならず、試験では常に誤り（超改まった書簡は別世界）。「歌いますの」「歌ってる人の」は崩れ形。"
+    }
+  },
+  "pattern-n4-shushoku-003": {
+    "hintI18n": { "en": "Whose cooking is on the table.", "ja": "この料理を作ったのは誰かを言う。" },
+    "promptContextI18n": { "en": "\"This is a dish my mother made.\"", "ja": "「これは母が作った料理です。」" },
+    "explanationI18n": {
+      "en": "The clause's subject takes 「が」: 母が作った料理. 「から」 would mean \"a dish made FROM mother\" and 「で」 \"a dish made USING mother\" — both nonsense; 「を」's slot is already taken by 料理. Two bonus notes: the topic marker は can't enter a modifier clause (use が), and the clause's が can swap with の (母の作った料理), an elegant equivalent.",
+      "ja": "節内の主語は「が」：母が作った料理。「から」だと「母から作った料理」、「で」だと「母で作った料理」で意味が壊れる。「を」の席は 料理 が使用中。おまけ二つ：主題の は は修飾節に入れない（が を使う）。節内の が は の と交替できる（母の作った料理）。"
+    }
+  },
+  "pattern-n4-shushoku-004": {
+    "hintI18n": { "en": "A new shop opened by the station — name included.", "ja": "駅前の新しい店を、名前つきで紹介。" },
+    "promptContextI18n": { "en": "\"A shop called Sakura opened in front of the station.\"", "ja": "「駅前に『さくら』という店ができました。」" },
+    "explanationI18n": {
+      "en": "Introducing something by name uses 「〜という＋noun」: 「さくら」という店 = a shop called Sakura. 「にいう」「でいう」「がいう」 aren't this pattern — the chunk is fixed as と + いう. ※駅前 = in front of the station.",
+      "ja": "名前を添えて紹介するのは「〜という＋名詞」：「さくら」という店。「にいう」「でいう」「がいう」はこの文型ではない——と＋いう で固定。"
+    }
+  },
+  "pattern-n4-shushoku-005": {
+    "hintI18n": { "en": "Next week's hotel is already booked.", "ja": "来週のホテルはもう手配済み。" },
+    "promptContextI18n": { "en": "\"The hotel we're staying at next week is already booked.\"", "ja": "「来週泊まるホテルは、もう予約しました。」" },
+    "explanationI18n": {
+      "en": "The clause's tense tracks its OWN event, not the main clause: the stay is next week, not yet happened → dictionary form 泊まるホテル (only the booking is done). 「泊まった」 clashes with 来週; 「泊まりますの」 is a polite-form scramble; 「泊まって」 is no sentence. ※泊まる = to stay (overnight), 予約 = reservation.",
+      "ja": "節の時制は「その出来事」基準で、主文に引きずられない：宿泊は来週でまだ先→辞書形 泊まるホテル（済んだのは予約だけ）。「泊まった」は来週と矛盾。「泊まりますの」は敬体の崩れ形。「泊まって」は文にならない。"
+    }
+  },
+  "pattern-n4-shushoku-006": {
+    "hintI18n": { "en": "Off to see a friend.", "ja": "友だちに会いに行く話。" },
+    "promptContextI18n": { "en": "\"I'm going to see a friend who still lives in Osaka.\"", "ja": "「大阪に今も住んでいる友だちに会いに行きます。」" },
+    "explanationI18n": {
+      "en": "\"A friend living in Osaka\" = a stative modifier clause: 住んでいる友だち. 「住んでいます」 is polite and generally can't modify (always wrong on tests); 「住んでいるの友だち」 has a stray の; 「住んでいた」 is \"used to live\" — flatly contradicting the clause's 今も (still now).",
+      "ja": "「大阪に住んでいる友だち」＝状態の修飾節。「住んでいます」は敬体で修飾節には原則入らない（試験では誤り）。「住んでいるの友だち」は の が余計。「住んでいた」は「昔住んでいた」で、節内の「今も」と真っ向から矛盾する。"
+    }
+  },
+  "pattern-n4-shushoku-007": {
+    "hintI18n": { "en": "Passing along Tanaka's message.", "ja": "田中さんの伝言を伝える。" },
+    "promptContextI18n": { "en": "\"Tanaka was saying he'll take next week off.\"", "ja": "「田中さんは来週休むと言っていました。」" },
+    "explanationI18n": {
+      "en": "Reporting what someone said uses 「〜と言っていました」 — the standard quote marker is と (colloquial speech also has って): 休むと言っていました. 「を」「に」「が」 can't mark quoted content. と言っていた carries more of a \"relaying this to you\" tone than と言った.",
+      "ja": "人の発言の伝達は「〜と言っていました」——標準の引用マーカーは と（話し言葉には って もある）：休むと言っていました。「を」「に」「が」は引用内容に付けられない。と言っていた は と言った より「あなたに伝えている」響きが出る。"
+    }
+  },
+  "pattern-n4-shushoku-008": {
+    "hintI18n": { "en": "Explaining a Japanese word.", "ja": "日本語の単語をひとつ解説。" },
+    "promptContextI18n": { "en": "\"『さくら』 is the name of this flower.\"", "ja": "「『さくら』というのは、この花の名前です。」" },
+    "explanationI18n": {
+      "en": "Definitions use 「〜というのは」 = \"so-called ~ / what ~ means\": 「さくら」というのは. The same という as in 004, plus のは to open a definition. 「はいう」「でいう」「をいう」 don't work in this pattern — the chunk is fixed with と.",
+      "ja": "定義は「〜というのは」：「さくら」というのは。004 と同じ という に のは を付けると定義文の頭になる。「はいう」「でいう」「をいう」はこの文型では成立しない——と で固定。"
+    }
+  },
+  "pattern-n4-kansetsu-001": {
+    "hintI18n": { "en": "Asked about the party, you're still on the fence.", "ja": "パーティーの話を振られたが、まだ迷っている。" },
+    "promptContextI18n": { "en": "\"I haven't decided whether to go to the party.\"", "ja": "「パーティーに行くかどうか、まだ決めていません。」" },
+    "explanationI18n": {
+      "en": "\"Whether ~\" = 「〜かどうか」: 行くかどうか = whether to go. The chunk is fixed as か + どうか; 「を」「に」「で」 all break it. ※パーティー = party, 決める = to decide.",
+      "ja": "「〜かどうか」＝〜するかしないか：行くかどうか。か＋どうか で固定のかたまり。「を」「に」「で」を入れると壊れる。"
+    }
+  },
+  "pattern-n4-kansetsu-002": {
+    "hintI18n": { "en": "Fishing for the meeting's start time.", "ja": "会議の開始時刻を尋ねる。" },
+    "promptContextI18n": { "en": "\"Do you know when the meeting starts?\"", "ja": "「会議がいつ始まるか、知っていますか。」" },
+    "explanationI18n": {
+      "en": "The clause already has a question word (いつ), so the indirect question takes plain 「〜か」: いつ始まるか. 「かどうか」 is only for yes/no clauses WITHOUT a question word — 「いつ始まるかどうか」 is wrong; 「ので」「まで」 can't build an indirect question. ※会議 = meeting.",
+      "ja": "節内にもう疑問詞（いつ）があるので、間接疑問は「〜か」：いつ始まるか。「かどうか」は疑問詞の「ない」Yes/No 型専用——「いつ始まるかどうか」は誤り。「ので」「まで」では間接疑問にならない。"
+    }
+  },
+  "pattern-n4-kansetsu-003": {
+    "hintI18n": { "en": "The keys are... somewhere.", "ja": "かぎの置き場所が思い出せない。" },
+    "promptContextI18n": { "en": "\"I forgot where I put the keys.\"", "ja": "「かぎをどこに置いたか、忘れてしまいました。」" },
+    "explanationI18n": {
+      "en": "Question word (どこ) + 「〜か」 = the indirect question: どこに置いたか忘れました. 「かどうか」 can't co-occur with a question word; 「まで」「より」 don't attach. ※かぎ = key, 置く = to put.",
+      "ja": "疑問詞（どこ）＋「〜か」＝間接疑問：どこに置いたか忘れました。「かどうか」は疑問詞と併用できない。「まで」「より」はつながらない。"
+    }
+  },
+  "pattern-n4-kansetsu-004": {
+    "hintI18n": { "en": "Checking the forecast for tomorrow.", "ja": "明日の天気を予報で確かめる。" },
+    "promptContextI18n": { "en": "\"I'll check the forecast to see whether it'll be sunny tomorrow.\"", "ja": "「明日晴れるかどうか、天気予報を見て確認します。」" },
+    "explanationI18n": {
+      "en": "A yes/no clause with no question word takes 「〜かどうか」: 晴れるかどうか = whether it'll clear up. 「かどうして」「がどうか」「をどうか」 are all non-sentences — the only fixed pairing is か + どうか. ※晴れる = to clear up, 天気予報 = weather forecast, 確認 = to check.",
+      "ja": "疑問詞のない Yes/No 型は「〜かどうか」：晴れるかどうか。「かどうして」「がどうか」「をどうか」はどれも文にならない——固定の組み合わせは か＋どうか だけ。"
+    }
+  },
+  "pattern-n4-kansetsu-005": {
+    "hintI18n": { "en": "Why is Tanaka fuming? Anyone know?", "ja": "田中さんの怒りの理由を探る。" },
+    "promptContextI18n": { "en": "\"Does anyone know why Tanaka is angry?\"", "ja": "「田中さんがどうして怒っているか、だれか知りませんか。」" },
+    "explanationI18n": {
+      "en": "Question word (どうして) + 「〜か」: どうして怒っているか. The rule once more: question word → か, none → かどうか — 「どうして〜かどうか」 is wrong. 「ので」「のに」 mark reason/contrast, not indirect questions. ※怒る = to get angry.",
+      "ja": "疑問詞（どうして）＋「〜か」：どうして怒っているか。ルール再確認：疑問詞あり→か、なし→かどうか——「どうして〜かどうか」は誤り。「ので」「のに」は理由/逆接で間接疑問にならない。"
+    }
+  },
+  "pattern-n4-kansetsu-006": {
+    "hintI18n": { "en": "Is that story even true?", "ja": "その話、信じていいのか。" },
+    "promptContextI18n": { "en": "\"I don't know whether that story is true.\"", "ja": "「その話が本当かどうか、分かりません。」" },
+    "explanationI18n": {
+      "en": "Nouns and な-adjectives attach to 「かどうか」 bare — だ drops: 本当かどうか. Filling in 「な」「だ」「の」 gives 本当などうか / 本当だどうか / 本当のどうか — all missing the か, none a sentence. Standard form = noun directly + かどうか (colloquial Japanese has a separate 「〜だか」, but at N4 learn the bare attachment). ※本当 = true.",
+      "ja": "名詞・な形容詞は「かどうか」に裸で付く——だ は落とす：本当かどうか。「な」「だ」「の」を入れると 本当などうか／本当だどうか／本当のどうか——どれも か が欠けて文にならない。標準形＝名詞＋かどうか（話し言葉には「〜だか」もあるが、N4 は裸接続で覚える）。"
+    }
+  },
+  "pattern-n4-kansetsu-007": {
+    "hintI18n": { "en": "Asking for their arrival time.", "ja": "到着時刻を教えてもらう。" },
+    "promptContextI18n": { "en": "\"Please tell me what time you're coming.\"", "ja": "「何時に来るか、教えてください。」" },
+    "explanationI18n": {
+      "en": "The inside of an indirect question stays plain + か: 何時に来るか教えてください. 「来るますか」 is broken attachment — polite forms generally stay out of indirect questions; the politeness lives in the final 教えてください. 「より」「なか」 can't build an indirect question. ※何時 = what time.",
+      "ja": "間接疑問の中身は普通形＋か：何時に来るか教えてください。「来るますか」は接続の破綻——敬体は原則、間接疑問の中に入れない。丁寧さは文末の 教えてください で足りる。「より」「なか」では間接疑問にならない。"
+    }
+  },
+  "pattern-n4-kansetsu-008": {
+    "hintI18n": { "en": "Pushing someone to make up their mind.", "ja": "早く決めてと迫る。" },
+    "promptContextI18n": { "en": "\"Going or not — decide already.\"", "ja": "「行くか行かないか、早く決めてください。」" },
+    "explanationI18n": {
+      "en": "「〜か〜ないか」 is かどうか spelled out: 行くか行かないか = go or not go. The second か can't become 「を」「で」「まで」 — both halves need か to pair up.",
+      "ja": "「〜か〜ないか」は かどうか の展開形：行くか行かないか。二つ目の か は「を」「で」「まで」に変えられない——両側とも か でペアになる。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -21,6 +21,8 @@ export type SentencePatternId =
   | "n4-suiryou"
   | "n4-ishi"
   | "n4-meirei"
+  | "n4-shushoku"
+  | "n4-kansetsu"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -67,6 +69,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n4-suiryou": "推量與原因 かもしれない・て",
   "n4-ishi": "打算與決定 つもり・ことにする",
   "n4-meirei": "命令與禁止 しろ・するな",
+  "n4-shushoku": "名詞修飾節 〜した＋名詞",
+  "n4-kansetsu": "間接疑問 かどうか・〜か",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -1757,6 +1761,208 @@ const N4_MEIREI_ITEMS: SentencePatternItem[] = [
 ];
 
 // ===========================================================================
+// N4 pattern: n4-shushoku -- noun-modifying clauses + という (#551).
+//   The tense inside a modifier clause is anchored by an explicit time
+//   adverb (きのう / 来週) so plain-vs-past never double-reads; の never
+//   appears where が is the answer (the が/の alternation is real);
+//   habitual 住む never competes with 住んでいる (both modify) -- the
+//   foil set there is polite/て/た forms killed by attachment or the
+//   meet-the-friend-in-Osaka anchor. と言った never competes with
+//   と言っていた (both report).
+// ===========================================================================
+const N4_SHUSHOKU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-shushoku-001",
+    patternId: "n4-shushoku",
+    promptText: "これはきのう___本です。",
+    hintZh: "說這本書昨天入手。",
+    promptContextZh: "「這是我昨天買的書。」",
+    expectedAnswer: "買った",
+    options: ["買った", "買う", "買います", "買って"],
+    explanation:
+      "把句子塞進名詞前面＝名詞修飾節，動詞用普通形：きのう買った本＝昨天買的書。「買う本」是「要買的書」，跟きのう矛盾；「買います」是敬體——敬體一般不進修飾節（考試一律當錯）；「買って本」不成句。"
+  },
+  {
+    id: "pattern-n4-shushoku-002",
+    patternId: "n4-shushoku",
+    promptText: "あそこで___人は田中さんです。",
+    hintZh: "指出在那邊唱歌的人是誰。",
+    promptContextZh: "「在那邊唱歌的人是田中。」",
+    expectedAnswer: "歌っている",
+    options: ["歌っている", "歌っています", "歌いますの", "歌ってる人の"],
+    explanation:
+      "修飾節裡用普通形：歌っている人＝正在唱歌的人。「歌っています人」把敬體塞進修飾節——一般不成句、考試一律當錯（超正式書信另當別論）；「歌いますの」「歌ってる人の」都是亂接。※歌う＝唱歌。"
+  },
+  {
+    id: "pattern-n4-shushoku-003",
+    patternId: "n4-shushoku",
+    promptText: "これは母___作った料理です。",
+    hintZh: "介紹桌上這道菜出自誰手。",
+    promptContextZh: "「這是媽媽做的菜。」",
+    expectedAnswer: "が",
+    options: ["が", "から", "を", "で"],
+    explanation:
+      "修飾節裡的主語用「が」：母が作った料理。「から」變成「從媽媽做出的菜」、「で」變成「用媽媽做出的菜」，都不成話；「を」的位置已被料理佔了。順帶記兩件事：主題的は進不了修飾節（要用が）；而節裡的が可以換成の（母の作った料理），是同義的漂亮寫法。"
+  },
+  {
+    id: "pattern-n4-shushoku-004",
+    patternId: "n4-shushoku",
+    promptText: "駅前に「さくら」___店ができました。",
+    hintZh: "說站前新開了一家店，順帶報店名。",
+    promptContextZh: "「站前開了一家叫『さくら』的店。」",
+    expectedAnswer: "という",
+    options: ["という", "にいう", "でいう", "がいう"],
+    explanation:
+      "報出名字、介紹新事物用「〜という＋名詞」：「さくら」という店＝叫さくら的店。「にいう」「でいう」「がいう」都不是這個句型——固定就是と＋いう。※駅前＝車站前。"
+  },
+  {
+    id: "pattern-n4-shushoku-005",
+    patternId: "n4-shushoku",
+    promptText: "来週___ホテルは、もう予約しました。",
+    hintZh: "說下週住宿的旅館已訂好。",
+    promptContextZh: "「下週要住的旅館已經訂好了。」",
+    expectedAnswer: "泊まる",
+    options: ["泊まる", "泊まった", "泊まりますの", "泊まって"],
+    explanation:
+      "修飾節的時態看「事件本身」發生了沒，不看主句：住宿在下週、還沒發生→辭書形泊まるホテル（訂房這個動作才是完成的）。「泊まった」跟来週矛盾；「泊まりますの」是敬體＋の的亂接；「泊まって」不成句。※泊まる＝住宿、予約＝預約。"
+  },
+  {
+    id: "pattern-n4-shushoku-006",
+    patternId: "n4-shushoku",
+    promptText: "大阪に今も___友だちに会いに行きます。",
+    hintZh: "說要去見朋友。",
+    promptContextZh: "「我要去見至今仍住在大阪的朋友。」",
+    expectedAnswer: "住んでいる",
+    options: ["住んでいる", "住んでいます", "住んでいるの", "住んでいた"],
+    explanation:
+      "「住在大阪的朋友」＝狀態的修飾節：住んでいる友だち。「住んでいます」是敬體，一般進不了修飾節（考試一律當錯）；「住んでいるの友だち」多了の、不成句；「住んでいた」是以前住，跟節內的「今も（至今仍）」直接矛盾。"
+  },
+  {
+    id: "pattern-n4-shushoku-007",
+    patternId: "n4-shushoku",
+    promptText: "田中さんは来週休む___。",
+    hintZh: "轉達田中請假的消息。",
+    promptContextZh: "「田中（先前）說他下週要請假。」",
+    expectedAnswer: "と言っていました",
+    options: ["と言っていました", "を言っていました", "に言っていました", "が言っていました"],
+    explanation:
+      "轉述別人說過的話用「〜と言っていました」——標準的引用助詞是と（口語另有って）：休むと言っていました。「を」「に」「が」都不能標引用內容。「と言っていた」比「と言った」更有「傳話給你」的口吻。"
+  },
+  {
+    id: "pattern-n4-shushoku-008",
+    patternId: "n4-shushoku",
+    promptText: "「さくら」___のは、この花の名前です。",
+    hintZh: "解釋一個日文詞。",
+    promptContextZh: "「所謂『さくら』，是這種花的名字。」",
+    expectedAnswer: "という",
+    options: ["という", "はいう", "でいう", "をいう"],
+    explanation:
+      "下定義用「〜というのは」＝所謂〜：「さくら」というのは＝所謂さくら。跟004是同一個という，後面接のは就變成定義句的開頭。「はいう」「でいう」「をいう」放進這個句型都不成立——固定就是と。"
+  }
+];
+
+// ===========================================================================
+// N4 pattern: n4-kansetsu -- indirect questions (#551).
+//   The か vs かどうか division IS the lesson, and it's anchored in the
+//   prompt: every 疑問詞 item carries its question word (いつ/どこ/どうして)
+//   so かどうか dies by rule, and every かどうか item has none. か+case
+//   particles (かは/かを/かが) are all REAL, so no option ever pairs か
+//   with a particle; plain か never competes where かどうか is the answer
+//   (行くか、決めていない is real) -- those items blank only part of the
+//   fixed chunk or use junk distractors.
+// ===========================================================================
+const N4_KANSETSU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-kansetsu-001",
+    patternId: "n4-kansetsu",
+    promptText: "パーティーに行く___どうか、まだ決めていません。",
+    hintZh: "被問到派對的事，表示還沒拿定主意。",
+    promptContextZh: "「還沒決定要不要去派對。」",
+    expectedAnswer: "か",
+    options: ["か", "を", "に", "で"],
+    explanation:
+      "「是否〜」＝「〜かどうか」：行くかどうか＝去或不去。整組固定是か＋どうか，「を」「に」「で」放進去都不成句。※パーティー＝派對、決める＝決定。"
+  },
+  {
+    id: "pattern-n4-kansetsu-002",
+    patternId: "n4-kansetsu",
+    promptText: "会議がいつ始まる___、知っていますか。",
+    hintZh: "打聽會議的開始時間。",
+    promptContextZh: "「你知道會議幾點開始嗎？」",
+    expectedAnswer: "か",
+    options: ["か", "かどうか", "ので", "まで"],
+    explanation:
+      "句子裡已經有疑問詞（いつ），間接疑問就用「〜か」：いつ始まるか。「かどうか」只用在沒有疑問詞的「是否」句——「いつ始まるかどうか」是錯的；「ので」「まで」接不出間接疑問。※会議＝會議。"
+  },
+  {
+    id: "pattern-n4-kansetsu-003",
+    patternId: "n4-kansetsu",
+    promptText: "かぎをどこに置いた___、忘れてしまいました。",
+    hintZh: "想不起鑰匙放哪了。",
+    promptContextZh: "「忘記鑰匙放在哪裡了。」",
+    expectedAnswer: "か",
+    options: ["か", "かどうか", "まで", "より"],
+    explanation:
+      "疑問詞（どこ）＋「〜か」＝間接疑問：どこに置いたか忘れました。「かどうか」跟疑問詞不能同用；「まで」「より」接不上。※かぎ＝鑰匙、置く＝放置。"
+  },
+  {
+    id: "pattern-n4-kansetsu-004",
+    patternId: "n4-kansetsu",
+    promptText: "明日晴れる___、天気予報を見て確認します。",
+    hintZh: "看預報確認明天的天氣。",
+    promptContextZh: "「明天會不會放晴，看天氣預報確認。」",
+    expectedAnswer: "かどうか",
+    options: ["かどうか", "かどうして", "がどうか", "をどうか"],
+    explanation:
+      "沒有疑問詞的「是否」句用「〜かどうか」：晴れるかどうか＝會不會放晴。「かどうして」「がどうか」「をどうか」都不成句——固定的組合只有か＋どうか。※晴れる＝放晴、天気予報＝天氣預報、確認＝確認。"
+  },
+  {
+    id: "pattern-n4-kansetsu-005",
+    patternId: "n4-kansetsu",
+    promptText: "田中さんがどうして怒っている___、だれか知りませんか。",
+    hintZh: "想知道田中生氣的原因。",
+    promptContextZh: "「有人知道田中為什麼在生氣嗎？」",
+    expectedAnswer: "か",
+    options: ["か", "かどうか", "ので", "のに"],
+    explanation:
+      "疑問詞（どうして）＋「〜か」：どうして怒っているか。再確認一次規則：有疑問詞→か、沒有→かどうか——「どうして〜かどうか」是錯的。「ので」「のに」是理由/逆接，接不出間接疑問。※怒る＝生氣。"
+  },
+  {
+    id: "pattern-n4-kansetsu-006",
+    patternId: "n4-kansetsu",
+    promptText: "その話が本当___どうか、分かりません。",
+    hintZh: "懷疑那個消息的真假。",
+    promptContextZh: "「不知道那件事是真是假。」",
+    expectedAnswer: "か",
+    options: ["か", "な", "だ", "の"],
+    explanation:
+      "名詞、な形容詞接「かどうか」直接裸接、だ要去掉：本当かどうか。「な」「だ」「の」填進去是「本当などうか」「本当だどうか」「本当のどうか」——全都缺了か、不成句。標準形＝名詞直接＋かどうか（口語另有「〜だか」的說法，N4 先記裸接）。※本当＝真的。"
+  },
+  {
+    id: "pattern-n4-kansetsu-007",
+    patternId: "n4-kansetsu",
+    promptText: "何時に来る___、教えてください。",
+    hintZh: "請對方留下到達時間。",
+    promptContextZh: "「請告訴我你幾點到。」",
+    expectedAnswer: "か",
+    options: ["か", "ますか", "より", "なか"],
+    explanation:
+      "間接疑問的內部用普通形＋か：何時に来るか教えてください。「来るますか」接續不成句——敬體一般不進間接疑問，禮貌放在句尾的教えてください就夠了；「より」「なか」都接不出間接疑問。※何時＝幾點。"
+  },
+  {
+    id: "pattern-n4-kansetsu-008",
+    patternId: "n4-kansetsu",
+    promptText: "行くか行かない___、早く決めてください。",
+    hintZh: "催人下決心。",
+    promptContextZh: "「要去不去，快點決定。」",
+    expectedAnswer: "か",
+    options: ["か", "を", "で", "まで"],
+    explanation:
+      "「〜か〜ないか」是かどうか的展開形：行くか行かないか＝去或不去。第二個か一樣不能換成「を」「で」「まで」——兩邊都要か才成對。"
+  }
+];
+
+// ===========================================================================
 // Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
 //   Absolute-beginner floor: kana-only sentences built from the starter
 //   vocabulary deck. Unique solutions are locked by IN-SENTENCE anchors
@@ -2618,6 +2824,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N4_SUIRYOU_ITEMS,
   ...N4_ISHI_ITEMS,
   ...N4_MEIREI_ITEMS,
+  ...N4_SHUSHOKU_ITEMS,
+  ...N4_KANSETSU_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -105,11 +105,15 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     const suiryou = buildSentencePatternPool({ patternIds: ["n4-suiryou"] });
     const ishi = buildSentencePatternPool({ patternIds: ["n4-ishi"] });
     const meirei = buildSentencePatternPool({ patternIds: ["n4-meirei"] });
+    const shushoku = buildSentencePatternPool({ patternIds: ["n4-shushoku"] });
+    const kansetsu = buildSentencePatternPool({ patternIds: ["n4-kansetsu"] });
     expect(ndesu).toHaveLength(8);
     expect(suiryou).toHaveLength(8);
     expect(ishi).toHaveLength(8);
     expect(meirei).toHaveLength(8);
-    for (const q of [...ndesu, ...suiryou, ...ishi, ...meirei]) {
+    expect(shushoku).toHaveLength(8);
+    expect(kansetsu).toHaveLength(8);
+    for (const q of [...ndesu, ...suiryou, ...ishi, ...meirei, ...shushoku, ...kansetsu]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -218,6 +218,8 @@ export type Copy = {
   drillPatternN4Suiryou: string;
   drillPatternN4Ishi: string;
   drillPatternN4Meirei: string;
+  drillPatternN4Shushoku: string;
+  drillPatternN4Kansetsu: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -235,6 +235,8 @@ export const en: Copy = {
   drillPatternN4Suiryou: "Drill conjecture + causal て",
   drillPatternN4Ishi: "Drill intention + decision",
   drillPatternN4Meirei: "Drill commands + prohibition",
+  drillPatternN4Shushoku: "Drill noun-modifying clauses",
+  drillPatternN4Kansetsu: "Drill indirect questions",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -235,6 +235,8 @@ export const id: Copy = {
   drillPatternN4Suiryou: "Latih dugaan + sebab",
   drillPatternN4Ishi: "Latih niat + keputusan",
   drillPatternN4Meirei: "Latih perintah + larangan",
+  drillPatternN4Shushoku: "Latih klausa pewatas nomina",
+  drillPatternN4Kansetsu: "Latih pertanyaan tak langsung",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -243,6 +243,8 @@ export const ja: Copy = {
   drillPatternN4Suiryou: "推量と理由の て を練習",
   drillPatternN4Ishi: "意志と決定を練習",
   drillPatternN4Meirei: "命令と禁止を練習",
+  drillPatternN4Shushoku: "名詞修飾節を練習",
+  drillPatternN4Kansetsu: "間接疑問を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -235,6 +235,8 @@ export const ko: Copy = {
   drillPatternN4Suiryou: "추량과 원인 연습",
   drillPatternN4Ishi: "의지와 결정 연습",
   drillPatternN4Meirei: "명령과 금지 연습",
+  drillPatternN4Shushoku: "명사 수식절 연습",
+  drillPatternN4Kansetsu: "간접 의문 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -235,6 +235,8 @@ export const my: Copy = {
   drillPatternN4Suiryou: "ခန့်မှန်းမှုနှင့် အကြောင်းရင်း လေ့ကျင့်ရန်",
   drillPatternN4Ishi: "ရည်ရွယ်ချက်နှင့် ဆုံးဖြတ်ချက် လေ့ကျင့်ရန်",
   drillPatternN4Meirei: "အမိန့်နှင့် တားမြစ်ချက် လေ့ကျင့်ရန်",
+  drillPatternN4Shushoku: "နာမ်အထူးပြုဝါကျ လေ့ကျင့်ရန်",
+  drillPatternN4Kansetsu: "သွယ်ဝိုက်မေးခွန်း လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -236,6 +236,8 @@ export const th: Copy = {
   drillPatternN4Suiryou: "ฝึกการคาดคะเนและเหตุผล",
   drillPatternN4Ishi: "ฝึกความตั้งใจและการตัดสินใจ",
   drillPatternN4Meirei: "ฝึกคำสั่งและการห้าม",
+  drillPatternN4Shushoku: "ฝึกอนุประโยคขยายคำนาม",
+  drillPatternN4Kansetsu: "ฝึกคำถามทางอ้อม",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -235,6 +235,8 @@ export const vi: Copy = {
   drillPatternN4Suiryou: "Luyện suy đoán và nguyên nhân",
   drillPatternN4Ishi: "Luyện dự định và quyết định",
   drillPatternN4Meirei: "Luyện mệnh lệnh và cấm chỉ",
+  drillPatternN4Shushoku: "Luyện mệnh đề bổ nghĩa danh từ",
+  drillPatternN4Kansetsu: "Luyện câu hỏi gián tiếp",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -235,6 +235,8 @@ export const zhHant: Copy = {
   drillPatternN4Suiryou: "練推量與原因",
   drillPatternN4Ishi: "練打算與決定",
   drillPatternN4Meirei: "練命令與禁止",
+  drillPatternN4Shushoku: "練名詞修飾節",
+  drillPatternN4Kansetsu: "練間接疑問",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- **n4-shushoku** 名詞修飾節：修飾節時態（時間副詞錨）／敬體排除／節內主語が（が/の 交替）／という 引介與定義，8 題
- **n4-kansetsu** 間接疑問：かどうか（無疑問詞）vs 疑問詞＋か 分工／名詞裸接／內部普通形，8 題
- 句型總數 198→214；「N4 文法」達 6 章（42 章 total）

## 設計要點
- 修飾節時態永遠有句內時間錨（きのう買った／来週泊まる／今も住んでいる）——普通形 vs 過去形不靠語感
- **か＋格助詞（かは/かを/かが）全是真實形**，任何選項不讓 か 搭助詞；裸 か 不與 かどうか 競爭（行くか、決めていない 是真的）
- か/かどうか 的分工靠句內疑問詞錨（いつ/どこ/どうして 在場→かどうか 死於規則）

## 品質閘
- 兩鏡頭對抗審：13 findings 全採納 —— 母へ作った受益讀法（高）、住んでいた 無錨真雙解（高，雙鏡頭）、にいう 人名讀法、敬體修飾節「鐵則」斷言軟化（超正式書信存在）、だかどうか 假規則等
- codex 終審：5 findings 全採納 —— 「今」句首附著歧義→「今も」塞進節內、か何か 口語成立→かどうして、は 對比讀法撤出干擾等
- `pnpm test` 883 全綠；build 綠；preview 實機驗證

Closes #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new N4 grammar study blocks and practice patterns for noun-modifying clauses and indirect questions.
  * Expanded multilingual labels and explanations so the new drills are available in more languages.

* **Bug Fixes**
  * Aligned content statistics and learning-block counts with the updated lesson set.
  * Updated related checks so the new study items are included in expected totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->