### PR TITLE
feat: N4 文法章 複合動詞＋變化句型（#552）

### DIFF
--- a/src/domain/contentStats.ts
+++ b/src/domain/contentStats.ts
@@ -15,7 +15,7 @@
 export const CONTENT_STATS = {
   examItems: 1999,
   n1Grammar: 418,
-  patternChecks: 214,
+  patternChecks: 230,
   vocab: 579,
   kanjiReadings: 671,
   grammarPatterns: 83

--- a/src/domain/learningBlocks.i18n.ts
+++ b/src/domain/learningBlocks.i18n.ts
@@ -1020,6 +1020,86 @@ export const learningBlockI18n: LearningBlockOverlays = {
       ]
     }
   },
+  "n4-fukugou": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Compound Verbs: 〜はじめる・〜方",
+      "explanation":
+        "Gluing two verbs into one = a compound verb, with the ます-stem up front. The four stages: 〜はじめる (start), 〜だす (sudden start, pairs with 急に), 〜つづける (keep doing), 〜おわる (finish) — watch transitivity: はじめる/つづける are transitive (you do it), はじまる/つづく are intransitive (it happens) — don't glue the wrong one. The direction pair: 〜ていく (away from the speaker) / 〜てくる (toward the speaker) — the same pair also marks time drift (変わってきた = has been changing up to now, 変わっていく = will keep changing). Two derivations: ます-stem + 方 (かた) = how to ~ (読み方); い-adjective minus い + さ = a noun (高さ).",
+      "notes": [
+        "Sudden start: 〜だす",
+        "Start / keep doing (transitive)",
+        "Direction: いく away, くる toward",
+        "ます-stem + 方 = method",
+        "Drop い + さ = noun"
+      ],
+      "pitfalls": [
+        "Don't glue the intransitive: ×習いはじまる → 習いはじめる (はじまる is for 会議がはじまる)",
+        "急に / 突然 pair with 〜だす; a plain start uses 〜はじめる",
+        "For the temporal ていく/てくる, think direction: toward now = てきた, toward the future = ていく"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "複合動詞 〜はじめる・〜方",
+      "explanation":
+        "動詞二つを一語に貼り合わせる＝複合動詞。前半は ます形の語幹。段階の四点セット：〜はじめる（開始）、〜だす（急な開始。急に とセット）、〜つづける（継続）、〜おわる（完了）——自他に注意：はじめる/つづける は他動（自分がする）、はじまる/つづく は自動（事が起こる）。方向のペア：〜ていく（話し手から離れる）/〜てくる（話し手へ向かう）——時間の推移にも使う（変わってきた＝今まで、変わっていく＝これから）。語形成二つ：ます語幹＋方（読み方）；い形容詞の い を取って さ（高さ）。",
+      "notes": [
+        "急な開始：〜だす",
+        "開始・継続（他動）",
+        "方向：いく／くる",
+        "ます語幹＋方＝やり方",
+        "い を取って さ＝名詞化"
+      ],
+      "pitfalls": [
+        "自他を貼り間違えない：×習いはじまる→習いはじめる",
+        "急に・突然 は 〜だす と、ふつうの開始は 〜はじめる",
+        "時間の ていく/てくる は方向で考える：今へ＝てきた、これから＝ていく"
+      ]
+    }
+  },
+  "n4-henka": {
+    "en": {
+      "category": "N4 Grammar",
+      "kicker": "N4 Patterns",
+      "title": "Change: ようになる・くする・まま",
+      "explanation":
+        "The full change system. 「〜ようになる」 = come to (be able to) ~: with a potential verb it's an ability change (泳げるようになった), with a plain verb a habit change (早く起きるようになった); negative change = drop the い of ない + くなる (来なくなった). 「〜ようにする」 = make an effort to ~, neighbor to ことにする (resolve to). Transitive change — making something ~: い-adjective + くする (明るくする), な-adjective/noun + にする (静かにする); contrast N5's self-change くなる/になる. 「〜まま」 = leaving things as they are: た-form + まま (つけたまま寝た), ない-form + まま (消さないまま出かけた).",
+      "notes": [
+        "Ability change: potential + ようになる",
+        "Effort: ようにする",
+        "Making it ~: く / に + する",
+        "Negative change: なく + なる",
+        "As-is: た/ない form + まま"
+      ],
+      "pitfalls": [
+        "ようにする = keep trying, ことにする = made up your mind — often interchangeable; read the context",
+        "Change markers pair up: い-adj → く, な-adj/noun → に (for both する and なる)",
+        "Before まま: a done state takes た (つけたまま), an undone one ない (消さないまま)"
+      ]
+    },
+    "ja": {
+      "category": "N4文法",
+      "kicker": "N4文型",
+      "title": "変化 ようになる・くする・まま",
+      "explanation":
+        "変化のフルセット。「〜ようになる」＝〜（できる）ようになる：可能動詞なら能力の変化（泳げるようになった）、一般動詞なら習慣の変化（早く起きるようになった）；否定の変化は ない の い を取って くなる（来なくなった）。「〜ようにする」＝〜するよう努める。ことにする（決心）とはお隣さん。他動の変化：い形容詞＋くする（明るくする）、な形容詞・名詞＋にする（静かにする）；N5 の くなる/になる（自変）と対。「〜まま」＝そのままの状態で：た形＋まま（つけたまま寝た）、ない形＋まま（消さないまま出かけた）。",
+      "notes": [
+        "能力の変化：可能動詞＋ようになる",
+        "努力：ようにする",
+        "〜にする・〜くする",
+        "否定の変化：なく＋なる",
+        "そのまま：た/ない形＋まま"
+      ],
+      "pitfalls": [
+        "ようにする＝努力、ことにする＝決心——交換できる場面も多い。文脈で読む",
+        "変化のマーカー：い形→く、な形・名詞→に（する にも なる にも）",
+        "まま の前：した状態は た形、していない状態は ない形"
+      ]
+    }
+  },
   "adverbial": {
     "en": {
       "category": "Modifying Adjectives / Nouns",

--- a/src/domain/learningBlocks.test.ts
+++ b/src/domain/learningBlocks.test.ts
@@ -59,9 +59,9 @@ describe("isLearningBlockComplete", () => {
     const trackable = learningBlocks.filter(
       (b) => b.group === "basic" && b.completionMode !== "reference"
     );
-    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 6 N4 grammar (#549-#551) + 11
+    // 2 kana + 1 starter-vocab (#533) + 2 Lesson-0 grammar (#534) + 13 N5 grammar (#543-#548) + 8 N4 grammar (#549-#552) + 11
     // conjugation + 7 sentence-pattern; only verb-types stays reference.
-    expect(trackable.length).toBe(42);
+    expect(trackable.length).toBe(44);
     expect(trackable.some((b) => b.id === "te-kudasai")).toBe(true);
     expect(byId("verb-types").completionMode).toBe("reference");
   });

--- a/src/domain/learningBlocks.ts
+++ b/src/domain/learningBlocks.ts
@@ -756,6 +756,56 @@ export const learningBlocks: LearningBlock[] = [
     recommendedAfter: ["n4-shushoku"]
   },
   {
+    id: "n4-fukugou",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "複合動詞 〜はじめる・〜方",
+    subtitle: "雨が降りだした／漢字の読み方",
+    explanation:
+      "把兩個動詞黏成一個＝複合動詞，前半用ます形語幹。階段四件組：〜はじめる（開始）、〜だす（突然開始，配急に）、〜つづける（持續）、〜おわる（做完）——注意自他：はじめる/つづける是他動（自己做），はじまる/つづく是自動（事情自己發生），別黏錯。方向一對：〜ていく（帶去、離開說話者）/〜てくる（帶來、朝向說話者）——同一對也能表時間推移（変わってきた＝一路變到現在、変わっていく＝今後繼續變）。構詞兩件：ます形語幹＋方（かた）＝〜的方法（読み方）；い形容詞去い＋さ＝名詞化（高さ）。",
+    examples: [
+      { formula: "急に雨が降りだした", note: "突發開始：〜だす" },
+      { formula: "去年から習いはじめた／3時間走りつづけた", note: "開始與持續（他動）" },
+      { formula: "持っていく／買ってくる", note: "方向：離開いく、回來くる" },
+      { formula: "この漢字の読み方", note: "ます語幹＋方＝方法" },
+      { formula: "山の高さ", note: "い形去い＋さ＝名詞化" }
+    ],
+    pitfalls: [
+      "自他別黏錯：×習いはじまる→習いはじめる（はじまる是会議がはじまる的自動詞）",
+      "急に、突然 配〜だす；一般的開始用〜はじめる",
+      "ていく/てくる的時間用法方向要想：朝現在＝てきた、朝未來＝ていく"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Fukugou", patternIds: ["n4-fukugou"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-kansetsu"]
+  },
+  {
+    id: "n4-henka",
+    group: "basic",
+    category: "N4 文法",
+    kicker: "N4 句型",
+    title: "變化 ようになる・くする・まま",
+    subtitle: "泳げるようになった／つけたまま",
+    explanation:
+      "變化的完整系統。「〜ようになる」＝變得（會）〜：接可能動詞是能力變化（泳げるようになった）、接一般動詞是習慣變化（早く起きるようになった）；否定的變化＝ない去い＋くなる（来なくなった）。「〜ようにする」＝盡量做到（努力目標），跟「ことにする（下決心）」是鄰居。他動的變化：把東西弄成〜——い形容詞＋くする（明るくする）、な形容詞/名詞＋にする（静かにする）；對照N5的自變（くなる/になる）。「〜まま」＝保持原樣：た形＋まま（つけたまま寝た）、ない形＋まま（消さないまま出かけた）。",
+    examples: [
+      { formula: "泳げるようになりました", note: "能力變化：可能動詞＋ようになる" },
+      { formula: "野菜を食べるようにしています", note: "努力目標：ようにする" },
+      { formula: "明るくする／静かにする", note: "他動變化：く／に＋する" },
+      { formula: "来なくなりました", note: "否定的變化：なく＋なる" },
+      { formula: "つけたまま寝てしまった", note: "保持原樣：た形＋まま" }
+    ],
+    pitfalls: [
+      "ようにする＝盡量努力、ことにする＝下定決心——語感不同但常可互換，看語境",
+      "變化標記對號入座：い形→く、な形/名詞→に（做｜変：する｜なる 都適用）",
+      "まま前面：完成的狀態用た形（つけたまま）、沒做的狀態用ない形（消さないまま）"
+    ],
+    patternDrills: [{ labelKey: "drillPatternN4Henka", patternIds: ["n4-henka"] }],
+    implicitCompleteWithHistory: true,
+    recommendedAfter: ["n4-fukugou"]
+  },
+  {
     id: "adverbial",
     group: "basic",
     category: "形容詞 / 名詞 修飾",

--- a/src/domain/sentencePatterns.i18n.ts
+++ b/src/domain/sentencePatterns.i18n.ts
@@ -1559,6 +1559,134 @@ export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {
       "ja": "「〜か〜ないか」は かどうか の展開形：行くか行かないか。二つ目の か は「を」「で」「まで」に変えられない——両側とも か でペアになる。"
     }
   },
+  "pattern-n4-fukugou-001": {
+    "hintI18n": { "en": "Advising someone on their way out to bundle up.", "ja": "出かける人に一枚多く持つよう勧める。" },
+    "promptContextI18n": { "en": "(To someone heading out) \"It's cold — you'd better take a jacket.\"", "ja": "（出かける人に）「寒いから、上着を持っていったほうがいいですよ。」" },
+    "explanationI18n": {
+      "en": "The speaker is here and the listener is leaving → 「持っていく」 = take (away): 持っていったほうがいい. 「持ってきた」 goes the opposite way (bring here); 「いって」「きて」 are て-forms and can't attach to ほうがいい (which needs the た-form). ※上着 = jacket.",
+      "ja": "話し手はここ、相手は離れる→「持っていく」：持っていったほうがいい。「持ってきた」は逆方向（ここへ持って来る）。「いって」「きて」は て形で、ほうがいい（た形が要る）につながらない。"
+    }
+  },
+  "pattern-n4-fukugou-002": {
+    "hintI18n": { "en": "Telling someone to wait here while you pop out.", "ja": "その場で待つよう頼み、自分は少し出る。" },
+    "promptContextI18n": { "en": "\"Wait here. I'll go buy some bread — be right back.\"", "ja": "「ここで待っていてください。パンを買ってくるよ。すぐ戻ります。」" },
+    "explanationI18n": {
+      "en": "Going and returning to where you're speaking → 「買ってくる」 = go buy (and come back): telling the listener to 「wait here」 plus 「すぐ戻ります」 both fix the speaker as returning. 「買っていく」 is buying and taking it elsewhere, clashing with coming back here; 「きた」「いった」 are past, clashing with not-yet-departed. ※戻る = to return.",
+      "ja": "行って、話している場所へ戻る→「買ってくる」：相手に「ここで待って」と言い、「すぐ戻ります」もあって、話し手は戻ると確定。「買っていく」は買って別の場所へ持って行くことで、ここへ戻ることと矛盾。「きた」「いった」は過去で、まだ出ていないことと矛盾。"
+    }
+  },
+  "pattern-n4-fukugou-003": {
+    "hintI18n": { "en": "The weather turned with no warning.", "ja": "前触れなく天気が急変。" },
+    "promptContextI18n": { "en": "\"It suddenly started to rain.\"", "ja": "「急に雨が降りだしました。」" },
+    "explanationI18n": {
+      "en": "A sudden, unheralded onset uses ます-stem + だす: 降りだしました = started raining — a golden match with 急に. 「おわりました」 (finish) and 「つづけました」 (continue) clash with a sudden start; 「なおしました」 is redoing (書きなおす type) — rain doesn't re-fall.",
+      "ja": "急な・前触れのない開始は「ます形＋だす」：降りだしました——「急に」と黄金の相性。「おわりました」（完了）「つづけました」（継続）は急な開始と矛盾。「なおしました」はやり直し（書きなおす型）で、雨は降り直さない。"
+    }
+  },
+  "pattern-n4-fukugou-004": {
+    "hintI18n": { "en": "When your Japanese studies began.", "ja": "日本語学習のスタート地点。" },
+    "promptContextI18n": { "en": "\"I started learning Japanese last year.\"", "ja": "「去年から日本語を習いはじめました。」" },
+    "explanationI18n": {
+      "en": "Starting to do something uses ます-stem + はじめる: 習いはじめました. 「はじまりました」 is intransitive (会議がはじまる) — learning Japanese yourself needs transitive はじめる; 「つづきました」 is likewise intransitive (つづける is the transitive one); 「おわりました」 clashes with \"starting last year.\" ※習う = to learn.",
+      "ja": "何かをし始めるのは「ます形＋はじめる」：習いはじめました。「はじまりました」は自動詞（会議がはじまる）——自分が日本語を習うのは他動詞 はじめる。「つづきました」も自動詞（他動は つづける）。「おわりました」は「去年から始める」と矛盾。"
+    }
+  },
+  "pattern-n4-fukugou-005": {
+    "hintI18n": { "en": "Mid-marathon: describe the runner's state.", "ja": "マラソン途中、選手の様子を描写。" },
+    "promptContextI18n": { "en": "\"He's been running for three hours straight.\"", "ja": "「彼は3時間ずっと走りつづけています。」" },
+    "explanationI18n": {
+      "en": "Continuing to do something uses ます-stem + つづける: 走りつづけています — 「3時間ずっと」 locks in continuation. 「おわって」 means finished running; 「はじめて」「だして」 are just-started, clashing with three hours straight. ※走る = to run.",
+      "ja": "続けてするのは「ます形＋つづける」：走りつづけています——「3時間ずっと」が継続を固定。「おわって」は走り終わった、「はじめて」「だして」は始まったばかりで、3時間ずっとと矛盾。"
+    }
+  },
+  "pattern-n4-fukugou-006": {
+    "hintI18n": { "en": "Checking on their dinner progress.", "ja": "食事が済んだか尋ねる。" },
+    "promptContextI18n": { "en": "\"Have you finished dinner?\"", "ja": "「もう晩ご飯を食べおわりましたか。」" },
+    "explanationI18n": {
+      "en": "Finishing uses ます-stem + おわる: 食べおわりましたか = have you finished eating? (pairs with もう). 「はじまりました」「つづきました」 are intransitive and can't attach to transitive 食べ; 「だされました」 is passive — no sentence. ※晩ご飯 = dinner.",
+      "ja": "し終えるのは「ます形＋おわる」：食べおわりましたか（もう とセット）。「はじまりました」「つづきました」は自動詞で、他動の 食べ につながらない。「だされました」は受身で文にならない。"
+    }
+  },
+  "pattern-n4-fukugou-007": {
+    "hintI18n": { "en": "Asking how to read a character.", "ja": "漢字の読み方を教わる。" },
+    "promptContextI18n": { "en": "\"Excuse me, please teach me how to read this kanji.\"", "ja": "「すみません、この漢字の読み方を教えてください。」" },
+    "explanationI18n": {
+      "en": "\"How to ~\" = ます-stem + 方 (かた): 読み方 = how to read, 使い方 = how to use, 作り方 = how to make. 「側 (がわ)」 is a side, 「型 (かた)」 a mold/model, 「者 (しゃ)」 a person — same sound, wrong kanji, none fits.",
+      "ja": "「〜のやり方」＝ます形＋方（かた）：読み方、使い方、作り方。「側（がわ）」は横、「型（かた）」は模型・型番、「者（しゃ）」は人——同音異字でどれも合わない。"
+    }
+  },
+  "pattern-n4-fukugou-008": {
+    "hintI18n": { "en": "Quoting a mountain's stats.", "ja": "山の数値を読み上げる。" },
+    "promptContextI18n": { "en": "\"This mountain's height is 3,776 meters.\"", "ja": "「この山の高さは3776メートルです。」" },
+    "explanationI18n": {
+      "en": "い-adjective minus い + さ turns it into a noun: 高い→高さ (height), 長い→長さ, 重い→重さ. 「高こと」「高の」「高もの」 don't attach — こと and の need the full form (高いこと). ※山 = mountain, メートル = meter.",
+      "ja": "い形容詞の い を取って さ＝名詞化：高い→高さ、長い→長さ、重い→重さ。「高こと」「高の」「高もの」はつながらない——こと・の は完全な形（高いこと）に付く。"
+    }
+  },
+  "pattern-n4-henka-001": {
+    "hintI18n": { "en": "The fruit of daily practice.", "ja": "毎日の練習の成果。" },
+    "promptContextI18n": { "en": "\"After practicing every day, I (finally) can swim.\"", "ja": "「毎日練習して、泳げるようになりました。」" },
+    "explanationI18n": {
+      "en": "An ability change uses potential verb + ようになる: 泳げるようになりました = came to be able to swim. Filling in 「ことに」 makes 「ことになる」 = to be arranged/decided — learning to swim through practice is a natural ability change, not an arrangement, so it doesn't fit; 「ようを」「ままに」 can't attach to なる — only 「ように」 forms an ability change.",
+      "ja": "能力の変化は可能動詞＋ようになる：泳げるようになりました。「ことに」を入れると「ことになる」＝決まる/取り決められる——練習で泳げるようになるのは自然な能力の変化で、取り決めではないので合わない。「ようを」「ままに」は なる につながらない——能力の変化を作れるのは「ように」だけ。"
+    }
+  },
+  "pattern-n4-henka-002": {
+    "hintI18n": { "en": "An effort you keep up for your health.", "ja": "健康のために続けている心がけ。" },
+    "promptContextI18n": { "en": "\"For my health, I try to eat vegetables every day.\"", "ja": "「健康のために、毎日野菜を食べるようにしています。」" },
+    "explanationI18n": {
+      "en": "\"Make an effort to ~\" = 「〜ようにする」: 食べるようにしています. 「よう」「ようも」「ようが」 can't attach to している. Division: ことにしている = a firm personal rule you've resolved on, ようにしている = striving toward a goal (without guaranteeing every time). ※野菜 = vegetables.",
+      "ja": "「〜するよう努める」＝「〜ようにする」：食べるようにしています。「よう」「ようも」「ようが」は している につながらない。分担：ことにしている＝決心した自分ルール、ようにしている＝目標に向けて努める（毎回できるとは限らない）。"
+    }
+  },
+  "pattern-n4-henka-003": {
+    "hintI18n": { "en": "A shift in your daily rhythm.", "ja": "生活リズムの変化。" },
+    "promptContextI18n": { "en": "\"Lately I've come to get up early.\"", "ja": "「最近、朝早く起きるようになりました。」" },
+    "explanationI18n": {
+      "en": "A habit change also uses 「〜ようになる」: 起きるようになりました = (I didn't before, but) now I get up early. 「そうに」's \"almost ~\" (そうになる) needs the ます-stem (起きそうになる); the dictionary form 起きる can't produce that meaning; 「ままに」「ものに」 can't express change.",
+      "ja": "習慣の変化も「〜ようになる」：起きるようになりました。「そうに」の「〜しそうになる（危うく）」は ます形が要る（起きそうになる）。辞書形 起きる ではこの意味にならない。「ままに」「ものに」は変化を表せない。"
+    }
+  },
+  "pattern-n4-henka-004": {
+    "hintI18n": { "en": "Changing how bright the room is.", "ja": "部屋の明るさを自分で変える。" },
+    "promptContextI18n": { "en": "\"It's dark — let's make the room brighter.\"", "ja": "「暗いですね。部屋を明るくしましょう。」" },
+    "explanationI18n": {
+      "en": "Making something ~: い-adjective minus い + く + する — 明るくする. 「に」 is for な-adjectives (静かにする); 「いに」「さ」 can't attach to する. Contrast N5: it changes by itself = くなる, you change it = くする. ※部屋 = room, 明るい = bright.",
+      "ja": "ものを「〜にする」：い形容詞の い を取って く＋する——明るくする。「に」は な形容詞用（静かにする）。「いに」「さ」は する につながらない。N5 と対照：自分で変わる＝くなる、自分で変える＝くする。"
+    }
+  },
+  "pattern-n4-henka-005": {
+    "hintI18n": { "en": "A request from a household with a baby.", "ja": "赤ちゃんのいる家からのお願い。" },
+    "promptContextI18n": { "en": "\"The baby is sleeping, so please be quiet.\"", "ja": "「赤ちゃんが寝ていますから、静かにしてください。」" },
+    "explanationI18n": {
+      "en": "The な-adjective \"make it ~\" = + に + する: 静かにする. 「く」 is for い-adjectives (明るくする); 「で」「へ」 can't attach to する. Pairs with 004: 明るく / 静かに, each its own change marker. ※赤ちゃん = baby.",
+      "ja": "な形容詞の「〜にする」＝＋に＋する：静かにする。「く」は い形容詞用（明るくする）。「で」「へ」は する につながらない。004 とペア：明るく／静かに、それぞれの変化マーカー。"
+    }
+  },
+  "pattern-n4-henka-006": {
+    "hintI18n": { "en": "You dozed off by accident.", "ja": "うっかり寝てしまった話。" },
+    "promptContextI18n": { "en": "\"I fell asleep with the AC left on.\"", "ja": "「エアコンをつけたまま、寝てしまいました。」" },
+    "explanationI18n": {
+      "en": "\"Leaving it as ~\" = た-form + まま: つけたまま寝てしまった = fell asleep with it on. 「ふり」 is pretending (つけたふりをして… does form a sentence) and 「つもり」 is intending (〜つもりで…) — but both still need をして/で, and neither means \"kept on\"; a bare comma won't connect. 「むき」 is a direction and can't attach. ※エアコン = air conditioner.",
+      "ja": "「そのままの状態で〜」＝た形＋まま：つけたまま寝てしまった。「ふり」は「つけたふりをして…」なら成句、「つもり」は「〜つもりで…」——だが どちらも をして/で が要り、意味も「つけたまま」ではない。いきなり読点にはつながらない。「むき」は向きで接続不可。"
+    }
+  },
+  "pattern-n4-henka-007": {
+    "hintI18n": { "en": "You remembered the lights only after leaving.", "ja": "出てから電気に気づく。" },
+    "promptContextI18n": { "en": "\"I went out without turning off the lights.\"", "ja": "「電気を消さないまま、出かけてしまいました。」" },
+    "explanationI18n": {
+      "en": "まま can also follow the negative form: 消さないまま = in the state of not having turned it off. 「なり」「きり」 are higher-level connectives (行ったきり type) and don't attach to a ない-form here; 「ほど」 is degree and doesn't fit the meaning. ※電気 = lights, 消す = to turn off.",
+      "ja": "まま は否定形にも付く：消さないまま。「なり」「きり」は上級の接続（行ったきり型）で、ここで ない形にはつながらない。「ほど」は程度で意味が合わない。"
+    }
+  },
+  "pattern-n4-henka-008": {
+    "hintI18n": { "en": "He's stopped showing up at school lately.", "ja": "最近、学校で彼を見かけない。" },
+    "promptContextI18n": { "en": "\"Lately he's stopped coming to school.\"", "ja": "「最近、彼は学校に来なくなりました。」" },
+    "explanationI18n": {
+      "en": "A negative change = ない minus い + く + なる: 来ない → 来なくなりました = came to stop coming. 「来ないく」 kept the い; 「来なさく」「来ずく」 aren't forms — ない's change follows the same rule as い-adjectives (drop い + く).",
+      "ja": "否定の変化＝ない の い を取って く＋なる：来ない→来なくなりました。「来ないく」は い が残り、「来なさく」「来ずく」は存在しない形——ない の変化は い形容詞と同じ（い を取って く）。"
+    }
+  },
   "pattern-te-kudasai-001": {
     "hintI18n": {
       "en": "A manager gives a subordinate a work deadline.",

--- a/src/domain/sentencePatterns.ts
+++ b/src/domain/sentencePatterns.ts
@@ -23,6 +23,8 @@ export type SentencePatternId =
   | "n4-meirei"
   | "n4-shushoku"
   | "n4-kansetsu"
+  | "n4-fukugou"
+  | "n4-henka"
   | "te-kudasai"
   | "nakute-mo-ii"
   | "te-morau"
@@ -71,6 +73,8 @@ const PATTERN_LABEL_ZH: Record<SentencePatternId, string> = {
   "n4-meirei": "命令與禁止 しろ・するな",
   "n4-shushoku": "名詞修飾節 〜した＋名詞",
   "n4-kansetsu": "間接疑問 かどうか・〜か",
+  "n4-fukugou": "複合動詞 〜はじめる・〜方",
+  "n4-henka": "變化 ようになる・くする・まま",
   "te-kudasai": "請求 / 許可 / 禁止",
   "nakute-mo-ii": "不必 / 必須",
   "te-morau": "授受視角",
@@ -1963,6 +1967,204 @@ const N4_KANSETSU_ITEMS: SentencePatternItem[] = [
 ];
 
 // ===========================================================================
+// N4 pattern: n4-fukugou -- compound verbs and stem-derivation (#552).
+//   ていく/てくる appear ONLY in physical-direction items (departing
+//   speaker → いく, returning speaker → くる, double-locked by scene +
+//   attachment); the temporal-drift use is taught in the chapter text but
+//   never tested -- future-tense drift readings make both live. だす never
+//   competes where はじめる is the answer (both inchoatives are real);
+//   transitivity mixups (はじまる/つづく) are the designed foils.
+// ===========================================================================
+const N4_FUKUGOU_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-fukugou-001",
+    patternId: "n4-fukugou",
+    promptText: "（出かける人に）寒いから、上着を持って___ほうがいいですよ。",
+    hintZh: "叮嚀要出門的人多帶一件。",
+    promptContextZh: "（對要出門的人）「很冷，帶件外套去比較好喔。」",
+    expectedAnswer: "いった",
+    options: ["いった", "きた", "いって", "きて"],
+    explanation:
+      "說話者在這裡、對方要離開→「持っていく」＝帶去：持っていったほうがいい。「持ってきた」方向相反（帶來這裡）；「いって」「きて」是て形，接不上ほうがいい（要用た形）。※上着＝外套。"
+  },
+  {
+    id: "pattern-n4-fukugou-002",
+    patternId: "n4-fukugou",
+    promptText: "ここで待っていてください。パンを買って___よ。すぐ戻ります。",
+    hintZh: "叫對方在原地等，自己去一下。",
+    promptContextZh: "「你在這裡等一下。我去買個麵包（回來），馬上回來。」",
+    expectedAnswer: "くる",
+    options: ["くる", "いく", "きた", "いった"],
+    explanation:
+      "去了會回到說話的地方→「買ってくる」＝去買（回來）：叫對方「在這裡等」＋「すぐ戻ります」都鎖定說話者會回來。「買っていく」是買了帶去別處，跟回到原地矛盾；「きた」「いった」是過去式，跟還沒出門矛盾。※戻る＝返回。"
+  },
+  {
+    id: "pattern-n4-fukugou-003",
+    patternId: "n4-fukugou",
+    promptText: "急に雨が降り___。",
+    hintZh: "天氣毫無預警變了臉。",
+    promptContextZh: "「突然下起雨來了。」",
+    expectedAnswer: "だしました",
+    options: ["だしました", "おわりました", "つづけました", "なおしました"],
+    explanation:
+      "突發、無預警的開始用「ます形語幹＋だす」：降りだしました＝下起來了——跟「急に」是黃金搭配。「おわりました」是結束、「つづけました」是繼續，都跟突然開始矛盾；「なおしました」是重做一次（書きなおす型），雨不會重下。"
+  },
+  {
+    id: "pattern-n4-fukugou-004",
+    patternId: "n4-fukugou",
+    promptText: "去年から日本語を習い___。",
+    hintZh: "說學日語的起點。",
+    promptContextZh: "「從去年開始學日語。」",
+    expectedAnswer: "はじめました",
+    options: ["はじめました", "はじまりました", "おわりました", "つづきました"],
+    explanation:
+      "開始做某事用「ます形語幹＋はじめる」：習いはじめました。「はじまりました」是自動詞（会議がはじまる）——自己學日語要用他動詞はじめる；「つづきました」同樣是自動詞（つづける才是他動）；「おわりました」跟「從去年開始」矛盾。※習う＝學習。"
+  },
+  {
+    id: "pattern-n4-fukugou-005",
+    patternId: "n4-fukugou",
+    promptText: "彼は3時間ずっと走り___います。",
+    hintZh: "馬拉松途中，描述選手的狀態。",
+    promptContextZh: "「他持續跑了三個小時。」",
+    expectedAnswer: "つづけて",
+    options: ["つづけて", "おわって", "はじめて", "だして"],
+    explanation:
+      "持續做用「ます形語幹＋つづける」：走りつづけています——「3時間ずっと」鎖定持續。「おわって」是跑完了、「はじめて」「だして」是才剛開始，都跟持續三小時矛盾。※走る＝跑。"
+  },
+  {
+    id: "pattern-n4-fukugou-006",
+    patternId: "n4-fukugou",
+    promptText: "もう晩ご飯を食べ___か。",
+    hintZh: "問對方吃飯的進度。",
+    promptContextZh: "「晚餐吃完了嗎？」",
+    expectedAnswer: "おわりました",
+    options: ["おわりました", "はじまりました", "つづきました", "だされました"],
+    explanation:
+      "做完用「ます形語幹＋おわる」：食べおわりましたか＝吃完了嗎（配もう）。「はじまりました」「つづきました」是自動詞、接不上他動的食べ；「だされました」是被動、不成話。※晩ご飯＝晚餐。"
+  },
+  {
+    id: "pattern-n4-fukugou-007",
+    patternId: "n4-fukugou",
+    promptText: "すみません、この漢字の読み___を教えてください。",
+    hintZh: "拿著生字請教別人。",
+    promptContextZh: "「不好意思，請教我這個漢字的唸法。」",
+    expectedAnswer: "方",
+    options: ["方", "側", "型", "者"],
+    explanation:
+      "「〜的方法」＝ます形語幹＋方（かた）：読み方＝唸法、使い方＝用法、作り方＝做法。「側（がわ）」是側邊、「型（かた）」是模型型號、「者（しゃ）」是人——同音異字全對不上。"
+  },
+  {
+    id: "pattern-n4-fukugou-008",
+    patternId: "n4-fukugou",
+    promptText: "この山の高___は3776メートルです。",
+    hintZh: "報出富士山的數據。",
+    promptContextZh: "「這座山的高度是3776公尺。」",
+    expectedAnswer: "さ",
+    options: ["さ", "こと", "の", "もの"],
+    explanation:
+      "い形容詞去い＋さ＝名詞化：高い→高さ（高度）、長い→長さ、重い→重さ。「高こと」「高の」「高もの」都接不上——こと、の要接完整的形（高いこと）。※山＝山、メートル＝公尺。"
+  }
+];
+
+// ===========================================================================
+// N4 pattern: n4-henka -- change and transformation (#552).
+//   ことにしている never appears where ようにしている is the answer (both
+//   are real habits) -- the ようにする item uses junk foils; ないようになる
+//   is real, so the negative-change item's foils are pure junk too; ままで
+//   is real and stays out of the まま items.
+// ===========================================================================
+const N4_HENKA_ITEMS: SentencePatternItem[] = [
+  {
+    id: "pattern-n4-henka-001",
+    patternId: "n4-henka",
+    promptText: "毎日練習して、泳げる___なりました。",
+    hintZh: "苦練的成果。",
+    promptContextZh: "「每天練習，（終於）變得會游泳了。」",
+    expectedAnswer: "ように",
+    options: ["ように", "ことに", "ようを", "ままに"],
+    explanation:
+      "能力的變化用「可能動詞＋ようになる」：泳げるようになりました＝變得會游了。填「ことに」會變成「ことになる」＝被安排/被決定——苦練學會是自然的能力變化、不是被安排，語意不合；「ようを」「ままに」接不上「なる」——只有「ように」能構成能力的變化。"
+  },
+  {
+    id: "pattern-n4-henka-002",
+    patternId: "n4-henka",
+    promptText: "健康のために、毎日野菜を食べる___しています。",
+    hintZh: "為健康維持的努力。",
+    promptContextZh: "「為了健康，我盡量每天吃蔬菜。」",
+    expectedAnswer: "ように",
+    options: ["ように", "よう", "ようも", "ようが"],
+    explanation:
+      "「盡量做到〜」＝「〜ようにする」：食べるようにしています。「よう」「ようも」「ようが」都接不上している。順帶分工：ことにしている＝下定決心的自我規定、ようにしている＝朝目標努力（不保證每次做到）。※野菜＝蔬菜。"
+  },
+  {
+    id: "pattern-n4-henka-003",
+    patternId: "n4-henka",
+    promptText: "最近、朝早く起きる___なりました。",
+    hintZh: "生活節奏的轉變。",
+    promptContextZh: "「最近變得會早起了。」",
+    expectedAnswer: "ように",
+    options: ["ように", "ままに", "そうに", "ものに"],
+    explanation:
+      "習慣的變化也用「〜ようになる」：起きるようになりました＝（以前不會）現在會早起了。「そうに」的『差點〜』（そうになる）要接ます形語幹（起きそうになる），辭書形 起きる 接不出這個意思；「ままに」「ものに」接不出變化。"
+  },
+  {
+    id: "pattern-n4-henka-004",
+    patternId: "n4-henka",
+    promptText: "暗いですね。部屋を明る___しましょう。",
+    hintZh: "動手改變房間的亮度。",
+    promptContextZh: "「好暗喔，把房間弄亮一點吧。」",
+    expectedAnswer: "く",
+    options: ["く", "に", "いに", "さ"],
+    explanation:
+      "把東西「弄成〜」：い形容詞去い＋く＋する——明るくする。「に」是な形容詞用的（静かにする）；「いに」「さ」都接不上する。對照N5：自己變＝くなる、動手改＝くする。※部屋＝房間、明るい＝明亮。"
+  },
+  {
+    id: "pattern-n4-henka-005",
+    patternId: "n4-henka",
+    promptText: "赤ちゃんが寝ていますから、静か___してください。",
+    hintZh: "家有嬰兒的請求。",
+    promptContextZh: "「嬰兒在睡覺，請安靜一點。」",
+    expectedAnswer: "に",
+    options: ["に", "く", "で", "へ"],
+    explanation:
+      "な形容詞的「弄成〜」＝＋に＋する：静かにする。「く」是い形容詞用的（明るくする）；「で」「へ」接不上する。跟004成對：明るく／静かに，各自的變化標記。※赤ちゃん＝嬰兒。"
+  },
+  {
+    id: "pattern-n4-henka-006",
+    patternId: "n4-henka",
+    promptText: "エアコンをつけた___、寝てしまいました。",
+    hintZh: "說自己不小心就睡著了。",
+    promptContextZh: "「開著空調就睡著了。」",
+    expectedAnswer: "まま",
+    options: ["まま", "ふり", "つもり", "むき"],
+    explanation:
+      "「保持原樣〜」＝た形＋まま：つけたまま寝てしまった＝開著就睡了。「ふり」是假裝（つけたふりをして… 可以成句）、「つもり」是打算（〜つもりで…）——但都要再接をして/で，且語意不是「保持開著」，直接接逗號都不成句；「むき」是朝向，接不上。※エアコン＝空調。"
+  },
+  {
+    id: "pattern-n4-henka-007",
+    patternId: "n4-henka",
+    promptText: "電気を消さない___、出かけてしまいました。",
+    hintZh: "出門後才想起燈的事。",
+    promptContextZh: "「沒關燈就出門了。」",
+    expectedAnswer: "まま",
+    options: ["まま", "なり", "きり", "ほど"],
+    explanation:
+      "否定形也能接まま：消さないまま＝沒關的狀態下。「なり」「きり」是更高級的接續（行ったきり型），接ない形在這裡不成句；「ほど」是程度，語意接不上。※電気＝電燈、消す＝關（燈）。"
+  },
+  {
+    id: "pattern-n4-henka-008",
+    patternId: "n4-henka",
+    promptText: "最近、彼は学校に___なりました。",
+    hintZh: "說他最近都沒出現在學校。",
+    promptContextZh: "「最近他變得不來學校了。」",
+    expectedAnswer: "来なく",
+    options: ["来なく", "来ないく", "来なさく", "来ずく"],
+    explanation:
+      "否定的變化＝ない形去い＋く＋なる：来ない→来なくなりました＝變得不來了。「来ないく」沒去い；「来なさく」「来ずく」都不是存在的形——ない的變化跟い形容詞同一套（去い＋く）。"
+  }
+];
+
+// ===========================================================================
 // Lesson-0 pattern A: starter-desu -- the AはBです sentence family (#534).
 //   Absolute-beginner floor: kana-only sentences built from the starter
 //   vocabulary deck. Unique solutions are locked by IN-SENTENCE anchors
@@ -2826,6 +3028,8 @@ export const sentencePatternItems: SentencePatternItem[] = [
   ...N4_MEIREI_ITEMS,
   ...N4_SHUSHOKU_ITEMS,
   ...N4_KANSETSU_ITEMS,
+  ...N4_FUKUGOU_ITEMS,
+  ...N4_HENKA_ITEMS,
   ...TE_KUDASAI_ITEMS,
   ...NAKUTE_MO_II_ITEMS,
   ...TE_MORAU_ITEMS,

--- a/src/domain/starterPatterns.test.ts
+++ b/src/domain/starterPatterns.test.ts
@@ -107,13 +107,17 @@ describe("N5 grammar patterns (#543: sonzai + ichi / #544: joshi2 + joshi3)", ()
     const meirei = buildSentencePatternPool({ patternIds: ["n4-meirei"] });
     const shushoku = buildSentencePatternPool({ patternIds: ["n4-shushoku"] });
     const kansetsu = buildSentencePatternPool({ patternIds: ["n4-kansetsu"] });
+    const fukugou = buildSentencePatternPool({ patternIds: ["n4-fukugou"] });
+    const henka = buildSentencePatternPool({ patternIds: ["n4-henka"] });
     expect(ndesu).toHaveLength(8);
     expect(suiryou).toHaveLength(8);
     expect(ishi).toHaveLength(8);
     expect(meirei).toHaveLength(8);
     expect(shushoku).toHaveLength(8);
     expect(kansetsu).toHaveLength(8);
-    for (const q of [...ndesu, ...suiryou, ...ishi, ...meirei, ...shushoku, ...kansetsu]) {
+    expect(fukugou).toHaveLength(8);
+    expect(henka).toHaveLength(8);
+    for (const q of [...ndesu, ...suiryou, ...ishi, ...meirei, ...shushoku, ...kansetsu, ...fukugou, ...henka]) {
       expect(q.options, q.id).toHaveLength(4);
       expect(new Set(q.options).size, q.id).toBe(4);
       expect(q.options!.filter((o) => q.expectedAnswers.includes(o)), q.id).toHaveLength(1);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -220,6 +220,8 @@ export type Copy = {
   drillPatternN4Meirei: string;
   drillPatternN4Shushoku: string;
   drillPatternN4Kansetsu: string;
+  drillPatternN4Fukugou: string;
+  drillPatternN4Henka: string;
   drillPatternTeKudasai: string;
   drillPatternNakuteMoII: string;
   drillPatternTeMorau: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -237,6 +237,8 @@ export const en: Copy = {
   drillPatternN4Meirei: "Drill commands + prohibition",
   drillPatternN4Shushoku: "Drill noun-modifying clauses",
   drillPatternN4Kansetsu: "Drill indirect questions",
+  drillPatternN4Fukugou: "Drill compound verbs",
+  drillPatternN4Henka: "Drill change patterns",
   drillPatternTeKudasai: "Pattern drill: request / permission / prohibition",
   drillPatternNakuteMoII: "Pattern drill: don't have to vs. must",
   drillPatternTeMorau: "Pattern drill: giving & receiving perspective",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -237,6 +237,8 @@ export const id: Copy = {
   drillPatternN4Meirei: "Latih perintah + larangan",
   drillPatternN4Shushoku: "Latih klausa pewatas nomina",
   drillPatternN4Kansetsu: "Latih pertanyaan tak langsung",
+  drillPatternN4Fukugou: "Latih verba majemuk",
+  drillPatternN4Henka: "Latih pola perubahan",
   drillPatternTeKudasai: "Latih pola: permintaan / izin / larangan",
   drillPatternNakuteMoII: "Latih pola: tidak perlu vs harus",
   drillPatternTeMorau: "Latih pola: sudut pandang memberi-menerima",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -245,6 +245,8 @@ export const ja: Copy = {
   drillPatternN4Meirei: "命令と禁止を練習",
   drillPatternN4Shushoku: "名詞修飾節を練習",
   drillPatternN4Kansetsu: "間接疑問を練習",
+  drillPatternN4Fukugou: "複合動詞を練習",
+  drillPatternN4Henka: "変化の文型を練習",
   drillPatternTeKudasai: "文型を練習：依頼 / 許可 / 禁止",
   drillPatternNakuteMoII: "文型を練習：不要 vs 義務",
   drillPatternTeMorau: "文型を練習：授受の視点",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -237,6 +237,8 @@ export const ko: Copy = {
   drillPatternN4Meirei: "명령과 금지 연습",
   drillPatternN4Shushoku: "명사 수식절 연습",
   drillPatternN4Kansetsu: "간접 의문 연습",
+  drillPatternN4Fukugou: "복합동사 연습",
+  drillPatternN4Henka: "변화 문형 연습",
   drillPatternTeKudasai: "문형 연습: 요청 / 허가 / 금지",
   drillPatternNakuteMoII: "문형 연습: ~하지 않아도 됨 vs ~해야 함",
   drillPatternTeMorau: "문형 연습: 주고받기 관점",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -237,6 +237,8 @@ export const my: Copy = {
   drillPatternN4Meirei: "အမိန့်နှင့် တားမြစ်ချက် လေ့ကျင့်ရန်",
   drillPatternN4Shushoku: "နာမ်အထူးပြုဝါကျ လေ့ကျင့်ရန်",
   drillPatternN4Kansetsu: "သွယ်ဝိုက်မေးခွန်း လေ့ကျင့်ရန်",
+  drillPatternN4Fukugou: "ပေါင်းစပ်ကြိယာ လေ့ကျင့်ရန်",
+  drillPatternN4Henka: "ပြောင်းလဲမှုပုံစံ လေ့ကျင့်ရန်",
   drillPatternTeKudasai: "ပုံစံ လေ့ကျင့်: တောင်းဆို / ခွင့်ပြု / တားမြစ်",
   drillPatternNakuteMoII: "ပုံစံ လေ့ကျင့်: မလိုအပ် vs. မဖြစ်မနေ",
   drillPatternTeMorau: "ပုံစံ လေ့ကျင့်: ပေးခြင်းနှင့် လက်ခံခြင်း ရှုထောင့်",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -238,6 +238,8 @@ export const th: Copy = {
   drillPatternN4Meirei: "ฝึกคำสั่งและการห้าม",
   drillPatternN4Shushoku: "ฝึกอนุประโยคขยายคำนาม",
   drillPatternN4Kansetsu: "ฝึกคำถามทางอ้อม",
+  drillPatternN4Fukugou: "ฝึกคำกริยาประสม",
+  drillPatternN4Henka: "ฝึกรูปประโยคการเปลี่ยนแปลง",
   drillPatternTeKudasai: "ฝึกรูปประโยค: ขอร้อง / อนุญาต / ห้าม",
   drillPatternNakuteMoII: "ฝึกรูปประโยค: ไม่จำเป็น vs จำเป็น",
   drillPatternTeMorau: "ฝึกรูปประโยค: มุมมองการให้-รับ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -237,6 +237,8 @@ export const vi: Copy = {
   drillPatternN4Meirei: "Luyện mệnh lệnh và cấm chỉ",
   drillPatternN4Shushoku: "Luyện mệnh đề bổ nghĩa danh từ",
   drillPatternN4Kansetsu: "Luyện câu hỏi gián tiếp",
+  drillPatternN4Fukugou: "Luyện động từ ghép",
+  drillPatternN4Henka: "Luyện mẫu câu biến đổi",
   drillPatternTeKudasai: "Luyện mẫu câu: yêu cầu / cho phép / cấm đoán",
   drillPatternNakuteMoII: "Luyện mẫu câu: không cần phải vs. bắt buộc",
   drillPatternTeMorau: "Luyện mẫu câu: góc nhìn cho & nhận",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -237,6 +237,8 @@ export const zhHant: Copy = {
   drillPatternN4Meirei: "練命令與禁止",
   drillPatternN4Shushoku: "練名詞修飾節",
   drillPatternN4Kansetsu: "練間接疑問",
+  drillPatternN4Fukugou: "練複合動詞",
+  drillPatternN4Henka: "練變化句型",
   drillPatternTeKudasai: "練句型：請求 / 許可 / 禁止",
   drillPatternNakuteMoII: "練句型：不必 vs 必須",
   drillPatternTeMorau: "練句型：授受視角",


### PR DESCRIPTION
## Summary
- **n4-fukugou** 複合動詞：ていく/てくる（方向）・はじめる/おわる/つづける/だす・〜方/〜さ，8 題
- **n4-henka** 變化：ようになる/ようにする・くする/にする・〜まま，8 題
- 句型總數 214→230；「N4 文法」達 8 章（44 章 total）

## 設計要點
- **ていく/てくる 只考物理方向**（視點＋接續雙鎖）——時間推移用法在章解說教、但不出題（未來時態讓兩向都活）
- 自他複合動詞（はじまる/つづく 自動 vs はじめる/つづける 他動）當設計干擾；急に 錨 〜だす
- 變化標記對號（い形→く、な形/名詞→に）

## 品質閘
- 對抗審 Opus 重跑（Fable 5 額度用盡後 /model 切 Opus）：Lens1 雙解獵人零 live 干擾、零答案錯誤；Lens2 5 findings 全採納（音を静かにする 自然度、ことにする→ことになる 歸類、そう 斷言限定、ふり/つもり 接續分述、方向/相位 hint 中性化）
- codex 終審 3 findings 全採納：買っていく 視點雙解→加「ここで待っていてください」硬錨、ものに 文語名詞化讀法→ようを、ふり 過度絕對化再修
- `pnpm test` 883 全綠；build 綠；preview 實機驗證

Closes #552