### PR TITLE
fix: TTS 範例朗讀爆音/開頭缺失/長句卡頓（SpeakButton）

### DIFF
--- a/src/components/SpeakButton.test.tsx
+++ b/src/components/SpeakButton.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SpeakButton } from "./SpeakButton";
+
+// The reported TTS bug (爆音 / 缺失一小段 / 卡頓): Chrome drops the start of an
+// utterance when speak() runs in the same tick as cancel(). So when the engine
+// is idle we must speak immediately WITHOUT cancel (no clip, no latency); only
+// when something is already playing do we cancel and defer the new speak.
+
+type MockSynth = {
+  speaking: boolean;
+  pending: boolean;
+  speak: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  getVoices: () => unknown[];
+};
+
+function setupSynth({ speaking = false } = {}): MockSynth {
+  const synth: MockSynth = {
+    speaking,
+    pending: false,
+    speak: vi.fn(),
+    cancel: vi.fn(function (this: MockSynth) {
+      synth.speaking = false;
+    }),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    getVoices: () => []
+  };
+  (window as unknown as { speechSynthesis: MockSynth }).speechSynthesis = synth;
+  (window as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance =
+    class {
+      text: string;
+      lang = "";
+      rate = 1;
+      voice: unknown = null;
+      constructor(t: string) {
+        this.text = t;
+      }
+      addEventListener() {}
+      removeEventListener() {}
+    };
+  return synth;
+}
+
+describe("SpeakButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { speechSynthesis?: unknown }).speechSynthesis;
+    delete (window as unknown as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
+  });
+
+  it("speaks immediately without cancel when the engine is idle (no clipped start)", () => {
+    const synth = setupSynth({ speaking: false });
+    render(<SpeakButton text="ねこ" language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    expect(synth.cancel).not.toHaveBeenCalled();
+  });
+
+  it("cancels then defers speak when already speaking (avoids the cancel→speak clip)", () => {
+    const synth = setupSynth({ speaking: true });
+    render(<SpeakButton text="ねこ" language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(synth.cancel).toHaveBeenCalledTimes(1);
+    // The new utterance must NOT be spoken in the same tick as cancel.
+    expect(synth.speak).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when speech synthesis is unavailable", () => {
+    // no setupSynth: window.speechSynthesis undefined
+    const { container } = render(<SpeakButton text="ねこ" language="zh-Hant" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -3,15 +3,37 @@ import { copy, type Language } from "../i18n";
 import { getJapaneseVoice } from "../lib/speech";
 import { readTtsRate } from "../lib/ttsRate";
 
+// Chrome silently stops synthesis after ~15s (long example sentences cut off
+// = the reported 卡頓). A pause()/resume() heartbeat keeps it going; it only
+// fires once a sentence is still playing past the interval, so short reads
+// (which finish first) are never touched. One shared timer -- there is a
+// single global speechSynthesis engine.
+let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+function stopKeepAlive() {
+  if (keepAliveTimer !== null) {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+  }
+}
+function startKeepAlive(synth: SpeechSynthesis) {
+  stopKeepAlive();
+  keepAliveTimer = setInterval(() => {
+    if (synth.speaking) {
+      synth.pause();
+      synth.resume();
+    } else {
+      stopKeepAlive();
+    }
+  }, 12000);
+}
+
 // Small inline button that reads its `text` aloud via the browser's
 // built-in SpeechSynthesis API. No external TTS service or audio asset
 // involved -- the voice quality depends on what the user's OS/browser
 // ships, but for "hear the kanji" / "hear the example sentence" the
 // built-in JA voices are good enough for a first cut. If the API or a
 // JA voice isn't available, the component renders nothing rather than a
-// broken-feeling button. Single-flight: if you click it again while
-// it's still speaking, the current utterance is cancelled first so the
-// new one starts cleanly.
+// broken-feeling button.
 export function SpeakButton({ text, language }: { text: string; language: Language }) {
   const supported =
     typeof window !== "undefined" &&
@@ -23,7 +45,7 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
 
   const handleClick = () => {
     try {
-      window.speechSynthesis.cancel();
+      const synth = window.speechSynthesis;
       const utterance = new window.SpeechSynthesisUtterance(text);
       // iOS/iPadOS ignores `lang` alone and may read kanji with a Chinese
       // voice -- pin an explicit ja-* voice when one is available.
@@ -33,11 +55,30 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
       // Read the rate fresh each click so a change in the 語速 control (#527)
       // applies immediately; defaults to the long-standing 0.95 when unset.
       utterance.rate = readTtsRate();
-      window.speechSynthesis.speak(utterance);
+      utterance.addEventListener("end", stopKeepAlive);
+      utterance.addEventListener("error", stopKeepAlive);
+
+      const speak = () => {
+        startKeepAlive(synth);
+        synth.speak(utterance);
+      };
+
+      // The reported "缺失一小段" (clipped start) / 爆音: Chrome drops the
+      // beginning of an utterance when speak() is called in the same tick as
+      // cancel(). So only cancel when something is actually playing, and give
+      // the engine a beat before the new utterance; when idle, speak now --
+      // no clip, no needless latency.
+      if (synth.speaking || synth.pending) {
+        synth.cancel();
+        setTimeout(speak, 130);
+      } else {
+        speak();
+      }
     } catch {
       // Voice synthesis can throw if the engine is in a bad state; the
       // worst case here is "no sound played", which is better than
       // crashing the practice flow.
+      stopKeepAlive();
     }
   };
 


### PR DESCRIPTION
## 使用者回饋
> 範例朗讀聲音會爆音、缺失一小段 / 範例聲音卡頓

跨多題出現（n2、n1…），是**全站性 TTS bug**、不是個別題目問題。

## 根因
[SpeakButton.tsx](src/components/SpeakButton.tsx) 用瀏覽器 Web Speech API。舊碼在同一個 tick 先 `cancel()` 再 `speak()`——這是 Chrome 有名的 **cancel→speak bug**：新語句的開頭會被吃掉（＝「缺失一小段」，聽起來也像爆音）。長句還會被 Chrome 在 ~15 秒自動停止（＝卡頓）。

## 修法
- **引擎閒置時直接 `speak()`**（不 cancel、不延遲）→ 開頭不再被截、也沒多餘延遲
- **正在朗讀時才 `cancel()`＋130ms 延遲**再 speak → 避開 cancel→speak race
- **長句加 `pause()`/`resume()` keepalive**（12s 心跳）→ 繞過 ~15s 自動停止；短句先講完、心跳不觸發，不影響一般朗讀

## 測試
新增 `SpeakButton.test.tsx`（TDD）：閒置→立即 speak 且不 cancel；朗讀中→cancel 後延遲 speak；不支援時 render null。`pnpm test` 886 全綠；build 綠；preview 實機（headless）雙擊不報錯、零 console error。

⚠ 音質本身要在真瀏覽器聽才能最終確認（headless 無音訊輸出）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech behavior so speech starts more reliably, avoids clipping, and handles active playback more smoothly.
  * Added better handling when speech synthesis is unavailable, so the control no longer renders in unsupported environments.

* **Tests**
  * Added coverage for idle, active, and unavailable speech scenarios to protect the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->