### PR TITLE
fix: 學習頁右側詳情面板被撐超長（版面崩掉）

### DIFF
--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -2,12 +2,24 @@
   display: grid;
   gap: 1rem;
   grid-template-columns: minmax(260px, 0.7fr) minmax(0, 1.55fr);
+  /* Top-align the columns: the chapter list (left) grew long as chapters were
+   * added, and grid's default align-items:stretch was stretching the detail
+   * panel (right) to match that height -- leaving a huge empty right side
+   * (reported "右邊超長"). Each column now takes its natural height. */
+  align-items: start;
   min-height: 640px;
 }
 
 .chapter-index,
 .chapter-content {
   min-width: 0;
+}
+
+/* With the long chapter list, keep the detail panel in view as you scroll
+   the index rather than leaving it stranded above the fold. */
+.chapter-content {
+  position: sticky;
+  top: 1rem;
 }
 
 .chapter-index {

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -17,6 +17,12 @@
     min-height: 0;
   }
 
+  /* Stacked single column on mobile: the detail sits below the index, so the
+     desktop sticky (which follows the long side-by-side list) isn't wanted. */
+  .chapter-content {
+    position: static;
+  }
+
   .chapter-index {
     border-bottom: 1px solid var(--rule);
     border-right: 0;


### PR DESCRIPTION
## 使用者回饋
> 感覺畫面崩掉了，右邊超長

（學習頁桌面版，左章節清單 + 右詳情面板）

## 根因
`.chapter-shell` 是 2 欄 grid，預設 `align-items: stretch` 把右側詳情面板拉高到跟左側章節清單一樣高。這陣子章節愈加愈多（N5/N4/N3 共數十章），左邊清單變超長（7000+px），右側短內容（一段說明）就被撐出數千 px 空白 → 「右邊超長」。

## 修法
- `.chapter-shell` 加 `align-items: start` → 右側取自然高度、不再被拉伸到左側清單的高度
- `.chapter-content` 設 `position: sticky; top: 1rem` → 清單很長時，詳情面板跟著捲動留在視野內（順手的 UX 改善）
- 手機版（1 欄堆疊）以 `position: static` 關閉 sticky

## 驗證
Preview 實機：桌面右側面板 **2261px（自然高度）而非左側 7331px**、捲動 1500px 時面板黏在頂端（top 206→24px）；手機 1 欄、sticky 關閉、寬度正常。零 console error。build 綠（純 CSS）。