### PR TITLE
fix: 學習頁詳情面板 sticky 後內容捲不動（題目回饋）

### DIFF
--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -16,8 +16,14 @@
 }
 
 /* With the long chapter list, keep the detail panel in view as you scroll
-   the index rather than leaving it stranded above the fold. */
+   the index rather than leaving it stranded above the fold. Cap it to the
+   viewport and let it scroll on its own: a sticky panel taller than the
+   screen pins its overflow out of reach until the page bottom (reported
+   as "content won't scroll" / "chapter drill only visible at the very
+   bottom"). */
 .chapter-content {
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
   position: sticky;
   top: 1rem;
 }

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -18,8 +18,11 @@
   }
 
   /* Stacked single column on mobile: the detail sits below the index, so the
-     desktop sticky (which follows the long side-by-side list) isn't wanted. */
+     desktop sticky (which follows the long side-by-side list) isn't wanted,
+     nor the viewport cap + inner scrollbar that comes with it. */
   .chapter-content {
+    max-height: none;
+    overflow-y: visible;
     position: static;
   }
 


### PR DESCRIPTION
使用者回報兩條同根問題：「點學習之後滑動不了內容，只能滑動分類」＋「課程章節要滑到最底部才能看到單一章節挑戰」。

**根因**：#580 給 `.chapter-content` 加了 `position: sticky` 解決右欄被拉長，但面板比視窗高時，sticky 會把下半截釘在可視範圍外——只有把左欄長清單捲完才露出來，等於「內容捲不動」、面板底部的章節挑戰按鈕更是要捲到頁底才看得到。

**修法**：sticky 面板夾進視窗高並給自己的捲軸——`max-height: calc(100vh - 2rem); overflow-y: auto`。手機單欄（≤980px）維持 `static` 並重設 `max-height/overflow`。

**實機驗證**（Browser preview）：
- 1280×800：`sticky / max-height 768px / overflow-y auto` 生效；內容溢出時面板可獨立捲動；長章「去練 N3 文法題」按鈕不需捲整頁即可視
- 窄視窗：`static / max-height none` 正常（無內捲軸）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation through long chapter lists by keeping the side panel within the viewport and enabling scrolling.
  * Updated mobile layouts so chapter content displays naturally without unnecessary height limits or scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->