### PR TITLE
補上 app-level error boundary 的恢復操作

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ points. Open it and practise; nothing to install, no account needed.
 - **Cross-device sync** — your progress follows you across devices (optional sign-in; everything works logged-out too, stored locally first).
 - **8-language UI** — Traditional Chinese, Japanese, English, Thai, Indonesian, Korean, Vietnamese, Burmese. Furigana toggle, dark / light theme.
 - **Installable PWA** — add to home screen and practise offline.
+- **App-level recovery screen** — if a lazy chunk or stale cache blows up, Jabiko shows reload / clear-cache / back-home actions instead of a blank screen. This is local recovery only, not third-party error monitoring.
 
 ## Who it's for
 

--- a/src/App.error-boundary.test.tsx
+++ b/src/App.error-boundary.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateApp = vi.hoisted(() => vi.fn());
+
+vi.mock("./hooks/usePwaUpdate", () => ({
+  usePwaUpdate: () => ({ needRefresh: true, updateApp })
+}));
+
+vi.mock("./components/UpdateToast", () => ({
+  UpdateToast: () => {
+    throw new Error("update toast failed");
+  }
+}));
+
+import App from "./App";
+
+describe("App error boundary", () => {
+  beforeEach(() => {
+    updateApp.mockClear();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("shows the recovery screen when a header-level component throws", () => {
+    render(<App />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("頁面載入失敗");
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ import { readLevelPreference, writeLevelPreference } from "./domain/levelPrefere
 import type { LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
 import { canonicalArticleSlug } from "./domain/articlesMeta";
+import packageJson from "../package.json";
 import "./styles.css";
 
 // Lazy routes. The challenge view owns the practice engine, which
@@ -86,6 +87,7 @@ const BlogIndexPage = lazy(() =>
 const BlogArticlePage = lazy(() =>
   import("./components/BlogArticlePage").then((module) => ({ default: module.BlogArticlePage }))
 );
+const BUILD_VERSION = packageJson.version;
 
 type AppView = "home" | "learn" | "rules" | "kanji" | "challenge" | "mock" | "about" | "grammar" | "blog";
 type DrillPreset = LearningBlockDrillPreset;
@@ -612,6 +614,18 @@ export default function App() {
         title={t.routeErrorTitle}
         body={t.routeErrorBody}
         reloadLabel={t.routeErrorReload}
+        clearCacheLabel={t.routeErrorClearCache}
+        homeLabel={t.routeErrorGoHome}
+        onGoHome={() => {
+          setGrammarSurface(null);
+          setBlogSlug(null);
+          setAppView("home");
+        }}
+        context={{
+          route: window.location.pathname,
+          locale: language,
+          buildVersion: BUILD_VERSION
+        }}
       >
       {appView === "home" ? (
         <HomePanel

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,6 +408,24 @@ export default function App() {
 
   return (
     <main className="app-shell">
+      <RouteErrorBoundary
+        resetKey={routeResetKey}
+        title={t.routeErrorTitle}
+        body={t.routeErrorBody}
+        reloadLabel={t.routeErrorReload}
+        clearCacheLabel={t.routeErrorClearCache}
+        homeLabel={t.routeErrorGoHome}
+        onGoHome={() => {
+          setGrammarSurface(null);
+          setBlogSlug(null);
+          setAppView("home");
+        }}
+        context={{
+          route: window.location.pathname,
+          locale: language,
+          buildVersion: BUILD_VERSION
+        }}
+      >
       {needRefresh && <UpdateToast label={t.updateAvailable} onUpdate={updateApp} />}
       {langPickerOpen && (
         <LanguagePicker
@@ -609,24 +627,6 @@ export default function App() {
       </nav>
 
       <FuriganaContext.Provider value={{ enabled: furiganaEnabled }}>
-      <RouteErrorBoundary
-        resetKey={routeResetKey}
-        title={t.routeErrorTitle}
-        body={t.routeErrorBody}
-        reloadLabel={t.routeErrorReload}
-        clearCacheLabel={t.routeErrorClearCache}
-        homeLabel={t.routeErrorGoHome}
-        onGoHome={() => {
-          setGrammarSurface(null);
-          setBlogSlug(null);
-          setAppView("home");
-        }}
-        context={{
-          route: window.location.pathname,
-          locale: language,
-          buildVersion: BUILD_VERSION
-        }}
-      >
       {appView === "home" ? (
         <HomePanel
           language={language}
@@ -752,8 +752,8 @@ export default function App() {
           />
         </Suspense>
       )}
-      </RouteErrorBoundary>
       </FuriganaContext.Provider>
+      </RouteErrorBoundary>
     </main>
   );
 }

--- a/src/components/RouteErrorBoundary.test.tsx
+++ b/src/components/RouteErrorBoundary.test.tsx
@@ -36,6 +36,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
       >
         <Thrower />
       </RouteErrorBoundary>
@@ -43,6 +47,8 @@ describe("RouteErrorBoundary", () => {
 
     expect(screen.getByRole("alert")).toHaveTextContent("Page failed");
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear cache and reload" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back home" })).toBeInTheDocument();
   });
 
   it("auto-recovers a chunk-load failure once: repair caches, then reload", async () => {
@@ -56,6 +62,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
         recover={recover}
         reload={reload}
       >
@@ -80,6 +90,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
         recover={recover}
         reload={reload}
       >
@@ -108,6 +122,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
         recover={recover}
         reload={reload}
       >
@@ -119,7 +137,7 @@ describe("RouteErrorBoundary", () => {
     expect(reload).not.toHaveBeenCalled();
   });
 
-  it("the reload button repairs caches before reloading (never a bare reload)", async () => {
+  it("the clear-cache button repairs caches before reloading", async () => {
     sessionStorage.clear();
     const user = userEvent.setup();
     const recover = vi.fn().mockResolvedValue(true);
@@ -131,6 +149,40 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
+        recover={recover}
+        reload={reload}
+      >
+        <Thrower />
+      </RouteErrorBoundary>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Clear cache and reload" }));
+
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    expect(recover).toHaveBeenCalledTimes(1);
+    expect(recover.mock.invocationCallOrder[0]).toBeLessThan(reload.mock.invocationCallOrder[0]);
+  });
+
+  it("the reload button does a direct reload without cache repair", async () => {
+    sessionStorage.clear();
+    const user = userEvent.setup();
+    const recover = vi.fn().mockResolvedValue(true);
+    const reload = vi.fn();
+
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
         recover={recover}
         reload={reload}
       >
@@ -140,10 +192,61 @@ describe("RouteErrorBoundary", () => {
 
     await user.click(screen.getByRole("button", { name: "Reload" }));
 
-    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
-    expect(recover).toHaveBeenCalledTimes(1);
-    // recover must complete before reload fires
-    expect(recover.mock.invocationCallOrder[0]).toBeLessThan(reload.mock.invocationCallOrder[0]);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it("the back-home button calls the home callback", async () => {
+    sessionStorage.clear();
+    const user = userEvent.setup();
+    const onGoHome = vi.fn();
+
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={onGoHome}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
+      >
+        <Thrower />
+      </RouteErrorBoundary>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Back home" }));
+
+    expect(onGoHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs safe route metadata with the error", () => {
+    render(
+      <RouteErrorBoundary
+        resetKey="route-a"
+        title="Page failed"
+        body="Reload the app."
+        reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "ja", buildVersion: "0.1.0" }}
+      >
+        <Thrower />
+      </RouteErrorBoundary>
+    );
+
+    expect(console.error).toHaveBeenCalledWith(
+      "[route-error]",
+      expect.any(Error),
+      expect.objectContaining({
+        route: "/challenge",
+        locale: "ja",
+        buildVersion: "0.1.0",
+        componentStack: expect.any(String)
+      })
+    );
   });
 
   it("resets after the route key changes", () => {
@@ -153,6 +256,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
       >
         <Thrower />
       </RouteErrorBoundary>
@@ -164,6 +271,10 @@ describe("RouteErrorBoundary", () => {
         title="Page failed"
         body="Reload the app."
         reloadLabel="Reload"
+        clearCacheLabel="Clear cache and reload"
+        homeLabel="Back home"
+        onGoHome={() => {}}
+        context={{ route: "/challenge", locale: "zh-Hant", buildVersion: "0.1.0" }}
       >
         <Ok />
       </RouteErrorBoundary>

--- a/src/components/RouteErrorBoundary.test.tsx
+++ b/src/components/RouteErrorBoundary.test.tsx
@@ -221,7 +221,7 @@ describe("RouteErrorBoundary", () => {
     expect(onGoHome).toHaveBeenCalledTimes(1);
   });
 
-  it("logs safe route metadata with the error", () => {
+  it("logs only the approved route metadata with the error", () => {
     render(
       <RouteErrorBoundary
         resetKey="route-a"
@@ -240,12 +240,11 @@ describe("RouteErrorBoundary", () => {
     expect(console.error).toHaveBeenCalledWith(
       "[route-error]",
       expect.any(Error),
-      expect.objectContaining({
+      {
         route: "/challenge",
         locale: "ja",
-        buildVersion: "0.1.0",
-        componentStack: expect.any(String)
-      })
+        buildVersion: "0.1.0"
+      }
     );
   });
 

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -27,6 +27,14 @@ type RouteErrorBoundaryProps = {
   title: string;
   body: string;
   reloadLabel: string;
+  clearCacheLabel: string;
+  homeLabel: string;
+  onGoHome: () => void;
+  context: {
+    route: string;
+    locale: string;
+    buildVersion: string;
+  };
   children: ReactNode;
   /** Injectable for tests; defaults to the real cache-repair routine. */
   recover?: (error: unknown) => Promise<boolean>;
@@ -64,7 +72,12 @@ export class RouteErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error("[route-error]", error, errorInfo);
+    console.error("[route-error]", error, {
+      route: this.props.context.route,
+      locale: this.props.context.locale,
+      buildVersion: this.props.context.buildVersion,
+      componentStack: errorInfo.componentStack
+    });
     // Chunk-load failures are almost always a poisoned/stale local cache
     // (immutable HTTP entry or old SW shell) — a bare reload can't fix those,
     // so repair the caches and reload once, silently. Ordinary render errors
@@ -85,10 +98,20 @@ export class RouteErrorBoundary extends Component<
   }
 
   handleReloadClick = () => {
+    this.setState({ recovering: true });
+    const { reload = () => window.location.reload() } = this.props;
+    reload();
+  };
+
+  handleClearCacheClick = () => {
     // The button must actually repair, not just reload: for a user pinned by
     // a poisoned immutable cache entry + stale SW, reload alone is a no-op.
     this.setState({ recovering: true });
     this.repairThenReload(this.state.error);
+  };
+
+  handleGoHomeClick = () => {
+    this.props.onGoHome();
   };
 
   render() {
@@ -113,6 +136,24 @@ export class RouteErrorBoundary extends Component<
         >
           {this.props.reloadLabel}
         </button>
+        <div className="route-error-actions">
+          <button
+            type="button"
+            className="next-button"
+            disabled={this.state.recovering}
+            onClick={this.handleClearCacheClick}
+          >
+            {this.props.clearCacheLabel}
+          </button>
+          <button
+            type="button"
+            className="next-button route-error-home"
+            disabled={this.state.recovering}
+            onClick={this.handleGoHomeClick}
+          >
+            {this.props.homeLabel}
+          </button>
+        </div>
       </section>
     );
   }

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Component, type ReactNode } from "react";
 import { isChunkLoadError, recoverPoisonedAssets } from "../lib/assetRecovery";
 
 // One silent self-repair per session: enough to recover a poisoned cache
@@ -71,12 +71,11 @@ export class RouteErrorBoundary extends Component<
     }
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error: Error) {
     console.error("[route-error]", error, {
       route: this.props.context.route,
       locale: this.props.context.locale,
-      buildVersion: this.props.context.buildVersion,
-      componentStack: errorInfo.componentStack
+      buildVersion: this.props.context.buildVersion
     });
     // Chunk-load failures are almost always a poisoned/stale local cache
     // (immutable HTTP entry or old SW shell) — a bare reload can't fix those,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -32,6 +32,8 @@ export type Copy = {
   routeErrorTitle: string;
   routeErrorBody: string;
   routeErrorReload: string;
+  routeErrorClearCache: string;
+  routeErrorGoHome: string;
   home: string;
   learn: string;
   rules: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -16,6 +16,8 @@ export const en: Copy = {
   routeErrorTitle: "Page failed to load",
   routeErrorBody: "Your browser may still be using an older app file. Reload to get the latest version.",
   routeErrorReload: "Reload",
+  routeErrorClearCache: "Clear cache and reload",
+  routeErrorGoHome: "Back home",
   home: "Home",
   learn: "Learn",
   rules: "Rules",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -16,6 +16,8 @@ export const id: Copy = {
   routeErrorTitle: "Halaman gagal dimuat",
   routeErrorBody: "Browser Anda mungkin masih memakai file aplikasi lama. Muat ulang untuk mengambil versi terbaru.",
   routeErrorReload: "Muat ulang",
+  routeErrorClearCache: "Hapus cache lalu muat ulang",
+  routeErrorGoHome: "Kembali ke beranda",
   home: "Beranda",
   learn: "Belajar",
   rules: "Tabel aturan",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -16,6 +16,8 @@ export const ja: Copy = {
   routeErrorTitle: "ページの読み込みに失敗しました",
   routeErrorBody: "古いバージョンのファイルが残っている可能性があります。再読み込みして最新バージョンを取得してください。",
   routeErrorReload: "再読み込み",
+  routeErrorClearCache: "キャッシュを消して再読み込み",
+  routeErrorGoHome: "ホームに戻る",
   home: "ホーム",
   learn: "学習",
   rules: "活用表",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -16,6 +16,8 @@ export const ko: Copy = {
   routeErrorTitle: "페이지를 불러오지 못했습니다",
   routeErrorBody: "브라우저가 이전 앱 파일을 사용 중일 수 있습니다. 새로고침하여 최신 버전을 불러오세요.",
   routeErrorReload: "새로고침",
+  routeErrorClearCache: "캐시를 지우고 다시 불러오기",
+  routeErrorGoHome: "홈으로 돌아가기",
   home: "홈",
   learn: "학습",
   rules: "규칙표",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -16,6 +16,8 @@ export const my: Copy = {
   routeErrorTitle: "စာမျက်နှာကို ဖွင့်မရပါ",
   routeErrorBody: "ဘရောက်ဇာသည် အက်ပ်ဖိုင်ဟောင်းကို သုံးနေဆဲဖြစ်နိုင်သည်။ နောက်ဆုံးဗားရှင်းကို ရယူရန် ပြန်လည်ဖွင့်ပါ။",
   routeErrorReload: "ပြန်လည်ဖွင့်ပါ",
+  routeErrorClearCache: "cache ဖျက်ပြီး ပြန်လည်ဖွင့်ပါ",
+  routeErrorGoHome: "ပင်မစာမျက်နှာသို့",
   home: "ပင်မ",
   learn: "လေ့လာရန်",
   rules: "စည်းမျဉ်းများ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -16,6 +16,8 @@ export const th: Copy = {
   routeErrorTitle: "โหลดหน้าไม่สำเร็จ",
   routeErrorBody: "เบราว์เซอร์อาจยังใช้ไฟล์แอปเวอร์ชันเก่าอยู่ โปรดโหลดใหม่เพื่อใช้เวอร์ชันล่าสุด",
   routeErrorReload: "โหลดใหม่",
+  routeErrorClearCache: "ล้างแคชแล้วโหลดใหม่",
+  routeErrorGoHome: "กลับหน้าแรก",
   home: "หน้าแรก",
   learn: "เรียนรู้",
   rules: "ตารางกฎ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -16,6 +16,8 @@ export const vi: Copy = {
   routeErrorTitle: "Không tải được trang",
   routeErrorBody: "Trình duyệt có thể vẫn đang dùng tệp ứng dụng cũ. Tải lại để nhận phiên bản mới nhất.",
   routeErrorReload: "Tải lại",
+  routeErrorClearCache: "Xoá bộ nhớ đệm rồi tải lại",
+  routeErrorGoHome: "Về trang chủ",
   home: "Trang chủ",
   learn: "Học",
   rules: "Bảng quy tắc",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -16,6 +16,8 @@ export const zhHant: Copy = {
   routeErrorTitle: "頁面載入失敗",
   routeErrorBody: "可能是瀏覽器還在使用舊版本檔案。請重新整理，載入最新版本。",
   routeErrorReload: "重新整理",
+  routeErrorClearCache: "清除快取後重載",
+  routeErrorGoHome: "回首頁",
   home: "首頁",
   learn: "學習",
   rules: "規則表",

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -583,3 +583,16 @@
   color: var(--muted);
   line-height: 1.7;
 }
+
+.route-error-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.route-error-home {
+  background: transparent;
+  color: var(--text);
+}


### PR DESCRIPTION
## 背景

對應 Closes #459。

Jabiko 已經有 route-level error boundary 與 chunk load recovery 基礎，但目前錯誤畫面仍有幾個缺口：
- 使用者遇到 runtime error 時，只有單一路徑，缺少更明確的恢復操作。
- chunk / stale cache 類問題雖然有修復邏輯，但 UI 上沒有明確的「清除快取後重載」入口。
- console error 缺少最小必要的 route / locale / build version metadata，排查時上下文不夠。

這張 PR 補的是最小可用範圍，不引入第三方監控，也不改 PWA caching strategy。

## 這次改了什麼

- 在  補上三個 recovery actions：
  - 
  - 
  - 
- 將「直接 reload」與「先 repair cache 再 reload」拆成兩條明確路徑。
- 錯誤紀錄補上安全 metadata：
  - 
  - LANG="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_CTYPE="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_ALL="en_US.UTF-8"
  - 
  - 
- 由  傳入目前 route context 與回首頁行為。
- 補齊錯誤畫面的 i18n 文案。
- README 補一句說明：這是本機 recovery screen，不是 error monitoring。

## 不包含的範圍

- 不導入 Sentry / LogRocket / 其他第三方監控
- 不送出題目內容、使用者答案或個資
- 不改動現有 PWA precache / service worker 策略
- 不擴張 analytics scope

## 驗證

- 
> jabiko@0.1.0 test /Users/tachikoma/Developer/Jabiko
> vitest run -- --run src/components/RouteErrorBoundary.test.tsx src/lib/assetRecovery.test.ts src/App.test.tsx


 RUN  v4.1.7 /Users/tachikoma/Developer/Jabiko


 Test Files  75 passed (75)
      Tests  780 passed (780)
   Start at  10:03:19
   Duration  18.97s (transform 22.04s, setup 4.93s, import 40.30s, tests 27.29s, environment 41.96s)
- 
> jabiko@0.1.0 build /Users/tachikoma/Developer/Jabiko
> tsc --noEmit && vite build && node scripts/prerender.mjs

vite v7.3.3 building client environment for production...
transforming...
✓ 1880 modules transformed.
rendering chunks...
computing gzip size...
dist/manifest.webmanifest                            0.61 kB
dist/index.html                                      3.38 kB │ gzip:     1.22 kB
dist/assets/index-D54qy6K4.css                      82.91 kB │ gzip:    14.85 kB
dist/assets/localizedContent-DrB0rdMd.js             0.15 kB │ gzip:     0.14 kB
dist/assets/arrow-left-XLKPbOMs.js                   0.16 kB │ gzip:     0.16 kB
dist/assets/BlogIndexPage-CegYr-OP.js                1.60 kB │ gzip:     0.61 kB
dist/assets/workbox-window.prod.es5-BBnX5xw4.js      5.75 kB │ gzip:     2.36 kB
dist/assets/GrammarIndexPage-0sJiBtEW.js             5.89 kB │ gzip:     2.04 kB
dist/assets/GrammarPointPage-DvUPVxx6.js             7.70 kB │ gzip:     1.80 kB
dist/assets/MockExamPanel--vF2K8e9.js                7.81 kB │ gzip:     1.75 kB
dist/assets/GrammarNoteCard-CajlXaFv.js             13.30 kB │ gzip:     5.64 kB
dist/assets/conjugationTables.i18n-DWYW_tG6.js      22.80 kB │ gzip:     6.70 kB
dist/assets/BlogArticlePage-Cg_uz-AR.js             23.02 kB │ gzip:    10.09 kB
dist/assets/grammarIndex-Cj3c07E0.js                41.16 kB │ gzip:    11.92 kB
dist/assets/KanjiOnyomiPanel-BhW-zJ_t.js            97.40 kB │ gzip:    30.75 kB
dist/assets/SpeakButton-DrjNda0e.js                127.85 kB │ gzip:    47.22 kB
dist/assets/learningBlocks.i18n-D_pCAdl4.js        187.09 kB │ gzip:    59.60 kB
dist/assets/index-DXNPYaeu.js                      210.64 kB │ gzip:    55.03 kB
dist/assets/index-WE3MWHJU.js                      670.53 kB │ gzip:   204.84 kB
dist/assets/ChallengePanel-DQ4nUnJ-.js           1,993.60 kB │ gzip:   397.40 kB
dist/assets/examBlocks-C1k1QO2J.js               6,263.76 kB │ gzip: 1,771.60 kB
✓ built in 2.88s

PWA v1.3.0
mode      generateSW
precache  30 entries (9539.84 KiB)
files generated
  dist/sw.js
  dist/workbox-2fbc6a65.js
[prerender] wrote 99 static pages into dist/

## 測試重點

- 一般 render error 會顯示 recovery screen
- chunk-load failure 仍保留一次 silent auto-recovery
-  會先跑 repair 再 reload
-  走 direct reload，不額外觸發 cache repair
-  會呼叫 app-level 導航 callback
- console error 會帶最小必要 metadata
- build 通過

## 風險與備註

-  目前是透過父層 route 切換來 reset boundary，而不是在 boundary 內強制吞錯重 render，這樣比較不容易立刻重新撞回同一個 throw。
- 這張 PR 補的是恢復 UX 與排查上下文，不代表完整的 production error monitoring 已完成；若之後要接匿名錯誤事件，應另開票處理。