### PR TITLE
拆分 Vitest 的 node/jsdom 測試專案

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 
-import { beforeEach, vi } from "vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, vi } from "vitest";
 
 // The PWA register module (#327) is a build-time virtual module with no test
 // implementation; stub it so anything importing usePwaUpdate (App) can load.
@@ -20,6 +21,10 @@ function pinTestLocale() {
 }
 
 pinTestLocale();
+
+afterEach(() => {
+  cleanup();
+});
 
 beforeEach(() => {
   pinTestLocale();

--- a/src/test/setupNode.ts
+++ b/src/test/setupNode.ts
@@ -1,0 +1,6 @@
+import { beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+  // Keep shuffleQuestions deterministic in tests: 0.9999 makes Fisher-Yates a no-op.
+  vi.spyOn(Math, "random").mockReturnValue(0.9999);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,8 +64,40 @@ export default defineConfig({
     })
   ],
   test: {
-    environment: "jsdom",
     globals: true,
-    setupFiles: "./src/test/setup.ts"
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "domain-node",
+          environment: "node",
+          setupFiles: "./src/test/setupNode.ts",
+          include: ["src/domain/**/*.test.ts"],
+          exclude: [
+            "src/domain/bookmarks.test.ts",
+            "src/domain/levelPreference.test.ts",
+            "src/domain/originMigration.test.ts"
+          ]
+        }
+      },
+      {
+        extends: true,
+        test: {
+          name: "jsdom",
+          environment: "jsdom",
+          setupFiles: "./src/test/setup.ts",
+          include: [
+            "src/App*.test.tsx",
+            "src/components/**/*.test.{ts,tsx}",
+            "src/hooks/**/*.test.{ts,tsx}",
+            "src/i18n.test.ts",
+            "src/lib/**/*.test.{ts,tsx}",
+            "src/domain/bookmarks.test.ts",
+            "src/domain/levelPreference.test.ts",
+            "src/domain/originMigration.test.ts"
+          ]
+        }
+      }
+    ]
   }
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,7 +72,11 @@ export default defineConfig({
           name: "domain-node",
           environment: "node",
           setupFiles: "./src/test/setupNode.ts",
-          include: ["src/domain/**/*.test.ts"],
+          include: [
+            "src/domain/**/*.test.ts",
+            "functions/**/*.test.mjs",
+            "scripts/**/*.test.ts"
+          ],
           exclude: [
             "src/domain/bookmarks.test.ts",
             "src/domain/levelPreference.test.ts",


### PR DESCRIPTION
## 摘要
- 把 Vitest 拆成 `domain-node` 與 `jsdom` 兩個專案，讓純 domain 測試不再預設吃 `jsdom`
- 把需要瀏覽器環境的 3 個 domain 測試留在 `jsdom` 專案，並讓專案繼承根層 Vite plugin 設定
- 補上 `jsdom` 顯式 cleanup 與 `node` 專案專用 setup，避免跨測試殘留與多餘初始化

## 為什麼
- #421 的目標是把大量純函式測試從全域 `jsdom` 中拆出，降低測試環境負擔
- 原本在 `projects` 模式下，還需要保留 PWA 虛擬模組解析與 React Testing Library 的清理行為

## 驗證
- `rtk pnpm exec vitest run --project domain-node`
- `rtk pnpm exec vitest run --project jsdom src/domain/bookmarks.test.ts src/domain/levelPreference.test.ts src/domain/originMigration.test.ts`
- `rtk pnpm test`
- `rtk pnpm build`

Closes #421
