### PR TITLE
修正：查看文法詳解後保留挑戰 session

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -747,7 +747,6 @@ export default function App() {
             language={language}
             targetLevel={targetLevel}
             onExit={() => setAppView("home")}
-            onOpenGrammar={openGrammar}
             onOpenFeedback={() => setFeedbackKind("wish")}
           />
         </Suspense>

--- a/src/components/ChallengePanel.tsx
+++ b/src/components/ChallengePanel.tsx
@@ -29,7 +29,6 @@ export function ChallengePanel({
   language,
   targetLevel = null,
   onExit,
-  onOpenGrammar,
   onOpenFeedback
 }: {
   init?: SessionInit;
@@ -40,8 +39,6 @@ export function ChallengePanel({
   // session hook to seed the daily / 綜合 / 単字 level range.
   targetLevel?: LevelRange | null;
   onExit: () => void;
-  // Navigate to a grammar point's study page from the post-answer feedback (#282).
-  onOpenGrammar?: (surface: string) => void;
   // Open the in-app feedback form from the completion card (#456).
   onOpenFeedback?: () => void;
 }) {
@@ -59,7 +56,6 @@ export function ChallengePanel({
       <DrillPanel
         language={language}
         onExit={onExit}
-        onOpenGrammar={onOpenGrammar}
         onOpenFeedback={onOpenFeedback}
         {...session}
       />

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -260,25 +260,11 @@ describe("FeedbackPanel grammar note (#137)", () => {
   });
 });
 
-describe("FeedbackPanel grammar study link (#282)", () => {
+describe("FeedbackPanel grammar study link (#282, #469)", () => {
   const grammarBase = examStyleQuestions.find((q) => q.promptLabel === "文法形式選擇")!;
   const linkName = copy["zh-Hant"].grammarStudyLink;
 
-  it("links a grammar item to its study page, calling onOpenGrammar with the surface", () => {
-    const onOpenGrammar = vi.fn();
-    render(
-      <FeedbackPanel
-        feedback={{ status: "incorrect", question: grammarBase, submittedAnswer: null }}
-        language="zh-Hant"
-        options={grammarBase.options ?? []}
-        onOpenGrammar={onOpenGrammar}
-      />
-    );
-    fireEvent.click(screen.getByRole("button", { name: linkName }));
-    expect(onOpenGrammar).toHaveBeenCalledWith(grammarBase.vocabulary.surface);
-  });
-
-  it("hides the link when no onOpenGrammar navigator is wired in", () => {
+  it("opens a grammar item in a separate tab so the active drill remains mounted", () => {
     render(
       <FeedbackPanel
         feedback={{ status: "incorrect", question: grammarBase, submittedAnswer: null }}
@@ -286,7 +272,10 @@ describe("FeedbackPanel grammar study link (#282)", () => {
         options={grammarBase.options ?? []}
       />
     );
-    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
+    const link = screen.getByRole("link", { name: linkName });
+    expect(link).toHaveAttribute("href", `/grammar/${encodeURIComponent(grammarBase.vocabulary.surface)}`);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("hides the link for a non-grammar (reading) item", () => {
@@ -295,10 +284,9 @@ describe("FeedbackPanel grammar study link (#282)", () => {
         feedback={{ status: "incorrect", question: readingPool[0], submittedAnswer: null }}
         language="zh-Hant"
         options={[]}
-        onOpenGrammar={vi.fn()}
       />
     );
-    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
+    expect(screen.queryByRole("link", { name: linkName })).toBeNull();
   });
 
   it("hides the link for a grammar surface that has no study page", () => {
@@ -311,10 +299,9 @@ describe("FeedbackPanel grammar study link (#282)", () => {
         feedback={{ status: "incorrect", question, submittedAnswer: null }}
         language="zh-Hant"
         options={[]}
-        onOpenGrammar={vi.fn()}
       />
     );
-    expect(screen.queryByRole("button", { name: linkName })).toBeNull();
+    expect(screen.queryByRole("link", { name: linkName })).toBeNull();
   });
 });
 

--- a/src/components/FeedbackPanel.tsx
+++ b/src/components/FeedbackPanel.tsx
@@ -20,15 +20,12 @@ export function FeedbackPanel({
   feedback,
   language,
   options,
-  onOpenGrammar,
   bookmarked,
   onToggleBookmark
 }: {
   feedback: NonNullable<Feedback>;
   language: Language;
   options: string[];
-  /** Navigate to this grammar point's study page (#282). Omitted = no link. */
-  onOpenGrammar?: (surface: string) => void;
   /** Whether the current question is bookmarked (#470). Omit both to hide the star. */
   bookmarked?: boolean;
   onToggleBookmark?: () => void;
@@ -71,9 +68,9 @@ export function FeedbackPanel({
     promptLabel === "文法形式選擇" || promptLabel === "語順組合" || promptLabel === "文章脈絡";
   const grammarSurface = feedback.question.vocabulary.surface;
   const grammarNote = isGrammarItem ? lookupGrammarNote(grammarSurface) : null;
-  // "Study this grammar point →" deep link (#282): only for grammar items whose
-  // point actually has a study page, and only when a navigator is wired in.
-  const showStudyLink = isGrammarItem && Boolean(onOpenGrammar) && hasGrammarPoint(grammarSurface);
+  // "Study this grammar point →" opens separately (#282, #469), preserving the
+  // active drill session in this tab while the learner reads the explanation.
+  const showStudyLink = isGrammarItem && hasGrammarPoint(grammarSurface);
 
   // One gloss string PER distractor, rendered one-per-line, so a long
   // option list stays readable on mobile instead of wrapping mid-item.
@@ -170,14 +167,15 @@ export function FeedbackPanel({
         </div>
       ) : null}
       {showStudyLink ? (
-        <button
-          type="button"
+        <a
           className="grammar-study-link"
-          onClick={() => onOpenGrammar?.(grammarSurface)}
+          href={`/grammar/${encodeURIComponent(grammarSurface)}`}
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {t.grammarStudyLink}
           <ArrowRight aria-hidden="true" />
-        </button>
+        </a>
       ) : null}
       <div className="report-question-block">
         {onToggleBookmark ? (

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -92,7 +92,6 @@ export function DrillPanel({
   isQuestionBookmarked,
   onToggleBookmark,
   onExit,
-  onOpenGrammar,
   onOpenFeedback
 }: Pick<
   PracticeSession,
@@ -123,7 +122,6 @@ export function DrillPanel({
 > & {
   language: Language;
   onExit: () => void;
-  onOpenGrammar?: (surface: string) => void;
   // Opens the in-app feedback form (#456) from the completion card, so a
   // learner who just spotted a bad question can report it in context.
   onOpenFeedback?: () => void;
@@ -280,7 +278,6 @@ export function DrillPanel({
               feedback={feedback}
               language={language}
               options={choiceOptions}
-              onOpenGrammar={onOpenGrammar}
               bookmarked={isQuestionBookmarked(feedback.question.id)}
               onToggleBookmark={() => onToggleBookmark(feedback.question.id)}
             />


### PR DESCRIPTION
## 變更
- 將答題回饋的「深入學習這個文法」改為安全的新分頁連結。
- 移除僅為頁內導覽存在的跨元件回呼，避免切換 view 導致挑戰面板卸載。
- 新增回歸測試，確認連結路徑與 `target="_blank"`／`rel="noopener noreferrer"`。

## 原因
原本開啟文法頁會卸載 `ChallengePanel`，使記憶體中的 drill session 遺失。

## 驗證
- `pnpm vitest run src/components/FeedbackPanel.test.tsx`
- `pnpm test`（87 個測試檔、907 項測試通過）
- `pnpm build`

Closes #469