### PR TITLE
feat: 新版更新改為安全窗自動套用（不再一律手動點 toast）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -294,8 +294,14 @@ export default function App() {
   // Persistent feedback entry (#456): the suggestion box was only reachable from
   // the homepage footer; this opens the same form from the always-visible header.
   const [feedbackKind, setFeedbackKind] = useState<FeedbackCategory | null>(null);
-  // Service-worker update prompt (#327): toast when a new build is ready.
-  const { needRefresh, updateApp } = usePwaUpdate();
+  // Service-worker update lifecycle (#327): toast when a new build is ready,
+  // plus safe-window auto apply — a pending update installs itself when the
+  // tab is hidden or the view changes, but NEVER mid-practice (challenge /
+  // mock own live question sets a reload would wipe), where the toast stays
+  // the only path.
+  const { needRefresh, updateApp } = usePwaUpdate(
+    appView === "challenge" || appView === "mock" ? null : appView
+  );
 
   const { theme, toggleTheme } = useTheme();
   // Global furigana (ruby) preference, default OFF (#134). The hook owns the

--- a/src/hooks/usePwaUpdate.test.tsx
+++ b/src/hooks/usePwaUpdate.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+// Capture registerSW's options + hand back a spy updateSW, so tests can fire
+// onNeedRefresh / onRegisteredSW like the real virtual:pwa-register would.
+const updateSW = vi.fn(() => Promise.resolve());
+let swOptions: {
+  onNeedRefresh?: () => void;
+  onRegisteredSW?: (url: string, registration: { update: () => Promise<void> } | undefined) => void;
+} = {};
+
+vi.mock("virtual:pwa-register", () => ({
+  registerSW: (options: typeof swOptions) => {
+    swOptions = options;
+    return updateSW;
+  }
+}));
+
+import { usePwaUpdate } from "./usePwaUpdate";
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, "hidden", { configurable: true, value: hidden });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: hidden ? "hidden" : "visible"
+  });
+}
+
+function fireVisibilityChange(hidden: boolean) {
+  setHidden(hidden);
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+describe("usePwaUpdate safe-window auto apply", () => {
+  beforeEach(() => {
+    updateSW.mockClear();
+    swOptions = {};
+    setHidden(false);
+  });
+
+  afterEach(() => {
+    setHidden(false);
+  });
+
+  it("surfaces needRefresh for the toast when an update arrives", () => {
+    const { result } = renderHook(() => usePwaUpdate("home"));
+    expect(result.current.needRefresh).toBe(false);
+    act(() => swOptions.onNeedRefresh?.());
+    expect(result.current.needRefresh).toBe(true);
+  });
+
+  it("applies immediately when the update arrives while the tab is hidden on a safe view", () => {
+    renderHook(() => usePwaUpdate("home"));
+    setHidden(true);
+    act(() => swOptions.onNeedRefresh?.());
+    expect(updateSW).toHaveBeenCalledWith(true);
+  });
+
+  it("applies when the tab goes hidden on a safe view with an update waiting", () => {
+    renderHook(() => usePwaUpdate("learn"));
+    act(() => swOptions.onNeedRefresh?.());
+    expect(updateSW).not.toHaveBeenCalled();
+    fireVisibilityChange(true);
+    expect(updateSW).toHaveBeenCalledWith(true);
+  });
+
+  it("never auto-applies mid-practice (safeViewKey null), even when hidden", () => {
+    renderHook(() => usePwaUpdate(null));
+    act(() => swOptions.onNeedRefresh?.());
+    setHidden(true);
+    act(() => swOptions.onNeedRefresh?.());
+    fireVisibilityChange(true);
+    expect(updateSW).not.toHaveBeenCalled();
+  });
+
+  it("applies when leaving practice for a safe view with an update waiting", () => {
+    const { rerender } = renderHook(({ key }: { key: string | null }) => usePwaUpdate(key), {
+      initialProps: { key: null as string | null }
+    });
+    act(() => swOptions.onNeedRefresh?.());
+    expect(updateSW).not.toHaveBeenCalled();
+    rerender({ key: "home" });
+    expect(updateSW).toHaveBeenCalledWith(true);
+  });
+
+  it("applies on a safe-to-safe view change with an update waiting", () => {
+    const { rerender } = renderHook(({ key }: { key: string | null }) => usePwaUpdate(key), {
+      initialProps: { key: "learn" as string | null }
+    });
+    act(() => swOptions.onNeedRefresh?.());
+    expect(updateSW).not.toHaveBeenCalled();
+    rerender({ key: "home" });
+    expect(updateSW).toHaveBeenCalledWith(true);
+  });
+
+  it("does not apply while the user stays visible on the same view (toast only)", () => {
+    const { result, rerender } = renderHook(({ key }: { key: string | null }) => usePwaUpdate(key), {
+      initialProps: { key: "learn" as string | null }
+    });
+    act(() => swOptions.onNeedRefresh?.());
+    rerender({ key: "learn" });
+    expect(updateSW).not.toHaveBeenCalled();
+    expect(result.current.needRefresh).toBe(true);
+  });
+
+  it("checks for a new SW when the tab becomes visible again", () => {
+    renderHook(() => usePwaUpdate("home"));
+    const registration = { update: vi.fn(() => Promise.resolve()) };
+    act(() => swOptions.onRegisteredSW?.("/sw.js", registration));
+    fireVisibilityChange(true);
+    registration.update.mockClear();
+    fireVisibilityChange(false);
+    expect(registration.update).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/usePwaUpdate.ts
+++ b/src/hooks/usePwaUpdate.ts
@@ -8,33 +8,89 @@ import { registerSW } from "virtual:pwa-register";
 // navigator.serviceWorker.register and never told the running page about a new
 // version, so users were stuck on the old build until an incognito visit.
 //
-// onRegisteredSW also polls for a new SW hourly, so a long-open tab still
-// notices a deploy instead of waiting for the browser's ~24h check.
+// Safe-window auto apply (user feedback 2026-07: "都要手動太不人性"): the app
+// knows when a reload is harmless, so it applies the waiting SW by itself at
+// those moments instead of always waiting for a toast click. `safeViewKey` is
+// the current top-level view name, or null while the learner is mid-practice
+// (challenge / mock — a reload there would wipe the running question set):
+//   - update arrives while the tab is hidden on a safe view  -> apply now
+//   - tab goes hidden on a safe view with an update waiting  -> apply (the
+//     reload happens in the background; the tab comes back on the new build)
+//   - the view CHANGES to (or between) safe views             -> apply (the
+//     page is transitioning anyway, one reload is barely visible)
+//   - visible + same view, or mid-practice                    -> never; the
+//     toast stays as the manual path
+//
+// Discovery: onRegisteredSW polls for a new SW hourly, and the tab re-checks
+// whenever it becomes visible again, so a long-open tab notices a deploy at
+// the next refocus instead of up to an hour later.
 const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
-export function usePwaUpdate() {
+export function usePwaUpdate(safeViewKey: string | null) {
   const [needRefresh, setNeedRefresh] = useState(false);
   const updateRef = useRef<((reloadPage?: boolean) => Promise<void>) | null>(null);
+  // Loose update() return type: the DOM lib types it Promise<ServiceWorkerRegistration>,
+  // test doubles return Promise<void>; we only ever fire-and-forget it.
+  const registrationRef = useRef<{ update: () => Promise<unknown> } | null>(null);
+  // Refs mirror the reactive values so the SW callbacks and the (single)
+  // visibilitychange listener always read the current state.
+  const needRefreshRef = useRef(false);
+  const safeKeyRef = useRef(safeViewKey);
+  safeKeyRef.current = safeViewKey;
+
+  const updateApp = useCallback(() => {
+    void updateRef.current?.(true);
+  }, []);
 
   useEffect(() => {
     updateRef.current = registerSW({
       immediate: true,
       onNeedRefresh() {
+        needRefreshRef.current = true;
         setNeedRefresh(true);
+        // Deploy landed while the learner was away: apply invisibly.
+        if (document.hidden && safeKeyRef.current !== null) {
+          void updateRef.current?.(true);
+        }
       },
       onRegisteredSW(_swUrl, registration) {
         if (registration) {
+          registrationRef.current = registration;
           setInterval(() => {
             void registration.update();
           }, UPDATE_CHECK_INTERVAL_MS);
         }
       }
     });
+    // registerSW is idempotent per page load; the empty deps are deliberate.
   }, []);
 
-  const updateApp = useCallback(() => {
-    void updateRef.current?.(true);
-  }, []);
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        if (needRefreshRef.current && safeKeyRef.current !== null) {
+          updateApp();
+        }
+      } else {
+        // Back in view: check for a new SW right away instead of waiting for
+        // the hourly poll.
+        void registrationRef.current?.update();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [updateApp]);
+
+  // View navigation is a safe seam: if an update is waiting and the learner
+  // lands on (or moves between) non-practice views, apply it there.
+  const previousKeyRef = useRef(safeViewKey);
+  useEffect(() => {
+    const changed = previousKeyRef.current !== safeViewKey;
+    previousKeyRef.current = safeViewKey;
+    if (changed && safeViewKey !== null && needRefresh) {
+      updateApp();
+    }
+  }, [safeViewKey, needRefresh, updateApp]);
 
   return { needRefresh, updateApp };
 }


### PR DESCRIPTION
使用者回饋：「更新新版本的機制⋯都要手動太不人性」。花雪拍板「安全窗自動更新」。

## 設計

原本 registerType "prompt"（#327）永遠等使用者點 UpdateToast。問題不在 prompt 本身，而是 app 其實知道何時 reload 無害。現在 waiting SW 會在安全窗自動套用：

| 情境 | 行為 |
|---|---|
| 部署時分頁在背景（最常見） | 立刻套用，切回來已是新版、同一頁 |
| 分頁切到背景＋有待套用更新 | 背景 reload，無感 |
| 換頁（進入／穿梭非練習 view） | 順勢套用（頁面本來就在轉場） |
| 挑戰／模擬考進行中 | 絕不自動動（reload 會洗掉當前題組），toast 維持手動路徑 |
| 可見且停在同一頁 | 只出 toast，不打斷閱讀 |

發現也變快：原本只有每小時 poll，現在分頁重新聚焦時立刻查一次新 SW。

## 實作
usePwaUpdate(safeViewKey: string | null)：App 對 challenge/mock 傳 null，其餘傳 view 名；key 變化＝換頁訊號。單一 visibilitychange listener：hidden→安全則套用；visible→registration.update()。Toast 手動路徑完全保留。

## TDD
8 個 hook 測試先觀察 RED（5 失敗）再 GREEN：mid-practice 永不自動（連 hidden 都不動）、hidden 時到達立即套用、離開練習回安全頁套用、safe→safe 換頁套用、同頁可見只出 toast、refocus 觸發 update 檢查。

## 驗證
pnpm test 917 綠、pnpm build 過。（SW 行為只存在於 prod build，unit 層全覆蓋。）
