### PR TITLE
feat(#608 P0-1): 手機學習區教材優先＋章節列（過渡方案）

### DIFF
--- a/src/components/LearningPanel.test.tsx
+++ b/src/components/LearningPanel.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LearningPanel } from "./LearningPanel";
+import { learningBlocks } from "../domain/learningBlocks";
+
+// #608 P0: on phones the 74-button chapter index used to sit ABOVE the lesson,
+// pushing the material ~7000px down. The mobile chapter bar surfaces the
+// current chapter + progress, prev/next, and a collapsible index. It renders
+// unconditionally (desktop hides it with CSS), so jsdom can exercise it.
+function renderPanel() {
+  return render(
+    <LearningPanel
+      language="zh-Hant"
+      progressAttempts={[]}
+      reviewCount={0}
+      onStartChallenge={vi.fn()}
+      onStartReview={vi.fn()}
+      onStartDrill={vi.fn()}
+      onStartPatternDrill={vi.fn()}
+      onStartExamSection={vi.fn()}
+      onStartKanaDrill={vi.fn()}
+      onStartStarterDrill={vi.fn()}
+    />
+  );
+}
+
+const basicBlocks = learningBlocks.filter((block) => block.group === "basic");
+
+describe("LearningPanel mobile chapter bar (#608)", () => {
+  it("shows the current chapter title and progress position", () => {
+    renderPanel();
+    const bar = screen.getByTestId("chapter-mobile-bar");
+    // Fresh learner: the first chapter is recommended, so 1 / total.
+    expect(bar.textContent).toContain(`1 / ${basicBlocks.length}`);
+    expect(bar.textContent).toContain(basicBlocks[0].title);
+  });
+
+  it("navigates with 下一章 / 上一章 and disables prev on the first chapter", () => {
+    renderPanel();
+    const next = screen.getByRole("button", { name: "下一章" });
+    const prev = screen.getByRole("button", { name: "上一章" });
+    expect(prev).toBeDisabled();
+
+    fireEvent.click(next);
+    expect(screen.getByTestId("chapter-mobile-bar").textContent).toContain(
+      `2 / ${basicBlocks.length}`
+    );
+    expect(screen.getByRole("heading", { level: 3 }).textContent).toBe(basicBlocks[1].title);
+    expect(prev).not.toBeDisabled();
+
+    fireEvent.click(prev);
+    expect(screen.getByTestId("chapter-mobile-bar").textContent).toContain(
+      `1 / ${basicBlocks.length}`
+    );
+    expect(screen.getByRole("button", { name: "上一章" })).toBeDisabled();
+  });
+
+  it("toggles the chapter index open and closes it again when a chapter is picked", () => {
+    renderPanel();
+    const toggle = screen.getByTestId("chapter-mobile-toggle");
+    const index = screen.getByLabelText("學習章節");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(index.className).not.toContain("mobile-open");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(index.className).toContain("mobile-open");
+
+    // Picking a chapter from the list selects it AND collapses the index so
+    // the material is immediately in view.
+    const target = screen.getByRole("button", {
+      name: (name) => name.includes(basicBlocks[2].title)
+    });
+    fireEvent.click(target);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(index.className).not.toContain("mobile-open");
+    expect(screen.getByRole("heading", { level: 3 }).textContent).toBe(basicBlocks[2].title);
+  });
+});

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { AlertTriangle, ArrowRight } from "lucide-react";
+import { AlertTriangle, ArrowRight, ChevronDown } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
 import type { KanaScript } from "../domain/kana";
@@ -77,6 +77,12 @@ export function LearningPanel({
 
   const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
   const activeCard = blockCards.find((card) => card.block.id === selectedBlockId) ?? recommended;
+  // #608 P0: on phones the 74-button index used to sit above the lesson,
+  // pushing the material thousands of px down. The mobile chapter bar keeps
+  // the index collapsed by default (desktop ignores this state; its sidebar
+  // is always visible via CSS) and offers prev/next in reading order.
+  const [indexOpen, setIndexOpen] = useState(false);
+  const activeIndex = blockCards.findIndex((card) => card.block.id === activeCard.block.id);
   // Localized copy of the active block. localizeLearningBlock preserves every
   // logic field (id / drills / examDrill / requiredForms …) and only swaps the
   // Chinese display text, so it's safe to use for both rendering and handlers.
@@ -129,7 +135,42 @@ export function LearningPanel({
   return (
     <section className="learning-panel" aria-label={t.learningRegion}>
       <div className="chapter-shell">
-        <aside className="chapter-index" aria-label={t.chapterIndexLabel}>
+        <div className="chapter-mobile-bar" data-testid="chapter-mobile-bar">
+          <button
+            type="button"
+            className="chapter-mobile-toggle"
+            data-testid="chapter-mobile-toggle"
+            aria-expanded={indexOpen}
+            onClick={() => setIndexOpen((open) => !open)}
+          >
+            <span className="chapter-mobile-progress">
+              {activeIndex + 1} / {blockCards.length}
+            </span>
+            <strong>{active.title}</strong>
+            <ChevronDown aria-hidden="true" />
+          </button>
+          <div className="chapter-mobile-nav">
+            <button
+              type="button"
+              disabled={activeIndex <= 0}
+              onClick={() => setSelectedBlockId(blockCards[activeIndex - 1].block.id)}
+            >
+              {t.chapterPrev}
+            </button>
+            <button
+              type="button"
+              disabled={activeIndex >= blockCards.length - 1}
+              onClick={() => setSelectedBlockId(blockCards[activeIndex + 1].block.id)}
+            >
+              {t.chapterNext}
+            </button>
+          </div>
+        </div>
+
+        <aside
+          className={`chapter-index${indexOpen ? " mobile-open" : ""}`}
+          aria-label={t.chapterIndexLabel}
+        >
           <div className="dashboard-card" aria-label={t.dashboardEyebrow}>
             <SproutSpot size={48} className="dashboard-spot" />
             <p className="eyebrow">{t.dashboardEyebrow}</p>
@@ -186,7 +227,12 @@ export function LearningPanel({
                       className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
                       aria-label={t.chapterViewLabel(disp.title)}
                       aria-pressed={block.id === active.id}
-                      onClick={() => setSelectedBlockId(block.id)}
+                      onClick={() => {
+                        setSelectedBlockId(block.id);
+                        // Collapse the mobile index so the picked material is
+                        // immediately in view (no-op visually on desktop).
+                        setIndexOpen(false);
+                      }}
                     >
                       {status ? <span>{status}</span> : null}
                       <strong>{disp.title}</strong>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -158,6 +158,9 @@ export type Copy = {
   kanjiSearchEmpty: string;
   learningRegion: string;
   chapterIndexLabel: string;
+  // #608 mobile chapter bar: prev / next chapter controls.
+  chapterPrev: string;
+  chapterNext: string;
   chapterEyebrow: string;
   chapterHeading: string;
   chapterIntro: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -159,6 +159,8 @@ export const en: Copy = {
   kanjiSearchEmpty: "No matching kanji found.",
   learningRegion: "Learn",
   chapterIndexLabel: "Study chapters",
+  chapterPrev: "Previous chapter",
+  chapterNext: "Next chapter",
   chapterEyebrow: "Course chapter",
   chapterHeading: "Unlock one chapter at a time",
   chapterIntro: "Pick a chapter to read the rule, examples, and common traps, then drill it on the practice page.",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -159,6 +159,8 @@ export const id: Copy = {
   kanjiSearchEmpty: "Tidak ditemukan kanji yang cocok.",
   learningRegion: "Belajar",
   chapterIndexLabel: "Bab pelajaran",
+  chapterPrev: "Bab sebelumnya",
+  chapterNext: "Bab berikutnya",
   chapterEyebrow: "Bab kursus",
   chapterHeading: "Buka bab satu per satu",
   chapterIntro: "Pilih satu bab untuk melihat aturan, contoh, dan kesalahan umum, lalu berlatih di halaman tantangan.",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -161,6 +161,8 @@ export const ja: Copy = {
   kanjiSearchEmpty: "該当する漢字が見つかりません。",
   learningRegion: "学習",
   chapterIndexLabel: "学習チャプター",
+  chapterPrev: "前の章",
+  chapterNext: "次の章",
   chapterEyebrow: "コースチャプター",
   chapterHeading: "一章ずつ進める",
   chapterIntro: "章を選んで、ルール・例・よくある間違いを確認してから、チャレンジで練習します。",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -159,6 +159,8 @@ export const ko: Copy = {
   kanjiSearchEmpty: "일치하는 한자를 찾을 수 없어요.",
   learningRegion: "학습",
   chapterIndexLabel: "학습 챕터",
+  chapterPrev: "이전 장",
+  chapterNext: "다음 장",
   chapterEyebrow: "코스 챕터",
   chapterHeading: "한 번에 한 챕터씩 잠금 해제",
   chapterIntro: "챕터를 골라 규칙, 예문, 자주 빠지는 함정을 읽은 뒤 연습 페이지에서 풀어 보세요.",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -159,6 +159,8 @@ export const my: Copy = {
   kanjiSearchEmpty: "ကိုက်ညီသော ခန်းဂျိ မတွေ့ပါ။",
   learningRegion: "လေ့လာရန်",
   chapterIndexLabel: "လေ့လာမှု အခန်းများ",
+  chapterPrev: "ယခင်အခန်း",
+  chapterNext: "နောက်အခန်း",
   chapterEyebrow: "သင်တန်း အခန်း",
   chapterHeading: "တစ်ခန်းချင်း ဖွင့်ပါ",
   chapterIntro: "အခန်းတစ်ခုကို ရွေး၍ စည်းမျဉ်း၊ နမူနာများနှင့် အမှားများကို ဖတ်ပြီး လေ့ကျင့်ရန်စာမျက်နှာတွင် လေ့ကျင့်ပါ။",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -160,6 +160,8 @@ export const th: Copy = {
   kanjiSearchEmpty: "ไม่พบคันจิที่ตรงกัน",
   learningRegion: "เรียนรู้",
   chapterIndexLabel: "บทเรียน",
+  chapterPrev: "บทก่อนหน้า",
+  chapterNext: "บทถัดไป",
   chapterEyebrow: "บทคอร์ส",
   chapterHeading: "ปลดล็อกทีละบท",
   chapterIntro: "เลือกหนึ่งบทเพื่ออ่านกฎ ตัวอย่าง และจุดที่พลาดบ่อย แล้วไปฝึกต่อในหน้าฝึกทำโจทย์",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -159,6 +159,8 @@ export const vi: Copy = {
   kanjiSearchEmpty: "Không tìm thấy kanji phù hợp.",
   learningRegion: "Học",
   chapterIndexLabel: "Chương học",
+  chapterPrev: "Chương trước",
+  chapterNext: "Chương sau",
   chapterEyebrow: "Chương khóa học",
   chapterHeading: "Mở khóa từng chương một",
   chapterIntro: "Chọn một chương để đọc quy tắc, ví dụ và các bẫy thường gặp, rồi luyện nó ở trang luyện tập.",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -159,6 +159,8 @@ export const zhHant: Copy = {
   kanjiSearchEmpty: "找不到符合的漢字。",
   learningRegion: "學習",
   chapterIndexLabel: "學習章節",
+  chapterPrev: "上一章",
+  chapterNext: "下一章",
   chapterEyebrow: "課程章節",
   chapterHeading: "一章一章解鎖",
   chapterIntro: "選一章看規則、例子與常見陷阱，再到挑戰頁練。",

--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -15,6 +15,13 @@
   min-width: 0;
 }
 
+/* #608: phone-only chapter bar (current chapter + prev/next + index toggle).
+   Desktop keeps the always-visible sidebar, so the bar stays hidden here;
+   the phone layout in responsive.css turns it on and reorders the shell. */
+.chapter-mobile-bar {
+  display: none;
+}
+
 /* With the long chapter list, keep the detail panel in view as you scroll
    the index rather than leaving it stranded above the fold. Cap it to the
    viewport and let it scroll on its own: a sticky panel taller than the

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -19,18 +19,80 @@
 
   /* Stacked single column on mobile: the detail sits below the index, so the
      desktop sticky (which follows the long side-by-side list) isn't wanted,
-     nor the viewport cap + inner scrollbar that comes with it. */
+     nor the viewport cap + inner scrollbar that comes with it. #608: the
+     lesson takes reading-order slot 2, right under the chapter bar. */
   .chapter-content {
     max-height: none;
+    order: 2;
     overflow-y: visible;
     position: static;
   }
 
+  /* #608 P0: material first on phones. The index aside dissolves
+     (display:contents) so its pieces reorder independently inside the
+     shell: the 74-button list only shows while the chapter bar is
+     expanded (slot 1, right under the bar), the review dashboard and
+     the challenge button stay reachable BELOW the lesson (slots 3-4),
+     and the sidebar intro copy is desktop-only. */
   .chapter-index {
-    border-bottom: 1px solid var(--rule);
-    border-right: 0;
-    grid-template-rows: auto;
-    padding: 0 0 1rem;
+    display: contents;
+  }
+
+  .chapter-index-copy {
+    display: none;
+  }
+
+  .chapter-list {
+    display: none;
+  }
+
+  .chapter-index.mobile-open .chapter-list {
+    display: grid;
+    order: 1;
+  }
+
+  .chapter-index .dashboard-card {
+    order: 3;
+  }
+
+  .chapter-index .secondary-challenge-button {
+    order: 4;
+  }
+
+  /* #608: the chapter bar itself (hidden on desktop in learning.css). */
+  .chapter-mobile-bar {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .chapter-mobile-toggle {
+    align-items: center;
+    display: flex;
+    gap: 0.6rem;
+    justify-content: flex-start;
+    min-height: 44px;
+    text-align: left;
+  }
+
+  .chapter-mobile-toggle strong {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chapter-mobile-progress {
+    color: var(--teal);
+    flex: 0 0 auto;
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  .chapter-mobile-nav {
+    display: grid;
+    gap: 0.55rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   /* Chapters are grouped now: keep the groups stacked, but lay each


### PR DESCRIPTION
#608 **P0-1（過渡方案）**：手機學習區「教材優先＋章節列」。

## 成效（390×844 實測）

| 指標 | 修前（issue 實測） | 修後 |
|---|---|---|
| 教材標題位置 | ~6,971px（先滑過 74 顆章節按鈕） | **~531px**（章節列正下方） |
| 章節目錄 | 常駐 6,474px | 預設收合，點章節列展開 |
| 複習提醒卡＋挑戰按鈕 | 教材前 | 保留，移到教材下方 |

## 做法

- **手機章節列**（`.chapter-mobile-bar`，桌面 `display:none`）：目前章節＋進度 `n / 73`＋展開/收合目錄（`aria-expanded`）＋**上一章／下一章**（依閱讀順序、邊界 disabled）；從目錄選章後自動收合、教材立即可見
- **CSS**：`.chapter-index` 手機改 `display: contents` 拆件重排——目錄（展開時）緊貼章節列、教材第 2、複習卡第 3、挑戰按鈕第 4；桌面側欄與 sticky 完全不動
- **i18n**：`Copy` 加 `chapterPrev`／`chapterNext`，8 語系全補（TS 強制）

## TDD／驗證

- 新 `LearningPanel.test.tsx` 3 測先 RED 後 GREEN：bar 標題＋進度、prev/next 導航與首章 disabled、展開→選章→自動收合
- `pnpm test` 920 綠
- 實機 390×844：無水平捲軸、章節列 44px 觸控高度、開/選/收全流程 ✓；1280 桌面：bar 隱藏、側欄並排、sticky 保留 ✓

## 範圍外（#608 後續）

完整章節選擇器（bottom sheet＋搜尋＋分類收合）、compact header／導覽（P0-2，涉 IA 拍板）、/kanji 分批（P1）、/rules 橫滑提示（P1）、手機文案（P2）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile chapter bar showing the current chapter, progress, and navigation controls.
  * Added previous/next chapter navigation with appropriate disabled states.
  * Added a collapsible mobile chapter index that closes after selecting a chapter.
  * Added translated chapter navigation labels across supported languages.

* **Tests**
  * Added coverage for mobile chapter navigation, progress display, and index behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->