### PR TITLE
feat(#608 P1+P2): 漢字分批渲染＋規則表捲動陰影＋手機藏鍵盤提示

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ import { useProgressAttempts } from "./hooks/useProgressAttempts";
 import type { SessionInit } from "./hooks/usePracticeSession";
 import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
-import type { LevelRange } from "./domain/levelRange";
+import { kanjiDefaultLevel, type LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
 import { canonicalArticleSlug } from "./domain/articlesMeta";
 import packageJson from "../package.json";
@@ -681,7 +681,7 @@ export default function App() {
         <AboutPanel language={language} />
       ) : appView === "kanji" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
-          <KanjiOnyomiPanel language={language} />
+          <KanjiOnyomiPanel language={language} defaultLevel={kanjiDefaultLevel(targetLevel)} />
         </Suspense>
       ) : appView === "mock" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>

--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -43,4 +43,24 @@ describe("KanjiOnyomiPanel (#195)", () => {
     fireEvent.click(screen.getByRole("button", { name: "訓讀" }));
     expect(screen.getAllByText(/たかい/).length).toBeGreaterThan(0);
   });
+
+  // #608 P1: the unfiltered view used to put all 671 kanji in the DOM at once
+  // (~54,000px page on phones). Families render in batches with a load-more.
+  it("caps the initial render and loads more on demand (#608)", () => {
+    const { container } = render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const initial = container.querySelectorAll(".kanji-cell").length;
+    expect(initial).toBeGreaterThan(0);
+    expect(initial).toBeLessThanOrEqual(80);
+
+    const loadMore = screen.getByRole("button", { name: /載入更多/ });
+    fireEvent.click(loadMore);
+    const afterOneClick = container.querySelectorAll(".kanji-cell").length;
+    expect(afterOneClick).toBeGreaterThan(initial);
+  });
+
+  it("defaults the level filter to the learner's band when provided (#608)", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
+    expect(screen.getByRole("button", { name: "N2" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "全部" })).toHaveAttribute("aria-pressed", "false");
+  });
 });

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
@@ -10,18 +10,37 @@ import { InkstoneSpot, MagnifierKanjiSpot } from "../illustrations";
 const LEVELS: Array<JlptLevel | "all"> = ["all", "N5", "N4", "N3", "N2", "N1"];
 type ReadingType = "on" | "kun";
 
+// #608 P1: whole reading-families render in batches of roughly this many
+// entries (the family that crosses the budget is included whole, so a batch
+// tops out around budget + biggest-family ≈ 40 + 23). Keeps the initial DOM
+// at ~50 cells instead of all 671 (~54,000px pages on phones).
+const FAMILY_ENTRY_BUDGET = 40;
+
 // 漢字讀音 速查表 (#195): browse kanji grouped by their primary reading
 // (homophone families -- the こう / しょう / せい ... that learners mix up),
 // toggle between 音読み and 訓読み, filter by level (N5–N1), search, and open a
 // card showing both readings + real example words (pulled from the vocab bank)
 // with TTS. The point is to confirm readings without getting fooled by voicing;
 // the example words keep it anchored to how the kanji reads inside compounds.
-export function KanjiOnyomiPanel({ language }: { language: Language }) {
+export function KanjiOnyomiPanel({
+  language,
+  // #608 P1: start on the learner's band (App maps the stored level
+  // preference via kanjiDefaultLevel) instead of all 671 entries.
+  defaultLevel = "all"
+}: {
+  language: Language;
+  defaultLevel?: JlptLevel | "all";
+}) {
   const t = copy[language];
   const [query, setQuery] = useState("");
-  const [level, setLevel] = useState<JlptLevel | "all">("all");
+  const [level, setLevel] = useState<JlptLevel | "all">(defaultLevel);
   const [readingType, setReadingType] = useState<ReadingType>("on");
   const [selected, setSelected] = useState<string | null>(null);
+  const [entryBudget, setEntryBudget] = useState(FAMILY_ENTRY_BUDGET);
+  useEffect(() => {
+    // Any filter change starts a fresh batched view.
+    setEntryBudget(FAMILY_ENTRY_BUDGET);
+  }, [query, level, readingType]);
 
   const activeLabel = readingType === "on" ? t.kanjiOnyomiLabel : t.kanjiKunyomiLabel;
 
@@ -54,6 +73,18 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
       (a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0], "ja")
     );
   }, [query, level, readingType, language]);
+
+  // Batched view (#608): show whole families until the entry budget is
+  // crossed; the rest sits behind a load-more button.
+  const visibleFamilies: typeof families = [];
+  let shownEntries = 0;
+  for (const family of families) {
+    if (shownEntries >= entryBudget) break;
+    visibleFamilies.push(family);
+    shownEntries += family[1].length;
+  }
+  const totalEntries = families.reduce((sum, [, entries]) => sum + entries.length, 0);
+  const remainingEntries = totalEntries - shownEntries;
 
   const detail = selected ? kanjiOnyomi.find((entry) => entry.kanji === selected) ?? null : null;
   const examples = detail ? kanjiExamples(detail.kanji) : [];
@@ -150,7 +181,7 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
       ) : null}
 
       {families.length > 0 ? (
-        families.map(([reading, entries]) => (
+        visibleFamilies.map(([reading, entries]) => (
           <div className="kanji-family" key={reading}>
             <h3 className="kanji-family-head">
               {reading}
@@ -187,6 +218,16 @@ export function KanjiOnyomiPanel({ language }: { language: Language }) {
           <p>{t.kanjiSearchEmpty}</p>
         </div>
       )}
+
+      {remainingEntries > 0 ? (
+        <button
+          type="button"
+          className="kanji-load-more"
+          onClick={() => setEntryBudget((budget) => budget + FAMILY_ENTRY_BUDGET)}
+        >
+          {t.kanjiLoadMore(remainingEntries)}
+        </button>
+      ) : null}
     </section>
   );
 }

--- a/src/domain/levelRange.test.ts
+++ b/src/domain/levelRange.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { levelsForRange, LEVEL_RANGE_OPTIONS, VOCAB_LEVEL_RANGE_OPTIONS } from "./levelRange";
+import {
+  kanjiDefaultLevel,
+  levelsForRange,
+  LEVEL_RANGE_OPTIONS,
+  VOCAB_LEVEL_RANGE_OPTIONS
+} from "./levelRange";
 import { buildExamQuestionPool } from "./examBlocks";
+
+// #608 P1: the kanji quick-reference defaults to the learner's band instead
+// of "all" (671 entries at once). A range maps to its HARDER level (the exam
+// they study toward); starter learners get N5; no preference keeps "all".
+describe("kanjiDefaultLevel", () => {
+  it("maps each band to its harder level", () => {
+    expect(kanjiDefaultLevel("n1n2")).toBe("N1");
+    expect(kanjiDefaultLevel("n2n3")).toBe("N2");
+    expect(kanjiDefaultLevel("n3n4")).toBe("N3");
+    expect(kanjiDefaultLevel("n4n5")).toBe("N4");
+    expect(kanjiDefaultLevel("starter")).toBe("N5");
+  });
+
+  it("keeps 全部 for the all band and for learners with no preference", () => {
+    expect(kanjiDefaultLevel("all")).toBe("all");
+    expect(kanjiDefaultLevel(null)).toBe("all");
+  });
+});
 
 describe("levelsForRange", () => {
   it("maps presets to JLPT levels and null for all", () => {

--- a/src/domain/levelRange.ts
+++ b/src/domain/levelRange.ts
@@ -35,3 +35,14 @@ const RANGE_LEVELS: Record<Exclude<LevelRange, "all">, JlptLevel[]> = {
 export function levelsForRange(range: LevelRange): JlptLevel[] | null {
   return range === "all" ? null : RANGE_LEVELS[range];
 }
+
+// #608 P1: the kanji quick-reference defaults to the learner's band instead
+// of "all" (671 entries at once). A range maps to its HARDER level -- the
+// exam the learner is studying toward; starter learners get N5. No stored
+// preference (or the explicit all band) keeps the unfiltered view, which the
+// panel's batched rendering keeps cheap anyway.
+export function kanjiDefaultLevel(range: LevelRange | null): JlptLevel | "all" {
+  if (range === null || range === "all") return "all";
+  if (range === "starter") return "N5";
+  return RANGE_LEVELS[range][0];
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -156,6 +156,8 @@ export type Copy = {
   kanjiExamplesLabel: string;
   kanjiNoExamples: string;
   kanjiSearchEmpty: string;
+  // #608 batched kanji table: "load more (N left)" button label.
+  kanjiLoadMore: (count: number) => string;
   learningRegion: string;
   chapterIndexLabel: string;
   // #608 mobile chapter bar: prev / next chapter controls.

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -157,6 +157,7 @@ export const en: Copy = {
   kanjiExamplesLabel: "Example words",
   kanjiNoExamples: "(No example words yet)",
   kanjiSearchEmpty: "No matching kanji found.",
+  kanjiLoadMore: (count: number) => `Load more (${count} more)`,
   learningRegion: "Learn",
   chapterIndexLabel: "Study chapters",
   chapterPrev: "Previous chapter",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -157,6 +157,7 @@ export const id: Copy = {
   kanjiExamplesLabel: "Contoh kata",
   kanjiNoExamples: "（belum ada contoh kata）",
   kanjiSearchEmpty: "Tidak ditemukan kanji yang cocok.",
+  kanjiLoadMore: (count: number) => `Muat lebih banyak (${count} lagi)`,
   learningRegion: "Belajar",
   chapterIndexLabel: "Bab pelajaran",
   chapterPrev: "Bab sebelumnya",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -159,6 +159,7 @@ export const ja: Copy = {
   kanjiExamplesLabel: "例語",
   kanjiNoExamples: "（収録された例語はまだありません）",
   kanjiSearchEmpty: "該当する漢字が見つかりません。",
+  kanjiLoadMore: (count: number) => `もっと見る（あと${count}字）`,
   learningRegion: "学習",
   chapterIndexLabel: "学習チャプター",
   chapterPrev: "前の章",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -157,6 +157,7 @@ export const ko: Copy = {
   kanjiExamplesLabel: "예시 단어",
   kanjiNoExamples: "(아직 예시 단어가 없어요)",
   kanjiSearchEmpty: "일치하는 한자를 찾을 수 없어요.",
+  kanjiLoadMore: (count: number) => `더 보기 (${count}자 남음)`,
   learningRegion: "학습",
   chapterIndexLabel: "학습 챕터",
   chapterPrev: "이전 장",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -157,6 +157,7 @@ export const my: Copy = {
   kanjiExamplesLabel: "နမူနာ စကားလုံးများ",
   kanjiNoExamples: "(နမူနာစကားလုံး မရှိသေးပါ)",
   kanjiSearchEmpty: "ကိုက်ညီသော ခန်းဂျိ မတွေ့ပါ။",
+  kanjiLoadMore: (count: number) => `နောက်ထပ်ကြည့်ရန် (ကျန် ${count} လုံး)`,
   learningRegion: "လေ့လာရန်",
   chapterIndexLabel: "လေ့လာမှု အခန်းများ",
   chapterPrev: "ယခင်အခန်း",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -158,6 +158,7 @@ export const th: Copy = {
   kanjiExamplesLabel: "คำตัวอย่าง",
   kanjiNoExamples: "(ยังไม่มีคำตัวอย่าง)",
   kanjiSearchEmpty: "ไม่พบคันจิที่ตรงกัน",
+  kanjiLoadMore: (count: number) => `โหลดเพิ่ม (เหลืออีก ${count} ตัว)`,
   learningRegion: "เรียนรู้",
   chapterIndexLabel: "บทเรียน",
   chapterPrev: "บทก่อนหน้า",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -157,6 +157,7 @@ export const vi: Copy = {
   kanjiExamplesLabel: "Từ ví dụ",
   kanjiNoExamples: "(Chưa có từ ví dụ)",
   kanjiSearchEmpty: "Không tìm thấy kanji phù hợp.",
+  kanjiLoadMore: (count: number) => `Tải thêm (còn ${count} chữ)`,
   learningRegion: "Học",
   chapterIndexLabel: "Chương học",
   chapterPrev: "Chương trước",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -157,6 +157,7 @@ export const zhHant: Copy = {
   kanjiExamplesLabel: "例詞",
   kanjiNoExamples: "（暫無收錄例詞）",
   kanjiSearchEmpty: "找不到符合的漢字。",
+  kanjiLoadMore: (count: number) => `載入更多（還有 ${count} 字）`,
   learningRegion: "學習",
   chapterIndexLabel: "學習章節",
   chapterPrev: "上一章",

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -132,6 +132,12 @@
   gap: 0.5rem;
 }
 
+/* #608: batched table -- families past the entry budget sit behind this. */
+.kanji-load-more {
+  justify-content: center;
+  width: 100%;
+}
+
 .kanji-family-head {
   margin: 0;
   display: flex;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -150,6 +150,26 @@
   .surface {
     font-size: 5rem;
   }
+
+  /* #608 P2: keyboard shortcuts don't exist on touch screens. */
+  .kbd-hint {
+    display: none;
+  }
+
+  /* #608 P1: swipe hint for the wide conjugation tables -- CSS-only
+     scrolling shadows (background-attachment local/scroll): the inner
+     shadow at an edge shows only while more columns hide past it, and
+     the paper-coloured cover layers erase it once fully scrolled. */
+  .rules-table-wrap {
+    background:
+      linear-gradient(90deg, var(--paper) 35%, transparent),
+      linear-gradient(270deg, var(--paper) 35%, transparent) 100% 0,
+      radial-gradient(farthest-side at 0 50%, color-mix(in srgb, var(--ink) 30%, transparent), transparent),
+      radial-gradient(farthest-side at 100% 50%, color-mix(in srgb, var(--ink) 30%, transparent), transparent) 100% 0;
+    background-attachment: local, local, scroll, scroll;
+    background-repeat: no-repeat;
+    background-size: 2.6rem 100%, 2.6rem 100%, 0.9rem 100%, 0.9rem 100%;
+  }
 }
 
 @media (max-width: 560px) {


### PR DESCRIPTION
#608 第二輪：P1×2＋P2×1 打包。

## /kanji 分批渲染（P1）

| 390×844 實測 | 修前 | 修後 |
|---|---|---|
| 初始 DOM cells | 671 | **53**（載入更多 → 86 → …） |
| 頁面高度 | ~54,121px | **~3,375px** |

- 讀音家族**整族分批**（預算 40 字/批，跨界的家族整族收滿，上限 ≈ 40＋最大族 23）＋「載入更多（還有 N 字）」按鈕；搜尋/篩選/音訓切換時重設批次
- **預設等級改吃使用者目標級別**：新 domain fn `kanjiDefaultLevel`（band 取較難級：n2n3→N2；starter→N5；無偏好/all 維持全部）；實機驗證 偏好 n2n3 → 開頁即 N2（41 cells）
- 搜尋與等級篩選手機維持可見 ✓

## /rules 捲動陰影（P1）

- `.rules-table-wrap`（≤980px）加 **CSS-only scrolling shadows**（`background-attachment: local/scroll` 四層）：右側有隱藏欄位時顯示內陰影、捲到底自動消失、零 JS 零 i18n
- 驗證：儲存格背景全透明（陰影不被蓋）、8 個表格容器中 1 個在 390px 實際溢出、可捲

## 手機藏鍵盤提示（P2）

- `.kbd-hint`（「桌面快捷：按 1–4 選答、Enter 進下一題」）≤980px 隱藏；1280 實機確認桌面仍顯示

## TDD／驗證

- KanjiOnyomiPanel +2 測（初始 cap≤80＋載入更多遞增、defaultLevel prop）、levelRange +2 測（band 映射）——先 RED 後 GREEN
- `pnpm test` 924 綠；i18n `kanjiLoadMore` 8 語系補齊（TS 強制）
- 桌面回歸：/kanji 桌面同樣受益於分批（行為變更：預設不再是全部，改吃目標級別——這是 #608 驗收項原文）
