### PR TITLE
feat: track published article views

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -2,18 +2,19 @@
 
 This document describes the **Phase 1** anonymous learning analytics layer
 introduced in issue #404. It is intentionally small: a single typed helper,
-an environment gate, eight learning events, and a hard privacy contract.
+an environment gate, nine coarse events, and a hard privacy contract.
 
 ## Why Zaraz
 
 Jabiko is a free, no-signup-first JLPT self-study app. The most valuable early
 analytics signal is whether learners actually start practice, submit answers,
-complete practice, change levels/locales, and return to weak-point review.
+complete practice, change levels/locales, return to weak-point review, and
+open published articles.
 Cloudflare Zaraz is used as an event router / tag manager — it does **not**
 replace Jabiko's own learning-progress data model or Supabase sync.
 
 Zaraz provides 1,000,000 free events/month per Cloudflare account. Phase 1
-event volume is kept intentionally small (eight learning-flow events, not
+event volume is kept intentionally small (nine coarse flow events, not
 per-interaction UI events).
 
 ## Helper
@@ -64,6 +65,12 @@ is correctly treated as disabled.
 | `level_changed`      | the learner changes the level range    | `scope` ("global" or "session"), `levelRange`, `locale`          |
 | `locale_changed`     | the learner switches the UI language   | `from` (LocaleCode), `to` (LocaleCode)                          |
 | `weak_review_started`| the learner opens weak-point review    | `dueCount` (a count, not content), `locale`                     |
+| `article_viewed`     | a published article is successfully displayed | `slug` (canonical article slug only)                       |
+
+`article_viewed` is emitted by `BlogArticlePage` after a published article has
+committed to the UI. The component keeps the last displayed slug in a ref, so
+StrictMode and re-renders do not duplicate an event; entering a different
+slug, or leaving and later re-entering an article route, is a new view.
 
 ### `view` allowed values
 
@@ -105,6 +112,10 @@ keys. The following are NOT present on any shape and cannot be passed through
 - raw Supabase user id / any PII id
 - IP address
 - nested objects or arrays containing user-generated content
+- article title, body, query string, referrer, or other navigation/free text
+
+`article_viewed` is deliberately limited to the canonical `slug`; it must not
+carry article prose or visitor/navigation data.
 
 This is enforced by a per-event allowlist of typed keys. To add a new payload
 field, the shape in `AnalyticsPayloadMap` must be extended first; ad-hoc keys
@@ -127,4 +138,6 @@ are rejected by the compiler.
 `window.zaraz.track`, missing `window.zaraz`, `window.zaraz.track` throwing,
 `window.zaraz.track` not a function, unknown event name (compile error),
 wrong payload type (compile error), and sensitive-key rejection (compile
-error).
+error), including the slug-only `article_viewed` allowlist. `BlogArticlePage`
+tests cover published-only triggering, StrictMode/rerender deduplication, slug
+changes, unknown/draft suppression, and re-entry after route departure.

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -53,12 +53,16 @@ describe("App", () => {
   // once here so every test below renders them synchronously regardless of
   // run order -- otherwise whichever test first navigates to a view would
   // run its synchronous assertions before the lazy chunk finished loading.
+  // GrammarPointPage is reached through a direct URL rather than one of these
+  // navigation clicks, so preload it explicitly for the route-level heading
+  // test below as well.
   // Generous timeouts here: this hook cold-loads the lazy chunks, and the
   // challenge chunk now carries the ~700KB pre-baked furigana table (#134 P4),
   // so the first transform+eval can exceed the 1s findBy default in CI before
   // any other test has warmed the modules. Once primed, the per-test
   // navigations below resolve from cache at the default timeout.
   beforeAll(async () => {
+    await import("./components/GrammarPointPage");
     const user = userEvent.setup();
     const { unmount } = render(<App />);
     await user.click(screen.getByRole("button", { name: "挑戰" }));

--- a/src/components/BlogArticlePage.test.tsx
+++ b/src/components/BlogArticlePage.test.tsx
@@ -1,10 +1,98 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { articleBySlug } from "../domain/articles";
 import { BlogArticlePage } from "./BlogArticlePage";
 
+const analyticsMocks = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+
+vi.mock("../lib/analytics", () => analyticsMocks);
+vi.mock("../domain/articles", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../domain/articles")>();
+  return { ...actual, articleBySlug: vi.fn(actual.articleBySlug) };
+});
+
 describe("BlogArticlePage", () => {
+  beforeEach(() => {
+    analyticsMocks.trackEvent.mockClear();
+    vi.mocked(articleBySlug).mockClear();
+  });
+
+  it("fires article_viewed once after a published article is displayed", () => {
+    render(
+      <BlogArticlePage
+        slug="sweet-steady-sweet-step"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("article_viewed", {
+      slug: "sweet-steady-sweet-step"
+    });
+  });
+
+  it("dedupes rerenders and StrictMode while tracking a new published slug", () => {
+    const props = {
+      language: "zh-Hant" as const,
+      onBack: vi.fn(),
+      onCta: vi.fn()
+    };
+    const { rerender } = render(
+      <StrictMode>
+        <BlogArticlePage slug="sweet-steady-sweet-step" {...props} />
+      </StrictMode>
+    );
+
+    rerender(
+      <StrictMode>
+        <BlogArticlePage slug="sweet-steady-sweet-step" {...props} />
+      </StrictMode>
+    );
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <StrictMode>
+        <BlogArticlePage slug="cho-saikyo-tokimeki" {...props} />
+      </StrictMode>
+    );
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(2);
+    expect(analyticsMocks.trackEvent).toHaveBeenLastCalledWith("article_viewed", {
+      slug: "cho-saikyo-tokimeki"
+    });
+  });
+
+  it("does not track a draft or an unknown article", () => {
+    const published = articleBySlug("sweet-steady-sweet-step");
+    if (!published) throw new Error("Expected published article fixture");
+    vi.mocked(articleBySlug).mockReturnValueOnce({ ...published, draft: true });
+
+    const { rerender } = render(
+      <BlogArticlePage slug="draft-article" language="zh-Hant" onBack={vi.fn()} onCta={vi.fn()} />
+    );
+    rerender(
+      <BlogArticlePage slug="unknown-article" language="zh-Hant" onBack={vi.fn()} onCta={vi.fn()} />
+    );
+
+    expect(analyticsMocks.trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("tracks the same article again after leaving its route", () => {
+    const props = {
+      language: "zh-Hant" as const,
+      onBack: vi.fn(),
+      onCta: vi.fn()
+    };
+    const { rerender } = render(<BlogArticlePage slug="sweet-steady-sweet-step" {...props} />);
+    rerender(<BlogArticlePage slug="unknown-article" {...props} />);
+    rerender(<BlogArticlePage slug="sweet-steady-sweet-step" {...props} />);
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(2);
+  });
+
   it("renders the SWEET STEP article from the canonical slug", () => {
     render(
       <BlogArticlePage

--- a/src/components/BlogArticlePage.tsx
+++ b/src/components/BlogArticlePage.tsx
@@ -1,6 +1,8 @@
 import { ArrowLeft, ArrowRight, ExternalLink } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { copy, type Language } from "../i18n";
 import { articleBySlug, type ArticleBlock, type ArticleCta } from "../domain/articles";
+import { trackEvent } from "../lib/analytics";
 
 // Single blog article page. The article body is zh-Hant original content and
 // is lazy-loaded from the blog route, so prose stays out of the initial bundle.
@@ -17,6 +19,21 @@ export function BlogArticlePage({
 }) {
   const t = copy[language];
   const article = articleBySlug(slug);
+  // Effects run after the article is committed, so only a successfully
+  // displayed published article is counted. Keep the last slug for this route
+  // instance: React StrictMode and ordinary rerenders cannot double-count it,
+  // while a different slug (or a route departure) starts a new view.
+  const lastViewedSlugRef = useRef<string | null>(null);
+  useEffect(() => {
+    const publishedSlug = article && !article.draft ? article.slug : null;
+    if (publishedSlug !== null && lastViewedSlugRef.current !== publishedSlug) {
+      lastViewedSlugRef.current = publishedSlug;
+      trackEvent("article_viewed", { slug: publishedSlug });
+    }
+    if (publishedSlug === null) {
+      lastViewedSlugRef.current = null;
+    }
+  }, [article?.draft, article?.slug]);
 
   const backButton = (
     <button type="button" className="ghost-button blog-back" onClick={onBack}>

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -49,6 +49,17 @@ describe("analytics.trackEvent", () => {
     });
   });
 
+  it("accepts article_viewed with a slug-only payload", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+
+    trackEvent("article_viewed", { slug: "sweet-steady-sweet-step" });
+
+    expect(track).toHaveBeenCalledWith("article_viewed", {
+      slug: "sweet-steady-sweet-step"
+    });
+  });
+
   it("no-ops without throwing when window.zaraz is missing", () => {
     __setAnalyticsEnabledForTest(true);
     clearZaraz();
@@ -99,6 +110,11 @@ describe("analytics.trackEvent", () => {
     trackEvent("level_changed", { scope: "global", levelRange: "all", locale: "zh-Hant", userId: "abc-123" });
   });
 
+  it("rejects article content at compile time", () => {
+    // @ts-expect-error -- article_viewed must never include title or body text
+    trackEvent("article_viewed", { slug: "sweet-steady-sweet-step", title: "文章標題" });
+  });
+
   it("accepts each Phase 1 event with its documented payload shape", () => {
     __setAnalyticsEnabledForTest(true);
     const track = installZaraz();
@@ -129,7 +145,8 @@ describe("analytics.trackEvent", () => {
     });
     trackEvent("locale_changed", { from: "ja", to: "zh-Hant" });
     trackEvent("weak_review_started", { dueCount: 5, locale: "zh-Hant" });
-    expect(track).toHaveBeenCalledTimes(7);
+    trackEvent("article_viewed", { slug: "sweet-steady-sweet-step" });
+    expect(track).toHaveBeenCalledTimes(8);
   });
 
   it("module import has no firing side effects", () => {
@@ -170,6 +187,24 @@ describe("analytics.trackEvent", () => {
       questionType: "daily",
       isCorrect: true,
       locale: "zh-Hant"
+    });
+  });
+
+  it("strips article content and navigation metadata from article_viewed", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    const smuggled = {
+      slug: "sweet-steady-sweet-step",
+      title: "從歌詞學日文",
+      body: "文章正文",
+      referrer: "https://example.com/",
+      search: "?q=private"
+    };
+
+    trackEvent("article_viewed", smuggled);
+
+    expect(track).toHaveBeenCalledWith("article_viewed", {
+      slug: "sweet-steady-sweet-step"
     });
   });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -10,7 +10,8 @@ export type AnalyticsEventName =
   | "study_page_viewed"
   | "level_changed"
   | "locale_changed"
-  | "weak_review_started";
+  | "weak_review_started"
+  | "article_viewed";
 
 export interface PageViewPayload {
   view: string;
@@ -55,6 +56,9 @@ export interface WeakReviewStartedPayload {
   dueCount: number;
   locale: LocaleCode;
 }
+export interface ArticleViewedPayload {
+  slug: string;
+}
 
 export interface AnalyticsPayloadMap {
   page_view: PageViewPayload;
@@ -65,6 +69,7 @@ export interface AnalyticsPayloadMap {
   level_changed: LevelChangedPayload;
   locale_changed: LocaleChangedPayload;
   weak_review_started: WeakReviewStartedPayload;
+  article_viewed: ArticleViewedPayload;
 }
 
 const ZARAZ_ENABLED_FLAG = import.meta.env.VITE_ZARAZ_ENABLED;
@@ -83,7 +88,8 @@ const ALLOWED_PAYLOAD_KEYS: Record<AnalyticsEventName, readonly string[]> = {
   study_page_viewed: ["surface", "locale"],
   level_changed: ["scope", "levelRange", "locale"],
   locale_changed: ["from", "to"],
-  weak_review_started: ["dueCount", "locale"]
+  weak_review_started: ["dueCount", "locale"],
+  article_viewed: ["slug"]
 };
 
 function sanitizePayload<K extends AnalyticsEventName>(


### PR DESCRIPTION
Part of #584

## Summary

- Add the typed, per-event-allowlisted `article_viewed` event with the only permitted payload: `{ slug }`.
- Emit it from `BlogArticlePage` only after a published article has committed; drafts, invalid slugs, redirects, and not-found pages do not send it.
- Deduplicate React StrictMode and same-slug rerenders with a route-instance ref. A different slug, or leaving and re-entering an article route, is counted as a new view.
- Document the event table and its privacy boundary: no title, body, query string, referrer, user input, or other free text.

## Validation

- `pnpm vitest run src/lib/analytics.test.ts src/components/BlogArticlePage.test.tsx` — 24 passed
- `pnpm test` — passed
- `pnpm build` — passed

No Cloudflare Dashboard settings, #477 work, RSS, JSON-LD, sitemap, 404, OG images, or article content changes are included.
