### PR TITLE
test: grammar route findBy 放寬 timeout（#611 後 CI flake、main 已紅）

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -129,7 +129,11 @@ describe("App", () => {
     window.history.replaceState({}, "", `/grammar/${encodeURIComponent(surface)}`);
     render(<App />);
 
-    await screen.findByRole("heading", { name: surface, level: 1 });
+    // This route resolves the heaviest lazy chain in the app (GrammarPointPage
+    // -> grammar notes -> exam bank; #611 split furigana into one more async
+    // module). The default 1s findBy timeout flaked on slow CI runners even
+    // though local runs pass, so give the first paint room to land.
+    await screen.findByRole("heading", { name: surface, level: 1 }, { timeout: 15000 });
     // Exactly one h1 on the SEO landing page, and it's the page-specific surface.
     const h1s = screen.getAllByRole("heading", { level: 1 });
     expect(h1s).toHaveLength(1);


### PR DESCRIPTION
main 在 #611（拆 furigana 二層）合併後 CI 變紅：App.test 的 grammar route 測試用預設 1s findBy 等**全 app 最重的 lazy 鏈**（GrammarPointPage→文法筆記→exam bank，#611 又加一層 async furigana 模組），CI runner 連兩次逾時；本地（含完整 App.test 57 測）皆過＝純時序 flake。

修法＝該測試的 findByRole 放寬到 15s（針對性，不動全域 asyncUtilTimeout，避免掩蓋其他真回歸）。

連帶效應：#613（味道文章 PR）的 CI 紅同樣繼承自這裡，本修合併後重跑即綠。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for the grammar route on slower environments.
  * Added documentation explaining the extended wait time for lazy-loaded content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->