### PR TITLE
docs(#314): AGENTS.md 全面同步現況（移除 rtk 幽靈規則）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,89 +1,72 @@
 # Jabiko — Codex Agent Guidelines
 
+> **Source of truth：`CLAUDE.md`。** 本檔是給 Codex 的精簡鏡像；兩檔衝突時以 CLAUDE.md 為準。（#314）
+
 ## 語言設定
 
-永遠使用台灣正體中文回覆。日文內容只用於學習材料、例句、UI 標籤或語法說明。
+永遠使用台灣正體中文回覆。日文只用於學習材料、例句、UI 標籤或語法說明。
 
-## 專案定位
+## 專案定位（2026-07 現況）
 
-Jabiko 是給《大家的日本語》學習者使用的日文變化練習網站。第一版以動詞變化訓練為主，並預留い形容詞、な形容詞與 `てもらえますか`、`てくれますか`、`てあげます` 等文型練習。
+Jabiko（jabiko.app）是免費、免註冊的 **JLPT N5–N1 日檢自習室**：文法／單字／漢字讀音／官方題型練習／模擬考／學習文章。題庫 3,600+、學習章 73+、文章區已上線。
 
-設計文件以 `docs/superpowers/specs/` 為準。實作前先確認最新 spec。
+- 技術棧：React 19 + TypeScript strict + Vite 7 + Vitest 4 + jsdom、pnpm、PWA（vite-plugin-pwa）
+- 資料：local-first（localStorage）＋**選配** Supabase 跨裝置同步（Google 登入）；Cloudflare Pages 部署＋prerender
+- i18n：上線語系 zh-Hant／ja／en（`LAUNCHED_LANGUAGES`），另有 ko/th/id/vi/my Copy 檔未上線
+
+舊描述（《大家的日本語》動詞變化工具、無後端無登入）已過時，勿依其做設計假設。`docs/superpowers/specs/` 是 2026-05 的歷史設計稿，非現行 spec。
 
 ## Shell 指令
 
-所有 shell 指令都必須以 `rtk` 開頭，以降低輸出 token。
+直接執行指令即可（**沒有 `rtk` 這個工具**——舊規範遺留，勿再等待或宣稱缺它而跳過驗證）。
 
-例：
+- Node／frontend tooling 一律 `pnpm`；不得使用 npm/yarn/bun（也不得產生其 lockfile）
+- 驗證三閘：`pnpm check:exam`（改題庫必跑）、`pnpm test`、`pnpm build`
+- 新增／修改**文章**後必跑 `pnpm build:sitemap`（sitemap drift guard 會擋 CI——這是 Codex 歷史上最常漏的一步）
+- 新增 exam 例句／題幹後跑 `pnpm build:furigana`
 
-```bash
-rtk git --no-optional-locks status
-rtk pnpm build
-rtk pnpm test
-```
+## 政策關鍵規則（CLAUDE.md 摘要，違反=擋 merge）
 
-Node / frontend tooling 統一使用 `pnpm`。不得使用 `npm install`、`npm run`、`npm test` 或其他 npm 指令。
-
-## 技術方向
-
-目前設計決策：
-
-- Vite
-- React
-- TypeScript
-- Vitest
-- LocalStorage
-
-第一版不需要後端、登入、雲端同步或 AI 解釋生成。
+- **TDD 強制**：先寫測試觀察 RED 再實作；例外僅限一次性 prototype、純設定檔、自動產生程式碼（要先告知）
+- **contentGuard 不變條件**：不得改 `src/domain/contentGuard.ts` 驗證規則，除非透過 issue 討論
+- **語言隔離**：`*Zh` 欄位不得對 zh-Hant 以外渲染，除非走 `pickLocalized()`＋有效 i18n overlay；`isZhHant` 是唯一閘門變數；不得動 `LAUNCHED_LANGUAGES`／`LocaleCode`／`pickLocalized()` fallback
+- **分層**：領域邏輯在 `src/domain/`，React 元件不放商業邏輯；TypeScript strict、禁 `any`
+- **Bundle 紀律**：examBlocks／furigana 資料／文章 body 只准進 lazy chunk，勿從 eager 路徑（App／components barrel／首頁）import
+- **EOL**：`exam/items/*.ts` 是 `-text`，暫存用 `git -c core.autocrlf=false add`，commit 前 `git diff --cached --check` 必須乾淨
 
 ## Scope 邊界
 
-- 不要把未要求的功能、重構或 future work 混進同一個變更。
-- 文件、研究草稿與討論紀錄不能自動視為 implementation source of truth；實作前要確認 spec。
-- 若發現需要新增依賴、調整架構或擴大功能範圍，先回報理由與替代方案。
-- 空專案初期可以調整腳手架，但仍要避免無關檔案與 metadata churn。
+- 不把未要求的功能、重構或 future work 混進同一個變更
+- 需要新增依賴、調整架構或擴大範圍時，先回報理由與替代方案
+- 內容批次（題庫／文章）天然 diff 大，屬正常，不必為 diff 大小道歉
 
-## Git 規範
+## Git／PR 規範
 
-- Branch 命名預設使用 `codex/<short-description>`，除非使用者指定其他名稱。
-- Commit 訊息使用簡潔英文祈使句或 `<type>: <short description>`。
-- 在 mixed worktree 中不得使用 `git add -A` 或 `git add .`；只 stage 本次任務需要的檔案。
-- 不要直接 revert 使用者未要求 revert 的變更。
-- GitHub / git 指令必須 non-interactive。
+- Branch 命名 `codex/<short-description>`；commit 訊息簡潔（英文祈使句或 `<type>: <desc>`）
+- 不用 `git add -A`／`git add .`；只 stage 本次任務檔案
+- GitHub／git 指令必須 non-interactive
+- **PR 開出來請轉為 ready**（draft 會擋 merge）
+- **勿開 stacked PR**（base 指向另一個 PR 的分支）：前面的 PR squash 合併刪分支時，後面的會被 GitHub 自動關閉且無法 reopen。多篇內容各自從 main 開分支
+- CI 必過閘只有「Test and build」；CodeRabbit 綠勾可能是 rate-limit skip，不算真審
 
 ## 供應鏈安全
 
-- 不得自行新增依賴，除非任務需要且已在回報中說明原因。
-- 不得執行 `npx`、`pnpm dlx`、`npm exec`、`curl | bash`、`wget | sh` 這類遠端即時執行指令。
-- `package.json` 與 lockfile 改動必須在回報中明確說明。
+- 不得自行新增依賴，除非任務需要且已在回報中說明原因
+- 不得執行 `npx`、`pnpm dlx`、`npm exec`、`curl | bash`、`wget | sh` 這類遠端即時執行指令
+- `package.json` 與 lockfile 改動必須在回報中明確說明
 
-## 前端品質重點
+## 內容品質（出題／文章）
 
-- 第一畫面應該是實際練習工具，不是 landing page。
-- UI 文字以台灣正體中文為主，日文用於題目、答案、例句與語法名稱。
-- 動詞與形容詞變化邏輯要放在可測試的 TypeScript 模組，不要散落在 React component。
-- 錯誤答案要顯示正解與規則說明，不能只顯示失敗狀態。
-- 練習流程要支援鍵盤操作，尤其是 Enter 送出與下一題。
-- 手機與桌面都要檢查文字不重疊、不截斷。
+- 出題先讀 `docs/item-quality-rubric.md`：唯一正解、干擾誘答、不洩漏、格式
+- 最大雷＝近義雙解與接續秒殺；教學句最大雷＝**顧客句用「〜ますか」問聽話者動作**（主語錯位）
+- 文章不轉載歌詞（外連＋片段佔位）；例句一律原創
 
 ## 測試與驗證
 
-宣稱完成前至少回報實際執行過的驗證。
-
-優先測：
-
-- 一類動詞 `て形` / `た形` 音便。
-- 一類動詞 `ない形` 母音變化。
-- 二類動詞規則變化。
-- 三類動詞不規則變化。
-- い形容詞與な形容詞的否定、過去、否定過去。
-- 答案 normalization。
-- 主要練習流程。
+宣稱完成前回報實際執行過的驗證（三閘結果 pass/fail）。優先測：變化邏輯（音便／ない形／不規則）、答案 normalization、contentGuard／contentStats drift、主要練習流程。
 
 ## 回報格式
 
-回報保持精簡：
-
-- 只列出關鍵變更：檔案名稱 + 一句說明。
-- 測試結果只報 pass/fail 與失敗原因，不貼完整 log。
-- 遇到錯誤時先給診斷與建議修法，再問是否繼續。
+- 只列關鍵變更：檔案＋一句說明
+- 測試結果只報 pass/fail 與失敗原因，不貼完整 log
+- 遇到錯誤先給診斷與建議修法，再問是否繼續

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Jabiko（jabiko.app）是免費、免註冊的 **JLPT N5–N1 日檢自習室**�
 直接執行指令即可（**沒有 `rtk` 這個工具**——舊規範遺留，勿再等待或宣稱缺它而跳過驗證）。
 
 - Node／frontend tooling 一律 `pnpm`；不得使用 npm/yarn/bun（也不得產生其 lockfile）
-- 驗證三閘：`pnpm check:exam`（改題庫必跑）、`pnpm test`、`pnpm build`
+- 驗證三閘：`pnpm test`、`pnpm build` 每個 PR 必跑；`pnpm check:exam` 在改動題庫（`src/domain/exam/`）時必跑，其他改動可省
 - 新增／修改**文章**後必跑 `pnpm build:sitemap`（sitemap drift guard 會擋 CI——這是 Codex 歷史上最常漏的一步）
 - 新增 exam 例句／題幹後跑 `pnpm build:furigana`
 
@@ -32,7 +32,7 @@ Jabiko（jabiko.app）是免費、免註冊的 **JLPT N5–N1 日檢自習室**�
 - **語言隔離**：`*Zh` 欄位不得對 zh-Hant 以外渲染，除非走 `pickLocalized()`＋有效 i18n overlay；`isZhHant` 是唯一閘門變數；不得動 `LAUNCHED_LANGUAGES`／`LocaleCode`／`pickLocalized()` fallback
 - **分層**：領域邏輯在 `src/domain/`，React 元件不放商業邏輯；TypeScript strict、禁 `any`
 - **Bundle 紀律**：examBlocks／furigana 資料／文章 body 只准進 lazy chunk，勿從 eager 路徑（App／components barrel／首頁）import
-- **EOL**：`exam/items/*.ts` 是 `-text`，暫存用 `git -c core.autocrlf=false add`，commit 前 `git diff --cached --check` 必須乾淨
+- **EOL**：`exam/items/*.ts` 是 `-text`，暫存用 `git -c core.autocrlf=false add <files>`（明列檔名），commit 前 `git diff --cached --check` 必須乾淨
 
 ## Scope 邊界
 


### PR DESCRIPTION
docs(#314): AGENTS.md 全面同步現況（rtk 幽靈規則移除）

AGENTS.md 停在 2026-05 的專案狀態，對 Codex 造成實害：

- 「所有指令必須以 rtk 開頭」——rtk 不存在，Codex 因此在多個 PR
  聲明「缺 rtk 未跑 pnpm test」直接跳過驗證（#613/#614 實例）
- 定位還是「大家的日本語動詞變化工具、無後端無登入無同步」——
  與現況（JLPT N5-N1 自習室、Supabase 同步、i18n 三語系）全面矛盾
- docs/superpowers/specs 已是歷史稿仍被指為 spec 依據

重寫要點：CLAUDE.md 明定為 source of truth；補政策關鍵規則鏡像
（TDD/contentGuard/語言隔離/bundle 紀律/EOL）；補 Codex 實測踩過的
三雷（忘 build:sitemap、draft PR、stacked PR）；內容品質雷點
（近義雙解/主語錯位）。

範圍依 2026-07-14 拍板縮定：只同步文件，不動 PR template、
不加 CI enforcement（原 #314 其餘項隨 #312 關閉）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and project guidelines with current technology, data, localization, and synchronization information.
  * Clarified required verification, testing, build, and reporting procedures.
  * Added guidance for content quality, supply-chain security, architecture, performance, language isolation, and line-ending handling.
  * Revised pull request and scope rules, including readiness and stacked pull request requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->