### PR TITLE
ci(#315): lockfile guard——擋外來 lockfile（pnpm only）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # #315: pnpm is the only package manager. Consistency with package.json
+      # is already enforced by --frozen-lockfile below; this step blocks a
+      # foreign lockfile from ever landing in the repo (agents occasionally
+      # run npm/yarn by habit).
+      - name: Lockfile guard (pnpm only)
+        run: |
+          if ls package-lock.json yarn.lock bun.lockb bun.lock npm-shrinkwrap.json 2>/dev/null | grep -q .; then
+            echo "::error::Foreign lockfile detected — pnpm-lock.yaml is the only allowed lockfile. Remove npm/yarn/bun lockfiles."
+            exit 1
+          fi
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
#315（已縮範圍）的實作：CI 加 ~10 行 guard step，擋 package-lock.json／yarn.lock／bun.lockb／bun.lock／npm-shrinkwrap.json 進 repo。一致性那半本來就由 --frozen-lockfile 強制。guard 邏輯本地雙向驗證過（乾淨 repo 過、模擬外來 lockfile 擋）。本 PR 的 CI 綠 = guard 無誤殺實證。合併後 #315 可關。