### PR TITLE
refactor: type practice pool options

### DIFF
--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -6,6 +6,7 @@ import { buildExamQuestionPool } from "./examBlocks";
 import { buildKanaQuestionPool } from "./kanaDrill";
 import { levelsForRange } from "./levelRange";
 import { buildQuestionPool } from "./practice";
+import type { PracticeMode } from "./practiceMode";
 import { buildSentencePatternPool } from "./sentencePatterns";
 import {
   buildAllKnownQuestions,
@@ -14,16 +15,16 @@ import {
   composeDailySet,
   resolveBookmarkedQuestions,
   uniqueForms,
-  type PracticePoolRequest
+  type PracticePoolOptions
 } from "./sessionPools";
 import type { PracticeQuestion } from "./types";
 import { vocabulary } from "./vocabulary";
 import { jlptVocabulary } from "./vocabulary-jlpt";
 
-// Default request = the "basic" drill. Each test changes exactly one mode,
+// Default options = the "basic" drill. Each test changes exactly one mode,
 // so the branch under test is isolated and impossible mode combinations
 // cannot be constructed.
-function poolParams(overrides: Partial<PracticePoolRequest> = {}): PracticePoolRequest {
+function poolParams(overrides: Partial<PracticePoolOptions> = {}): PracticePoolOptions {
   return {
     mode: "basic",
     partOfSpeech: "verb",
@@ -36,17 +37,25 @@ function poolParams(overrides: Partial<PracticePoolRequest> = {}): PracticePoolR
   };
 }
 
-describe("buildPracticeQuestions mode request (#623)", () => {
+describe("buildPracticeQuestions mode options (#623)", () => {
   it("selects exactly one pool branch from mode", () => {
     const questions = buildPracticeQuestions({
       ...poolParams(),
       mode: "kana",
       kanaScript: "katakana",
-      sessionLength: 10
+      sessionLength: null
     });
 
-    expect(questions).toHaveLength(10);
+    expect(questions).toHaveLength(312);
     expect(questions.every((question) => question.id.startsWith("kana-katakana-"))).toBe(true);
+  });
+
+  it("throws for a corrupt mode instead of silently falling back to basic", () => {
+    const corruptMode = "corrupt" as unknown as PracticeMode;
+
+    expect(() => buildPracticeQuestions(poolParams({ mode: corruptMode }))).toThrow(
+      "Unsupported practice mode: corrupt"
+    );
   });
 });
 
@@ -238,10 +247,14 @@ describe("buildPracticeQuestions", () => {
     expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
   });
 
-  it("pattern mode: returns the sentence-pattern pool (same membership)", () => {
-    const questions = buildPracticeQuestions(poolParams({ mode: "pattern" }));
-    const expected = buildSentencePatternPool();
+  it("pattern mode: passes patternIds through to the filtered pool", () => {
+    const patternIds = ["starter-desu"] as const;
+    const questions = buildPracticeQuestions(
+      poolParams({ mode: "pattern", patternIds: [...patternIds] })
+    );
+    const expected = buildSentencePatternPool({ patternIds: [...patternIds] });
 
+    expect(questions.length).toBeGreaterThan(0);
     expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
   });
 

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -6,6 +6,7 @@ import { buildExamQuestionPool } from "./examBlocks";
 import { buildKanaQuestionPool } from "./kanaDrill";
 import { levelsForRange } from "./levelRange";
 import { buildQuestionPool } from "./practice";
+import { buildSentencePatternPool } from "./sentencePatterns";
 import {
   buildAllKnownQuestions,
   buildModeCounts,
@@ -13,26 +14,18 @@ import {
   composeDailySet,
   resolveBookmarkedQuestions,
   uniqueForms,
-  type PracticePoolParams
+  type PracticePoolRequest
 } from "./sessionPools";
 import type { PracticeQuestion } from "./types";
 import { vocabulary } from "./vocabulary";
 import { jlptVocabulary } from "./vocabulary-jlpt";
 
-// Default mode flags = the "basic" drill (every focus flag false). Each
-// test flips exactly the flag(s) for the branch it exercises, so the
-// branch under test is isolated.
-function poolParams(overrides: Partial<PracticePoolParams> = {}): PracticePoolParams {
+// Default request = the "basic" drill. Each test changes exactly one mode,
+// so the branch under test is isolated and impossible mode combinations
+// cannot be constructed.
+function poolParams(overrides: Partial<PracticePoolRequest> = {}): PracticePoolRequest {
   return {
-    isExamFocus: false,
-    isClozeFocus: false,
-    isPatternFocus: false,
-    isReviewFocus: false,
-    isVocabFocus: false,
-    isDailyFocus: false,
-    isKanaFocus: false,
-    isStarterFocus: false,
-    isBookmarksFocus: false,
+    mode: "basic",
     partOfSpeech: "verb",
     verbGroup: "godan",
     targetForms: ["te"],
@@ -43,28 +36,42 @@ function poolParams(overrides: Partial<PracticePoolParams> = {}): PracticePoolPa
   };
 }
 
+describe("buildPracticeQuestions mode request (#623)", () => {
+  it("selects exactly one pool branch from mode", () => {
+    const questions = buildPracticeQuestions({
+      ...poolParams(),
+      mode: "kana",
+      kanaScript: "katakana",
+      sessionLength: 10
+    });
+
+    expect(questions).toHaveLength(10);
+    expect(questions.every((question) => question.id.startsWith("kana-katakana-"))).toBe(true);
+  });
+});
+
 describe("buildPracticeQuestions kana branch (#533)", () => {
   it("kana focus builds the requested script's pool, defaulting to hiragana", () => {
     const hira = buildPracticeQuestions(
-      poolParams({ isKanaFocus: true, kanaScript: "hiragana", sessionLength: null })
+      poolParams({ mode: "kana", kanaScript: "hiragana", sessionLength: null })
     );
     expect(hira).toHaveLength(208);
     expect(hira.every((question) => question.id.startsWith("kana-hiragana-"))).toBe(true);
 
     const fallback = buildPracticeQuestions(
-      poolParams({ isKanaFocus: true, sessionLength: null })
+      poolParams({ mode: "kana", sessionLength: null })
     );
     expect(fallback.every((question) => question.id.startsWith("kana-hiragana-"))).toBe(true);
 
     const kata = buildPracticeQuestions(
-      poolParams({ isKanaFocus: true, kanaScript: "katakana", sessionLength: null })
+      poolParams({ mode: "kana", kanaScript: "katakana", sessionLength: null })
     );
     expect(kata).toHaveLength(312);
   });
 
   it("kana focus honours the session-length cap", () => {
     const capped = buildPracticeQuestions(
-      poolParams({ isKanaFocus: true, kanaScript: "hiragana", sessionLength: 10 })
+      poolParams({ mode: "kana", kanaScript: "hiragana", sessionLength: 10 })
     );
     expect(capped).toHaveLength(10);
   });
@@ -78,7 +85,7 @@ describe("buildPracticeQuestions kana branch (#533)", () => {
 
 describe("buildPracticeQuestions starter branch (#533)", () => {
   it("starter focus builds one meaning question per deck word", () => {
-    const pool = buildPracticeQuestions(poolParams({ isStarterFocus: true, sessionLength: null }));
+    const pool = buildPracticeQuestions(poolParams({ mode: "starter", sessionLength: null }));
     expect(pool.length).toBeGreaterThanOrEqual(90);
     expect(pool.every((question) => question.targetForm === "meaning")).toBe(true);
     expect(pool.every((question) => question.id.startsWith("starter-"))).toBe(true);
@@ -86,7 +93,7 @@ describe("buildPracticeQuestions starter branch (#533)", () => {
 
   it("starter focus honours the session-length cap and resolves in buildAllKnownQuestions", () => {
     const capped = buildPracticeQuestions(
-      poolParams({ isStarterFocus: true, sessionLength: 10 })
+      poolParams({ mode: "starter", sessionLength: 10 })
     );
     expect(capped).toHaveLength(10);
     const known = buildAllKnownQuestions();
@@ -174,14 +181,14 @@ describe("buildPracticeQuestions", () => {
   });
 
   it("exam mode (綜合, range all): mirrors the default exam pool contents", () => {
-    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "all" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "exam", levelRange: "all" }));
     const expected = buildExamQuestionPool("all");
 
     expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
   });
 
   it("exam mode (綜合, n1n2 range): narrows to N1+N2 only", () => {
-    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n1n2" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "exam", levelRange: "n1n2" }));
 
     expect(questions.length).toBeGreaterThan(0);
     expect(
@@ -190,7 +197,7 @@ describe("buildPracticeQuestions", () => {
   });
 
   it("exam mode (綜合, n2n3 range): narrows to N2+N3 only", () => {
-    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n2n3" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "exam", levelRange: "n2n3" }));
 
     expect(questions.length).toBeGreaterThan(0);
     expect(
@@ -199,7 +206,7 @@ describe("buildPracticeQuestions", () => {
   });
 
   it("exam mode (備考, n4n5 range): narrows to N4+N5 only (#65/#92)", () => {
-    const questions = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "n4n5" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "exam", levelRange: "n4n5" }));
 
     expect(questions.length).toBeGreaterThan(0);
     expect(
@@ -216,7 +223,7 @@ describe("buildPracticeQuestions", () => {
     const promptLabel = sample!.promptLabel!;
 
     const questions = buildPracticeQuestions(
-      poolParams({ isExamFocus: true, examSection: { level: "N1", promptLabel } })
+      poolParams({ mode: "exam", examSection: { level: "N1", promptLabel } })
     );
 
     expect(questions.length).toBeGreaterThan(0);
@@ -225,8 +232,15 @@ describe("buildPracticeQuestions", () => {
   });
 
   it("cloze mode: returns the cloze pool (same membership)", () => {
-    const questions = buildPracticeQuestions(poolParams({ isClozeFocus: true }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "cloze" }));
     const expected = buildClozeQuestionPool(clozeSentences, vocabulary);
+
+    expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
+  });
+
+  it("pattern mode: returns the sentence-pattern pool (same membership)", () => {
+    const questions = buildPracticeQuestions(poolParams({ mode: "pattern" }));
+    const expected = buildSentencePatternPool();
 
     expect(new Set(questions.map((q) => q.id))).toEqual(new Set(expected.map((q) => q.id)));
   });
@@ -234,7 +248,7 @@ describe("buildPracticeQuestions", () => {
   it("review mode: returns the snapshot queue verbatim (same order, no shuffle)", () => {
     const snapshot = buildExamQuestionPool("N1").slice(0, 3);
     const questions = buildPracticeQuestions(
-      poolParams({ isReviewFocus: true, reviewQueue: snapshot })
+      poolParams({ mode: "review", reviewQueue: snapshot })
     );
 
     expect(questions).toBe(snapshot);
@@ -243,7 +257,7 @@ describe("buildPracticeQuestions", () => {
   it("bookmarks mode: returns the bookmarked snapshot verbatim (add-order, no shuffle)", () => {
     const snapshot = buildExamQuestionPool("N1").slice(0, 3);
     const questions = buildPracticeQuestions(
-      poolParams({ isBookmarksFocus: true, bookmarkedQuestions: snapshot })
+      poolParams({ mode: "bookmarks", bookmarkedQuestions: snapshot })
     );
 
     expect(questions).toBe(snapshot);
@@ -251,13 +265,13 @@ describe("buildPracticeQuestions", () => {
 
   it("bookmarks mode: empty when nothing is starred", () => {
     const questions = buildPracticeQuestions(
-      poolParams({ isBookmarksFocus: true, bookmarkedQuestions: [] })
+      poolParams({ mode: "bookmarks", bookmarkedQuestions: [] })
     );
     expect(questions).toEqual([]);
   });
 
   it("vocab mode: reading-only drill, narrowed by level range", () => {
-    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "n1n2" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "vocab", levelRange: "n1n2" }));
 
     expect(questions.length).toBeGreaterThan(0);
     expect(questions.every((q) => q.targetForm === "reading")).toBe(true);
@@ -269,13 +283,13 @@ describe("buildPracticeQuestions", () => {
   it("vocab mode (n4n5 has no JLPT vocab): falls back to a non-empty reading pool (#199)", () => {
     // 単字 only has N1/N2 jlpt entries. A global n4n5 preference must not
     // empty the 単字 pool -- it falls back to the full reading deck.
-    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "n4n5" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "vocab", levelRange: "n4n5" }));
     expect(questions.length).toBeGreaterThan(0);
     expect(questions.every((q) => q.targetForm === "reading")).toBe(true);
   });
 
   it("vocab mode (range all): keeps the whole JLPT vocab reading pool", () => {
-    const questions = buildPracticeQuestions(poolParams({ isVocabFocus: true, levelRange: "all" }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "vocab", levelRange: "all" }));
     const expected = buildQuestionPool(jlptVocabulary, {
       partOfSpeech: "mixed",
       verbGroup: "all",
@@ -287,7 +301,7 @@ describe("buildPracticeQuestions", () => {
 
   it("daily mode: composes a finite 今日練習 set from the due snapshot", () => {
     const due = buildExamQuestionPool("N1").slice(0, 4);
-    const questions = buildPracticeQuestions(poolParams({ isDailyFocus: true, reviewQueue: due }));
+    const questions = buildPracticeQuestions(poolParams({ mode: "daily", reviewQueue: due }));
 
     expect(questions.length).toBeGreaterThan(0);
     expect(questions.length).toBeLessThanOrEqual(20);
@@ -299,7 +313,7 @@ describe("buildPracticeQuestions", () => {
 
   it("daily mode: threads the level range into the composed set (n4n5 -> N4/N5) (#199)", () => {
     const questions = buildPracticeQuestions(
-      poolParams({ isDailyFocus: true, reviewQueue: [], levelRange: "n4n5" })
+      poolParams({ mode: "daily", reviewQueue: [], levelRange: "n4n5" })
     );
     expect(questions.length).toBeGreaterThan(0);
     expect(
@@ -430,7 +444,7 @@ describe("buildPracticeQuestions unattempted-first exam ordering (#385)", () => 
     const pool = buildExamQuestionPool("all");
     const attemptedIds = new Set(pool.slice(0, 8).map((q) => q.id));
     const out = buildPracticeQuestions(
-      poolParams({ isExamFocus: true, levelRange: "all", attemptedIds })
+      poolParams({ mode: "exam", levelRange: "all", attemptedIds })
     );
     // membership unchanged...
     expect(new Set(out.map((q) => q.id))).toEqual(new Set(pool.map((q) => q.id)));
@@ -445,7 +459,7 @@ describe("buildPracticeQuestions unattempted-first exam ordering (#385)", () => 
     const pool = buildExamQuestionPool("all");
     const attemptedIds = new Set(pool.slice(0, 10).map((q) => q.id));
     const capped = buildPracticeQuestions(
-      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: 20, attemptedIds })
+      poolParams({ mode: "exam", levelRange: "all", sessionLength: 20, attemptedIds })
     );
     expect(capped.length).toBe(20);
     // The bank has far more than 20 unattempted, so a capped set is all fresh.
@@ -453,7 +467,7 @@ describe("buildPracticeQuestions unattempted-first exam ordering (#385)", () => 
   });
 
   it("no attemptedIds: membership unchanged (fresh learner sees the plain pool)", () => {
-    const out = buildPracticeQuestions(poolParams({ isExamFocus: true, levelRange: "all" }));
+    const out = buildPracticeQuestions(poolParams({ mode: "exam", levelRange: "all" }));
     expect(new Set(out.map((q) => q.id))).toEqual(
       new Set(buildExamQuestionPool("all").map((q) => q.id))
     );
@@ -491,14 +505,14 @@ describe("buildPracticeQuestions session-length cap (#154)", () => {
 
   it("caps the exam pool to sessionLength", () => {
     const capped = buildPracticeQuestions(
-      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: 20 })
+      poolParams({ mode: "exam", levelRange: "all", sessionLength: 20 })
     );
     expect(capped.length).toBe(20);
   });
 
   it("treats null sessionLength as no cap (full pool)", () => {
     const full = buildPracticeQuestions(
-      poolParams({ isExamFocus: true, levelRange: "all", sessionLength: null })
+      poolParams({ mode: "exam", levelRange: "all", sessionLength: null })
     );
     expect(full.length).toBe(buildExamQuestionPool("all").length);
   });
@@ -506,14 +520,14 @@ describe("buildPracticeQuestions session-length cap (#154)", () => {
   it("does NOT cap review mode (clears the whole due queue)", () => {
     const due = buildExamQuestionPool("all").slice(0, 25);
     const questions = buildPracticeQuestions(
-      poolParams({ isReviewFocus: true, reviewQueue: due, sessionLength: 20 })
+      poolParams({ mode: "review", reviewQueue: due, sessionLength: 20 })
     );
     expect(questions.length).toBe(25);
   });
 
   it("does NOT shrink 今日練習 below its own target via sessionLength", () => {
     const daily = buildPracticeQuestions(
-      poolParams({ isDailyFocus: true, reviewQueue: [], sessionLength: 5 })
+      poolParams({ mode: "daily", reviewQueue: [], sessionLength: 5 })
     );
     expect(daily.length).toBeGreaterThan(5);
   });

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -36,6 +36,10 @@ export function uniqueForms(forms: TargetForm[]): TargetForm[] {
   return Array.from(new Set(forms));
 }
 
+// Deliberate runtime contract: the legacy flag dispatcher could silently fall
+// through to the basic pool for a malformed state; an unknown mode now throws.
+// Any future persisted/query-string session mode must be validated against the
+// PracticeMode union before it reaches this boundary.
 function assertNever(value: never): never {
   throw new Error(`Unsupported practice mode: ${String(value)}`);
 }
@@ -219,10 +223,10 @@ export function resolveBookmarkedQuestions(
 // hook derives these from its state (one mode), props (reviewQueue
 // snapshot), and config (filter / partOfSpeech / verbGroup / targetForms
 // / levelRange), then hands them in so this stays a pure function.
-export type PracticePoolRequest = {
+export type PracticePoolOptions = {
   // A single mode value makes impossible states (for example exam + review)
-  // unrepresentable. The previous nine booleans also made branch priority
-  // depend on the order of the if-statements below.
+  // unrepresentable. With the previous nine booleans, branch priority depended
+  // on the order of the old if-statements.
   mode: PracticeMode;
   examSection?: { level: MockExamLevel; promptLabel: string };
   patternIds?: SentencePatternId[];
@@ -257,7 +261,7 @@ export type PracticePoolRequest = {
 // mode/range branch (section-filtered exam, 綜合 level-range exam, cloze,
 // pattern, review snapshot, vocab reading drill, 今日練習, basic drill)
 // stays exactly as it was.
-export function buildPracticeQuestions(params: PracticePoolRequest): PracticeQuestion[] {
+export function buildPracticeQuestions(options: PracticePoolOptions): PracticeQuestion[] {
   const {
     mode,
     examSection,
@@ -271,7 +275,7 @@ export function buildPracticeQuestions(params: PracticePoolRequest): PracticeQue
     bookmarkedQuestions,
     sessionLength,
     attemptedIds
-  } = params;
+  } = options;
   const fresh = (pool: PracticeQuestion[]): PracticeQuestion[] =>
     attemptedIds ? prioritizeUnattempted(pool, attemptedIds) : pool;
 
@@ -331,8 +335,8 @@ export function buildPracticeQuestions(params: PracticePoolRequest): PracticeQue
     case "review":
       // Snapshot the SRS queue at session start. Subsequent answers
       // update the LIVE reviewQueue (used by the home banner count),
-      // but this useMemo is intentionally NOT re-keyed on it -- see
-      // the deps comment below for the regression that fixes.
+      // but the questions memo is intentionally NOT re-keyed on it -- see the
+      // dependency comment in usePracticeSession.ts for the regression fixed.
       // Ordering is preserved (no extra shuffle): getReviewQueue
       // already sorts most-overdue first.
       return reviewQueue;
@@ -376,8 +380,9 @@ export function buildPracticeQuestions(params: PracticePoolRequest): PracticeQue
 
     case "daily":
       // Snapshot the current due queue at session start (same as review
-      // mode); the live reviewQueue stays excluded from the deps below. The
-      // fresh portion is narrowed to the learner's target band (#199).
+      // mode); the live reviewQueue stays excluded from the questions memo
+      // dependencies in usePracticeSession.ts. The fresh portion is narrowed
+      // to the learner's target band (#199).
       return composeDailySet(reviewQueue, levelRange);
 
     case "bookmarks":

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -19,6 +19,7 @@ import { buildKanaQuestionPool } from "./kanaDrill";
 import type { KanaScript } from "./kana";
 import { levelsForRange, type LevelRange } from "./levelRange";
 import type { MockExamLevel } from "./mockExam";
+import type { PracticeMode } from "./practiceMode";
 import { buildSentencePatternPool, type SentencePatternId } from "./sentencePatterns";
 import {
   buildQuestionPool,
@@ -33,6 +34,10 @@ import { jlptVocabulary } from "./vocabulary-jlpt";
 
 export function uniqueForms(forms: TargetForm[]): TargetForm[] {
   return Array.from(new Set(forms));
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported practice mode: ${String(value)}`);
 }
 
 const DAILY_TARGET = 20;
@@ -211,19 +216,14 @@ export function resolveBookmarkedQuestions(
 }
 
 // All the inputs the active-pool builder needs from the React layer. The
-// hook derives these from its state (mode flags), props (reviewQueue
+// hook derives these from its state (one mode), props (reviewQueue
 // snapshot), and config (filter / partOfSpeech / verbGroup / targetForms
 // / levelRange), then hands them in so this stays a pure function.
-export type PracticePoolParams = {
-  isExamFocus: boolean;
-  isClozeFocus: boolean;
-  isPatternFocus: boolean;
-  isReviewFocus: boolean;
-  isVocabFocus: boolean;
-  isDailyFocus: boolean;
-  isKanaFocus: boolean;
-  isStarterFocus: boolean;
-  isBookmarksFocus: boolean;
+export type PracticePoolRequest = {
+  // A single mode value makes impossible states (for example exam + review)
+  // unrepresentable. The previous nine booleans also made branch priority
+  // depend on the order of the if-statements below.
+  mode: PracticeMode;
   examSection?: { level: MockExamLevel; promptLabel: string };
   patternIds?: SentencePatternId[];
   // Gojuon script for kana mode (#533); undefined -> hiragana.
@@ -257,17 +257,9 @@ export type PracticePoolParams = {
 // mode/range branch (section-filtered exam, 綜合 level-range exam, cloze,
 // pattern, review snapshot, vocab reading drill, 今日練習, basic drill)
 // stays exactly as it was.
-export function buildPracticeQuestions(params: PracticePoolParams): PracticeQuestion[] {
+export function buildPracticeQuestions(params: PracticePoolRequest): PracticeQuestion[] {
   const {
-    isExamFocus,
-    isClozeFocus,
-    isPatternFocus,
-    isReviewFocus,
-    isVocabFocus,
-    isDailyFocus,
-    isKanaFocus,
-    isStarterFocus,
-    isBookmarksFocus,
+    mode,
     examSection,
     patternIds,
     kanaScript,
@@ -290,123 +282,122 @@ export function buildPracticeQuestions(params: PracticePoolParams): PracticeQues
   const cap = (pool: PracticeQuestion[]): PracticeQuestion[] =>
     sessionLength != null && sessionLength > 0 ? pool.slice(0, sessionLength) : pool;
 
-  if (isExamFocus) {
-    // Section-filtered when launched from the 模擬考 picker; the
-    // plain "綜合考題庫" mode card leaves examSection unset and
-    // mixes every section.
-    const section = examSection;
-    if (section) {
+  switch (mode) {
+    case "exam": {
+      // Section-filtered when launched from the 模擬考 picker; the
+      // plain "綜合考題庫" mode card leaves examSection unset and
+      // mixes every section.
+      const section = examSection;
+      if (section) {
+        return cap(
+          shuffleQuestions(
+            buildExamQuestionPool(section.level).filter(
+              (question) => question.promptLabel === section.promptLabel
+            )
+          )
+        );
+      }
+      // 綜合考題庫 + 備考 presets: optionally narrowed to a level range, then
+      // unattempted (新題) items first so a capped session pulls new content
+      // before anything already done (#385). The section-filtered mock path
+      // above keeps its pure shuffle (a mock test shouldn't reorder by history).
+      return cap(fresh(shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"))));
+    }
+
+    case "cloze":
+      return cap(shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary)));
+
+    case "pattern":
+      return cap(shuffleQuestions(buildSentencePatternPool({ patternIds })));
+
+    case "kana":
+      // Kana recognition drill (#533): the 入門 chapter CTAs pick the script.
+      return cap(shuffleQuestions(buildKanaQuestionPool({ script: kanaScript ?? "hiragana" })));
+
+    case "starter":
+      // Starter-vocab meaning drill (#533): see the kana word, pick its
+      // meaning. Distractors come from the same deck (pool-based), whose
+      // pairwise-distinct meanings are locked by starterVocabulary.test.ts.
       return cap(
         shuffleQuestions(
-          buildExamQuestionPool(section.level).filter(
-            (question) => question.promptLabel === section.promptLabel
-          )
+          buildQuestionPool(starterVocabulary, {
+            partOfSpeech: "mixed",
+            verbGroup: "all",
+            targetForms: ["meaning"]
+          })
+        )
+      );
+
+    case "review":
+      // Snapshot the SRS queue at session start. Subsequent answers
+      // update the LIVE reviewQueue (used by the home banner count),
+      // but this useMemo is intentionally NOT re-keyed on it -- see
+      // the deps comment below for the regression that fixes.
+      // Ordering is preserved (no extra shuffle): getReviewQueue
+      // already sorts most-overdue first.
+      return reviewQueue;
+
+    case "vocab": {
+      // 単字 mode: N1/N2 reading drill. Reading-only on purpose --
+      // for a Chinese-speaking learner the kanji usually telegraphs
+      // the meaning (影響 = 影響), so an isolated meaning question is
+      // trivial and can't be rescued by stronger distractors. The
+      // genuinely hard, JLPT-relevant skill is the READING (よみ):
+      // 影響 is えいきょう, not えいきゅう. Meaning is still tested,
+      // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
+      // 詞彙用法 sections -- which is the authentic way to test it.
+      const levels = levelsForRange(levelRange);
+      const narrowed = levels
+        ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
+        : jlptVocabulary;
+      // 単字 only has N1/N2 jlpt entries (VOCAB_LEVEL_RANGE_OPTIONS excludes
+      // n4n5 for this reason). A global n4n5 preference would narrow this to an
+      // empty pool, so fall back to the full reading deck rather than show an
+      // empty 単字 session (#199).
+      const vocabSource = narrowed.length > 0 ? narrowed : jlptVocabulary;
+      const vocabPool = shuffleQuestions(
+        buildQuestionPool(vocabSource, {
+          partOfSpeech: "mixed",
+          verbGroup: "all",
+          targetForms: ["reading"]
+        })
+      );
+      // De-run by reading length: consecutive questions then tend to
+      // have different-length answers -> different distractor bands ->
+      // no "same options twice in a row" feel even when the random
+      // shuffle clusters same-length words together.
+      return cap(
+        reduceAdjacentClusters(
+          vocabPool,
+          (question) => String(question.expectedAnswers[0]?.length ?? 0)
         )
       );
     }
-    // 綜合考題庫 + 備考 presets: optionally narrowed to a level range, then
-    // unattempted (新題) items first so a capped session pulls new content
-    // before anything already done (#385). The section-filtered mock path
-    // above keeps its pure shuffle (a mock test shouldn't reorder by history).
-    return cap(fresh(shuffleQuestions(buildExamQuestionPool(levelsForRange(levelRange) ?? "all"))));
-  }
 
-  if (isClozeFocus) {
-    return cap(shuffleQuestions(buildClozeQuestionPool(clozeSentences, vocabulary)));
-  }
+    case "daily":
+      // Snapshot the current due queue at session start (same as review
+      // mode); the live reviewQueue stays excluded from the deps below. The
+      // fresh portion is narrowed to the learner's target band (#199).
+      return composeDailySet(reviewQueue, levelRange);
 
-  if (isPatternFocus) {
-    return cap(shuffleQuestions(buildSentencePatternPool({ patternIds })));
-  }
+    case "bookmarks":
+      // 收藏 mode (#470): a finite pass over the learner's starred questions,
+      // in add-order (getBookmarkedIds order). Snapshot at session start like
+      // review -- toggling a star mid-session doesn't reshuffle the live pass.
+      return bookmarkedQuestions;
 
-  if (isKanaFocus) {
-    // Kana recognition drill (#533): the 入門 chapter CTAs pick the script.
-    return cap(shuffleQuestions(buildKanaQuestionPool({ script: kanaScript ?? "hiragana" })));
-  }
+    case "basic":
+      return cap(
+        shuffleQuestions(
+          buildQuestionPool(vocabulary, {
+            partOfSpeech,
+            verbGroup,
+            targetForms
+          })
+        )
+      );
 
-  if (isStarterFocus) {
-    // Starter-vocab meaning drill (#533): see the kana word, pick its
-    // meaning. Distractors come from the same deck (pool-based), whose
-    // pairwise-distinct meanings are locked by starterVocabulary.test.ts.
-    return cap(
-      shuffleQuestions(
-        buildQuestionPool(starterVocabulary, {
-          partOfSpeech: "mixed",
-          verbGroup: "all",
-          targetForms: ["meaning"]
-        })
-      )
-    );
+    default:
+      return assertNever(mode);
   }
-
-  if (isReviewFocus) {
-    // Snapshot the SRS queue at session start. Subsequent answers
-    // update the LIVE reviewQueue (used by the home banner count),
-    // but this useMemo is intentionally NOT re-keyed on it -- see
-    // the deps comment below for the regression that fixes.
-    // Ordering is preserved (no extra shuffle): getReviewQueue
-    // already sorts most-overdue first.
-    return reviewQueue;
-  }
-
-  if (isVocabFocus) {
-    // 単字 mode: N1/N2 reading drill. Reading-only on purpose --
-    // for a Chinese-speaking learner the kanji usually telegraphs
-    // the meaning (影響 = 影響), so an isolated meaning question is
-    // trivial and can't be rescued by stronger distractors. The
-    // genuinely hard, JLPT-relevant skill is the READING (よみ):
-    // 影響 is えいきょう, not えいきゅう. Meaning is still tested,
-    // but in CONTEXT, via the exam pool's 詞彙填空 / 類義替換 /
-    // 詞彙用法 sections -- which is the authentic way to test it.
-    const levels = levelsForRange(levelRange);
-    const narrowed = levels
-      ? jlptVocabulary.filter((item) => item.level != null && levels.includes(item.level))
-      : jlptVocabulary;
-    // 単字 only has N1/N2 jlpt entries (VOCAB_LEVEL_RANGE_OPTIONS excludes
-    // n4n5 for this reason). A global n4n5 preference would narrow this to an
-    // empty pool, so fall back to the full reading deck rather than show an
-    // empty 単字 session (#199).
-    const vocabSource = narrowed.length > 0 ? narrowed : jlptVocabulary;
-    const vocabPool = shuffleQuestions(
-      buildQuestionPool(vocabSource, {
-        partOfSpeech: "mixed",
-        verbGroup: "all",
-        targetForms: ["reading"]
-      })
-    );
-    // De-run by reading length: consecutive questions then tend to
-    // have different-length answers -> different distractor bands ->
-    // no "same options twice in a row" feel even when the random
-    // shuffle clusters same-length words together.
-    return cap(
-      reduceAdjacentClusters(
-        vocabPool,
-        (question) => String(question.expectedAnswers[0]?.length ?? 0)
-      )
-    );
-  }
-
-  if (isDailyFocus) {
-    // Snapshot the current due queue at session start (same as review
-    // mode); the live reviewQueue stays excluded from the deps below. The
-    // fresh portion is narrowed to the learner's target band (#199).
-    return composeDailySet(reviewQueue, levelRange);
-  }
-
-  if (isBookmarksFocus) {
-    // 收藏 mode (#470): a finite pass over the learner's starred questions,
-    // in add-order (getBookmarkedIds order). Snapshot at session start like
-    // review -- toggling a star mid-session doesn't reshuffle the live pass.
-    return bookmarkedQuestions;
-  }
-
-  return cap(
-    shuffleQuestions(
-      buildQuestionPool(vocabulary, {
-        partOfSpeech,
-        verbGroup,
-        targetForms
-      })
-    )
-  );
 }

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -279,15 +279,7 @@ export function usePracticeSession({
     () => {
       void sessionSeed;
       return buildPracticeQuestions({
-        isExamFocus,
-        isClozeFocus,
-        isPatternFocus,
-        isReviewFocus,
-        isVocabFocus,
-        isDailyFocus,
-        isKanaFocus,
-        isStarterFocus,
-        isBookmarksFocus,
+        mode: practiceMode,
         examSection: practiceFilter.examSection,
         patternIds: practiceFilter.patternIds,
         kanaScript: practiceFilter.kanaScript,
@@ -315,15 +307,7 @@ export function usePracticeSession({
     // snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
-      isExamFocus,
-      isClozeFocus,
-      isPatternFocus,
-      isReviewFocus,
-      isVocabFocus,
-      isDailyFocus,
-      isKanaFocus,
-      isStarterFocus,
-      isBookmarksFocus,
+      practiceMode,
       practiceFilter.patternIds,
       practiceFilter.examSection,
       practiceFilter.kanaScript,


### PR DESCRIPTION
Closes part of #623.

## What changed

- replace the nine `is*Focus` flags in `PracticePoolParams` with one `mode: PracticeMode` option
- rename the boundary type to the repo-conventional `PracticePoolOptions`
- dispatch every pool branch through an exhaustive `switch`; adding a future `PracticeMode` without a branch now fails TypeScript via `assertNever`
- key the practice-session question memo directly on `practiceMode` instead of nine derived booleans
- migrate the existing pool tests to the new options and add explicit mode-routing + filtered pattern-pool characterization coverage

## Why

The old shape allowed impossible combinations such as exam and review both being true. The result then depended on `if` ordering. This PR makes one active mode a type-level invariant before the later session-snapshot work in #623.

## Scope

Behavior-preserving refactor for valid `PracticeMode` inputs:

- no question-bank or pool-composition changes
- no session-snapshot lifecycle changes
- no UI changes
- no new dependency
- lazy import boundaries remain unchanged

For malformed runtime input, the contract is now explicit: an unknown mode throws instead of silently falling through to the basic pool. The code comment and regression test pin this behavior; future persisted/query-string modes must be validated before this boundary.

## Review follow-up

- document and test the corrupt-mode throw contract
- pin `patternIds` passthrough with `starter-desu`
- fix stale cross-file dependency comments
- use `PracticePoolOptions` naming
- make both kana routing assertions discriminating by checking the full 312-item katakana pool

## TDD

RED was observed first: passing `mode: "kana"` to the old implementation fell through to the basic pool while the other 951 tests remained green.

## Validation

- focused pool tests: 53 passed
- isolated `App.test.tsx`: 57 passed
- full suite with reduced local concurrency: 92 files / 954 tests passed
- `corepack pnpm build`: passed; 103 pages prerendered
- initial index chunk: 677.43 kB, unchanged from main
- `git diff --check`: passed

Local runner note: the default-concurrency full run twice hit the same two pre-existing 5-second `App.test.tsx` user-event timeouts; both pass when that file runs alone, and the complete suite passes with `--maxWorkers=2`. No App/test timeout code is changed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice sessions now use a unified mode-based selection system across exam, kana, starter, cloze, pattern, review, vocabulary, daily, bookmarks, and basic practice.
  * Exam sessions prioritize unattempted questions and support section and level-range filtering.
  * Vocabulary sessions improve level fallback and answer-length variety.
* **Bug Fixes**
  * Invalid practice modes now fail clearly instead of silently producing incorrect question sets.
  * Session length limits and queue handling are applied more consistently across practice modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->