### PR TITLE
refactor: make practice pool snapshot explicit

### DIFF
--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
+import { BOOKMARKS_KEY } from "../domain/bookmarks";
+import { buildAllKnownQuestions } from "../domain/sessionPools";
+import type { Attempt, PracticeQuestion } from "../domain/types";
 import { initialLevelRange, usePracticeSession } from "./usePracticeSession";
 
 const baseHookArgs = {
@@ -7,6 +10,79 @@ const baseHookArgs = {
   progressAttempts: [],
   recordAttempt: () => {}
 };
+
+function makeAttempt(question: PracticeQuestion, isCorrect: boolean, timestamp: number): Attempt {
+  return {
+    questionId: question.id,
+    vocabularyId: question.vocabulary.id,
+    targetForm: question.targetForm,
+    prompt: question.vocabulary.surface,
+    expectedAnswers: question.expectedAnswers,
+    submittedAnswer: isCorrect ? question.expectedAnswers[0] : "wrong",
+    isCorrect,
+    timestamp,
+    responseTimeMs: 100
+  };
+}
+
+describe("usePracticeSession pool snapshot (#623)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("keeps the review pass stable until an explicit reset captures the latest queue", () => {
+    const question = buildAllKnownQuestions()[0];
+    const missed = makeAttempt(question, false, 1);
+    const cleared = makeAttempt(question, true, 2);
+    const { result, rerender } = renderHook(
+      ({ progressAttempts }: { progressAttempts: Attempt[] }) =>
+        usePracticeSession({
+          ...baseHookArgs,
+          init: { mode: "review" },
+          progressAttempts
+        }),
+      { initialProps: { progressAttempts: [missed] } }
+    );
+
+    expect(result.current.currentQuestion?.id).toBe(question.id);
+    expect(result.current.sessionTotal).toBe(1);
+
+    rerender({ progressAttempts: [missed, cleared] });
+
+    expect(result.current.reviewQueue).toHaveLength(0);
+    expect(result.current.currentQuestion?.id).toBe(question.id);
+    expect(result.current.sessionTotal).toBe(1);
+
+    act(() => result.current.resetSession());
+
+    expect(result.current.reviewEmpty).toBe(true);
+    expect(result.current.currentQuestion).toBeNull();
+    expect(result.current.sessionTotal).toBe(0);
+  });
+
+  it("keeps the bookmark pass stable until an explicit reset captures the latest bookmarks", () => {
+    const question = buildAllKnownQuestions()[0];
+    window.localStorage.setItem(BOOKMARKS_KEY, JSON.stringify([question.id]));
+    const { result } = renderHook(() =>
+      usePracticeSession({ ...baseHookArgs, init: { mode: "bookmarks" } })
+    );
+
+    expect(result.current.currentQuestion?.id).toBe(question.id);
+    expect(result.current.sessionTotal).toBe(1);
+
+    act(() => result.current.onToggleBookmark(question.id));
+
+    expect(result.current.bookmarkedQuestions).toHaveLength(0);
+    expect(result.current.currentQuestion?.id).toBe(question.id);
+    expect(result.current.sessionTotal).toBe(1);
+
+    act(() => result.current.resetSession());
+
+    expect(result.current.bookmarksEmpty).toBe(true);
+    expect(result.current.currentQuestion).toBeNull();
+    expect(result.current.sessionTotal).toBe(0);
+  });
+});
 
 // applyModePreset must keep honouring the global target preference when a
 // mode is picked from the in-session picker -- not only on first mount.

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -17,6 +17,7 @@ import {
   buildModeCounts,
   buildPracticeQuestions,
   resolveBookmarkedQuestions,
+  type PracticePoolOptions,
   uniqueForms
 } from "../domain/sessionPools";
 import { collectAttemptedIds } from "../domain/unattempted";
@@ -73,6 +74,16 @@ export type SessionInit = {
   // JLPT level range for the exam (綜合) + vocab (単字) pools; default all.
   levelRange?: LevelRange;
 };
+
+type LivePracticePoolInputs = Pick<
+  PracticePoolOptions,
+  "reviewQueue" | "bookmarkedQuestions" | "attemptedIds"
+>;
+
+// One immutable set of pool-building inputs for the active pass. Live
+// progress and bookmark changes are intentionally captured only when a
+// mode/config change or explicit reset starts a new pass.
+type PracticePoolSnapshot = Readonly<PracticePoolOptions>;
 
 // The level range a session starts in (#199). An explicit launch request
 // (init.levelRange) always wins; otherwise it inherits the learner's global
@@ -235,10 +246,9 @@ export function usePracticeSession({
     setBookmarkVersion((version) => version + 1);
   };
 
-  // Snapshot of every question the learner has attempted, so the exam pool
-  // surfaces 新題 (unattempted) first (#385). Like reviewQueue it's fed into
-  // the pool builder but kept OUT of the `questions` memo deps below -- a fresh
-  // snapshot is captured on mode change / reset, never reshuffled mid-session.
+  // Every question the learner has attempted, so the exam pool surfaces 新題
+  // (unattempted) first (#385). The live value is captured into the session
+  // snapshot below on mode/config change or reset, never mid-session.
   const attemptedIds = useMemo(() => collectAttemptedIds(progressAttempts), [progressAttempts]);
 
   // Pool size per practice mode, shown on the mode cards so the learner
@@ -275,10 +285,23 @@ export function usePracticeSession({
     ? t.targetForms[selectedForm]
     : activeFocusForms.map((form) => t.targetForms[form]).join(" / ") || t.focusSummaryEmpty;
 
-  const questions = useMemo(
+  // Keep the latest dynamic inputs available for the next snapshot without
+  // making them recapture (and reshuffle/shrink) the active pass. Updating a
+  // ref during render is safe here: it is only read while constructing a new
+  // snapshot, never used directly to render the current pass.
+  const latestPoolInputsRef = useRef<LivePracticePoolInputs>({
+    reviewQueue,
+    bookmarkedQuestions,
+    attemptedIds
+  });
+  latestPoolInputsRef.current = { reviewQueue, bookmarkedQuestions, attemptedIds };
+
+  const poolSnapshot = useMemo<PracticePoolSnapshot>(
     () => {
+      // sessionSeed is the explicit "start a fresh pass" signal.
       void sessionSeed;
-      return buildPracticeQuestions({
+      const liveInputs = latestPoolInputsRef.current;
+      return {
         mode: practiceMode,
         examSection: practiceFilter.examSection,
         patternIds: practiceFilter.patternIds,
@@ -287,25 +310,12 @@ export function usePracticeSession({
         verbGroup,
         targetForms,
         levelRange,
-        reviewQueue,
-        bookmarkedQuestions,
+        reviewQueue: liveInputs.reviewQueue,
+        bookmarkedQuestions: liveInputs.bookmarkedQuestions,
         sessionLength,
-        attemptedIds
-      });
+        attemptedIds: liveInputs.attemptedIds
+      };
     },
-    // INTENTIONALLY excluding `reviewQueue` from deps. The live queue
-    // is reactive to every progressAttempts change (any answered
-    // question shifts it), and including it here would re-run the
-    // useMemo on every answer -- which in non-review modes reshuffles
-    // the pool, and in review mode shrinks it. Either way the result
-    // is currentQuestion getting ripped out from under the feedback
-    // panel that's still showing the previous answer (user-visible
-    // bug: "答題後跳到下一題、不能答、解析還在；按下一題又跳一題").
-    // The closure inside captures the latest `reviewQueue` whenever
-    // this useMemo DOES re-run (mode change / sessionSeed bump), so
-    // entering review mode + explicit reset still get a fresh
-    // snapshot.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       practiceMode,
       practiceFilter.patternIds,
@@ -319,6 +329,8 @@ export function usePracticeSession({
       sessionSeed
     ]
   );
+
+  const questions = useMemo(() => buildPracticeQuestions(poolSnapshot), [poolSnapshot]);
   // Review and 今日練習 are FINITE passes over a snapshot: walk each item
   // once, no modulo wrap, then stop (and show a completion screen). Every
   // other mode is an endless drill (modulo wrap via selectQuestion).


### PR DESCRIPTION
## Summary

- introduce a named, typed `PracticePoolSnapshot` for each active practice pass
- capture live review, bookmark, and attempted-question inputs only on mode/config changes or explicit reset
- remove the intentionally incomplete dependency list from the question-pool memo
- add hook-level characterization tests for review and bookmark snapshot refresh timing

Part of #623. This PR intentionally does not change the reducer or the hook's public API.

## Verification

- `corepack pnpm test --maxWorkers=2` — 92 files / 956 tests passed
- `corepack pnpm build` — passed; 103 pages prerendered
- initial bundle remains 677.43 kB; practice data remains behind `ChallengePanel`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Practice sessions now keep a stable question set during an active review or bookmarks session.
  * New attempts or bookmark changes no longer unexpectedly reshuffle the current session.
  * Session data refreshes when starting a new pass or explicitly resetting the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->