### PR TITLE
refactor: centralize app route contract

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
 import { kanjiDefaultLevel, type LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
-import { canonicalArticleSlug } from "./domain/articlesMeta";
+import { parseRoute, serializeRoute, type AppView } from "./domain/routes";
 import packageJson from "../package.json";
 import "./styles.css";
 
@@ -94,7 +94,6 @@ const BlogArticlePage = lazy(() =>
 );
 const BUILD_VERSION = packageJson.version;
 
-type AppView = "home" | "learn" | "rules" | "kanji" | "kana" | "challenge" | "mock" | "about" | "grammar" | "blog";
 type DrillPreset = LearningBlockDrillPreset;
 
 // The LAUNCHED locales, in menu order, for the header language picker. Each
@@ -106,81 +105,6 @@ const LANGUAGE_OPTIONS: readonly Language[] = LAUNCHED_LANGUAGES;
 // 文型/文章 had one, which looked half-finished). One shared style keeps
 // the nine call sites identical.
 const navIconStyle = { verticalAlign: "middle", marginRight: "0.2rem" } as const;
-
-// Lightweight URL routing: each top-level view maps to a path so the browser
-// back/forward buttons, refresh, and shareable/bookmarkable links all work
-// (no router dependency). The challenge view's internal mode/filter stays as
-// ephemeral state -- deep-linking a specific drill is out of scope here.
-// Needs a SPA fallback on the host (public/_redirects) so a direct hit on a
-// sub-path serves index.html.
-const VIEW_PATHS: Record<AppView, string> = {
-  home: "/",
-  learn: "/learn",
-  rules: "/rules",
-  kanji: "/kanji",
-  // #619: standalone kana chart. Route only -- deliberately NOT a nav tab
-  // (header entries are being consolidated, #608); reached from the kana
-  // study chapters, the beginner flow, and search engines.
-  kana: "/kana",
-  challenge: "/challenge",
-  mock: "/mock",
-  about: "/about",
-  // Base path; the live grammar route carries a surface segment (see parseRoute
-  // / pathForView). Bare /grammar with no surface falls back to home.
-  grammar: "/grammar",
-  // Blog index; individual articles carry a slug segment (/blog/<slug>).
-  blog: "/blog"
-};
-
-function viewFromPath(pathname: string): AppView {
-  const match = (Object.entries(VIEW_PATHS) as [AppView, string][]).find(
-    ([, path]) => path === pathname
-  );
-  return match ? match[0] : "home";
-}
-
-// Per-grammar-point study pages (#281) live at /grammar/<encoded-surface>, the
-// one dynamic route. parseRoute pulls both the view and (for grammar) the
-// decoded surface off the path; pathForView is its inverse for URL sync.
-function parseRoute(pathname: string): {
-  view: AppView;
-  grammarSurface: string | null;
-  blogSlug: string | null;
-} {
-  const grammar = pathname.match(/^\/grammar\/(.+)$/);
-  if (grammar) {
-    let surface = grammar[1];
-    try {
-      surface = decodeURIComponent(surface);
-    } catch {
-      // Malformed escape -- keep the raw segment rather than throwing.
-    }
-    return { view: "grammar", grammarSurface: surface, blogSlug: null };
-  }
-  // Individual article route /blog/<slug> (#483); bare /blog is the index.
-  const blog = pathname.match(/^\/blog\/(.+)$/);
-  if (blog) {
-    let slug = blog[1];
-    try {
-      slug = decodeURIComponent(slug);
-    } catch {
-      // Malformed escape -- keep the raw segment.
-    }
-    slug = canonicalArticleSlug(slug);
-    return { view: "blog", grammarSurface: null, blogSlug: slug };
-  }
-  return { view: viewFromPath(pathname), grammarSurface: null, blogSlug: null };
-}
-
-function pathForView(view: AppView, grammarSurface: string | null, blogSlug: string | null): string {
-  if (view === "grammar" && grammarSurface) {
-    return `/grammar/${encodeURIComponent(grammarSurface)}`;
-  }
-  if (view === "blog" && blogSlug) {
-    return `/blog/${encodeURIComponent(blogSlug)}`;
-  }
-  return VIEW_PATHS[view];
-}
 
 export default function App() {
   const [appView, setAppView] = useState<AppView>(() => parseRoute(window.location.pathname).view);
@@ -216,7 +140,7 @@ export default function App() {
   // Keep the URL in sync when the view changes (push a history entry only
   // when the path actually differs, so popstate-driven changes don't loop).
   useEffect(() => {
-    const target = pathForView(appView, grammarSurface, blogSlug);
+    const target = serializeRoute({ view: appView, grammarSurface, blogSlug });
     if (window.location.pathname !== target) {
       window.history.pushState({ view: appView }, "", target);
     }

--- a/src/domain/prerender/staticPages.ts
+++ b/src/domain/prerender/staticPages.ts
@@ -11,7 +11,8 @@
 //
 // Pure data -> strings; no fs, no DOM. The I/O lives in scripts/prerender.mjs.
 // NOT imported by the app (build-time only), so it adds zero bundle weight.
-import { SITE_ORIGIN, VIEW_SEO, seoForView, type SeoView } from "../seo";
+import { SITE_ORIGIN, VIEW_SEO, seoForView } from "../seo";
+import type { AppView } from "../routes";
 import { grammarPatterns, type GrammarPattern } from "../grammarDatabase";
 import { publishedArticleMetas } from "../articlesMeta";
 import { publishedArticles, type ArticleBlock } from "../articles";
@@ -263,7 +264,7 @@ function kanaBody(): string {
   return wrap("五十音表（平假名・片假名對照）", parts.join(""));
 }
 
-function simpleViewBody(view: SeoView): string {
+function simpleViewBody(view: AppView): string {
   const entry = VIEW_SEO[view];
   return wrap(entry.title.split(" · ")[0], `${paragraph(entry.description)}<p><a href="/">回 Jabiko 首頁</a></p>`);
 }
@@ -274,7 +275,7 @@ export function buildStaticPages(): StaticPage[] {
   const pages: StaticPage[] = [];
   const byId = new Map(grammarPatterns.map((pattern) => [pattern.id, pattern]));
 
-  const push = (view: SeoView, path: string, bodyHtml: string, surface?: string, slug?: string) => {
+  const push = (view: AppView, path: string, bodyHtml: string, surface?: string, slug?: string) => {
     const seo = seoForView(view, surface ?? null, slug ?? null);
     pages.push({ path, title: seo.title, description: seo.description, canonical: seo.canonical, bodyHtml });
   };

--- a/src/domain/routes.test.ts
+++ b/src/domain/routes.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { APP_VIEW_PATHS, parseRoute, serializeRoute, type AppRoute, type AppView } from "./routes";
+
+const staticRoute = (view: AppView): AppRoute => ({
+  view,
+  grammarSurface: null,
+  blogSlug: null
+});
+
+describe("app route contract (#623)", () => {
+  it("round-trips every top-level view through its shared static path", () => {
+    for (const view of Object.keys(APP_VIEW_PATHS) as AppView[]) {
+      const route = staticRoute(view);
+      expect(parseRoute(serializeRoute(route)), view).toEqual(route);
+    }
+  });
+
+  it("round-trips an encoded grammar surface", () => {
+    const route: AppRoute = {
+      view: "grammar",
+      grammarSurface: "〜てもいい",
+      blogSlug: null
+    };
+
+    expect(serializeRoute(route)).toBe(`/grammar/${encodeURIComponent("〜てもいい")}`);
+    expect(parseRoute(serializeRoute(route))).toEqual(route);
+  });
+
+  it("canonicalizes a legacy blog alias while parsing", () => {
+    const parsed = parseRoute("/blog/sweet-step-steady");
+
+    expect(parsed).toEqual({
+      view: "blog",
+      grammarSurface: null,
+      blogSlug: "sweet-steady-sweet-step"
+    });
+    expect(serializeRoute(parsed)).toBe("/blog/sweet-steady-sweet-step");
+  });
+
+  it("falls an unknown path back to the home route", () => {
+    expect(parseRoute("/does-not-exist")).toEqual(staticRoute("home"));
+  });
+
+  it("does not throw on a malformed encoded segment", () => {
+    expect(parseRoute("/grammar/%E0%A4%A")).toEqual({
+      view: "grammar",
+      grammarSurface: "%E0%A4%A",
+      blogSlug: null
+    });
+  });
+});

--- a/src/domain/routes.ts
+++ b/src/domain/routes.ts
@@ -1,0 +1,75 @@
+import { canonicalArticleSlug } from "./articlesMeta";
+
+// Single source of truth for top-level app views and their static paths.
+// Dynamic grammar and blog routes extend their respective base paths below.
+export const APP_VIEW_PATHS = {
+  home: "/",
+  learn: "/learn",
+  rules: "/rules",
+  kanji: "/kanji",
+  kana: "/kana",
+  challenge: "/challenge",
+  mock: "/mock",
+  about: "/about",
+  grammar: "/grammar",
+  blog: "/blog"
+} as const;
+
+export type AppView = keyof typeof APP_VIEW_PATHS;
+
+export interface AppRoute {
+  view: AppView;
+  grammarSurface: string | null;
+  blogSlug: string | null;
+}
+
+function staticRoute(view: AppView): AppRoute {
+  return { view, grammarSurface: null, blogSlug: null };
+}
+
+function decodePathSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // Preserve the existing fallback for malformed escapes instead of
+    // letting one bad URL prevent the app shell from rendering.
+    return segment;
+  }
+}
+
+/** Parse a pathname into the state consumed by the App shell. */
+export function parseRoute(pathname: string): AppRoute {
+  const grammar = pathname.match(/^\/grammar\/(.+)$/);
+  if (grammar) {
+    return {
+      view: "grammar",
+      grammarSurface: decodePathSegment(grammar[1]),
+      blogSlug: null
+    };
+  }
+
+  const blog = pathname.match(/^\/blog\/(.+)$/);
+  if (blog) {
+    return {
+      view: "blog",
+      grammarSurface: null,
+      blogSlug: canonicalArticleSlug(decodePathSegment(blog[1]))
+    };
+  }
+
+  const view = (Object.keys(APP_VIEW_PATHS) as AppView[]).find(
+    (candidate) => APP_VIEW_PATHS[candidate] === pathname
+  );
+  return staticRoute(view ?? "home");
+}
+
+/** Serialize App route state back to its canonical pathname. */
+export function serializeRoute(route: AppRoute): string {
+  if (route.view === "grammar" && route.grammarSurface) {
+    return `${APP_VIEW_PATHS.grammar}/${encodeURIComponent(route.grammarSurface)}`;
+  }
+  if (route.view === "blog" && route.blogSlug) {
+    return `${APP_VIEW_PATHS.blog}/${encodeURIComponent(route.blogSlug)}`;
+  }
+  return APP_VIEW_PATHS[route.view];
+}

--- a/src/domain/seo.test.ts
+++ b/src/domain/seo.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { SITE_ORIGIN, VIEW_SEO, seoForView, type SeoView } from "./seo";
+import { SITE_ORIGIN, VIEW_SEO, seoForView } from "./seo";
+import type { AppView } from "./routes";
 
-// The static-route views (every SeoView except the dynamic "grammar" route).
+// The static-route views (every AppView except the dynamic "grammar" route).
 // "blog" has a static index entry (VIEW_SEO.blog) plus a dynamic /blog/<slug>
 // variant, tested separately below like grammar.
-const VIEWS: Exclude<SeoView, "grammar">[] = [
+const VIEWS: Exclude<AppView, "grammar">[] = [
   "home",
   "learn",
   "rules",
@@ -18,7 +19,7 @@ const VIEWS: Exclude<SeoView, "grammar">[] = [
 
 describe("seo", () => {
   it("has an entry for every view", () => {
-    const allViews: SeoView[] = [...VIEWS, "grammar"];
+    const allViews: AppView[] = [...VIEWS, "grammar"];
     for (const view of allViews) {
       expect(VIEW_SEO[view], view).toBeDefined();
     }
@@ -32,7 +33,7 @@ describe("seo", () => {
   });
 
   it("gives every view a distinct title and description (no shared SPA meta)", () => {
-    const allViews: SeoView[] = [...VIEWS, "grammar"];
+    const allViews: AppView[] = [...VIEWS, "grammar"];
     const titles = new Set(allViews.map((v) => seoForView(v).title));
     const descriptions = new Set(allViews.map((v) => seoForView(v).description));
     expect(titles.size).toBe(allViews.length);
@@ -47,7 +48,7 @@ describe("seo", () => {
   });
 
   it("keeps descriptions within a sane SEO length (<=160 chars)", () => {
-    const allViews: SeoView[] = [...VIEWS, "grammar"];
+    const allViews: AppView[] = [...VIEWS, "grammar"];
     for (const view of allViews) {
       expect(seoForView(view).description.length, view).toBeLessThanOrEqual(160);
     }

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -8,19 +8,7 @@
 //
 // Pure data + a small resolver -> trivially testable, no DOM here.
 import { articleMetaBySlug } from "./articlesMeta";
-
-/** Top-level views that have their own URL (mirrors App's AppView / VIEW_PATHS). */
-export type SeoView =
-  | "home"
-  | "learn"
-  | "rules"
-  | "kanji"
-  | "kana"
-  | "challenge"
-  | "mock"
-  | "about"
-  | "grammar"
-  | "blog";
+import { APP_VIEW_PATHS, type AppView } from "./routes";
 
 /** Production origin; canonical URLs are absolute so crawlers dedupe cleanly. */
 export const SITE_ORIGIN = "https://jabiko.app";
@@ -28,70 +16,70 @@ export const SITE_ORIGIN = "https://jabiko.app";
 interface PageSeo {
   title: string;
   description: string;
-  /** Path at SITE_ORIGIN. Keep in sync with App's VIEW_PATHS. */
+  /** Static path from the shared app route contract. */
   path: string;
 }
 
-export const VIEW_SEO: Record<SeoView, PageSeo> = {
+export const VIEW_SEO: Record<AppView, PageSeo> = {
   home: {
     title: "Jabiko · JLPT 日檢自習室｜N5–N1 文法單字題型練習",
     description:
       "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型分區練習，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
-    path: "/"
+    path: APP_VIEW_PATHS.home
   },
   learn: {
     title: "分章學習 · JLPT／日檢文法變化 · Jabiko",
     description:
       "從動詞、形容詞變化一路到常用句型，一章一章看規則、例句與最容易踩的陷阱，看完直接練——日檢 N5〜N1 文法打底。",
-    path: "/learn"
+    path: APP_VIEW_PATHS.learn
   },
   rules: {
     title: "日語動詞變化規則速查表 · JLPT／日檢 · Jabiko",
     description:
       "動詞變化、ます／て形、各種接續整理成一頁可查的表，日檢文法複習時掃一眼就好。",
-    path: "/rules"
+    path: APP_VIEW_PATHS.rules
   },
   kanji: {
     title: "漢字音讀速查 · JLPT／日檢 N5–N1 · Jabiko",
     description:
       "依音讀（同音家族）查漢字、確認讀音與例詞，把濁音、長短音一次搞清楚，涵蓋 JLPT／日檢 N5〜N1 漢字。",
-    path: "/kanji"
+    path: APP_VIEW_PATHS.kanji
   },
   kana: {
     title: "五十音表（平假名・片假名對照）· 附發音 · Jabiko",
     description:
       "完整五十音表：平假名、片假名對照，清音、濁音・半濁音、拗音分區，每格附羅馬拼音與發音播放，看完可直接進假名認讀練習。",
-    path: "/kana"
+    path: APP_VIEW_PATHS.kana
   },
   challenge: {
     title: "JLPT／日檢線上題庫練習 · Jabiko 自習室",
     description:
       "基礎變化、句中填空、句型練習，加上 N1〜N4 日檢備考綜合題庫——自由選等級與題型，線上免費開練。",
-    path: "/challenge"
+    path: APP_VIEW_PATHS.challenge
   },
   mock: {
     title: "JLPT／日檢題型分區練習 · Jabiko",
     description:
       "依 JLPT／日檢 N1・N2・N3 官方題型分區線上練習：漢字読み、文法、語順組合、讀解，照真實考卷結構逐區攻略。",
-    path: "/mock"
+    path: APP_VIEW_PATHS.mock
   },
   about: {
     title: "關於 Jabiko · JLPT 自習室",
     description:
       "Jabiko 的名字由來與作者介紹——一個免費、開源、和朋友一起做的 JLPT 自習網站。",
-    path: "/about"
+    path: APP_VIEW_PATHS.about
   },
   grammar: {
     title: "JLPT 文型資料庫 · 日檢文法索引 · Jabiko",
     description:
       "JLPT N5–N1 文型一覽：全部文型、接續規則、用法與例句。支援搜尋、等級瀏覽與影視例句篩選——JLPT 文法攻略。",
-    path: "/grammar"
+    path: APP_VIEW_PATHS.grammar
   },
   blog: {
     title: "文章｜流行語・推し活・時下日文 · Jabiko",
     description:
       "課本不教、但你天天會撞到的時下日文——流行語、推し活、日劇動漫、從歌詞學日文，原創筆記邊讀邊練。",
-    path: "/blog"
+    path: APP_VIEW_PATHS.blog
   }
 };
 
@@ -110,7 +98,7 @@ export interface ResolvedSeo {
  * entry distinct from HOME.
  */
 export function seoForView(
-  view: SeoView,
+  view: AppView,
   grammarSurface?: string | null,
   blogSlug?: string | null
 ): ResolvedSeo {

--- a/src/hooks/useSeoMeta.test.tsx
+++ b/src/hooks/useSeoMeta.test.tsx
@@ -1,7 +1,8 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSeoMeta } from "./useSeoMeta";
-import { seoForView, type SeoView } from "../domain/seo";
+import { seoForView } from "../domain/seo";
+import type { AppView } from "../domain/routes";
 
 const desc = () =>
   document.head.querySelector('meta[name="description"]')?.getAttribute("content");
@@ -34,7 +35,7 @@ describe("useSeoMeta", () => {
 
   it("updates existing tags in place when the view changes (no duplicates)", () => {
     const { rerender } = renderHook(({ v }) => useSeoMeta(v), {
-      initialProps: { v: "home" as SeoView }
+      initialProps: { v: "home" as AppView }
     });
     rerender({ v: "kanji" });
 

--- a/src/hooks/useSeoMeta.ts
+++ b/src/hooks/useSeoMeta.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
-import { seoForView, type SeoView } from "../domain/seo";
+import { seoForView } from "../domain/seo";
+import type { AppView } from "../domain/routes";
 
 // Find-or-create a <meta> tag (keyed by name= or property=) and set its content.
 function upsertMeta(attr: "name" | "property", key: string, content: string) {
@@ -28,7 +29,7 @@ function upsertCanonical(href: string) {
 // renders the JS sees route-specific title/description rather than the shared
 // static shell. Idempotent: re-applies in place, never duplicates a tag.
 export function useSeoMeta(
-  view: SeoView,
+  view: AppView,
   grammarSurface?: string | null,
   blogSlug?: string | null
 ) {


### PR DESCRIPTION
## Summary

- move `AppView`, static paths, pathname parsing, and route serialization into a pure shared domain contract
- make App, SEO metadata, the SEO hook, and prerender use the same `AppView` and path registry
- preserve grammar-surface decoding, blog-slug alias canonicalization, malformed URL fallback, and unknown-path home fallback
- add round-trip tests for every static view plus dynamic grammar and blog routes

Part of #623. This PR does not add a router dependency or change App rendering.

## Verification

- `corepack pnpm test --maxWorkers=2` — 93 files / 961 tests passed
- `corepack pnpm build` — passed; 103 pages prerendered
- all existing lazy chunks remain unchanged
- initial bundle: 677.51 kB (+0.08 kB; gzip +0.04 kB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized route handling for standard pages, grammar surfaces, and blog articles.
  * URLs now support consistent encoding, decoding, and canonical blog aliases.
  * Unknown routes safely return to the home page, while malformed URL segments are preserved without errors.

* **SEO**
  * Standardized page paths used for canonical URLs and metadata.

* **Tests**
  * Added coverage for route parsing, serialization, aliases, fallbacks, and malformed URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->