### PR TITLE
fix: in-place kanji cell TTS + sharpen に照らして explanation

### DIFF
--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { KanjiOnyomiPanel } from "./KanjiOnyomiPanel";
 
 // The default view renders the whole table (~hundreds of cells), which makes
@@ -62,5 +62,100 @@ describe("KanjiOnyomiPanel (#195)", () => {
     render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
     expect(screen.getByRole("button", { name: "N2" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "全部" })).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+// Feedback 2026-07: hearing a kanji's reading used to require selecting the
+// cell, scrolling up to the detail card's TTS button, then scrolling back down
+// to pick the next kanji. The selected cell now grows an in-place speak button
+// so the listen-compare loop never leaves the grid.
+type MockSynth = {
+  speaking: boolean;
+  pending: boolean;
+  speak: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  getVoices: () => unknown[];
+};
+
+function setupSynth(): MockSynth {
+  const synth: MockSynth = {
+    speaking: false,
+    pending: false,
+    speak: vi.fn(),
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    getVoices: () => []
+  };
+  (window as unknown as { speechSynthesis: MockSynth }).speechSynthesis = synth;
+  (window as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = class {
+    text: string;
+    lang = "";
+    rate = 1;
+    voice: unknown = null;
+    constructor(t: string) {
+      this.text = t;
+    }
+    addEventListener() {}
+    removeEventListener() {}
+  };
+  return synth;
+}
+
+// Pull the first reading of the given type out of a cell's own text (the cell
+// shows "音 こう・…" / "訓 たかい・…"), so the assertions never hardcode data.
+function firstCellReading(cell: HTMLElement, type: "on" | "kun"): string {
+  const text = cell.querySelector(`.kanji-cell-${type}`)?.textContent ?? "";
+  return text.replace(/^\S+\s+/, "").split("・")[0];
+}
+
+describe("KanjiOnyomiPanel in-place cell TTS", () => {
+  let synth: MockSynth;
+  beforeEach(() => {
+    synth = setupSynth();
+  });
+  afterEach(() => {
+    delete (window as unknown as { speechSynthesis?: unknown }).speechSynthesis;
+    delete (window as unknown as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
+  });
+
+  it("grows a speak button on the selected cell only, reading its 音読み", () => {
+    renderNarrowed("高");
+    const grid = document.querySelector(".kanji-grid") as HTMLElement;
+    expect(within(grid).queryByRole("button", { name: "朗讀日文" })).toBeNull();
+
+    const cell = grid.querySelector<HTMLButtonElement>("button.kanji-cell");
+    expect(cell).not.toBeNull();
+    const expectedReading = firstCellReading(cell!, "on");
+    expect(expectedReading.length).toBeGreaterThan(0);
+    fireEvent.click(cell!);
+
+    const wrap = cell!.closest(".kanji-cell-wrap");
+    expect(wrap).not.toBeNull();
+    const speak = within(wrap as HTMLElement).getByRole("button", { name: "朗讀日文" });
+    expect(within(grid).getAllByRole("button", { name: "朗讀日文" })).toHaveLength(1);
+
+    fireEvent.click(speak);
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    expect((synth.speak.mock.calls[0][0] as { text: string }).text).toBe(expectedReading);
+  });
+
+  it("reads the active reading type (訓讀 view speaks the kun reading)", () => {
+    renderNarrowed("高");
+    fireEvent.click(screen.getByRole("button", { name: "訓讀" }));
+
+    const grid = document.querySelector(".kanji-grid") as HTMLElement;
+    const cell = grid.querySelector<HTMLButtonElement>("button.kanji-cell");
+    expect(cell).not.toBeNull();
+    const expectedReading = firstCellReading(cell!, "kun");
+    expect(expectedReading.length).toBeGreaterThan(0);
+
+    fireEvent.click(cell!);
+    const wrap = cell!.closest(".kanji-cell-wrap") as HTMLElement;
+    fireEvent.click(within(wrap).getByRole("button", { name: "朗讀日文" }));
+
+    expect((synth.speak.mock.calls[0][0] as { text: string }).text).toBe(expectedReading);
   });
 });

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -189,26 +189,44 @@ export function KanjiOnyomiPanel({
               <span className="kanji-family-count">{entries.length}</span>
             </h3>
             <div className="kanji-grid">
-              {entries.map((entry) => (
-                <button
-                  key={entry.kanji}
-                  type="button"
-                  className={`kanji-cell${selected === entry.kanji ? " selected" : ""}`}
-                  aria-pressed={selected === entry.kanji}
-                  onClick={() => setSelected(entry.kanji)}
-                >
-                  <span className="kanji-cell-char">{entry.kanji}</span>
-                  <span className="kanji-cell-read">
-                    {entry.onyomi.length > 0 ? (
-                      <span className="kanji-cell-on">{t.kanjiCellOnPrefix} {entry.onyomi.join("・")}</span>
+              {entries.map((entry) => {
+                const isSelected = selected === entry.kanji;
+                // Feedback 2026-07: listening used to mean scrolling back up to
+                // the detail card's TTS button after every selection. The
+                // selected cell grows an in-place speak button instead; it reads
+                // the ACTIVE type's reading (the family the learner is browsing),
+                // unlike the card which always leads with 音読み.
+                const cellSpeak =
+                  readingType === "on"
+                    ? entry.onyomi[0] ?? entry.kunyomi[0]
+                    : entry.kunyomi[0] ?? entry.onyomi[0];
+                return (
+                  <div className="kanji-cell-wrap" key={entry.kanji}>
+                    <button
+                      type="button"
+                      className={`kanji-cell${isSelected ? " selected" : ""}`}
+                      aria-pressed={isSelected}
+                      onClick={() => setSelected(entry.kanji)}
+                    >
+                      <span className="kanji-cell-char">{entry.kanji}</span>
+                      <span className="kanji-cell-read">
+                        {entry.onyomi.length > 0 ? (
+                          <span className="kanji-cell-on">{t.kanjiCellOnPrefix} {entry.onyomi.join("・")}</span>
+                        ) : null}
+                        {entry.kunyomi.length > 0 ? (
+                          <span className="kanji-cell-kun">{t.kanjiCellKunPrefix} {entry.kunyomi.join("・")}</span>
+                        ) : null}
+                      </span>
+                      <span className="kanji-cell-mean">{kanjiMeaning(entry, language)}</span>
+                    </button>
+                    {isSelected && cellSpeak ? (
+                      <span className="kanji-cell-speak">
+                        <SpeakButton text={cellSpeak} language={language} />
+                      </span>
                     ) : null}
-                    {entry.kunyomi.length > 0 ? (
-                      <span className="kanji-cell-kun">{t.kanjiCellKunPrefix} {entry.kunyomi.join("・")}</span>
-                    ) : null}
-                  </span>
-                  <span className="kanji-cell-mean">{kanjiMeaning(entry, language)}</span>
-                </button>
-              ))}
+                  </div>
+                );
+              })}
             </div>
           </div>
         ))

--- a/src/domain/exam/items/n1.ts
+++ b/src/domain/exam/items/n1.ts
@@ -2343,8 +2343,8 @@ export const n1Items: PracticeQuestion[] = [
     hintI18n: { "ja": "行為が合法かどうかを判断する際に基準とするもの。", "en": "The reference standard used to judge whether the conduct is lawful." },
     expectedAnswer: "に照らして",
     options: ["に照らして","に基づいて","にともなって","について"],
-    explanation: "「N + に照らして」是「對照 N（標準／前例／規定）來判斷」（正式、書面）。「に基づいて」是「以 N 為依據／基礎」（中性依據，不含對照動作）；「にともなって」是「隨著 N」（連動）；「について」是「關於」（主題）。本句要強調「拿法律當標尺判斷他的行為」的對照動作，「に照らして」最精準。",
-    explanationI18n: { "ja": "「N + に照らして」は「N（基準・前例・規定）と照らし合わせて判断する」（正式・書き言葉）です。「に基づいて」は「Nに基づいて／を基礎にして」（中立的な根拠で、照らし合わせるという動作は含まない）、「にともなって」は「Nに伴って」（連動）、「について」は「…について」（主題）です。この文は「法律をものさしにして彼の行為を判断する」という照合の動作を強調したいので、「に照らして」が最も的確です。", "en": "「N + に照らして」means \"to judge in light of N (a standard / precedent / rule)\" (formal, written). 「に基づいて」means \"based on / grounded in N\" (a neutral basis, without the act of comparison); 「にともなって」means \"along with N\" (linkage); 「について」means \"about\" (a topic). Here, to stress the act of \"holding his conduct up against the law as a yardstick,\" 「に照らして」is the most precise." },
+    explanation: "「N + に照らして」是「對照 N（標準／前例／規定）來檢驗、評斷」（正式、書面），後面可直接接判斷結果——本句的「法律」正是檢驗行為是否違規的「基準」。「に基づいて」則要求後件出現「判断する／決定する／処分する」這類「以 N 為根據去做某事」的動作述語；本句後件是名詞述語「違反だ」，句中沒有可依附的動作，所以不成立（會覺得通順，是因為腦中自動補上了「に基づいて（判断すると）」）。「にともなって」是「隨著 N」（連動）；「について」是「關於」（主題）。",
+    explanationI18n: { "ja": "「に基づいて」は「Nを土台にして何かを判断する・決める・行う」という動作述語（「判断する」「決定する」「処分する」など）を後件に要求します。この文の後件は名詞述語「違反だ」で、基づくべき判断行為が文中に現れていないため成立しません（自然に読めるとすれば「に基づいて（判断すると）」と頭の中で補っているからです）。ここでの「法律」は行為が違反かどうかを照合する「基準」なので、「N + に照らして」（基準・前例・規定と照らし合わせて判断する／正式・書き言葉）が正解です。「にともなって」は「Nに伴って」（連動）、「について」は「…について」（主題）です。", "en": "「に基づいて」requires an action/decision predicate built ON N — 判断する, 決定する, 処分する and the like. This sentence ends in the bare noun predicate 違反だ, so there is no action for に基づいて to anchor to; it only \"sounds fine\" if you mentally insert (判断すると). The law here is the standard the conduct is checked AGAINST, which is exactly 「N + に照らして」 (\"in light of N\"; formal, written). 「にともなって」means \"along with N\" (linkage); 「について」means \"about\" (a topic)." },
   }),
   examQuestion({
     id: "n1-grammar-yorihokanai",

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -181,6 +181,36 @@
   box-shadow: var(--button-hover-shadow);
 }
 
+/* In-place TTS on the selected cell (2026-07 feedback: hearing a reading used
+   to require scrolling back up to the detail card). The wrap keeps the speak
+   control a SIBLING of the cell button -- buttons can't nest. */
+.kanji-cell-wrap {
+  position: relative;
+  display: flex;
+}
+
+.kanji-cell-wrap > .kanji-cell {
+  flex: 1;
+  width: 100%;
+}
+
+.kanji-cell-speak {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.3rem;
+}
+
+.kanji-cell-speak .speak-button {
+  margin-left: 0;
+  background: var(--paper);
+  /* Compact circle: the global 2.75rem button min-height would drape the
+     pill over the cell's reading line -- exactly what the learner is here
+     to see. Top-right beside the large glyph is the one empty corner. */
+  width: 1.9rem;
+  height: 1.9rem;
+  min-height: 1.9rem;
+}
+
 .kanji-cell.selected {
   border-color: var(--matcha);
   background: color-mix(in srgb, var(--matcha) 12%, var(--paper));


### PR DESCRIPTION
兩件使用者回報一次修：

## 1. 漢字速查：選中格子就地出發音鍵

回報原文：「漢字的部分想聽讀音 需要滑到最上面聽完，再下來選另一個，會有點麻煩花時間」。

- 點選任何漢字格後，該格右上角原地浮出緊湊發音鍵（30×30 圓鍵），聽讀音不再離開表格；詳細卡照舊（想看例詞發音的人不受影響）
- 唸的是**當前瀏覽的讀音類型**：音讀 view 唸音読み、訓讀 view 唸訓読み（詳細卡維持音読み優先不變）
- 緊湊尺寸覆寫（1.9rem）：全域按鈕 min-height 2.75rem 會讓鍵垂到讀音列上，蓋住使用者正要看的東西
- 結構上 speak 鍵是 cell 按鈕的 sibling（`.kanji-cell-wrap` 包一層）——button 不能巢狀

## 2. n1-grammar-niterashite 解析強化（回報：に基づいて 感覺也可以）

codex（gpt-5.4, xhigh）對抗判定：**非雙解**。機制：「に基づいて」後件必須是「判断する／決定する／処分する」類動作述語；本句後件是裸名詞述語「違反だ」，沒有可依附的動作，不成立（覺得通會是因為腦內補了「（判断すると）」）。題目與選項不動，只重寫 zh/ja/en 三份解析成機制級說明，移除原本「最精準」這種默認次佳可通的比較級措辭（正是回報困惑的來源）。

## 驗證

- TDD：KanjiOnyomiPanel 2 條新測試先 RED 後 GREEN（唯一 overlay、唸對 active reading type）；全套 963 tests 綠
- `pnpm check:exam` 過；n1.ts 以 `core.autocrlf=false` 暫存、`git diff --cached --check` 乾淨
- Preview 實測（桌機＋390px）：overlay 不蓋大字不蓋讀音列、無橫向溢出、點擊發音 console 零錯誤；overlay 尺寸與全站 speak button 視覺一致


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-place Japanese pronunciation button for selected kanji readings.
  * Pronunciation follows the active on’yomi or kun’yomi view, with fallback support when a reading is unavailable.

* **Bug Fixes**
  * Improved the N1 grammar explanation distinguishing related Japanese expressions.

* **Tests**
  * Added coverage verifying pronunciation controls and reading selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->