### PR TITLE
feat(#608): compact mobile header + 5-entry nav with 更多 menu

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1217,6 +1217,10 @@ describe("App", () => {
       "aria-current",
       "page"
     );
+    // The collapsed trigger carries the current location while a folded view
+    // is active (PR #628 review).
+    const selectedTrigger = within(nav).getByRole("button", { name: "更多（目前：關於）" });
+    expect(selectedTrigger.className).toContain("selected");
 
     window.history.replaceState({}, "", "/");
   });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1191,6 +1191,52 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
   });
 
+  it("navigates to secondary views through the nav's 更多 menu (#608)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const nav = screen.getByRole("navigation", { name: "學習流程" });
+    const trigger = within(nav).getByRole("button", { name: "更多" });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(trigger);
+    const menu = screen.getByRole("menu", { name: "更多" });
+    // Secondary views first, then the header tools below the divider.
+    for (const label of ["規則表", "漢字", "文章", "關於"]) {
+      expect(within(menu).getByRole("menuitem", { name: label })).toBeInTheDocument();
+    }
+    expect(within(menu).getByRole("menuitemcheckbox", { name: /註音/ })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: /色模式/ })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "意見回饋" })).toBeInTheDocument();
+
+    await user.click(within(menu).getByRole("menuitem", { name: "關於" }));
+    expect(screen.queryByRole("menu", { name: "更多" })).not.toBeInTheDocument();
+    // Same navigation contract as the plain nav button: URL + aria-current.
+    expect(window.location.pathname).toBe("/about");
+    expect(within(nav).getByRole("button", { name: "關於" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("keeps the 文章 entry out of the 更多 menu for non-zh languages (#608/#483)", async () => {
+    localStorage.setItem("jabiko.lang", "en");
+    const user = userEvent.setup();
+    render(<App />);
+
+    const { copy } = await import("./i18n");
+    await user.click(screen.getByRole("button", { name: copy.en.navMore }));
+    const menu = screen.getByRole("menu", { name: copy.en.navMore });
+    expect(
+      within(menu).queryByRole("menuitem", { name: copy.en.blog })
+    ).not.toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: copy.en.about })).toBeInTheDocument();
+
+    localStorage.setItem("jabiko.lang", "zh-Hant");
+  });
+
   it("opens the feedback form from a persistent header button (any view, #456)", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -624,6 +624,7 @@ export default function App() {
         </button>
         <MoreMenu
           triggerLabel={t.navMore}
+          triggerCurrentLabel={t.navMoreWithCurrent}
           items={moreMenuItems}
           tools={{
             heading: t.navMoreTools,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { UpdateToast } from "./components/UpdateToast";
 import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 import { usePwaUpdate } from "./hooks/usePwaUpdate";
 import { JabikoMark } from "./components/JabikoMark";
+import { MoreMenu, type MoreMenuNavItem } from "./components/MoreMenu";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
 import { useFurigana } from "./hooks/useFurigana";
@@ -295,6 +296,58 @@ export default function App() {
   const ThemeIcon = theme === "dark" ? Sun : Moon;
   const furiganaToggleLabel = furiganaEnabled ? t.furiganaHide : t.furiganaShow;
 
+  // One source for the sync-status line so the header auth block and the
+  // mobile 更多 menu can't drift apart (#608).
+  const authSyncHint = !user
+    ? t.authSignInHint
+    : syncStatus === "error"
+      ? t.authSyncErrorHint
+      : syncStatus === "synced"
+        ? t.authSyncedHint
+        : t.authSyncingHint;
+
+  // #608: on phones the nav keeps five primary entries (home / learn /
+  // challenge / mock / grammar); these four secondary views collapse into the
+  // 更多 menu. Same handlers as the full nav buttons, so navigation contract
+  // (URL sync, aria-current) is identical whichever entry point is used.
+  const moreMenuItems: MoreMenuNavItem[] = [
+    {
+      key: "rules",
+      label: t.rules,
+      icon: <Table aria-hidden="true" size={16} style={navIconStyle} />,
+      selected: appView === "rules",
+      onSelect: () => setAppView("rules")
+    },
+    {
+      key: "kanji",
+      label: t.kanji,
+      icon: <BookA aria-hidden="true" size={16} style={navIconStyle} />,
+      selected: appView === "kanji",
+      onSelect: () => setAppView("kanji")
+    },
+    ...(blogAvailable
+      ? [
+          {
+            key: "blog",
+            label: t.blog,
+            icon: <Newspaper aria-hidden="true" size={16} style={navIconStyle} />,
+            selected: appView === "blog",
+            onSelect: () => {
+              setBlogSlug(null);
+              setAppView("blog");
+            }
+          }
+        ]
+      : []),
+    {
+      key: "about",
+      label: t.about,
+      icon: <Info aria-hidden="true" size={16} style={navIconStyle} />,
+      selected: appView === "about",
+      onSelect: () => setAppView("about")
+    }
+  ];
+
   const openChallenge = (request?: SessionInit) => {
     // `request` seeds the session when ChallengePanel MOUNTS (its
     // usePracticeSession reads init via useState initializers). Every
@@ -386,7 +439,12 @@ export default function App() {
           onClose={() => setFeedbackKind(null)}
         />
       ) : null}
-      <div className="app-heading" aria-label={t.appIntroLabel}>
+      {/* #608: non-home views compress the heading to a one-line brand bar on
+          phones (CSS-only; desktop and the home hero keep the full intro). */}
+      <div
+        className={`app-heading${appView === "home" ? "" : " app-heading-compact"}`}
+        aria-label={t.appIntroLabel}
+      >
         <div className="app-brand">
           <JabikoMark className="app-brand-mark" />
           <div>
@@ -424,15 +482,7 @@ export default function App() {
                   {t.authErrors[authError]}
                 </span>
               ) : (
-                <span className="auth-hint">
-                  {!user
-                    ? t.authSignInHint
-                    : syncStatus === "error"
-                      ? t.authSyncErrorHint
-                      : syncStatus === "synced"
-                        ? t.authSyncedHint
-                        : t.authSyncingHint}
-                </span>
+                <span className="auth-hint">{authSyncHint}</span>
               )}
             </div>
           )}
@@ -482,6 +532,7 @@ export default function App() {
       <nav className="view-switch segmented" aria-label={t.flowLabel}>
         <button
           type="button"
+          data-nav="home"
           className={appView === "home" ? "selected" : ""}
           aria-current={appView === "home" ? "page" : undefined}
           onClick={() => setAppView("home")}
@@ -491,6 +542,7 @@ export default function App() {
         </button>
         <button
           type="button"
+          data-nav="learn"
           className={appView === "learn" ? "selected" : ""}
           aria-current={appView === "learn" ? "page" : undefined}
           onClick={() => setAppView("learn")}
@@ -500,7 +552,8 @@ export default function App() {
         </button>
         <button
           type="button"
-          className={appView === "rules" ? "selected" : ""}
+          data-nav="rules"
+          className={`nav-secondary${appView === "rules" ? " selected" : ""}`}
           aria-current={appView === "rules" ? "page" : undefined}
           onClick={() => setAppView("rules")}
         >
@@ -509,7 +562,8 @@ export default function App() {
         </button>
         <button
           type="button"
-          className={appView === "kanji" ? "selected" : ""}
+          data-nav="kanji"
+          className={`nav-secondary${appView === "kanji" ? " selected" : ""}`}
           aria-current={appView === "kanji" ? "page" : undefined}
           onClick={() => setAppView("kanji")}
         >
@@ -518,6 +572,7 @@ export default function App() {
         </button>
         <button
           type="button"
+          data-nav="grammar"
           className={appView === "grammar" && (grammarSurface === null || isGrammarLevelRoute) ? "selected" : ""}
           aria-current={appView === "grammar" && (grammarSurface === null || isGrammarLevelRoute) ? "page" : undefined}
           onClick={() => { setGrammarSurface(null); setAppView("grammar"); }}
@@ -528,7 +583,8 @@ export default function App() {
         {blogAvailable ? (
           <button
             type="button"
-            className={appView === "blog" ? "selected" : ""}
+            data-nav="blog"
+            className={`nav-secondary${appView === "blog" ? " selected" : ""}`}
             aria-current={appView === "blog" ? "page" : undefined}
             onClick={() => { setBlogSlug(null); setAppView("blog"); }}
           >
@@ -538,6 +594,7 @@ export default function App() {
         ) : null}
         <button
           type="button"
+          data-nav="challenge"
           className={appView === "challenge" ? "selected" : ""}
           aria-current={appView === "challenge" ? "page" : undefined}
           onClick={() => openChallenge({ mode: "daily" })}
@@ -547,6 +604,7 @@ export default function App() {
         </button>
         <button
           type="button"
+          data-nav="mock"
           className={appView === "mock" ? "selected" : ""}
           aria-current={appView === "mock" ? "page" : undefined}
           onClick={() => setAppView("mock")}
@@ -556,13 +614,42 @@ export default function App() {
         </button>
         <button
           type="button"
-          className={appView === "about" ? "selected" : ""}
+          data-nav="about"
+          className={`nav-secondary${appView === "about" ? " selected" : ""}`}
           aria-current={appView === "about" ? "page" : undefined}
           onClick={() => setAppView("about")}
         >
           <Info aria-hidden="true" size={16} style={navIconStyle} />
           {t.about}
         </button>
+        <MoreMenu
+          triggerLabel={t.navMore}
+          items={moreMenuItems}
+          tools={{
+            heading: t.navMoreTools,
+            language:
+              LANGUAGE_OPTIONS.length > 1
+                ? { label: t.languageSwitchLabel, onOpen: () => setLangPickerOpen(true) }
+                : undefined,
+            furigana: {
+              label: furiganaToggleLabel,
+              pressed: furiganaEnabled,
+              onToggle: toggleFurigana
+            },
+            theme: { label: themeToggleLabel, onToggle: toggleTheme },
+            feedback: { label: t.feedbackTitle, onOpen: () => setFeedbackKind("wish") },
+            auth: isSupabaseConfigured
+              ? {
+                  signedInAs: user ? (user.user_metadata.full_name ?? user.email ?? "") : null,
+                  hint: authError ? t.authErrors[authError] : authSyncHint,
+                  signInLabel: t.authSignIn,
+                  signOutLabel: t.authSignOut,
+                  onSignIn: signInWithGoogle,
+                  onSignOut: signOut
+                }
+              : undefined
+          }}
+        />
       </nav>
 
       <FuriganaContext.Provider value={{ enabled: furiganaEnabled }}>

--- a/src/components/MoreMenu.test.tsx
+++ b/src/components/MoreMenu.test.tsx
@@ -39,8 +39,19 @@ function makeTools(overrides: Partial<MoreMenuTools> = {}): MoreMenuTools {
 }
 
 function renderMenu(items = makeItems(), tools = makeTools()) {
-  render(<MoreMenu triggerLabel="更多" items={items} tools={tools} />);
+  render(
+    <MoreMenu
+      triggerLabel="更多"
+      triggerCurrentLabel={(page) => `更多（目前：${page}）`}
+      items={items}
+      tools={tools}
+    />
+  );
   return { items, tools };
+}
+
+function menuItems(): HTMLButtonElement[] {
+  return [...screen.getByRole("menu").querySelectorAll<HTMLButtonElement>("[role^='menuitem']")];
 }
 
 describe("MoreMenu (#608)", () => {
@@ -74,7 +85,8 @@ describe("MoreMenu (#608)", () => {
       makeTools({ furigana: { label: "顯示註音", pressed: true, onToggle: vi.fn() } })
     );
 
-    await user.click(screen.getByRole("button", { name: "更多" }));
+    // With 漢字 selected the collapsed trigger already names the current page.
+    await user.click(screen.getByRole("button", { name: "更多（目前：漢字）" }));
     const menu = screen.getByRole("menu");
     expect(within(menu).getByRole("menuitem", { name: "漢字" })).toHaveAttribute(
       "aria-current",
@@ -127,6 +139,65 @@ describe("MoreMenu (#608)", () => {
     expect(screen.getByRole("menu")).toBeInTheDocument();
 
     fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  // PR #628 review: while a folded view is active the collapsed trigger is the
+  // only place the current location can show -- it takes the selected style and
+  // names the current page.
+  it("marks the collapsed trigger selected and names the current page", () => {
+    renderMenu(makeItems([{}, { selected: true }]));
+
+    const trigger = screen.getByRole("button", { name: "更多（目前：漢字）" });
+    expect(trigger.className).toContain("selected");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps the plain trigger name and no selected style when nothing inside is active", () => {
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    expect(trigger.className).not.toContain("selected");
+  });
+
+  // PR #628 review: role="menu" implies a single tab stop -- only the focused
+  // item is tabbable, the rest sit at tabIndex -1.
+  it("roves tabindex with the focus (single tab stop)", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    let items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items.slice(1).every((item) => item.tabIndex === -1)).toBe(true);
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowDown" });
+    items = menuItems();
+    expect(items[0].tabIndex).toBe(-1);
+    expect(items[1].tabIndex).toBe(0);
+    expect(items[1]).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "End" });
+    items = menuItems();
+    expect(items[items.length - 1].tabIndex).toBe(0);
+    expect(items[items.length - 1]).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Home" });
+    items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("Tab closes the menu and hands focus back to the trigger", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    await user.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Tab" });
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();
   });

--- a/src/components/MoreMenu.test.tsx
+++ b/src/components/MoreMenu.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MoreMenu, type MoreMenuNavItem, type MoreMenuTools } from "./MoreMenu";
+
+// #608: on phones the nav keeps five primary entries; everything else lives in
+// this 更多 menu -- secondary views on top, the header tools (language /
+// furigana / theme / feedback / auth) below a labelled divider. Menu semantics
+// (aria-expanded, roving focus, Escape) are pinned here at the component level;
+// App.test.tsx covers the wiring.
+
+function makeItems(overrides: Partial<MoreMenuNavItem>[] = []): MoreMenuNavItem[] {
+  const base: MoreMenuNavItem[] = [
+    { key: "rules", label: "規則表", icon: null, selected: false, onSelect: vi.fn() },
+    { key: "kanji", label: "漢字", icon: null, selected: false, onSelect: vi.fn() },
+    { key: "about", label: "關於", icon: null, selected: false, onSelect: vi.fn() }
+  ];
+  overrides.forEach((patch, index) => Object.assign(base[index], patch));
+  return base;
+}
+
+function makeTools(overrides: Partial<MoreMenuTools> = {}): MoreMenuTools {
+  return {
+    heading: "設定與工具",
+    language: { label: "切換語言", onOpen: vi.fn() },
+    furigana: { label: "顯示註音", pressed: false, onToggle: vi.fn() },
+    theme: { label: "深色模式", onToggle: vi.fn() },
+    feedback: { label: "意見回饋", onOpen: vi.fn() },
+    auth: {
+      signedInAs: null,
+      hint: null,
+      signInLabel: "登入",
+      signOutLabel: "登出",
+      onSignIn: vi.fn(),
+      onSignOut: vi.fn()
+    },
+    ...overrides
+  };
+}
+
+function renderMenu(items = makeItems(), tools = makeTools()) {
+  render(<MoreMenu triggerLabel="更多" items={items} tools={tools} />);
+  return { items, tools };
+}
+
+describe("MoreMenu (#608)", () => {
+  it("starts closed and opens into a menu with every given entry plus the tools", async () => {
+    const user = userEvent.setup();
+    const { tools } = renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    expect(trigger).toHaveAttribute("aria-haspopup", "menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    const menu = screen.getByRole("menu", { name: "更多" });
+    for (const label of ["規則表", "漢字", "關於"]) {
+      expect(within(menu).getByRole("menuitem", { name: label })).toBeInTheDocument();
+    }
+    expect(within(menu).getByText(tools.heading)).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "切換語言" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitemcheckbox", { name: "顯示註音" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "深色模式" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "意見回饋" })).toBeInTheDocument();
+    expect(within(menu).getByRole("menuitem", { name: "登入" })).toBeInTheDocument();
+  });
+
+  it("marks the selected view with aria-current and reflects the furigana state", async () => {
+    const user = userEvent.setup();
+    renderMenu(
+      makeItems([{}, { selected: true }]),
+      makeTools({ furigana: { label: "顯示註音", pressed: true, onToggle: vi.fn() } })
+    );
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByRole("menuitem", { name: "漢字" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(within(menu).getByRole("menuitem", { name: "規則表" })).not.toHaveAttribute(
+      "aria-current"
+    );
+    expect(within(menu).getByRole("menuitemcheckbox", { name: "顯示註音" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("runs the entry's action and closes on click", async () => {
+    const user = userEvent.setup();
+    const { items } = renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    await user.click(screen.getByRole("menuitem", { name: "漢字" }));
+
+    expect(items[1].onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "更多" })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("focuses the first entry on open, moves focus with the arrow keys", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowDown" });
+    expect(screen.getByRole("menuitem", { name: "漢字" })).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowUp" });
+    expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus();
+  });
+
+  it("closes on Escape and returns focus to the trigger", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    await user.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes on an outside pointer press", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("fires the tool callbacks (language picker, sign-in) and closes after", async () => {
+    const user = userEvent.setup();
+    const { tools } = renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    await user.click(screen.getByRole("menuitem", { name: "切換語言" }));
+    expect(tools.language?.onOpen).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    await user.click(screen.getByRole("menuitem", { name: "登入" }));
+    expect(tools.auth?.onSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows sign-out (with the signed-in name) instead of sign-in when logged in", async () => {
+    const user = userEvent.setup();
+    renderMenu(
+      makeItems(),
+      makeTools({
+        auth: {
+          signedInAs: "花雪",
+          hint: "已同步",
+          signInLabel: "登入",
+          signOutLabel: "登出",
+          onSignIn: vi.fn(),
+          onSignOut: vi.fn()
+        }
+      })
+    );
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const menu = screen.getByRole("menu");
+    expect(within(menu).getByRole("menuitem", { name: "登出" })).toBeInTheDocument();
+    expect(within(menu).queryByRole("menuitem", { name: "登入" })).not.toBeInTheDocument();
+    expect(within(menu).getByText(/花雪/)).toBeInTheDocument();
+    expect(within(menu).getByText("已同步")).toBeInTheDocument();
+  });
+});

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -35,24 +35,39 @@ export interface MoreMenuTools {
 
 export function MoreMenu({
   triggerLabel,
+  triggerCurrentLabel,
   items,
   tools
 }: {
   triggerLabel: string;
+  /** Accessible name for the collapsed trigger while a folded view is active,
+   *  e.g. 更多（目前：文章）-- the trigger is then the only place the current
+   *  location can show (PR #628 review). */
+  triggerCurrentLabel: (page: string) => string;
   items: MoreMenuNavItem[];
   tools: MoreMenuTools;
 }) {
   const [open, setOpen] = useState(false);
+  // role="menu" is a single tab stop: only the focused entry keeps tabIndex 0
+  // (roving tabindex), tracked by its data-menu-key.
+  const [focusKey, setFocusKey] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelId = useId();
 
+  const selectedItem = items.find((item) => item.selected) ?? null;
+
   // Focus the first entry once the panel is in the DOM (menu-button pattern).
   useEffect(() => {
-    if (!open) return;
-    rootRef.current
-      ?.querySelector<HTMLButtonElement>("[role^='menuitem']")
-      ?.focus();
+    if (!open) {
+      setFocusKey(null);
+      return;
+    }
+    const first = rootRef.current?.querySelector<HTMLButtonElement>("[role^='menuitem']");
+    if (first) {
+      setFocusKey(first.dataset.menuKey ?? null);
+      first.focus();
+    }
   }, [open]);
 
   // A press anywhere outside closes the menu without swallowing the press.
@@ -80,6 +95,13 @@ export function MoreMenu({
       triggerRef.current?.focus();
       return;
     }
+    if (event.key === "Tab") {
+      // Menu pattern: Tab leaves the menu. Close and put focus back on the
+      // trigger so the default Tab continues from there (no preventDefault).
+      close();
+      triggerRef.current?.focus();
+      return;
+    }
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End") {
       return;
     }
@@ -97,18 +119,26 @@ export function MoreMenu({
           : event.key === "ArrowDown"
             ? (current + 1) % focusables.length
             : (current - 1 + focusables.length) % focusables.length;
-    focusables[next]?.focus();
+    const target = focusables[next];
+    if (target) {
+      setFocusKey(target.dataset.menuKey ?? null);
+      target.focus();
+    }
   };
+
+  // Roving-tabindex helper: only the focused entry is tabbable.
+  const rove = (key: string) => (focusKey === key ? 0 : -1);
 
   return (
     <div className="nav-more" ref={rootRef}>
       <button
         type="button"
         ref={triggerRef}
-        className="nav-more-trigger"
+        className={`nav-more-trigger${selectedItem ? " selected" : ""}`}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={open ? panelId : undefined}
+        aria-label={selectedItem ? triggerCurrentLabel(selectedItem.label) : undefined}
         onClick={() => setOpen((value) => !value)}
         onKeyDown={(event) => {
           if (event.key === "ArrowDown" && !open) {
@@ -133,6 +163,8 @@ export function MoreMenu({
               key={item.key}
               type="button"
               role="menuitem"
+              data-menu-key={item.key}
+              tabIndex={rove(item.key)}
               className={`nav-more-item${item.selected ? " selected" : ""}`}
               aria-current={item.selected ? "page" : undefined}
               onClick={closeAnd(item.onSelect)}
@@ -151,6 +183,8 @@ export function MoreMenu({
             <button
               type="button"
               role="menuitem"
+              data-menu-key="tool-language"
+              tabIndex={rove("tool-language")}
               className="nav-more-item"
               onClick={closeAnd(tools.language.onOpen)}
             >
@@ -161,6 +195,8 @@ export function MoreMenu({
           <button
             type="button"
             role="menuitemcheckbox"
+            data-menu-key="tool-furigana"
+            tabIndex={rove("tool-furigana")}
             className="nav-more-item"
             aria-checked={tools.furigana.pressed}
             onClick={closeAnd(tools.furigana.onToggle)}
@@ -171,6 +207,8 @@ export function MoreMenu({
           <button
             type="button"
             role="menuitem"
+            data-menu-key="tool-theme"
+            tabIndex={rove("tool-theme")}
             className="nav-more-item"
             onClick={closeAnd(tools.theme.onToggle)}
           >
@@ -180,6 +218,8 @@ export function MoreMenu({
           <button
             type="button"
             role="menuitem"
+            data-menu-key="tool-feedback"
+            tabIndex={rove("tool-feedback")}
             className="nav-more-item"
             onClick={closeAnd(tools.feedback.onOpen)}
           >
@@ -193,6 +233,8 @@ export function MoreMenu({
                 <button
                   type="button"
                   role="menuitem"
+                  data-menu-key="tool-auth"
+                  tabIndex={rove("tool-auth")}
                   className="nav-more-item"
                   onClick={closeAnd(tools.auth.onSignOut)}
                 >
@@ -203,6 +245,8 @@ export function MoreMenu({
                 <button
                   type="button"
                   role="menuitem"
+                  data-menu-key="tool-auth"
+                  tabIndex={rove("tool-auth")}
                   className="nav-more-item"
                   onClick={closeAnd(tools.auth.onSignIn)}
                 >

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, Globe, Languages, LogIn, LogOut, MessageCircle, SunMoon } from "lucide-react";
+
+// #608: the mobile nav keeps five primary entries; the rest of the site lives
+// behind this 更多 menu -- secondary views first, then the header tools
+// (language / furigana / theme / feedback / auth) under a labelled divider.
+// Desktop never shows the trigger (CSS), but the component is always mounted
+// so the behaviour is identical wherever the breakpoint puts it.
+
+export interface MoreMenuNavItem {
+  key: string;
+  label: string;
+  icon: ReactNode;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export interface MoreMenuTools {
+  heading: string;
+  /** Absent when only one UI language is launched (mirrors the header). */
+  language?: { label: string; onOpen: () => void };
+  furigana: { label: string; pressed: boolean; onToggle: () => void };
+  theme: { label: string; onToggle: () => void };
+  feedback: { label: string; onOpen: () => void };
+  /** Absent when Supabase isn't configured (mirrors the header auth block). */
+  auth?: {
+    signedInAs: string | null;
+    hint: string | null;
+    signInLabel: string;
+    signOutLabel: string;
+    onSignIn: () => void;
+    onSignOut: () => void;
+  };
+}
+
+export function MoreMenu({
+  triggerLabel,
+  items,
+  tools
+}: {
+  triggerLabel: string;
+  items: MoreMenuNavItem[];
+  tools: MoreMenuTools;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelId = useId();
+
+  // Focus the first entry once the panel is in the DOM (menu-button pattern).
+  useEffect(() => {
+    if (!open) return;
+    rootRef.current
+      ?.querySelector<HTMLButtonElement>("[role^='menuitem']")
+      ?.focus();
+  }, [open]);
+
+  // A press anywhere outside closes the menu without swallowing the press.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const close = () => setOpen(false);
+  const closeAnd = (action: () => void) => () => {
+    action();
+    close();
+  };
+
+  const onPanelKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      triggerRef.current?.focus();
+      return;
+    }
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End") {
+      return;
+    }
+    const focusables = [
+      ...(rootRef.current?.querySelectorAll<HTMLButtonElement>("[role^='menuitem']") ?? [])
+    ];
+    if (focusables.length === 0) return;
+    event.preventDefault();
+    const current = focusables.indexOf(document.activeElement as HTMLButtonElement);
+    const next =
+      event.key === "Home"
+        ? 0
+        : event.key === "End"
+          ? focusables.length - 1
+          : event.key === "ArrowDown"
+            ? (current + 1) % focusables.length
+            : (current - 1 + focusables.length) % focusables.length;
+    focusables[next]?.focus();
+  };
+
+  return (
+    <div className="nav-more" ref={rootRef}>
+      <button
+        type="button"
+        ref={triggerRef}
+        className="nav-more-trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowDown" && !open) {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
+      >
+        {triggerLabel}
+        <ChevronDown aria-hidden="true" size={16} />
+      </button>
+      {open ? (
+        <div
+          className="nav-more-panel"
+          role="menu"
+          id={panelId}
+          aria-label={triggerLabel}
+          onKeyDown={onPanelKeyDown}
+        >
+          {items.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              role="menuitem"
+              className={`nav-more-item${item.selected ? " selected" : ""}`}
+              aria-current={item.selected ? "page" : undefined}
+              onClick={closeAnd(item.onSelect)}
+            >
+              {item.icon}
+              {item.label}
+            </button>
+          ))}
+
+          <div className="nav-more-divider" role="separator" aria-hidden="true" />
+          <p className="nav-more-heading" aria-hidden="true">
+            {tools.heading}
+          </p>
+
+          {tools.language ? (
+            <button
+              type="button"
+              role="menuitem"
+              className="nav-more-item"
+              onClick={closeAnd(tools.language.onOpen)}
+            >
+              <Globe aria-hidden="true" size={16} />
+              {tools.language.label}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            role="menuitemcheckbox"
+            className="nav-more-item"
+            aria-checked={tools.furigana.pressed}
+            onClick={closeAnd(tools.furigana.onToggle)}
+          >
+            <Languages aria-hidden="true" size={16} />
+            {tools.furigana.label}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="nav-more-item"
+            onClick={closeAnd(tools.theme.onToggle)}
+          >
+            <SunMoon aria-hidden="true" size={16} />
+            {tools.theme.label}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            className="nav-more-item"
+            onClick={closeAnd(tools.feedback.onOpen)}
+          >
+            <MessageCircle aria-hidden="true" size={16} />
+            {tools.feedback.label}
+          </button>
+
+          {tools.auth ? (
+            <>
+              {tools.auth.signedInAs ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="nav-more-item"
+                  onClick={closeAnd(tools.auth.onSignOut)}
+                >
+                  <LogOut aria-hidden="true" size={16} />
+                  {tools.auth.signOutLabel}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="nav-more-item"
+                  onClick={closeAnd(tools.auth.onSignIn)}
+                >
+                  <LogIn aria-hidden="true" size={16} />
+                  {tools.auth.signInLabel}
+                </button>
+              )}
+              {tools.auth.signedInAs || tools.auth.hint ? (
+                <p className="nav-more-hint">
+                  {tools.auth.signedInAs ? <span>{tools.auth.signedInAs}</span> : null}
+                  {tools.auth.hint ? <span>{tools.auth.hint}</span> : null}
+                </p>
+              ) : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,6 +27,8 @@ export type Copy = {
   furiganaShow: string;
   furiganaHide: string;
   flowLabel: string;
+  navMore: string;
+  navMoreTools: string;
   loading: string;
   updateAvailable: string;
   routeErrorTitle: string;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -29,6 +29,8 @@ export type Copy = {
   flowLabel: string;
   navMore: string;
   navMoreTools: string;
+  /** Collapsed 更多 trigger's accessible name while a folded view is active. */
+  navMoreWithCurrent: (page: string) => string;
   loading: string;
   updateAvailable: string;
   routeErrorTitle: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -11,6 +11,8 @@ export const en: Copy = {
   furiganaShow: "Show furigana",
   furiganaHide: "Hide furigana",
   flowLabel: "Study flow",
+  navMore: "More",
+  navMoreTools: "Settings & tools",
   loading: "Loading…",
   updateAvailable: "A new version is available — tap to update",
   routeErrorTitle: "Page failed to load",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -13,6 +13,7 @@ export const en: Copy = {
   flowLabel: "Study flow",
   navMore: "More",
   navMoreTools: "Settings & tools",
+  navMoreWithCurrent: (page) => `More (current: ${page})`,
   loading: "Loading…",
   updateAvailable: "A new version is available — tap to update",
   routeErrorTitle: "Page failed to load",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -11,6 +11,8 @@ export const id: Copy = {
   furiganaShow: "Tampilkan furigana",
   furiganaHide: "Sembunyikan furigana",
   flowLabel: "Alur belajar",
+  navMore: "Lainnya",
+  navMoreTools: "Pengaturan & alat",
   loading: "Memuat…",
   updateAvailable: "Versi baru tersedia — ketuk untuk memperbarui",
   routeErrorTitle: "Halaman gagal dimuat",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -13,6 +13,7 @@ export const id: Copy = {
   flowLabel: "Alur belajar",
   navMore: "Lainnya",
   navMoreTools: "Pengaturan & alat",
+  navMoreWithCurrent: (page) => `Lainnya (saat ini: ${page})`,
   loading: "Memuat…",
   updateAvailable: "Versi baru tersedia — ketuk untuk memperbarui",
   routeErrorTitle: "Halaman gagal dimuat",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -11,6 +11,8 @@ export const ja: Copy = {
   furiganaShow: "ふりがなを表示",
   furiganaHide: "ふりがなを隠す",
   flowLabel: "学習の流れ",
+  navMore: "その他",
+  navMoreTools: "設定・ツール",
   loading: "読み込み中…",
   updateAvailable: "新しいバージョンがあります。タップして更新",
   routeErrorTitle: "ページの読み込みに失敗しました",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -13,6 +13,7 @@ export const ja: Copy = {
   flowLabel: "学習の流れ",
   navMore: "その他",
   navMoreTools: "設定・ツール",
+  navMoreWithCurrent: (page) => `その他（現在：${page}）`,
   loading: "読み込み中…",
   updateAvailable: "新しいバージョンがあります。タップして更新",
   routeErrorTitle: "ページの読み込みに失敗しました",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -11,6 +11,8 @@ export const ko: Copy = {
   furiganaShow: "후리가나 표시",
   furiganaHide: "후리가나 숨김",
   flowLabel: "학습 흐름",
+  navMore: "더보기",
+  navMoreTools: "설정 및 도구",
   loading: "불러오는 중…",
   updateAvailable: "새 버전이 있습니다 — 탭하여 업데이트",
   routeErrorTitle: "페이지를 불러오지 못했습니다",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -13,6 +13,7 @@ export const ko: Copy = {
   flowLabel: "학습 흐름",
   navMore: "더보기",
   navMoreTools: "설정 및 도구",
+  navMoreWithCurrent: (page) => `더보기(현재: ${page})`,
   loading: "불러오는 중…",
   updateAvailable: "새 버전이 있습니다 — 탭하여 업데이트",
   routeErrorTitle: "페이지를 불러오지 못했습니다",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -13,6 +13,7 @@ export const my: Copy = {
   flowLabel: "လေ့လာမှု အဆင့်ဆင့်",
   navMore: "နောက်ထပ်",
   navMoreTools: "ဆက်တင်နှင့် ကိရိယာများ",
+  navMoreWithCurrent: (page) => `နောက်ထပ် (လက်ရှိ - ${page})`,
   loading: "ဖွင့်နေသည်…",
   updateAvailable: "ဗားရှင်းအသစ် ရရှိနိုင်ပါပြီ — အပ်ဒိတ်လုပ်ရန် တို့ပါ",
   routeErrorTitle: "စာမျက်နှာကို ဖွင့်မရပါ",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -11,6 +11,8 @@ export const my: Copy = {
   furiganaShow: "ဖူရိဂါနာ ပြရန်",
   furiganaHide: "ဖူရိဂါနာ ဖျောက်ရန်",
   flowLabel: "လေ့လာမှု အဆင့်ဆင့်",
+  navMore: "နောက်ထပ်",
+  navMoreTools: "ဆက်တင်နှင့် ကိရိယာများ",
   loading: "ဖွင့်နေသည်…",
   updateAvailable: "ဗားရှင်းအသစ် ရရှိနိုင်ပါပြီ — အပ်ဒိတ်လုပ်ရန် တို့ပါ",
   routeErrorTitle: "စာမျက်နှာကို ဖွင့်မရပါ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -11,6 +11,8 @@ export const th: Copy = {
   furiganaShow: "แสดงคำอ่าน",
   furiganaHide: "ซ่อนคำอ่าน",
   flowLabel: "ขั้นตอนการเรียน",
+  navMore: "เพิ่มเติม",
+  navMoreTools: "การตั้งค่าและเครื่องมือ",
   loading: "กำลังโหลด…",
   updateAvailable: "มีเวอร์ชันใหม่ — แตะเพื่ออัปเดต",
   routeErrorTitle: "โหลดหน้าไม่สำเร็จ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -13,6 +13,7 @@ export const th: Copy = {
   flowLabel: "ขั้นตอนการเรียน",
   navMore: "เพิ่มเติม",
   navMoreTools: "การตั้งค่าและเครื่องมือ",
+  navMoreWithCurrent: (page) => `เพิ่มเติม (ปัจจุบัน: ${page})`,
   loading: "กำลังโหลด…",
   updateAvailable: "มีเวอร์ชันใหม่ — แตะเพื่ออัปเดต",
   routeErrorTitle: "โหลดหน้าไม่สำเร็จ",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -13,6 +13,7 @@ export const vi: Copy = {
   flowLabel: "Lộ trình học",
   navMore: "Xem thêm",
   navMoreTools: "Cài đặt & công cụ",
+  navMoreWithCurrent: (page) => `Xem thêm (hiện tại: ${page})`,
   loading: "Đang tải…",
   updateAvailable: "Đã có phiên bản mới — chạm để cập nhật",
   routeErrorTitle: "Không tải được trang",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -11,6 +11,8 @@ export const vi: Copy = {
   furiganaShow: "Hiện furigana",
   furiganaHide: "Ẩn furigana",
   flowLabel: "Lộ trình học",
+  navMore: "Xem thêm",
+  navMoreTools: "Cài đặt & công cụ",
   loading: "Đang tải…",
   updateAvailable: "Đã có phiên bản mới — chạm để cập nhật",
   routeErrorTitle: "Không tải được trang",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -13,6 +13,7 @@ export const zhHant: Copy = {
   flowLabel: "學習流程",
   navMore: "更多",
   navMoreTools: "設定與工具",
+  navMoreWithCurrent: (page) => `更多（目前：${page}）`,
   loading: "載入中…",
   updateAvailable: "有新版本，點此更新",
   routeErrorTitle: "頁面載入失敗",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -11,6 +11,8 @@ export const zhHant: Copy = {
   furiganaShow: "顯示註音",
   furiganaHide: "隱藏註音",
   flowLabel: "學習流程",
+  navMore: "更多",
+  navMoreTools: "設定與工具",
   loading: "載入中…",
   updateAvailable: "有新版本，點此更新",
   routeErrorTitle: "頁面載入失敗",

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -246,6 +246,86 @@
   font-weight: 800;
 }
 
+/* ---- #608: nav 更多 menu (mobile-only trigger) ------------------------- */
+
+/* The menu block lives inside the nav; desktop shows all nine entries, so
+   the whole thing stays display:none until the phone breakpoint in
+   responsive.css flips it on. */
+.nav-more {
+  display: none;
+  position: relative;
+}
+
+.nav-more-trigger {
+  align-items: center;
+  display: inline-flex;
+  font-weight: 800;
+  gap: 0.25rem;
+  padding-inline: 0.9rem;
+}
+
+.nav-more-panel {
+  background: var(--paper);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.15rem;
+  min-width: 13.5rem;
+  padding: 0.45rem;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  z-index: 30;
+}
+
+.nav-more-item {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  box-shadow: none;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-start;
+  min-height: 44px;
+  padding: 0.5rem 0.65rem;
+  text-align: left;
+  width: 100%;
+}
+
+.nav-more-item:hover,
+.nav-more-item:focus-visible {
+  background: var(--field-bg);
+}
+
+.nav-more-item.selected {
+  background: color-mix(in srgb, var(--matcha) 14%, var(--paper));
+}
+
+.nav-more-divider {
+  border-top: 1px solid var(--panel-border);
+  margin: 0.3rem 0.2rem 0.15rem;
+}
+
+.nav-more-heading {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  margin: 0;
+  padding: 0.1rem 0.65rem;
+}
+
+.nav-more-hint {
+  color: var(--muted);
+  display: grid;
+  font-size: 0.75rem;
+  gap: 0.1rem;
+  margin: 0;
+  padding: 0 0.65rem 0.3rem;
+}
+
 .eyebrow {
   color: var(--teal);
   font-size: 0.76rem;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -266,6 +266,81 @@
     display: inline-flex;
   }
 
+  /* ---- #608: compact mobile header + 5-entry nav ----------------------- */
+
+  /* The header tool row and auth block move into the nav's 更多 menu on
+     phones -- hidden here (not removed) so desktop keeps them inline. */
+  .utility-actions,
+  .heading-auth {
+    display: none;
+  }
+
+  /* Non-home views: one-line brand bar. The home view keeps the eyebrow +
+     tagline intro (the class is absent there). */
+  .app-heading-compact {
+    align-items: center;
+    margin-bottom: 0.6rem;
+  }
+
+  .app-heading-compact .eyebrow,
+  .app-heading-compact .heading-actions p {
+    display: none;
+  }
+
+  .app-heading-compact .app-brand-mark {
+    height: 2.1rem;
+    width: 2.1rem;
+  }
+
+  .app-heading-compact .app-title {
+    font-size: 1.3rem;
+  }
+
+  /* Five primary entries + 更多; the secondary views fold into the menu.
+     `order` re-ranks the surviving buttons by importance without touching
+     the desktop DOM order. */
+  .view-switch .nav-secondary {
+    display: none;
+  }
+
+  .view-switch .nav-more {
+    display: block;
+    order: 6;
+    /* Anchor the panel to the whole nav (below) instead of the trigger --
+       a trigger-anchored 13.5rem panel pokes past the viewport at 320px. */
+    position: static;
+  }
+
+  .view-switch.segmented {
+    position: relative;
+  }
+
+  .nav-more-panel {
+    left: 0;
+    min-width: 0;
+    right: 0;
+  }
+
+  .view-switch [data-nav="home"] {
+    order: 1;
+  }
+
+  .view-switch [data-nav="learn"] {
+    order: 2;
+  }
+
+  .view-switch [data-nav="challenge"] {
+    order: 3;
+  }
+
+  .view-switch [data-nav="mock"] {
+    order: 4;
+  }
+
+  .view-switch [data-nav="grammar"] {
+    order: 5;
+  }
+
   .controls-panel,
   .drill-panel,
   .learning-panel,


### PR DESCRIPTION
#608 最後一塊：手機 header＋主導覽精簡。**Draft，等 review，不 merge、不關 #608。**

## 手機版改了什麼（560px 斷點內；桌面 DOM／樣式零變動）

1. **非首頁 header 壓成一行品牌列**：`app-heading-compact`（隱藏 eyebrow＋標語、logo 3rem→2.1rem、標題 1.65rem→1.3rem）。首頁保留完整介紹（eyebrow＋標語照舊）。
2. **主導覽剩 5 個主要入口＋「更多」**：首頁・學習・挑戰・題型練習・文型（CSS `order` 重排重要性，桌面 DOM 順序不動）。
3. **「更多」選單**（新 `MoreMenu` 元件，nav 內最後一項）：
   - 上半：規則表／漢字／文章／關於（文章沿用同一個 `blogAvailable` 旗標，非 zh-Hant 不出現）
   - 「設定與工具」分隔線下半：切換語言／顯示註音／深色模式／意見回饋／登入・登出（含同步狀態 hint，與 header 同一個 `authSyncHint` 來源、不會 drift）
4. **工具列與 auth 區塊在手機隱藏**（收進選單；`display:none`，桌面原樣）。

## 為什麼這樣排序

主要五項＝每日循環（首頁儀表板→學習→練習兩入口）＋文法資料庫（SEO 主要著陸面、學習主動線）；規則表／漢字是查表型工具（用時才找）、文章與關於是低頻入口——放「更多」第一層，一次點擊可達。

## Accessibility

- trigger：`aria-haspopup="menu"`＋`aria-expanded`＋`aria-controls`；ArrowDown 直接開
- panel：`role="menu"`、項目 `role="menuitem"`（注音為 `menuitemcheckbox`＋`aria-checked`）、目前頁 `aria-current="page"`
- 鍵盤：開啟即焦點第一項、↑↓/Home/End roving focus、**Escape 關閉並歸還焦點到 trigger**、外點關閉
- 觸控：選單項與 nav 按鈕全數 ≥44px；panel 錨定整條 nav（320px 不出界）
- SEO heading 語意不變（h1 仍唯一、grammar 路由讓位規則照舊）；URL 同步與 aria-current 契約與原 nav 按鈕完全一致（同一組 handler）

## 量測（390×844，內容前框架高度）

| 頁面 | 改前 | 改後 |
|---|---|---|
| 首頁 nav 底 | 420px | **234px**（首個 CTA 603→417） |
| /learn 框架 | 416px | **167px**（教材 440→191 開始） |
| /challenge・/blog | ~416px | **167-168px** |

320px：6 鍵兩列、無水平捲軸、選單全寬貼齊；768／1280：9 鍵完整 nav＋工具列，與 main 逐項一致。

## TDD／驗證

- RED 先行：`MoreMenu.test.tsx` 8 條（開合／aria／鍵盤／Escape 焦點／外點／工具 callback／登入登出切換）＋ `App.test.tsx` 2 條（更多→關於導航含 URL/aria-current；en 不出現文章）— 均先觀察失敗
- `pnpm test`：**973 全綠**（含既有 59 條 App 測試不退化）
- `pnpm build` 過；**103 prerender 頁不變**；lazy chunk 邊界不動
- **Bundle**：index 677.51→683.06 kB（**gzip 206.74→208.24，+1.5 kB**＝MoreMenu＋4 個 lucide 圖示）
- 實機（dev＋prod build 各驗一輪）：320/390/768/1280 × 首頁/學習/挑戰/文章；選單開合、選單導航、外點、zh 閘門；冷載＋互動 console 零錯誤
- 截圖 18 張存於 `C:\Users\islu2\Documents\Projects\_shots\608\`（含 320/390 開啟選單特寫；不入版控）

## 範圍紀律

未動：章節搜尋、bottom sheet、漢字/規則表、reducer、practice engine、AppViewRenderer、配色卡片、桌面 UI；零新依賴。

Part of #608（merge 後由 花雪 決定關閉時點）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly “More” navigation menu for secondary pages and settings.
  * Added language, furigana, theme, feedback, and account actions to the menu.
  * Added localized menu labels across supported languages.
  * Added keyboard, pointer, and accessibility support, including current-page indicators.
  * Blog navigation is shown only when available.

* **Style**
  * Updated mobile navigation and header layouts for a compact five-item display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->