### PR TITLE
Add privacy policy and terms pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Jabiko · ジャビ子
 
-**A free, open, no-signup JLPT self-study web app.** Practice grammar, kanji
+**A free, no-signup JLPT self-study web app.** Practice grammar, kanji
 readings, vocabulary, and mock-exam-style questions from **N5 to N1** — wrong
 answers flow into spaced-repetition review, so you keep drilling your weak
 points. Open it and practise; nothing to install, no account needed.
 
-> 免費、免註冊、開源的 **JLPT 日檢自習室**：N5〜N1 文法、漢字讀音、單字與依官方題型的練習，答錯自動排進間隔重複複習，跨裝置同步，打開就能練。
+> 免費、免註冊的 **JLPT 日檢自習室**：N5〜N1 文法、漢字讀音、單字與依官方題型的練習，答錯自動排進間隔重複複習，跨裝置同步，打開就能練。
 
 **▶ Live: [jabiko.app](https://jabiko.app/)**
 
@@ -69,11 +69,14 @@ flight / planned: AI-assisted content localisation (per-locale explanations),
 a personal favourites list, more grammar study chapters (N3/N2), achievement
 badges + daily goals, and data-driven difficulty once there's enough signal.
 
-## License & credits
+## Ownership, privacy & terms
 
 Built by **花雪 (HanaYukii)**. The mascot ジャビ子 is Jabiko's own.
 
-> **License:** the source is public but a formal open-source license file has
-> not been added yet — see [issue tracker] before reusing the code.
+Source visibility does not grant permission to copy, modify, redistribute, or
+use the code commercially. Unless a specific file says otherwise, rights are
+reserved in the source code, original articles, question bank, Jabiko name,
+mascot, and visual assets.
 
-[issue tracker]: https://github.com/nurockplayer/Jabiko/issues
+- [Privacy Policy](https://jabiko.app/privacy)
+- [Terms of Use](https://jabiko.app/terms)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ The question bank is generated from typed data in `src/domain/exam/items/` via
 `scripts/import-exam-items.mjs`; content correctness is enforced by
 `src/domain/contentGuard.test.ts`.
 
-## Contributing
+## Development workflow
+
+These are maintainer workflow notes. Please contact the maintainer before
+preparing an external contribution.
 
 - **TDD** is the house rule: write the failing test first, then the code.
 - New question-bank content follows a batch pipeline (author → adversarial
@@ -62,12 +65,11 @@ The question bank is generated from typed data in `src/domain/exam/items/` via
   `CLAUDE.md` and `docs/item-quality-rubric.md`.
 - Every change lands via a PR; CI (`Test and build`) must be green before merge.
 
-## Roadmap
+## Project status
 
-Tracked in [GitHub Issues](https://github.com/nurockplayer/Jabiko/issues). In
-flight / planned: AI-assisted content localisation (per-locale explanations),
-a personal favourites list, more grammar study chapters (N3/N2), achievement
-badges + daily goals, and data-driven difficulty once there's enough signal.
+Concrete work is tracked in [GitHub Issues](https://github.com/nurockplayer/Jabiko/issues).
+The backlog intentionally keeps only scoped, independently verifiable work;
+broader ideas are opened when there is a current product need.
 
 ## Ownership, privacy & terms
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -75,7 +75,8 @@ slug, or leaving and later re-entering an article route, is a new view.
 ### `view` allowed values
 
 `page_view.view` is the app view string (`home`, `learn`, `rules`, `kanji`,
-`challenge`, `mock`, `about`, `grammar`). It is typed as `string` in the
+`kana`, `challenge`, `mock`, `about`, `privacy`, `terms`, `grammar`, or
+`blog`). It is typed as `string` in the
 payload (the lib layer intentionally does not import the App-internal
 `AppView` union to keep layering clean — see decision boundaries in
 `.codex-spec.md`).

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考</title>
     <meta
       name="description"
-      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
+      content="免費、免註冊的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta name="theme-color" content="#647c5c" />
     <!-- Browser-tab favicon (Jabiko mascot). SVG scales crisply in modern
@@ -24,7 +24,7 @@
     <meta property="og:title" content="Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       property="og:description"
-      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
+      content="免費、免註冊的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta property="og:image" content="https://jabiko.app/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -36,7 +36,7 @@
     <meta name="twitter:title" content="Jabiko · JLPT 日檢自習室｜N5–N1 文法單字模擬考" />
     <meta
       name="twitter:description"
-      content="免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
+      content="免費、免註冊的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
     />
     <meta name="twitter:image" content="https://jabiko.app/og-image.png" />
 
@@ -51,7 +51,7 @@
         "applicationCategory": "EducationalApplication",
         "operatingSystem": "Web",
         "inLanguage": "zh-Hant",
-        "description": "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
+        "description": "免費、免註冊的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型的整卷模擬考，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。"
       }
     </script>
   </head>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -52,6 +52,16 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://jabiko.app/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://jabiko.app/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://jabiko.app/grammar/n5</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>

--- a/scripts/build-sitemap.mjs
+++ b/scripts/build-sitemap.mjs
@@ -31,6 +31,8 @@ const ROUTES = [
   { path: "/grammar", changefreq: "weekly", priority: "0.7" },
   { path: "/blog", changefreq: "weekly", priority: "0.7" },
   { path: "/about", changefreq: "monthly", priority: "0.5" },
+  { path: "/privacy", changefreq: "yearly", priority: "0.3" },
+  { path: "/terms", changefreq: "yearly", priority: "0.3" },
 ];
 
 const LEVEL_HUBS = ["n5", "n4", "n3", "n2", "n1"].map((level) => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import type { SentencePatternId } from "./domain/sentencePatterns";
 import type { JlptLevel } from "./domain/types";
 import { countMistakes } from "./domain/srs";
 import { copy, LAUNCHED_LANGUAGES, type Language } from "./i18n";
-import { HomePanel, LearningPanel, RulesPanel, AboutPanel, LegalPanel } from "./components";
+import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
 import { LanguageFlag } from "./components/LanguageFlag";
 import { FeedbackForm } from "./components/FeedbackForm";
@@ -92,6 +92,11 @@ const BlogIndexPage = lazy(() =>
 );
 const BlogArticlePage = lazy(() =>
   import("./components/BlogArticlePage").then((module) => ({ default: module.BlogArticlePage }))
+);
+// Legal documents carry full zh-Hant, ja, and en policy text. Keep that prose
+// out of the initial bundle; the footer labels live in a separate tiny module.
+const LegalPanel = lazy(() =>
+  import("./components/LegalPanel").then((module) => ({ default: module.LegalPanel }))
 );
 const BUILD_VERSION = packageJson.version;
 
@@ -702,7 +707,9 @@ export default function App() {
       ) : appView === "about" ? (
         <AboutPanel language={language} />
       ) : appView === "privacy" || appView === "terms" ? (
-        <LegalPanel language={language} page={appView} />
+        <Suspense fallback={<PanelFallback label={t.loading} />}>
+          <LegalPanel language={language} page={appView} />
+        </Suspense>
       ) : appView === "kanji" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
           <KanjiOnyomiPanel language={language} defaultLevel={kanjiDefaultLevel(targetLevel)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import type { SentencePatternId } from "./domain/sentencePatterns";
 import type { JlptLevel } from "./domain/types";
 import { countMistakes } from "./domain/srs";
 import { copy, LAUNCHED_LANGUAGES, type Language } from "./i18n";
-import { HomePanel, LearningPanel, RulesPanel, AboutPanel } from "./components";
+import { HomePanel, LearningPanel, RulesPanel, AboutPanel, LegalPanel } from "./components";
 import { LanguagePicker } from "./components/LanguagePicker";
 import { LanguageFlag } from "./components/LanguageFlag";
 import { FeedbackForm } from "./components/FeedbackForm";
@@ -701,6 +701,8 @@ export default function App() {
         <RulesPanel language={language} />
       ) : appView === "about" ? (
         <AboutPanel language={language} />
+      ) : appView === "privacy" || appView === "terms" ? (
+        <LegalPanel language={language} page={appView} />
       ) : appView === "kanji" ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
           <KanjiOnyomiPanel language={language} defaultLevel={kanjiDefaultLevel(targetLevel)} />

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,5 +1,6 @@
 import { copy, type Language } from "../i18n";
 import { JabikoMark } from "./JabikoMark";
+import { LegalLinks } from "./LegalLinks";
 
 // The author's personal "about" page.
 const ABOUT_URL = "https://hanayukii.dev/about";
@@ -43,6 +44,8 @@ export function AboutPanel({ language }: { language: Language }) {
         <p className="about-author-name">{t.aboutAuthor2Name}</p>
         <p>{t.aboutAuthor2Body}</p>
       </article>
+
+      <LegalLinks language={language} />
     </section>
   );
 }

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -238,6 +238,21 @@ describe("HomePanel feedback entry", () => {
   });
 });
 
+describe("HomePanel legal links", () => {
+  it("links to the privacy policy and terms from the footer", () => {
+    renderHome();
+
+    expect(screen.getByRole("link", { name: "隱私政策" })).toHaveAttribute(
+      "href",
+      "/privacy"
+    );
+    expect(screen.getByRole("link", { name: "使用條款" })).toHaveAttribute(
+      "href",
+      "/terms"
+    );
+  });
+});
+
 describe("HomePanel donate link", () => {
   const ecpayUrl =
     "https://payment.ecpay.com.tw/Broadcaster/Donate/57DD8DC811013DF1C576D7ED22ACF911";

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -15,6 +15,7 @@ import { ActivityTrend } from "./dashboard/ActivityTrend";
 import { TypeBars } from "./dashboard/TypeBars";
 import { FeedbackForm } from "./FeedbackForm";
 import { ShareButtons } from "./challenge/ShareButtons";
+import { LegalLinks } from "./LegalLinks";
 import type { FeedbackCategory } from "../domain/feedbackRemote";
 
 // External walkthrough / 使用說明書: the author's blog post about Jabiko.
@@ -595,6 +596,7 @@ export function HomePanel({
         <div className="home-footer-share">
           <ShareButtons language={language} text={t.shareSiteText} title={t.shareSiteTitle} />
         </div>
+        <LegalLinks language={language} />
       </footer>
     </section>
   );

--- a/src/components/LegalLinks.tsx
+++ b/src/components/LegalLinks.tsx
@@ -1,5 +1,6 @@
 import type { Language } from "../i18n";
-import { legalCopyFor, type LegalPageKind } from "../domain/legalContent";
+import type { LegalPageKind } from "../domain/legalContent";
+import { legalLabelsFor } from "../domain/legalLabels";
 
 export function LegalLinks({
   language,
@@ -8,7 +9,7 @@ export function LegalLinks({
   language: Language;
   current?: LegalPageKind;
 }) {
-  const legal = legalCopyFor(language);
+  const legal = legalLabelsFor(language);
 
   return (
     <nav className="legal-links" aria-label={legal.navigationLabel}>

--- a/src/components/LegalLinks.tsx
+++ b/src/components/LegalLinks.tsx
@@ -1,0 +1,24 @@
+import type { Language } from "../i18n";
+import { legalCopyFor, type LegalPageKind } from "../domain/legalContent";
+
+export function LegalLinks({
+  language,
+  current
+}: {
+  language: Language;
+  current?: LegalPageKind;
+}) {
+  const legal = legalCopyFor(language);
+
+  return (
+    <nav className="legal-links" aria-label={legal.navigationLabel}>
+      <a href="/privacy" aria-current={current === "privacy" ? "page" : undefined}>
+        {legal.privacyLabel}
+      </a>
+      <span aria-hidden="true">·</span>
+      <a href="/terms" aria-current={current === "terms" ? "page" : undefined}>
+        {legal.termsLabel}
+      </a>
+    </nav>
+  );
+}

--- a/src/components/LegalPanel.test.tsx
+++ b/src/components/LegalPanel.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { LegalPanel } from "./LegalPanel";
+
+describe("LegalPanel", () => {
+  it("renders the privacy policy and marks its footer link current", () => {
+    render(<LegalPanel language="zh-Hant" page="privacy" />);
+
+    expect(screen.getByRole("heading", { name: "隱私政策" })).toBeInTheDocument();
+    expect(screen.getByText(/Google OAuth 與 Supabase Auth/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "隱私政策" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("link", { name: "使用條款" })).toHaveAttribute(
+      "href",
+      "/terms"
+    );
+  });
+
+  it("renders launched English and Japanese legal copy", () => {
+    const view = render(<LegalPanel language="en" page="terms" />);
+    expect(screen.getByRole("heading", { name: "Terms of Use" })).toBeInTheDocument();
+    expect(screen.getByText(/does not grant permission/)).toBeInTheDocument();
+
+    view.rerender(<LegalPanel language="ja" page="privacy" />);
+    expect(screen.getByRole("heading", { name: "プライバシーポリシー" })).toBeInTheDocument();
+    expect(screen.getByText(/Google OAuth と Supabase Auth/)).toBeInTheDocument();
+  });
+});

--- a/src/components/LegalPanel.tsx
+++ b/src/components/LegalPanel.tsx
@@ -12,21 +12,21 @@ export function LegalPanel({
   language: Language;
   page: LegalPageKind;
 }) {
-  const document = legalDocumentFor(language, page);
+  const legalDocument = legalDocumentFor(language, page);
   const titleId = `legal-${page}-title`;
 
   return (
     <section className="legal-panel" aria-labelledby={titleId}>
       <header className="legal-hero">
-        <p className="eyebrow">{document.eyebrow}</p>
-        <h2 id={titleId}>{document.title}</h2>
-        <p className="legal-intro">{document.intro}</p>
-        <p className="legal-updated">{document.updatedLabel}</p>
+        <p className="eyebrow">{legalDocument.eyebrow}</p>
+        <h2 id={titleId}>{legalDocument.title}</h2>
+        <p className="legal-intro">{legalDocument.intro}</p>
+        <p className="legal-updated">{legalDocument.updatedLabel}</p>
       </header>
 
-      {document.sections.map((section) => (
+      {legalDocument.sections.map((section) => (
         <article className="legal-section" key={section.title}>
-          <h2>{section.title}</h2>
+          <h3>{section.title}</h3>
           {section.paragraphs?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
           {section.items ? (
             <ul>

--- a/src/components/LegalPanel.tsx
+++ b/src/components/LegalPanel.tsx
@@ -1,0 +1,42 @@
+import type { Language } from "../i18n";
+import {
+  legalDocumentFor,
+  type LegalPageKind
+} from "../domain/legalContent";
+import { LegalLinks } from "./LegalLinks";
+
+export function LegalPanel({
+  language,
+  page
+}: {
+  language: Language;
+  page: LegalPageKind;
+}) {
+  const document = legalDocumentFor(language, page);
+  const titleId = `legal-${page}-title`;
+
+  return (
+    <section className="legal-panel" aria-labelledby={titleId}>
+      <header className="legal-hero">
+        <p className="eyebrow">{document.eyebrow}</p>
+        <h2 id={titleId}>{document.title}</h2>
+        <p className="legal-intro">{document.intro}</p>
+        <p className="legal-updated">{document.updatedLabel}</p>
+      </header>
+
+      {document.sections.map((section) => (
+        <article className="legal-section" key={section.title}>
+          <h2>{section.title}</h2>
+          {section.paragraphs?.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+          {section.items ? (
+            <ul>
+              {section.items.map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          ) : null}
+        </article>
+      ))}
+
+      <LegalLinks language={language} current={page} />
+    </section>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,4 +14,3 @@ export { HomePanel } from "./HomePanel";
 export { LearningPanel } from "./LearningPanel";
 export { RulesPanel } from "./RulesPanel";
 export { AboutPanel } from "./AboutPanel";
-export { LegalPanel } from "./LegalPanel";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,3 +14,4 @@ export { HomePanel } from "./HomePanel";
 export { LearningPanel } from "./LearningPanel";
 export { RulesPanel } from "./RulesPanel";
 export { AboutPanel } from "./AboutPanel";
+export { LegalPanel } from "./LegalPanel";

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { LAUNCHED_LANGUAGES } from "../i18n";
+import { legalCopyFor, legalDocumentFor } from "./legalContent";
+
+describe("legal content", () => {
+  it("provides privacy and terms copy for every launched language", () => {
+    for (const language of LAUNCHED_LANGUAGES) {
+      const copy = legalCopyFor(language);
+      expect(copy.privacy.title, `${language}:privacy`).toBeTruthy();
+      expect(copy.privacy.sections.length, `${language}:privacy sections`).toBeGreaterThan(0);
+      expect(copy.terms.title, `${language}:terms`).toBeTruthy();
+      expect(copy.terms.sections.length, `${language}:terms sections`).toBeGreaterThan(0);
+    }
+  });
+
+  it("states the actual sync and analytics boundaries", () => {
+    const privacy = legalDocumentFor("zh-Hant", "privacy");
+    const text = privacy.sections
+      .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+      .join("\n");
+
+    expect(text).toContain("你送出的答案");
+    expect(text).toContain("題目全文");
+    expect(text).toContain("不會出售個人資料");
+  });
+
+  it("does not claim that public source code is open source", () => {
+    const terms = legalDocumentFor("zh-Hant", "terms");
+    const text = terms.sections
+      .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+      .join("\n");
+
+    expect(text).toContain("不代表已授權");
+    expect(text).not.toContain("開源");
+  });
+});

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -24,6 +24,31 @@ describe("legal content", () => {
     expect(text).toContain("不會出售個人資料");
   });
 
+  it("keeps sync and question-report disclosures aligned across languages", () => {
+    const disclosureText = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+        .join("\n");
+
+    const zh = disclosureText("zh-Hant");
+    expect(zh).toContain("單字識別碼");
+    expect(zh).toContain("作答目標形式");
+    expect(zh).toContain("題型標籤");
+    expect(zh).toContain("單字表記與讀音");
+
+    const ja = disclosureText("ja");
+    expect(ja).toContain("語彙 ID");
+    expect(ja).toContain("解答対象の形式");
+    expect(ja).toContain("問題形式のラベル");
+    expect(ja).toContain("表記と読み");
+
+    const en = disclosureText("en");
+    expect(en).toContain("vocabulary IDs");
+    expect(en).toContain("target forms");
+    expect(en).toContain("question-type label");
+    expect(en).toContain("surface form and reading");
+  });
+
   it("does not claim that public source code is open source", () => {
     const terms = legalDocumentFor("zh-Hant", "terms");
     const text = terms.sections

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -1,0 +1,380 @@
+import type { LocaleCode } from "./types";
+
+export type LegalPageKind = "privacy" | "terms";
+
+export interface LegalSection {
+  title: string;
+  paragraphs?: readonly string[];
+  items?: readonly string[];
+}
+
+export interface LegalDocument {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  updatedLabel: string;
+  sections: readonly LegalSection[];
+}
+
+export interface LegalPageCopy {
+  navigationLabel: string;
+  privacyLabel: string;
+  termsLabel: string;
+  privacy: LegalDocument;
+  terms: LegalDocument;
+}
+
+const UPDATED_AT = "2026-07-17";
+
+const LEGAL_COPY = {
+  "zh-Hant": {
+    navigationLabel: "法律與隱私",
+    privacyLabel: "隱私政策",
+    termsLabel: "使用條款",
+    privacy: {
+      eyebrow: "法律與隱私",
+      title: "隱私政策",
+      intro:
+        "Jabiko 以免註冊即可使用為原則。這份政策說明資料會留在哪裡、登入同步與回報功能會送出什麼，以及你可以如何處理自己的資料。",
+      updatedLabel: `最後更新：${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. 未登入時儲存在瀏覽器的資料",
+          paragraphs: [
+            "練習紀錄、作答內容、正誤、作答時間、收藏，以及語言、主題、注音、語速、目標級別等偏好，主要儲存在你目前瀏覽器的 localStorage。這些資料不會因為單純使用網站就自動變成 Jabiko 帳號資料。",
+            "你可以透過瀏覽器的網站資料設定清除本機資料。清除瀏覽器資料、使用無痕模式或更換裝置，可能讓未同步的進度永久消失。"
+          ]
+        },
+        {
+          title: "2. Google 登入與跨裝置同步",
+          paragraphs: [
+            "登入是選用功能，由 Google OAuth 與 Supabase Auth 處理。登入時，Jabiko 會取得帳號識別碼，以及 Google 提供的基本帳號資訊，例如名稱與電子郵件地址。",
+            "登入後，練習紀錄會同步到 Supabase。同步資料可能包含題目識別碼、題目提示、預期答案、你送出的答案、正誤、時間戳與作答時間，目的是讓進度可以在不同裝置合併與延續。每位使用者只能透過公開 API 讀取或寫入自己的練習紀錄。"
+          ]
+        },
+        {
+          title: "3. 匿名使用分析",
+          paragraphs: [
+            "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。",
+            "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
+          ]
+        },
+        {
+          title: "4. 意見回饋與題目回報",
+          paragraphs: [
+            "送出一般回饋時，會保存類別、訊息、是否希望回覆，以及你自行填寫的聯絡方式。題目回報還會包含題目 ID、提示、預期答案、你所選的答案、級別與介面語言，方便定位問題。",
+            "若你已登入，Supabase 會在伺服器端記錄帳號 ID、電子郵件與登入提供者；匿名使用者則不會有這些帳號欄位。回報資料不會透過網站公開讀取。請不要在自由輸入欄位提供不必要的敏感資料。"
+          ]
+        },
+        {
+          title: "5. 外部服務",
+          items: [
+            "Cloudflare：網站傳遞、安全與選用的 Zaraz 分析。",
+            "Supabase：Google 登入、登入狀態、練習同步與回報資料庫。",
+            "Google：你主動選擇 Google 登入時的身分驗證。",
+            "ECPay 與其他外部連結：只有在你主動點擊後才會前往第三方網站；付款資料不會由 Jabiko 前端保存。"
+          ]
+        },
+        {
+          title: "6. 保存、刪除與聯絡",
+          paragraphs: [
+            "本機資料會保留到你清除瀏覽器網站資料為止。遠端練習紀錄與回報會保留到完成其同步、維護、回覆或問題追蹤用途，或由你提出刪除要求為止。",
+            "目前尚未提供完整的自助匯出與刪除介面。若要詢問或刪除帳號相關資料，請先登入相同帳號，再使用網站的「回饋」功能並勾選希望回覆；請勿在公開 GitHub issue 張貼個人資料。Jabiko 不會出售個人資料。"
+          ]
+        },
+        {
+          title: "7. 政策變更",
+          paragraphs: [
+            "功能或資料處理方式有實質改變時，這份政策會同步更新日期與內容。若變更會明顯影響使用者權益，會以網站上的適當方式提醒。"
+          ]
+        }
+      ]
+    },
+    terms: {
+      eyebrow: "法律與隱私",
+      title: "使用條款",
+      intro:
+        "使用 Jabiko 即表示你理解這是一項免費的日文學習輔助服務。以下條款用白話說明服務範圍、內容責任與使用限制。",
+      updatedLabel: `最後更新：${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. 服務性質",
+          paragraphs: [
+            "Jabiko 提供日文文法、詞彙、漢字、題型練習、文章與學習進度工具。服務不隸屬於日本國際交流基金會、日本國際教育支援協會或 JLPT 官方，也不保證考試成績、合格或內容永遠沒有錯誤。"
+          ]
+        },
+        {
+          title: "2. 合理使用",
+          items: [
+            "不得以自動化請求、攻擊、繞過安全控制或其他方式干擾網站與其他使用者。",
+            "不得利用回饋欄位傳送違法、侵害他人權利、惡意或大量垃圾內容。",
+            "發現題目或解說有問題時，請使用回報功能；Jabiko 可依判斷修正、保留或移除內容。"
+          ]
+        },
+        {
+          title: "3. 程式碼、內容與品牌",
+          paragraphs: [
+            "程式碼可以在公開儲存庫中被查看，不代表已授權複製、修改、再散布或商業使用。除非特定檔案另有明確授權，Jabiko 的程式碼、原創文章、題庫、名稱、吉祥物與視覺素材均保留權利。",
+            "日文語言本身、一般事實與你依法可使用的內容不受這段額外限制；第三方商標、作品名稱與外部內容仍屬各權利人。"
+          ]
+        },
+        {
+          title: "4. 外部服務與贊助連結",
+          paragraphs: [
+            "網站可能連到 Google、ECPay、GitHub 或其他第三方服務。第三方網站的內容、交易、隱私與可用性由該服務負責。贊助屬自願支持，不會購買考試結果或保證功能永久提供。"
+          ]
+        },
+        {
+          title: "5. 服務變更與可用性",
+          paragraphs: [
+            "Jabiko 可能新增、修改、暫停或移除功能與內容，也可能因維護、供應商故障或不可控制的原因暫時無法使用。會盡力維持服務與資料安全，但不保證完全不中斷或資料永不遺失；重要學習紀錄請自行保留必要備份。"
+          ]
+        },
+        {
+          title: "6. 責任限制與聯絡",
+          paragraphs: [
+            "在法律允許的範圍內，Jabiko 不對因使用或無法使用本服務、依賴學習內容、第三方服務或資料遺失所造成的間接損失負責。這不排除依法不能排除的責任。",
+            "對條款、隱私或內容有疑問，可以使用網站的「回饋」功能聯絡。"
+          ]
+        }
+      ]
+    }
+  },
+  ja: {
+    navigationLabel: "法的情報・プライバシー",
+    privacyLabel: "プライバシーポリシー",
+    termsLabel: "利用規約",
+    privacy: {
+      eyebrow: "法的情報・プライバシー",
+      title: "プライバシーポリシー",
+      intro:
+        "Jabiko は、登録しなくても使えることを基本としています。本ポリシーでは、ブラウザ内に残る情報、ログイン同期やフィードバックで送信される情報、その管理方法を説明します。",
+      updatedLabel: `最終更新：${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. ログイン前にブラウザへ保存される情報",
+          paragraphs: [
+            "練習履歴、回答、正誤、回答時間、ブックマーク、言語・テーマ・ふりがな・読み上げ速度・目標レベルなどの設定は、主に現在のブラウザの localStorage に保存されます。閲覧しただけで Jabiko のアカウント情報になることはありません。",
+            "ブラウザのサイトデータ設定から削除できます。サイトデータの削除、シークレットモードの利用、端末変更により、同期していない進捗が失われる場合があります。"
+          ]
+        },
+        {
+          title: "2. Google ログインと端末間同期",
+          paragraphs: [
+            "ログインは任意で、Google OAuth と Supabase Auth を利用します。ログイン時にはアカウント識別子と、Google が提供する氏名・メールアドレスなどの基本情報を扱います。",
+            "ログイン後の練習履歴は Supabase に同期されます。同期情報には問題 ID、問題文、想定解、送信した回答、正誤、日時、回答時間が含まれる場合があります。公開 API では、各利用者は自分の履歴だけを読み書きできます。"
+          ]
+        },
+        {
+          title: "3. 匿名の利用状況分析",
+          paragraphs: [
+            "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。",
+            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、検索文字列、自由入力文を含めません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
+          ]
+        },
+        {
+          title: "4. フィードバックと問題報告",
+          paragraphs: [
+            "一般のフィードバックでは、種別、本文、返信希望の有無、任意で入力した連絡先を保存します。問題報告には、問題 ID、問題文、想定解、選択した回答、レベル、表示言語も含まれます。",
+            "ログイン中は、Supabase がサーバー側でアカウント ID、メールアドレス、ログイン事業者を記録します。匿名時はこれらの欄は空です。報告内容はサイトの公開 API から閲覧できません。不要な機微情報は入力しないでください。"
+          ]
+        },
+        {
+          title: "5. 外部サービス",
+          items: [
+            "Cloudflare：サイト配信、安全対策、任意の Zaraz 分析。",
+            "Supabase：Google ログイン、セッション、練習同期、フィードバック保存。",
+            "Google：利用者が Google ログインを選んだ場合の認証。",
+            "ECPay その他の外部リンク：利用者がリンクを開いた後は第三者のサービスとなり、Jabiko のフロントエンドは決済情報を保存しません。"
+          ]
+        },
+        {
+          title: "6. 保存、削除、問い合わせ",
+          paragraphs: [
+            "ローカル情報はブラウザのサイトデータを削除するまで残ります。同期履歴とフィードバックは、同期・保守・返信・問題追跡に必要な期間、または削除依頼を受けるまで保持します。",
+            "現時点では完全な自己操作によるエクスポート・削除画面はありません。アカウント情報の確認や削除を希望する場合は、同じアカウントでログインし、サイトの「フィードバック」で返信希望を選んでください。公開 GitHub issue に個人情報を書かないでください。個人情報を販売することはありません。"
+          ]
+        },
+        {
+          title: "7. ポリシーの変更",
+          paragraphs: [
+            "機能や情報の取扱いに実質的な変更がある場合、本ポリシーの内容と更新日を変更します。利用者への影響が大きい場合は、サイト上で適切にお知らせします。"
+          ]
+        }
+      ]
+    },
+    terms: {
+      eyebrow: "法的情報・プライバシー",
+      title: "利用規約",
+      intro:
+        "Jabiko は無料の日本語学習補助サービスです。以下では、サービスの範囲、コンテンツに関する責任、利用上の制限を簡潔に説明します。",
+      updatedLabel: `最終更新：${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. サービスの性質",
+          paragraphs: [
+            "Jabiko は文法、語彙、漢字、問題形式の練習、記事、学習進捗ツールを提供します。国際交流基金、国際教育支援協会、JLPT 公式とは関係がなく、試験結果や合格、内容の完全な正確性を保証しません。"
+          ]
+        },
+        {
+          title: "2. 適切な利用",
+          items: [
+            "自動化された過剰なリクエスト、攻撃、安全対策の回避など、サイトや他の利用者を妨害する行為は禁止します。",
+            "フィードバック欄を使って、違法な内容、権利侵害、悪意ある内容、大量の迷惑投稿を送信してはいけません。",
+            "問題や解説の誤りは報告機能からお知らせください。Jabiko は判断により内容を修正、維持、削除できます。"
+          ]
+        },
+        {
+          title: "3. ソースコード、コンテンツ、ブランド",
+          paragraphs: [
+            "ソースコードが公開リポジトリで閲覧できても、複製、改変、再配布、商用利用が許可されたことにはなりません。個別ファイルに明示的なライセンスがない限り、Jabiko のコード、オリジナル記事、問題データ、名称、マスコット、視覚素材の権利は留保されます。",
+            "日本語そのもの、一般的事実、法令上利用可能な内容を追加で制限するものではありません。第三者の商標、作品名、外部コンテンツの権利は各権利者に帰属します。"
+          ]
+        },
+        {
+          title: "4. 外部サービスと支援リンク",
+          paragraphs: [
+            "Google、ECPay、GitHub などの第三者サイトへリンクする場合があります。第三者サイトの内容、取引、プライバシー、可用性は各事業者が管理します。支援は任意であり、試験結果やサービスの恒久提供を購入するものではありません。"
+          ]
+        },
+        {
+          title: "5. 変更と可用性",
+          paragraphs: [
+            "機能やコンテンツを追加、変更、停止、削除する場合があります。保守、外部事業者の障害、その他管理できない事情により一時的に利用できないこともあります。安全と継続に努めますが、無停止やデータの完全な保持は保証しません。必要な学習記録は利用者自身でも保管してください。"
+          ]
+        },
+        {
+          title: "6. 責任の制限と問い合わせ",
+          paragraphs: [
+            "法令で認められる範囲で、本サービスの利用・利用不能、学習内容への依存、第三者サービス、データ消失から生じた間接損害について責任を負いません。法令上排除できない責任を除外するものではありません。",
+            "規約、プライバシー、コンテンツに関する質問は、サイトの「フィードバック」からお送りください。"
+          ]
+        }
+      ]
+    }
+  },
+  en: {
+    navigationLabel: "Legal and privacy",
+    privacyLabel: "Privacy Policy",
+    termsLabel: "Terms of Use",
+    privacy: {
+      eyebrow: "Legal and privacy",
+      title: "Privacy Policy",
+      intro:
+        "Jabiko is designed to work without registration. This policy explains what stays in your browser, what is sent when you use sign-in, sync, analytics, or feedback, and how you can manage that data.",
+      updatedLabel: `Last updated: ${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. Data stored in your browser before sign-in",
+          paragraphs: [
+            "Practice history, submitted answers, correctness, response time, bookmarks, and preferences such as language, theme, furigana, speech rate, and target level are stored mainly in localStorage in your current browser. Simply using the site does not automatically turn this data into Jabiko account data.",
+            "You can remove local data through your browser's site-data settings. Clearing browser data, using private browsing, or changing devices may permanently remove progress that has not been synced."
+          ]
+        },
+        {
+          title: "2. Google sign-in and cross-device sync",
+          paragraphs: [
+            "Sign-in is optional and is handled by Google OAuth and Supabase Auth. When you sign in, Jabiko handles an account identifier and basic profile information provided by Google, such as your name and email address.",
+            "After sign-in, practice history is synced to Supabase. Synced records may include question and vocabulary IDs, prompts, expected answers, your submitted answer, correctness, timestamps, and response time. Public API access is restricted so each user can read or write only their own practice records."
+          ]
+        },
+        {
+          title: "3. Anonymous usage analytics",
+          paragraphs: [
+            "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used.",
+            "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."
+          ]
+        },
+        {
+          title: "4. Feedback and question reports",
+          paragraphs: [
+            "General feedback stores its category, message, whether you requested a reply, and any contact detail you enter. A question report also includes the question ID, prompt, expected answers, selected answer, level, and interface language so the issue can be located.",
+            "If you are signed in, Supabase records your account ID, email, and sign-in provider on the server. Those fields remain empty for anonymous submissions. Reports are not readable through the site's public API. Do not include unnecessary sensitive information in free-form fields."
+          ]
+        },
+        {
+          title: "5. External services",
+          items: [
+            "Cloudflare: site delivery, security, and optional Zaraz analytics.",
+            "Supabase: Google sign-in, sessions, practice sync, and feedback storage.",
+            "Google: authentication when you choose Google sign-in.",
+            "ECPay and other external links: third-party services apply after you choose to open them; payment details are not stored by the Jabiko frontend."
+          ]
+        },
+        {
+          title: "6. Retention, deletion, and contact",
+          paragraphs: [
+            "Local data remains until you clear the browser's site data. Remote practice records and feedback are kept while needed for sync, maintenance, replies, or issue tracking, or until you request deletion.",
+            "A complete self-service export and deletion screen is not yet available. To ask about or request deletion of account-linked data, sign in with the same account and use the site's Feedback form with the reply option selected. Do not post personal data in a public GitHub issue. Jabiko does not sell personal data."
+          ]
+        },
+        {
+          title: "7. Changes to this policy",
+          paragraphs: [
+            "When features or data handling change materially, this policy and its update date will be revised. Changes with a significant effect on users will be highlighted through an appropriate notice on the site."
+          ]
+        }
+      ]
+    },
+    terms: {
+      eyebrow: "Legal and privacy",
+      title: "Terms of Use",
+      intro:
+        "Jabiko is a free Japanese-learning aid. These terms explain the scope of the service, responsibility for learning content, and basic limits on use.",
+      updatedLabel: `Last updated: ${UPDATED_AT}`,
+      sections: [
+        {
+          title: "1. Nature of the service",
+          paragraphs: [
+            "Jabiko provides Japanese grammar, vocabulary, kanji, question-type practice, articles, and progress tools. It is not affiliated with the Japan Foundation, Japan Educational Exchanges and Services, or the official JLPT, and it does not guarantee exam results, passing, or error-free content."
+          ]
+        },
+        {
+          title: "2. Acceptable use",
+          items: [
+            "Do not disrupt the site or other users through automated excessive requests, attacks, attempts to bypass security controls, or similar conduct.",
+            "Do not use feedback fields to send unlawful, rights-infringing, malicious, or bulk spam content.",
+            "Use the report feature if a question or explanation appears wrong. Jabiko may correct, retain, or remove content at its discretion."
+          ]
+        },
+        {
+          title: "3. Source code, content, and brand",
+          paragraphs: [
+            "Source code being visible in a public repository does not grant permission to copy, modify, redistribute, or use it commercially. Unless a specific file carries a separate express licence, rights are reserved in Jabiko's code, original articles, question bank, name, mascot, and visual assets.",
+            "This does not add restrictions to the Japanese language itself, general facts, or material you may otherwise lawfully use. Third-party trade marks, work titles, and external material remain the property of their respective owners."
+          ]
+        },
+        {
+          title: "4. External services and support links",
+          paragraphs: [
+            "The site may link to services such as Google, ECPay, or GitHub. Each provider is responsible for its own content, transactions, privacy, and availability. Financial support is voluntary and does not purchase an exam result or guarantee permanent availability of any feature."
+          ]
+        },
+        {
+          title: "5. Changes and availability",
+          paragraphs: [
+            "Jabiko may add, change, suspend, or remove features and content. Maintenance, provider outages, or events outside our control may make the service temporarily unavailable. We work to keep the service and data safe, but do not guarantee uninterrupted service or permanent data retention. Keep any backup of learning records that is important to you."
+          ]
+        },
+        {
+          title: "6. Limitation of liability and contact",
+          paragraphs: [
+            "To the extent permitted by law, Jabiko is not responsible for indirect losses arising from use or inability to use the service, reliance on learning content, third-party services, or data loss. This does not exclude liability that cannot lawfully be excluded.",
+            "Use the site's Feedback form for questions about these terms, privacy, or content."
+          ]
+        }
+      ]
+    }
+  }
+} as const satisfies Record<"zh-Hant" | "ja" | "en", LegalPageCopy>;
+
+export function legalCopyFor(language: LocaleCode): LegalPageCopy {
+  if (language === "zh-Hant" || language === "ja" || language === "en") {
+    return LEGAL_COPY[language];
+  }
+  return LEGAL_COPY.en;
+}
+
+export function legalDocumentFor(language: LocaleCode, page: LegalPageKind): LegalDocument {
+  return legalCopyFor(language)[page];
+}

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -1,4 +1,5 @@
 import type { LocaleCode } from "./types";
+import { legalLabelsFor, type LegalPageLabels } from "./legalLabels";
 
 export type LegalPageKind = "privacy" | "terms";
 
@@ -16,27 +17,23 @@ export interface LegalDocument {
   sections: readonly LegalSection[];
 }
 
-export interface LegalPageCopy {
-  navigationLabel: string;
-  privacyLabel: string;
-  termsLabel: string;
+export interface LegalPageCopy extends LegalPageLabels {
   privacy: LegalDocument;
   terms: LegalDocument;
 }
 
-const UPDATED_AT = "2026-07-17";
+const PRIVACY_UPDATED_AT = "2026-07-18";
+const TERMS_UPDATED_AT = "2026-07-18";
 
 const LEGAL_COPY = {
   "zh-Hant": {
-    navigationLabel: "法律與隱私",
-    privacyLabel: "隱私政策",
-    termsLabel: "使用條款",
+    ...legalLabelsFor("zh-Hant"),
     privacy: {
       eyebrow: "法律與隱私",
       title: "隱私政策",
       intro:
         "Jabiko 以免註冊即可使用為原則。這份政策說明資料會留在哪裡、登入同步與回報功能會送出什麼，以及你可以如何處理自己的資料。",
-      updatedLabel: `最後更新：${UPDATED_AT}`,
+      updatedLabel: `最後更新：${PRIVACY_UPDATED_AT}`,
       sections: [
         {
           title: "1. 未登入時儲存在瀏覽器的資料",
@@ -49,7 +46,7 @@ const LEGAL_COPY = {
           title: "2. Google 登入與跨裝置同步",
           paragraphs: [
             "登入是選用功能，由 Google OAuth 與 Supabase Auth 處理。登入時，Jabiko 會取得帳號識別碼，以及 Google 提供的基本帳號資訊，例如名稱與電子郵件地址。",
-            "登入後，練習紀錄會同步到 Supabase。同步資料可能包含題目識別碼、題目提示、預期答案、你送出的答案、正誤、時間戳與作答時間，目的是讓進度可以在不同裝置合併與延續。每位使用者只能透過公開 API 讀取或寫入自己的練習紀錄。"
+            "登入後，練習紀錄會同步到 Supabase。同步資料可能包含題目識別碼、單字識別碼、作答目標形式、題目提示、預期答案、你送出的答案、正誤、時間戳與作答時間，目的是讓進度可以在不同裝置合併與延續。每位使用者只能透過公開 API 讀取或寫入自己的練習紀錄。"
           ]
         },
         {
@@ -62,7 +59,7 @@ const LEGAL_COPY = {
         {
           title: "4. 意見回饋與題目回報",
           paragraphs: [
-            "送出一般回饋時，會保存類別、訊息、是否希望回覆，以及你自行填寫的聯絡方式。題目回報還會包含題目 ID、提示、預期答案、你所選的答案、級別與介面語言，方便定位問題。",
+            "送出一般回饋時，會保存類別、訊息、是否希望回覆，以及你自行填寫的聯絡方式。題目回報還會包含回報原因、題目 ID、題型標籤、作答目標形式、級別、單字 ID、單字表記與讀音、題目提示、預期答案、你所選的答案、介面語言，以及你自行填寫的補充說明，方便定位問題。",
             "若你已登入，Supabase 會在伺服器端記錄帳號 ID、電子郵件與登入提供者；匿名使用者則不會有這些帳號欄位。回報資料不會透過網站公開讀取。請不要在自由輸入欄位提供不必要的敏感資料。"
           ]
         },
@@ -94,8 +91,8 @@ const LEGAL_COPY = {
       eyebrow: "法律與隱私",
       title: "使用條款",
       intro:
-        "使用 Jabiko 即表示你理解這是一項免費的日文學習輔助服務。以下條款用白話說明服務範圍、內容責任與使用限制。",
-      updatedLabel: `最後更新：${UPDATED_AT}`,
+        "Jabiko 是一項免費的日文學習輔助服務。以下條款用白話說明服務範圍、內容責任與使用限制。",
+      updatedLabel: `最後更新：${TERMS_UPDATED_AT}`,
       sections: [
         {
           title: "1. 服務性質",
@@ -121,7 +118,7 @@ const LEGAL_COPY = {
         {
           title: "4. 外部服務與贊助連結",
           paragraphs: [
-            "網站可能連到 Google、ECPay、GitHub 或其他第三方服務。第三方網站的內容、交易、隱私與可用性由該服務負責。贊助屬自願支持，不會購買考試結果或保證功能永久提供。"
+            "網站可能連到 Google、ECPay、GitHub 或其他第三方服務。第三方網站的內容、交易、隱私與可用性由該服務負責。贊助屬自願支持，並非購買考試成績，也不保證功能永久提供。"
           ]
         },
         {
@@ -141,15 +138,13 @@ const LEGAL_COPY = {
     }
   },
   ja: {
-    navigationLabel: "法的情報・プライバシー",
-    privacyLabel: "プライバシーポリシー",
-    termsLabel: "利用規約",
+    ...legalLabelsFor("ja"),
     privacy: {
       eyebrow: "法的情報・プライバシー",
       title: "プライバシーポリシー",
       intro:
         "Jabiko は、登録しなくても使えることを基本としています。本ポリシーでは、ブラウザ内に残る情報、ログイン同期やフィードバックで送信される情報、その管理方法を説明します。",
-      updatedLabel: `最終更新：${UPDATED_AT}`,
+      updatedLabel: `最終更新：${PRIVACY_UPDATED_AT}`,
       sections: [
         {
           title: "1. ログイン前にブラウザへ保存される情報",
@@ -162,20 +157,20 @@ const LEGAL_COPY = {
           title: "2. Google ログインと端末間同期",
           paragraphs: [
             "ログインは任意で、Google OAuth と Supabase Auth を利用します。ログイン時にはアカウント識別子と、Google が提供する氏名・メールアドレスなどの基本情報を扱います。",
-            "ログイン後の練習履歴は Supabase に同期されます。同期情報には問題 ID、問題文、想定解、送信した回答、正誤、日時、回答時間が含まれる場合があります。公開 API では、各利用者は自分の履歴だけを読み書きできます。"
+            "ログイン後の練習履歴は Supabase に同期されます。同期情報には問題 ID、語彙 ID、解答対象の形式、問題の提示文、想定解、送信した回答、正誤、日時、回答時間が含まれる場合があります。公開 API では、各利用者は自分の履歴だけを読み書きできます。"
           ]
         },
         {
           title: "3. 匿名の利用状況分析",
           paragraphs: [
             "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。",
-            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、検索文字列、自由入力文を含めません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
+            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
           ]
         },
         {
           title: "4. フィードバックと問題報告",
           paragraphs: [
-            "一般のフィードバックでは、種別、本文、返信希望の有無、任意で入力した連絡先を保存します。問題報告には、問題 ID、問題文、想定解、選択した回答、レベル、表示言語も含まれます。",
+            "一般のフィードバックでは、種別、本文、返信希望の有無、任意で入力した連絡先を保存します。問題報告には、報告理由、問題 ID、問題形式のラベル、解答対象の形式、レベル、語彙 ID、表記と読み、問題の提示文、想定解、選択した回答、表示言語、任意の補足説明も含まれます。",
             "ログイン中は、Supabase がサーバー側でアカウント ID、メールアドレス、ログイン事業者を記録します。匿名時はこれらの欄は空です。報告内容はサイトの公開 API から閲覧できません。不要な機微情報は入力しないでください。"
           ]
         },
@@ -208,19 +203,19 @@ const LEGAL_COPY = {
       title: "利用規約",
       intro:
         "Jabiko は無料の日本語学習補助サービスです。以下では、サービスの範囲、コンテンツに関する責任、利用上の制限を簡潔に説明します。",
-      updatedLabel: `最終更新：${UPDATED_AT}`,
+      updatedLabel: `最終更新：${TERMS_UPDATED_AT}`,
       sections: [
         {
           title: "1. サービスの性質",
           paragraphs: [
-            "Jabiko は文法、語彙、漢字、問題形式の練習、記事、学習進捗ツールを提供します。国際交流基金、国際教育支援協会、JLPT 公式とは関係がなく、試験結果や合格、内容の完全な正確性を保証しません。"
+            "Jabiko は文法、語彙、漢字、問題形式の練習、記事、学習進捗ツールを提供します。国際交流基金、日本国際教育支援協会、JLPT 公式とは関係がなく、試験結果や合格、内容の完全な正確性を保証しません。"
           ]
         },
         {
           title: "2. 適切な利用",
           items: [
             "自動化された過剰なリクエスト、攻撃、安全対策の回避など、サイトや他の利用者を妨害する行為は禁止します。",
-            "フィードバック欄を使って、違法な内容、権利侵害、悪意ある内容、大量の迷惑投稿を送信してはいけません。",
+            "フィードバック欄を使って、違法な内容、権利侵害、悪意ある内容、大量の迷惑投稿を送信しないでください。",
             "問題や解説の誤りは報告機能からお知らせください。Jabiko は判断により内容を修正、維持、削除できます。"
           ]
         },
@@ -240,29 +235,27 @@ const LEGAL_COPY = {
         {
           title: "5. 変更と可用性",
           paragraphs: [
-            "機能やコンテンツを追加、変更、停止、削除する場合があります。保守、外部事業者の障害、その他管理できない事情により一時的に利用できないこともあります。安全と継続に努めますが、無停止やデータの完全な保持は保証しません。必要な学習記録は利用者自身でも保管してください。"
+            "機能やコンテンツを追加、変更、停止、削除する場合があります。保守、外部事業者の障害、その他管理できない事情により一時的に利用できないこともあります。安全と継続に努めますが、中断なく利用できることやデータの完全な保持は保証しません。必要な学習記録は利用者自身でも保管してください。"
           ]
         },
         {
           title: "6. 責任の制限と問い合わせ",
           paragraphs: [
             "法令で認められる範囲で、本サービスの利用・利用不能、学習内容への依存、第三者サービス、データ消失から生じた間接損害について責任を負いません。法令上排除できない責任を除外するものではありません。",
-            "規約、プライバシー、コンテンツに関する質問は、サイトの「フィードバック」からお送りください。"
+            "規約、プライバシー、コンテンツに関する質問は、サイトの「ご意見・ご感想」からお送りください。"
           ]
         }
       ]
     }
   },
   en: {
-    navigationLabel: "Legal and privacy",
-    privacyLabel: "Privacy Policy",
-    termsLabel: "Terms of Use",
+    ...legalLabelsFor("en"),
     privacy: {
       eyebrow: "Legal and privacy",
       title: "Privacy Policy",
       intro:
         "Jabiko is designed to work without registration. This policy explains what stays in your browser, what is sent when you use sign-in, sync, analytics, or feedback, and how you can manage that data.",
-      updatedLabel: `Last updated: ${UPDATED_AT}`,
+      updatedLabel: `Last updated: ${PRIVACY_UPDATED_AT}`,
       sections: [
         {
           title: "1. Data stored in your browser before sign-in",
@@ -275,7 +268,7 @@ const LEGAL_COPY = {
           title: "2. Google sign-in and cross-device sync",
           paragraphs: [
             "Sign-in is optional and is handled by Google OAuth and Supabase Auth. When you sign in, Jabiko handles an account identifier and basic profile information provided by Google, such as your name and email address.",
-            "After sign-in, practice history is synced to Supabase. Synced records may include question and vocabulary IDs, prompts, expected answers, your submitted answer, correctness, timestamps, and response time. Public API access is restricted so each user can read or write only their own practice records."
+            "After sign-in, practice history is synced to Supabase. Synced records may include question and vocabulary IDs, target forms, prompts, expected answers, your submitted answer, correctness, timestamps, and response time. Public API access is restricted so each user can read or write only their own practice records."
           ]
         },
         {
@@ -288,7 +281,7 @@ const LEGAL_COPY = {
         {
           title: "4. Feedback and question reports",
           paragraphs: [
-            "General feedback stores its category, message, whether you requested a reply, and any contact detail you enter. A question report also includes the question ID, prompt, expected answers, selected answer, level, and interface language so the issue can be located.",
+            "General feedback stores its category, message, whether you requested a reply, and any contact detail you enter. A question report also includes its reason, question ID, question-type label, target form, level, vocabulary ID, surface form and reading, prompt, expected answers, selected answer, interface language, and any optional detail you provide so the issue can be located.",
             "If you are signed in, Supabase records your account ID, email, and sign-in provider on the server. Those fields remain empty for anonymous submissions. Reports are not readable through the site's public API. Do not include unnecessary sensitive information in free-form fields."
           ]
         },
@@ -321,7 +314,7 @@ const LEGAL_COPY = {
       title: "Terms of Use",
       intro:
         "Jabiko is a free Japanese-learning aid. These terms explain the scope of the service, responsibility for learning content, and basic limits on use.",
-      updatedLabel: `Last updated: ${UPDATED_AT}`,
+      updatedLabel: `Last updated: ${TERMS_UPDATED_AT}`,
       sections: [
         {
           title: "1. Nature of the service",
@@ -340,8 +333,8 @@ const LEGAL_COPY = {
         {
           title: "3. Source code, content, and brand",
           paragraphs: [
-            "Source code being visible in a public repository does not grant permission to copy, modify, redistribute, or use it commercially. Unless a specific file carries a separate express licence, rights are reserved in Jabiko's code, original articles, question bank, name, mascot, and visual assets.",
-            "This does not add restrictions to the Japanese language itself, general facts, or material you may otherwise lawfully use. Third-party trade marks, work titles, and external material remain the property of their respective owners."
+            "Source code being visible in a public repository does not grant permission to copy, modify, redistribute, or use it commercially. Unless a specific file carries a separate express license, rights are reserved in Jabiko's code, original articles, question bank, name, mascot, and visual assets.",
+            "This does not add restrictions to the Japanese language itself, general facts, or material you may otherwise lawfully use. Third-party trademarks, work titles, and external material remain the property of their respective owners."
           ]
         },
         {

--- a/src/domain/legalLabels.ts
+++ b/src/domain/legalLabels.ts
@@ -1,0 +1,32 @@
+import type { LocaleCode } from "./types";
+
+export interface LegalPageLabels {
+  navigationLabel: string;
+  privacyLabel: string;
+  termsLabel: string;
+}
+
+const LEGAL_LABELS = {
+  "zh-Hant": {
+    navigationLabel: "法律與隱私",
+    privacyLabel: "隱私政策",
+    termsLabel: "使用條款"
+  },
+  ja: {
+    navigationLabel: "法的情報・プライバシー",
+    privacyLabel: "プライバシーポリシー",
+    termsLabel: "利用規約"
+  },
+  en: {
+    navigationLabel: "Legal and privacy",
+    privacyLabel: "Privacy Policy",
+    termsLabel: "Terms of Use"
+  }
+} as const satisfies Record<"zh-Hant" | "ja" | "en", LegalPageLabels>;
+
+export function legalLabelsFor(language: LocaleCode): LegalPageLabels {
+  if (language === "zh-Hant" || language === "ja" || language === "en") {
+    return LEGAL_LABELS[language];
+  }
+  return LEGAL_LABELS.en;
+}

--- a/src/domain/prerender/staticPages.test.ts
+++ b/src/domain/prerender/staticPages.test.ts
@@ -92,11 +92,23 @@ describe("buildStaticPages", () => {
       "/challenge",
       "/mock",
       "/about",
+      "/privacy",
+      "/terms",
       "/grammar",
       "/blog"
     ]) {
       expect(byPath.has(route), route).toBe(true);
     }
+  });
+
+  it("prerenders the full legal documents", () => {
+    const privacy = byPath.get("/privacy");
+    const terms = byPath.get("/terms");
+
+    expect(privacy?.bodyHtml).toContain("Google 登入與跨裝置同步");
+    expect(privacy?.bodyHtml).toContain("匿名使用分析");
+    expect(terms?.bodyHtml).toContain("程式碼、內容與品牌");
+    expect(terms?.bodyHtml).toContain("不代表已授權");
   });
 
   // #619: /kana is an SEO reference page -- the prerendered body must carry

--- a/src/domain/prerender/staticPages.ts
+++ b/src/domain/prerender/staticPages.ts
@@ -18,6 +18,7 @@ import { publishedArticleMetas } from "../articlesMeta";
 import { publishedArticles, type ArticleBlock } from "../articles";
 import { KANA_TABLE, type KanaGroup, type KanaScript } from "../kana";
 import type { JlptLevel } from "../types";
+import { legalDocumentFor, type LegalPageKind } from "../legalContent";
 
 export interface StaticPage {
   /** Decoded URL path, e.g. "/grammar/〜てもいい". */
@@ -95,7 +96,9 @@ const NAV_LINKS: ReadonlyArray<{ href: string; label: string }> = [
   { href: "/blog", label: "文章" },
   { href: "/challenge", label: "題庫練習" },
   { href: "/mock", label: "題型練習" },
-  { href: "/about", label: "關於" }
+  { href: "/about", label: "關於" },
+  { href: "/privacy", label: "隱私政策" },
+  { href: "/terms", label: "使用條款" }
 ];
 
 const LEVELS: JlptLevel[] = ["N5", "N4", "N3", "N2", "N1"];
@@ -269,6 +272,23 @@ function simpleViewBody(view: AppView): string {
   return wrap(entry.title.split(" · ")[0], `${paragraph(entry.description)}<p><a href="/">回 Jabiko 首頁</a></p>`);
 }
 
+function legalPageBody(page: LegalPageKind): string {
+  const document = legalDocumentFor("zh-Hant", page);
+  const sections = document.sections
+    .map((section) => {
+      const paragraphs = section.paragraphs?.map(paragraph).join("") ?? "";
+      const items = section.items
+        ? `<ul>${section.items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`
+        : "";
+      return `<section><h2>${escapeHtml(section.title)}</h2>${paragraphs}${items}</section>`;
+    })
+    .join("");
+  return wrap(
+    document.title,
+    `${paragraph(document.intro)}${paragraph(document.updatedLabel)}${sections}`
+  );
+}
+
 // ---------------------------------------------------------------------------
 
 export function buildStaticPages(): StaticPage[] {
@@ -283,6 +303,9 @@ export function buildStaticPages(): StaticPage[] {
   push("home", "/", homeBody());
   for (const view of ["learn", "rules", "kanji", "challenge", "mock", "about"] as const) {
     push(view, VIEW_SEO[view].path, simpleViewBody(view));
+  }
+  for (const view of ["privacy", "terms"] as const) {
+    push(view, VIEW_SEO[view].path, legalPageBody(view));
   }
   push("kana", "/kana", kanaBody());
   push("grammar", "/grammar", grammarIndexBody());

--- a/src/domain/routes.ts
+++ b/src/domain/routes.ts
@@ -11,6 +11,8 @@ export const APP_VIEW_PATHS = {
   challenge: "/challenge",
   mock: "/mock",
   about: "/about",
+  privacy: "/privacy",
+  terms: "/terms",
   grammar: "/grammar",
   blog: "/blog"
 } as const;

--- a/src/domain/seo.test.ts
+++ b/src/domain/seo.test.ts
@@ -14,6 +14,8 @@ const VIEWS: Exclude<AppView, "grammar">[] = [
   "challenge",
   "mock",
   "about",
+  "privacy",
+  "terms",
   "blog"
 ];
 

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -24,7 +24,7 @@ export const VIEW_SEO: Record<AppView, PageSeo> = {
   home: {
     title: "Jabiko · JLPT 日檢自習室｜N5–N1 文法單字題型練習",
     description:
-      "免費、免註冊、開源的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型分區練習，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
+      "免費、免註冊的 JLPT 日檢自習室：N5〜N1 文法、漢字、單字與依官方題型分區練習，答錯自動排進間隔重複複習，支援跨裝置同步，打開就能練、免安裝。",
     path: APP_VIEW_PATHS.home
   },
   learn: {
@@ -66,8 +66,20 @@ export const VIEW_SEO: Record<AppView, PageSeo> = {
   about: {
     title: "關於 Jabiko · JLPT 自習室",
     description:
-      "Jabiko 的名字由來與作者介紹——一個免費、開源、和朋友一起做的 JLPT 自習網站。",
+      "Jabiko 的名字由來與作者介紹——一個免費、和朋友一起做的 JLPT 自習網站。",
     path: APP_VIEW_PATHS.about
+  },
+  privacy: {
+    title: "隱私政策｜Jabiko",
+    description:
+      "了解 Jabiko 在瀏覽器、Google 登入、跨裝置同步、匿名使用分析與回報功能中如何處理資料。",
+    path: APP_VIEW_PATHS.privacy
+  },
+  terms: {
+    title: "使用條款｜Jabiko",
+    description:
+      "Jabiko 的服務範圍、合理使用規則、內容責任、程式碼與原創內容權利，以及外部服務說明。",
+    path: APP_VIEW_PATHS.terms
   },
   grammar: {
     title: "JLPT 文型資料庫 · 日檢文法索引 · Jabiko",

--- a/src/domain/sitemap.test.ts
+++ b/src/domain/sitemap.test.ts
@@ -40,7 +40,7 @@ describe("sitemap.xml drift guard (#479 / #483)", () => {
   });
 
   it("includes the core static routes + the grammar index + the blog index", () => {
-    for (const route of ["/", "/learn", "/challenge", "/mock", "/kanji", "/kana", "/rules", "/grammar", "/about", "/blog"]) {
+    for (const route of ["/", "/learn", "/challenge", "/mock", "/kanji", "/kana", "/rules", "/grammar", "/about", "/privacy", "/terms", "/blog"]) {
       expect(sitemapXml).toContain(`<loc>https://jabiko.app${route}</loc>`);
     }
   });
@@ -89,7 +89,7 @@ describe("sitemap grammar level hubs and lastmod (#584-B)", () => {
   });
 
   it("omits lastmod for static routes that have no reliable content date", () => {
-    for (const route of ["/", "/learn", "/challenge", "/mock", "/kanji", "/kana", "/rules", "/grammar", "/about"]) {
+    for (const route of ["/", "/learn", "/challenge", "/mock", "/kanji", "/kana", "/rules", "/grammar", "/about", "/privacy", "/terms"]) {
       const block = urlBlockFor(`https://jabiko.app${route}`);
       expect(block, route).toBeDefined();
       expect(block!, `${route} should not contain <lastmod>`).not.toContain("<lastmod>");

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,5 +12,6 @@
 @import "./styles/rules.css";
 @import "./styles/mock.css";
 @import "./styles/about.css";
+@import "./styles/legal.css";
 @import "./styles/blog.css";
 @import "./styles/responsive.css";

--- a/src/styles/legal.css
+++ b/src/styles/legal.css
@@ -38,7 +38,7 @@
   background: var(--paper);
 }
 
-.legal-section h2 {
+.legal-section h3 {
   margin: 0 0 0.55rem;
   color: var(--ink);
   font-size: 1.05rem;

--- a/src/styles/legal.css
+++ b/src/styles/legal.css
@@ -1,0 +1,93 @@
+.legal-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.legal-hero {
+  padding: 0.6rem 0 0.25rem;
+  text-align: center;
+}
+
+.legal-hero h2 {
+  margin: 0.35rem 0 0;
+  color: var(--ink);
+  font-size: 1.6rem;
+}
+
+.legal-intro {
+  max-width: 660px;
+  margin: 0.65rem auto 0;
+  color: var(--ink);
+  line-height: 1.8;
+}
+
+.legal-updated {
+  margin: 0.55rem 0 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.legal-section {
+  padding: 1.1rem 1.2rem;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  background: var(--paper);
+}
+
+.legal-section h2 {
+  margin: 0 0 0.55rem;
+  color: var(--ink);
+  font-size: 1.05rem;
+}
+
+.legal-section p,
+.legal-section li {
+  color: var(--ink);
+  font-size: 0.95rem;
+  line-height: 1.85;
+}
+
+.legal-section p {
+  margin: 0;
+}
+
+.legal-section p + p {
+  margin-top: 0.65rem;
+}
+
+.legal-section ul {
+  margin: 0;
+  padding-left: 1.35rem;
+}
+
+.legal-section li + li {
+  margin-top: 0.4rem;
+}
+
+.legal-links {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.legal-links a {
+  color: var(--teal);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.legal-links a:hover,
+.legal-links a[aria-current="page"] {
+  text-decoration: underline;
+}
+
+.home-footer .legal-links {
+  margin-top: 0.35rem;
+}


### PR DESCRIPTION
## Summary

- add localized Privacy Policy and Terms of Use pages at `/privacy` and `/terms`
- document the actual local storage, optional Google/Supabase sync, analytics, feedback, and deletion behavior
- link both pages from the home and about footers, and include them in SEO, prerendering, and the sitemap
- remove public-facing claims that Jabiko is open source and clarify that source visibility is not a reuse licence

## Product decision

This intentionally does **not** add an open-source `LICENSE`. Jabiko may change repository visibility later, so the site and README now reserve rights unless a specific file expressly says otherwise.

## Verification

- 1009 tests passed across 98 test files
- targeted legal/routing/SEO/prerender tests: 94 passed
- TypeScript typecheck passed
- production build passed
- prerender generated 105 static pages, including `/privacy` and `/terms`

Closes #457


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized Privacy Policy and Terms of Use pages in Traditional Chinese, Japanese, and English.
  * Added legal-page links to the home and About pages.
  * Added SEO metadata, sitemap entries, and crawler-visible content for both pages.
* **Documentation**
  * Updated project workflow, status, ownership, privacy, and terms information.
  * Refined analytics documentation and app descriptions to remove open-source wording.
* **Bug Fixes**
  * Improved legal-page navigation, localization, accessibility, and active-link indication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->