### PR TITLE
fix: question-report format rework + contact field for replies

### DIFF
--- a/src/components/QuestionReportForm.test.tsx
+++ b/src/components/QuestionReportForm.test.tsx
@@ -63,6 +63,35 @@ describe("QuestionReportForm", () => {
     expect(arg.message).toContain("題目回報");
   });
 
+  // 2026-07 report-UX fix: the reply checkbox used to point anonymous users at
+  // a contact field that only existed on the general feedback form. Ticking
+  // 希望收到回信 now reveals the same optional contact input here.
+  it("reveals a contact input when the reply checkbox is ticked, and submits it", async () => {
+    const submit = vi.fn().mockResolvedValue(undefined);
+    renderForm({ submit });
+
+    expect(screen.queryByPlaceholderText(/聯絡方式/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("checkbox", { name: "希望收到回信" }));
+    const contact = screen.getByPlaceholderText(/聯絡方式/);
+    fireEvent.change(contact, { target: { value: "hana@example.com" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "送出回報" }));
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    const arg = submit.mock.calls[0][0];
+    expect(arg.wantsReply).toBe(true);
+    expect(arg.contact).toBe("hana@example.com");
+    // Contact rides the dedicated column, never the message text.
+    expect(arg.message).not.toContain("hana@example.com");
+  });
+
+  it("omits contact when the reply checkbox stays unticked", async () => {
+    const submit = vi.fn().mockResolvedValue(undefined);
+    renderForm({ submit });
+    fireEvent.click(screen.getByRole("button", { name: "送出回報" }));
+    await waitFor(() => expect(submit).toHaveBeenCalled());
+    expect(submit.mock.calls[0][0].contact).toBeUndefined();
+  });
+
   it("sends wantsReply=true when the reply checkbox is ticked (#468)", async () => {
     const submit = vi.fn().mockResolvedValue(undefined);
     renderForm({ submit });

--- a/src/components/QuestionReportForm.tsx
+++ b/src/components/QuestionReportForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type FormEvent } from "react";
 import { Send, X } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { getSupabase } from "../lib/supabase";
-import { submitFeedback, FEEDBACK_MAX, type FeedbackInput } from "../domain/feedbackRemote";
+import { submitFeedback, FEEDBACK_MAX, CONTACT_MAX, type FeedbackInput } from "../domain/feedbackRemote";
 import { buildQuestionReportMessage, type ReportReason } from "../domain/questionReport";
 import type { PracticeQuestion } from "../domain/types";
 
@@ -50,6 +50,7 @@ export function QuestionReportForm({
   const [reason, setReason] = useState<ReportReason>("wrongAnswer");
   const [detail, setDetail] = useState("");
   const [wantsReply, setWantsReply] = useState(false);
+  const [contact, setContact] = useState("");
   const [status, setStatus] = useState<Status>("idle");
 
   // buildQuestionReportMessage prepends the structured question block (plus a
@@ -99,7 +100,14 @@ export function QuestionReportForm({
         language,
         selectedAnswer
       });
-      await submit({ category: "bug", message, wantsReply });
+      // Contact rides the dedicated feedback column (never the message text),
+      // and only when a reply was actually requested.
+      await submit({
+        category: "bug",
+        message,
+        wantsReply,
+        contact: wantsReply ? contact.trim() || undefined : undefined
+      });
       setStatus("done");
     } catch {
       setStatus("error");
@@ -182,7 +190,22 @@ export function QuestionReportForm({
           />
           {t.feedbackWantsReply}
         </label>
-        {wantsReply ? <p className="feedback-reply-hint">{t.feedbackWantsReplyHint}</p> : null}
+        {wantsReply ? (
+          <>
+            <p className="feedback-reply-hint">{t.feedbackWantsReplyHint}</p>
+            {/* 2026-07 fix: the hint told anonymous users to leave a contact
+                "below", but this form never had the field -- only the general
+                FeedbackForm did. Same input, same dedicated column. */}
+            <input
+              className="feedback-contact"
+              type="text"
+              value={contact}
+              onChange={(event) => setContact(event.target.value)}
+              placeholder={t.feedbackContact}
+              maxLength={CONTACT_MAX}
+            />
+          </>
+        ) : null}
         <p className="feedback-anon">{t.feedbackAnon}</p>
 
         {status === "error" ? (

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -30,23 +30,29 @@ describe("legal content", () => {
         .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
         .join("\n");
 
+    // 2026-07 report rework: the packed report no longer carries vocab id /
+    // reading (derivable from the question id), and the reply checkbox now
+    // stores a contact detail -- the disclosures track that in all languages.
     const zh = disclosureText("zh-Hant");
     expect(zh).toContain("單字識別碼");
     expect(zh).toContain("作答目標形式");
     expect(zh).toContain("題型標籤");
-    expect(zh).toContain("單字表記與讀音");
+    expect(zh).toContain("單字表記");
+    expect(zh).toContain("若勾選希望回覆，也會保存你填寫的聯絡方式");
 
     const ja = disclosureText("ja");
     expect(ja).toContain("語彙 ID");
     expect(ja).toContain("解答対象の形式");
     expect(ja).toContain("問題形式のラベル");
-    expect(ja).toContain("表記と読み");
+    expect(ja).toContain("語彙の表記");
+    expect(ja).toContain("返信を希望した場合は、入力した連絡先も保存されます");
 
     const en = disclosureText("en");
     expect(en).toContain("vocabulary IDs");
     expect(en).toContain("target forms");
     expect(en).toContain("question-type label");
-    expect(en).toContain("surface form and reading");
+    expect(en).toContain("surface form");
+    expect(en).toContain("if you request a reply, the contact detail you enter is stored as well");
   });
 
   it("does not claim that public source code is open source", () => {

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -59,7 +59,7 @@ const LEGAL_COPY = {
         {
           title: "4. 意見回饋與題目回報",
           paragraphs: [
-            "送出一般回饋時，會保存類別、訊息、是否希望回覆，以及你自行填寫的聯絡方式。題目回報還會包含回報原因、題目 ID、題型標籤、作答目標形式、級別、單字 ID、單字表記與讀音、題目提示、預期答案、你所選的答案、介面語言，以及你自行填寫的補充說明，方便定位問題。",
+            "送出一般回饋時，會保存類別、訊息、是否希望回覆，以及你自行填寫的聯絡方式。題目回報還會包含回報原因、題目 ID、題型標籤、作答目標形式、級別、單字表記、題目提示、預期答案、你所選的答案、介面語言，以及你自行填寫的補充說明，方便定位問題；若勾選希望回覆，也會保存你填寫的聯絡方式。",
             "若你已登入，Supabase 會在伺服器端記錄帳號 ID、電子郵件與登入提供者；匿名使用者則不會有這些帳號欄位。回報資料不會透過網站公開讀取。請不要在自由輸入欄位提供不必要的敏感資料。"
           ]
         },
@@ -170,7 +170,7 @@ const LEGAL_COPY = {
         {
           title: "4. フィードバックと問題報告",
           paragraphs: [
-            "一般のフィードバックでは、種別、本文、返信希望の有無、任意で入力した連絡先を保存します。問題報告には、報告理由、問題 ID、問題形式のラベル、解答対象の形式、レベル、語彙 ID、表記と読み、問題の提示文、想定解、選択した回答、表示言語、任意の補足説明も含まれます。",
+            "一般のフィードバックでは、種別、本文、返信希望の有無、任意で入力した連絡先を保存します。問題報告には、報告理由、問題 ID、問題形式のラベル、解答対象の形式、レベル、語彙の表記、問題の提示文、想定解、選択した回答、表示言語、任意の補足説明も含まれます。返信を希望した場合は、入力した連絡先も保存されます。",
             "ログイン中は、Supabase がサーバー側でアカウント ID、メールアドレス、ログイン事業者を記録します。匿名時はこれらの欄は空です。報告内容はサイトの公開 API から閲覧できません。不要な機微情報は入力しないでください。"
           ]
         },
@@ -281,7 +281,7 @@ const LEGAL_COPY = {
         {
           title: "4. Feedback and question reports",
           paragraphs: [
-            "General feedback stores its category, message, whether you requested a reply, and any contact detail you enter. A question report also includes its reason, question ID, question-type label, target form, level, vocabulary ID, surface form and reading, prompt, expected answers, selected answer, interface language, and any optional detail you provide so the issue can be located.",
+            "General feedback stores its category, message, whether you requested a reply, and any contact detail you enter. A question report also includes its reason, question ID, question-type label, target form, level, surface form, prompt, expected answers, selected answer, interface language, and any optional detail you provide so the issue can be located; if you request a reply, the contact detail you enter is stored as well.",
             "If you are signed in, Supabase records your account ID, email, and sign-in provider on the server. Those fields remain empty for anonymous submissions. Reports are not readable through the site's public API. Do not include unnecessary sensitive information in free-form fields."
           ]
         },

--- a/src/domain/questionReport.test.ts
+++ b/src/domain/questionReport.test.ts
@@ -25,8 +25,12 @@ const baseQuestion: PracticeQuestion = {
   promptText: "この仕事は面倒だ。"
 };
 
+// 2026-07 report-format rework: the reviewer reads (1) which question,
+// (2) what the learner picked and why they reported, (3) the learner's own
+// words -- so those lead the message. Everything derivable from the question
+// id is compressed into a context block below a `---` separator.
 describe("buildQuestionReportMessage", () => {
-  it("packs every metadata field into a human-readable message", () => {
+  it("leads with the id, the essentials line, then the learner's detail", () => {
     const message = buildQuestionReportMessage({
       question: baseQuestion,
       reason: "wrongAnswer",
@@ -34,90 +38,96 @@ describe("buildQuestionReportMessage", () => {
       language: "zh-Hant",
       selectedAnswer: "めいわく"
     });
+    const lines = message.split("\n");
 
-    // A clear header marking this as a question report.
-    expect(message).toContain("題目回報");
-    expect(message).toContain("question report");
-    // Reason key.
-    expect(message).toContain("wrongAnswer");
-    // Question identity + type + level.
-    expect(message).toContain("q-demo-001");
-    // promptLabel AND targetForm are emitted separately, not collapsed into one.
-    expect(message).toContain("漢字読み"); // promptLabel
-    expect(message).toContain("reading"); // targetForm (kept even when promptLabel exists)
-    expect(message).toContain("N2");
-    expect(message).toContain("面倒"); // surface
-    // Extra vocabulary identity: id + reading.
-    expect(message).toContain("v-demo"); // vocabulary id
-    expect(message).toContain("めんどう"); // vocabulary reading
-    expect(message).toContain("この仕事は面倒だ。"); // promptText
-    // Both expected answers joined.
-    expect(message).toContain("めんどう");
-    expect(message).toContain("めんどうな");
-    // The learner's pick.
-    expect(message).toContain("めいわく");
-    // UI language.
-    expect(message).toContain("zh-Hant");
-    // Free-text detail.
-    expect(message).toContain("正解が二つあるはず");
+    expect(lines[0]).toBe("[題目回報 / question report] q-demo-001");
+    expect(lines[1]).toBe("reason: wrongAnswer · selected: めいわく · ui: zh-Hant");
+    expect(lines[2]).toBe("detail: 正解が二つあるはず");
+    // The learner's words sit ABOVE the derived context.
+    expect(message.indexOf("detail:")).toBeLessThan(message.indexOf("---"));
   });
 
-  it("emits promptLabel and targetForm on separate labelled lines", () => {
+  it("compresses the derived question data into the context block", () => {
     const message = buildQuestionReportMessage({
       question: baseQuestion,
       reason: "wrongAnswer",
       language: "zh-Hant"
     });
     const lines = message.split("\n");
-    expect(lines).toContain("promptLabel: 漢字読み");
-    expect(lines).toContain("targetForm: reading");
-    // Vocabulary identity is its own structured pair, not folded into surface.
-    expect(lines).toContain("vocabId: v-demo");
-    expect(lines).toContain("reading: めんどう");
+
+    expect(lines).toContain("---");
+    expect(lines).toContain("context: 漢字読み · reading · N2 · 面倒");
+    expect(lines).toContain("expected: めんどう / めんどうな");
+    expect(lines).toContain("prompt: この仕事は面倒だ。");
+    // The old one-line-per-field block is gone (all derivable from the id).
+    expect(message).not.toContain("vocabId:");
+    expect(message).not.toContain("promptLabel:");
+    expect(message).not.toContain("targetForm:");
+    expect(message).not.toContain("surface:");
   });
 
-  it("shows a dash for an absent promptLabel but still emits targetForm", () => {
+  it("renders dashes for missing values and never the word undefined", () => {
     const { promptLabel, ...rest } = baseQuestion;
     void promptLabel;
-    const message = buildQuestionReportMessage({
-      question: rest as PracticeQuestion,
-      reason: "typo",
-      language: "zh-Hant"
-    });
-    const lines = message.split("\n");
-    expect(lines).toContain("promptLabel: -"); // missing -> dash, never "undefined"
-    expect(lines).toContain("targetForm: reading"); // targetForm always present
-    expect(message).not.toContain("undefined");
-  });
-
-  it("renders placeholders for missing optional promptText / level / selectedAnswer", () => {
     const question: PracticeQuestion = {
-      ...baseQuestion,
+      ...(rest as PracticeQuestion),
       promptText: undefined,
       vocabulary: { ...baseQuestion.vocabulary, level: undefined }
     };
     const message = buildQuestionReportMessage({
       question,
-      reason: "other",
+      reason: "typo",
       language: "zh-Hant",
       selectedAnswer: null
     });
-    // Should not blow up and should still mention the surface + id.
-    expect(message).toContain("q-demo-001");
-    expect(message).toContain("面倒");
-    // Missing fields rendered as a dash placeholder, never "undefined".
+    const lines = message.split("\n");
+
+    expect(lines[1]).toBe("reason: typo · selected: - · ui: zh-Hant");
+    expect(lines).toContain("context: - · reading · - · 面倒");
+    // No promptText -> the prompt line is omitted entirely.
+    expect(message).not.toContain("prompt:");
     expect(message).not.toContain("undefined");
-    expect(message).toContain("-");
   });
 
-  it("omits the detail section gracefully when no detail is given", () => {
+  it("omits the detail line when the learner wrote nothing", () => {
     const message = buildQuestionReportMessage({
       question: baseQuestion,
       reason: "awkwardMeaning",
       language: "zh-Hant"
     });
-    expect(message).not.toContain("undefined");
+    expect(message).not.toContain("detail:");
     expect(message).toContain("awkwardMeaning");
+  });
+
+  it("trims an over-long prompt inside the context block", () => {
+    const question: PracticeQuestion = {
+      ...baseQuestion,
+      promptText: "あ".repeat(500)
+    };
+    const message = buildQuestionReportMessage({
+      question,
+      reason: "other",
+      language: "zh-Hant"
+    });
+    const promptLine = message.split("\n").find((line) => line.startsWith("prompt:"));
+    expect(promptLine).toBeDefined();
+    expect(promptLine!.length).toBeLessThanOrEqual("prompt: ".length + 161);
+    expect(promptLine).toContain("…");
+  });
+
+  it("caps at FEEDBACK_MAX with the essentials AND context surviving a huge detail", () => {
+    const message = buildQuestionReportMessage({
+      question: baseQuestion,
+      reason: "other",
+      detail: "あ".repeat(FEEDBACK_MAX * 2),
+      language: "zh-Hant"
+    });
+    expect(message.length).toBeLessThanOrEqual(FEEDBACK_MAX);
+    // Essentials + context are reserved first; only the detail is trimmed.
+    expect(message).toContain("q-demo-001");
+    expect(message).toContain("context: 漢字読み · reading · N2 · 面倒");
+    expect(message).toContain("expected: めんどう / めんどうな");
+    expect(message).toContain("detail: ");
   });
 
   it("is deterministic for identical input", () => {
@@ -129,21 +139,5 @@ describe("buildQuestionReportMessage", () => {
       selectedAnswer: "めんどう"
     };
     expect(buildQuestionReportMessage(input)).toBe(buildQuestionReportMessage(input));
-  });
-
-  it("caps the message at FEEDBACK_MAX even with an over-long detail", () => {
-    const message = buildQuestionReportMessage({
-      question: baseQuestion,
-      reason: "other",
-      detail: "あ".repeat(FEEDBACK_MAX * 2),
-      language: "zh-Hant"
-    });
-    expect(message.length).toBeLessThanOrEqual(FEEDBACK_MAX);
-    // The full structured metadata block survives the cap (only detail trims).
-    expect(message).toContain("q-demo-001");
-    expect(message).toContain("v-demo"); // vocab id
-    expect(message).toContain("めんどう"); // vocab reading
-    expect(message).toContain("漢字読み"); // promptLabel
-    expect(message).toContain("reading"); // targetForm
   });
 });

--- a/src/domain/questionReport.ts
+++ b/src/domain/questionReport.ts
@@ -32,47 +32,48 @@ function orDash(value: string | null | undefined): string {
   return trimmed ? trimmed : DASH;
 }
 
+// The prompt is convenience context; long 短文/読解 stems get trimmed so the
+// report stays scannable in a table row.
+const PROMPT_TRIM = 160;
+
 export function buildQuestionReportMessage(input: QuestionReportInput): string {
   const { question, reason, detail, language, selectedAnswer } = input;
   const vocab = question.vocabulary;
 
-  // promptLabel (the human question-type tag, e.g. 漢字読み / 文法形式選擇) and
-  // targetForm are emitted SEPARATELY rather than collapsed into one field:
-  // exam items default targetForm to "reading", so collapsing would hide the
-  // real form. A reviewer needs both to identify what the question tests.
-  const level = orDash(vocab.level);
-  const expected = question.expectedAnswers.join(" / ") || DASH;
-
-  const header = "[題目回報 / question report]";
-  const lines = [
-    header,
-    `reason: ${reason}`,
-    `questionId: ${orDash(question.id)}`,
-    `promptLabel: ${orDash(question.promptLabel)}`,
-    `targetForm: ${orDash(question.targetForm)}`,
-    `level: ${level}`,
-    `vocabId: ${orDash(vocab.id)}`,
-    `surface: ${orDash(vocab.surface)}`,
-    `reading: ${orDash(vocab.reading)}`,
-    `prompt: ${orDash(question.promptText)}`,
-    `expectedAnswers: ${expected}`,
-    `selectedAnswer: ${orDash(selectedAnswer)}`,
-    `uiLanguage: ${language}`
+  // 2026-07 rework: a reviewer reads (1) which question, (2) the pick +
+  // report reason, (3) the learner's own words -- so those lead. Everything
+  // below the `---` separator is derivable from the question id and exists
+  // only so a table row makes sense without opening the repo.
+  const essentials = [
+    `[題目回報 / question report] ${orDash(question.id)}`,
+    `reason: ${reason} · selected: ${orDash(selectedAnswer)} · ui: ${language}`
   ];
 
-  // The structured header block must always survive the cap; only the free-text
-  // detail is trimmed to fit. Reserve room for the detail label + a newline.
-  const structured = lines.join("\n");
-  const detailText = detail?.trim();
-  if (!detailText) {
-    return structured.slice(0, FEEDBACK_MAX);
+  const promptText = question.promptText?.trim();
+  const contextLines = [
+    "---",
+    `context: ${orDash(question.promptLabel)} · ${question.targetForm} · ${orDash(vocab.level)} · ${orDash(vocab.surface)}`,
+    `expected: ${question.expectedAnswers.join(" / ") || DASH}`
+  ];
+  if (promptText) {
+    contextLines.push(
+      `prompt: ${promptText.length > PROMPT_TRIM ? `${promptText.slice(0, PROMPT_TRIM)}…` : promptText}`
+    );
   }
 
-  const detailPrefix = "\ndetail: ";
-  const room = FEEDBACK_MAX - structured.length - detailPrefix.length;
-  if (room <= 0) {
-    // Pathological: even the structured block alone exceeds the cap.
-    return structured.slice(0, FEEDBACK_MAX);
+  const skeleton = [...essentials, ...contextLines].join("\n");
+  const detailText = detail?.trim();
+  if (!detailText) {
+    return skeleton.slice(0, FEEDBACK_MAX);
   }
-  return `${structured}${detailPrefix}${detailText.slice(0, room)}`;
+
+  const detailPrefix = "detail: ";
+  // Essentials and context are reserved first; the detail gets the remaining
+  // room (+1 for the newline its own line adds when inserted).
+  const room = FEEDBACK_MAX - skeleton.length - detailPrefix.length - 1;
+  if (room <= 0) {
+    // Pathological: keep the learner's voice over the convenience block.
+    return [...essentials, `${detailPrefix}${detailText}`].join("\n").slice(0, FEEDBACK_MAX);
+  }
+  return [...essentials, `${detailPrefix}${detailText.slice(0, room)}`, ...contextLines].join("\n");
 }


### PR DESCRIPTION
fix: question-report format rework + contact field for replies

Two report-pipeline gaps:

1. Format: the learner's own words sat BELOW 13 lines of metadata,
   most of it derivable from the question id. New shape leads with
   what a reviewer actually reads -- id, then reason/selected/ui on
   one line, then the learner's detail -- and compresses the derived
   fields into a `---` context block (promptLabel · targetForm ·
   level · surface / expected / prompt trimmed to 160 chars).
   14 lines -> ~7; essentials and context survive the FEEDBACK_MAX
   cap, only the detail trims; a pathological overflow keeps the
   learner's voice over the convenience block.

2. Contact: the 希望收到回信 checkbox's hint told anonymous users to
   leave a contact "below" -- but the report form never had that
   field (only the general FeedbackForm did). Ticking the box now
   reveals the same optional contact input, stored in the existing
   dedicated `contact` column (never the message text) and only sent
   when a reply was requested. Zero schema change.

Privacy policy §4 updated in zh/ja/en to match the new packed fields
(vocab id / reading dropped -- derivable; contact-on-reply added),
with the cross-language alignment test tokens tracking it.

TDD: format tests rewritten + 2 new form tests observed RED first;
1017 tests green; contact flow verified live in the report dialog.
