### PR TITLE
fix: remove duplicate arrows from blog back buttons

### DIFF
--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -112,3 +112,12 @@ describe("i18n locale key completeness (#299)", () => {
     });
   }
 });
+
+describe("blog back-button labels", () => {
+  for (const [language, localeCopy] of Object.entries(copy)) {
+    it(`${language} leaves the arrow to the icon instead of duplicating it in text`, () => {
+      expect(localeCopy.blogBackToHome).not.toContain("←");
+      expect(localeCopy.blogBackToList).not.toContain("←");
+    });
+  }
+});

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -396,8 +396,8 @@ export const en: Copy = {
   grammarSourceOther: "Other",
   // ---- Blog / 文章 (#483) ----
   blog: "Articles",
-  blogBackToHome: "← Home",
-  blogBackToList: "← All articles",
+  blogBackToHome: "Home",
+  blogBackToList: "All articles",
   blogHeroEyebrow: "JABIKO ARTICLES",
   blogIndexTitle: "The Japanese textbooks skip",
   blogIndexIntro: "Original notes on the Japanese you actually run into — slang, idol-fan culture, drama and anime lines, learning from song lyrics, and more that textbooks leave out.",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -396,8 +396,8 @@ export const id: Copy = {
   grammarSourceOther: "Lainnya",
   // ---- Blog / 文章 (#483) ----
   blog: "Artikel",
-  blogBackToHome: "← Beranda",
-  blogBackToList: "← Semua artikel",
+  blogBackToHome: "Beranda",
+  blogBackToList: "Semua artikel",
   blogHeroEyebrow: "ARTIKEL JABIKO",
   blogIndexTitle: "Bahasa Jepang yang tak diajarkan buku",
   blogIndexIntro: "Catatan orisinal tentang bahasa Jepang masa kini — slang, budaya oshikatsu, dialog drama dan anime, belajar dari lirik lagu, dan hal lain yang tak ada di buku tapi sering kamu temui.",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -404,8 +404,8 @@ export const ja: Copy = {
   grammarSourceOther: "その他",
   // ---- Blog / 文章 (#483) ----
   blog: "記事",
-  blogBackToHome: "← ホームへ",
-  blogBackToList: "← 記事一覧へ",
+  blogBackToHome: "ホームへ",
+  blogBackToList: "記事一覧へ",
   blogHeroEyebrow: "JABIKO 記事",
   blogIndexTitle: "教科書にない日本語をここで",
   blogIndexIntro: "オリジナルの「今の日本語」ノート——流行語、推し活、ドラマ・アニメのセリフ、歌詞で学ぶ日本語など、教科書には載らないけれど日常でよく出会う表現を集めています。",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -396,8 +396,8 @@ export const ko: Copy = {
   grammarSourceOther: "기타",
   // ---- Blog / 文章 (#483) ----
   blog: "아티클",
-  blogBackToHome: "← 홈으로",
-  blogBackToList: "← 전체 목록",
+  blogBackToHome: "홈으로",
+  blogBackToList: "전체 목록",
   blogHeroEyebrow: "JABIKO 아티클",
   blogIndexTitle: "교과서엔 없는 일본어",
   blogIndexIntro: "요즘 일본어에 대한 오리지널 노트 — 유행어, 오시카츠 문화, 드라마·애니 대사, 가사로 배우는 일본어 등 교과서엔 없지만 매일 마주치는 표현을 모았어요.",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -396,8 +396,8 @@ export const my: Copy = {
   grammarSourceOther: "အခြား",
   // ---- Blog / 文章 (#483) ----
   blog: "ဆောင်းပါးများ",
-  blogBackToHome: "← ပင်မသို့",
-  blogBackToList: "← ဆောင်းပါးအားလုံး",
+  blogBackToHome: "ပင်မသို့",
+  blogBackToList: "ဆောင်းပါးအားလုံး",
   blogHeroEyebrow: "JABIKO ဆောင်းပါး",
   blogIndexTitle: "ကျောင်းစာအုပ်မှာ မပါတဲ့ ဂျပန်စာ",
   blogIndexIntro: "ခေတ်စား ဂျပန်စာနဲ့ပတ်သက်တဲ့ မူရင်းမှတ်စုများ — ဆလန်စကား၊ oshikatsu ယဉ်ကျေးမှု၊ ဇာတ်လမ်းတွဲနဲ့ anime စကားများ၊ သီချင်းစာသားကနေ သင်ယူခြင်း စသဖြင့် ကျောင်းစာအုပ်မှာ မပါပေမဲ့ နေ့စဉ်တွေ့ရတဲ့ အသုံးအနှုန်းများ။",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -397,8 +397,8 @@ export const th: Copy = {
   grammarSourceOther: "อื่นๆ",
   // ---- Blog / 文章 (#483) ----
   blog: "บทความ",
-  blogBackToHome: "← หน้าแรก",
-  blogBackToList: "← บทความทั้งหมด",
+  blogBackToHome: "หน้าแรก",
+  blogBackToList: "บทความทั้งหมด",
   blogHeroEyebrow: "บทความ JABIKO",
   blogIndexTitle: "ภาษาญี่ปุ่นที่ตำราไม่สอน",
   blogIndexIntro: "โน้ตภาษาญี่ปุ่นร่วมสมัยต้นฉบับ — คำสแลง วัฒนธรรมโอชิคัตสึ บทพูดจากละครและอนิเมะ เรียนจากเนื้อเพลง และอื่น ๆ ที่ตำราไม่มีแต่เจอบ่อยในชีวิตจริง",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -396,8 +396,8 @@ export const vi: Copy = {
   grammarSourceOther: "Khác",
   // ---- Blog / 文章 (#483) ----
   blog: "Bài viết",
-  blogBackToHome: "← Trang chủ",
-  blogBackToList: "← Tất cả bài viết",
+  blogBackToHome: "Trang chủ",
+  blogBackToList: "Tất cả bài viết",
   blogHeroEyebrow: "BÀI VIẾT JABIKO",
   blogIndexTitle: "Tiếng Nhật sách giáo khoa bỏ qua",
   blogIndexIntro: "Những ghi chú gốc về tiếng Nhật đời thường — tiếng lóng, văn hóa oshikatsu, lời thoại phim và anime, học qua lời bài hát, và nhiều thứ sách giáo khoa không dạy nhưng bạn gặp mỗi ngày.",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -396,8 +396,8 @@ export const zhHant: Copy = {
   grammarSourceOther: "其他",
   // ---- Blog / 文章 (#483) ----
   blog: "文章",
-  blogBackToHome: "← 回首頁",
-  blogBackToList: "← 回文章列表",
+  blogBackToHome: "回首頁",
+  blogBackToList: "回文章列表",
   blogHeroEyebrow: "JABIKO 文章",
   blogIndexTitle: "課本不教的日文，這裡補",
   blogIndexIntro: "這一區收原創的時下日文筆記——流行語、推し活、日劇動漫台詞、從歌詞學日文⋯⋯補課本不教、但你天天會撞到的部分。",


### PR DESCRIPTION
## What changed

- Removed the literal `←` prefix from both blog back-button labels in all eight locale files.
- Kept the existing Lucide `ArrowLeft` icon as the single visual arrow.
- Added a cross-locale regression test so translated labels cannot reintroduce the duplicate arrow.

## Root cause

`BlogIndexPage` and `BlogArticlePage` already render an `ArrowLeft` SVG, while the localized text also contained a literal arrow character.

## Validation

- TDD: 8 locale cases failed before the copy fix and passed afterward
- `pnpm test` — pass (98 files, 1,025 tests)
- `pnpm build` — pass (105 prerendered pages)
- 390×844 production preview — one SVG arrow, text `回首頁`, no horizontal overflow