### PR TITLE
feat(seo): 每頁 JSON-LD——文章 BlogPosting、/about Person

### DIFF
--- a/src/domain/prerender/staticPages.test.ts
+++ b/src/domain/prerender/staticPages.test.ts
@@ -76,6 +76,26 @@ describe("applyHead", () => {
     const html = applyHead(TEMPLATE, { ...page, title: 'A"B<C>' });
     expect(html).toContain("<title>A&quot;B&lt;C&gt;</title>");
   });
+
+  it("keeps the default WebApplication JSON-LD when the page has none", () => {
+    const html = applyHead(TEMPLATE, page);
+    expect(html).toContain('"@type": "WebApplication"');
+  });
+
+  it("swaps in the page's JSON-LD, replacing the default WebApplication block", () => {
+    const jsonLd = '{"@context":"https://schema.org","@type":"BlogPosting","headline":"x"}';
+    const html = applyHead(TEMPLATE, { ...page, jsonLd });
+    expect(html).toContain(jsonLd);
+    expect(html).not.toContain("WebApplication");
+    // exactly one ld+json script remains
+    expect(html.match(/type="application\/ld\+json"/g)?.length).toBe(1);
+  });
+
+  it("sets og:type=article when the page declares it", () => {
+    const html = applyHead(TEMPLATE, { ...page, ogType: "article" });
+    expect(html).toContain('property="og:type" content="article"');
+    expect(html).not.toContain('property="og:type" content="website"');
+  });
 });
 
 describe("buildStaticPages", () => {
@@ -169,6 +189,30 @@ describe("buildStaticPages", () => {
       expect(page.canonical.startsWith("https://jabiko.app"), page.path).toBe(true);
       expect(page.bodyHtml.includes('<a href="/">'), page.path).toBe(true);
       expect(page.bodyHtml.includes("<h1>"), page.path).toBe(true);
+    }
+  });
+
+  it("gives every published article a BlogPosting JSON-LD and og:type=article", () => {
+    for (const meta of publishedArticleMetas) {
+      const article = byPath.get(`/blog/${meta.slug}`)!;
+      expect(article.jsonLd, meta.slug).toBeDefined();
+      const parsed = JSON.parse(article.jsonLd!);
+      expect(parsed["@type"]).toBe("BlogPosting");
+      expect(parsed.headline).toBe(meta.title);
+      expect(parsed.datePublished).toBe(meta.publishedAt);
+      expect(article.ogType).toBe("article");
+    }
+  });
+
+  it("gives /about a Person JSON-LD", () => {
+    const about = byPath.get("/about")!;
+    expect(about.jsonLd).toBeDefined();
+    expect(JSON.parse(about.jsonLd!)["@type"]).toBe("Person");
+  });
+
+  it("leaves app views without page-specific JSON-LD (keeps WebApplication)", () => {
+    for (const route of ["/", "/learn", "/challenge", "/kana"]) {
+      expect(byPath.get(route)!.jsonLd, route).toBeUndefined();
     }
   });
 

--- a/src/domain/prerender/staticPages.ts
+++ b/src/domain/prerender/staticPages.ts
@@ -19,6 +19,7 @@ import { publishedArticles, type ArticleBlock } from "../articles";
 import { KANA_TABLE, type KanaGroup, type KanaScript } from "../kana";
 import type { JlptLevel } from "../types";
 import { legalDocumentFor, type LegalPageKind } from "../legalContent";
+import { articleJsonLd, personJsonLd } from "./structuredData";
 
 export interface StaticPage {
   /** Decoded URL path, e.g. "/grammar/〜てもいい". */
@@ -29,6 +30,16 @@ export interface StaticPage {
   canonical: string;
   /** Static HTML injected into <div id="root"> for non-JS crawlers. */
   bodyHtml: string;
+  /**
+   * Per-page JSON-LD. When set, applyHead swaps the template's default
+   * WebApplication schema for this. Undefined -> the app views keep the
+   * generic WebApplication schema.
+   */
+  jsonLd?: string;
+  /** og:type override; defaults to the template's "website". */
+  ogType?: string;
+  /** article:published_time (ISO date) for article pages. */
+  publishedTime?: string;
 }
 
 export function escapeHtml(value: string): string {
@@ -79,6 +90,23 @@ export function applyHead(template: string, page: StaticPage): string {
   html = replaceMetaContent(html, "property", "og:description", page.description);
   html = replaceMetaContent(html, "name", "twitter:title", page.title);
   html = replaceMetaContent(html, "name", "twitter:description", page.description);
+  if (page.ogType) {
+    html = replaceMetaContent(html, "property", "og:type", page.ogType);
+  }
+  if (page.publishedTime) {
+    const meta = `    <meta property="article:published_time" content="${escapeHtml(page.publishedTime)}" />\n  </head>`;
+    html = html.replace("</head>", meta);
+  }
+  if (page.jsonLd) {
+    // Swap the template's default WebApplication schema for this page's. A
+    // function replacer keeps `$` inside the JSON from being read as a
+    // replacement pattern.
+    const jsonLd = page.jsonLd;
+    html = html.replace(
+      /(<script type="application\/ld\+json">)[\s\S]*?(<\/script>)/,
+      (_match, open: string, close: string) => `${open}${jsonLd}${close}`
+    );
+  }
   html = html.replace('<div id="root"></div>', `<div id="root">${page.bodyHtml}</div>`);
   return html;
 }
@@ -295,15 +323,21 @@ export function buildStaticPages(): StaticPage[] {
   const pages: StaticPage[] = [];
   const byId = new Map(grammarPatterns.map((pattern) => [pattern.id, pattern]));
 
-  const push = (view: AppView, path: string, bodyHtml: string, surface?: string, slug?: string) => {
+  const push = (view: AppView, path: string, bodyHtml: string, surface?: string, slug?: string): StaticPage => {
     const seo = seoForView(view, surface ?? null, slug ?? null);
-    pages.push({ path, title: seo.title, description: seo.description, canonical: seo.canonical, bodyHtml });
+    const page: StaticPage = { path, title: seo.title, description: seo.description, canonical: seo.canonical, bodyHtml };
+    pages.push(page);
+    return page;
   };
 
   push("home", "/", homeBody());
-  for (const view of ["learn", "rules", "kanji", "challenge", "mock", "about"] as const) {
+  for (const view of ["learn", "rules", "kanji", "challenge", "mock"] as const) {
     push(view, VIEW_SEO[view].path, simpleViewBody(view));
   }
+  // /about carries a Person entity so every article's author resolves to a
+  // real person (E-E-A-T / author authority).
+  const aboutPage = push("about", VIEW_SEO.about.path, simpleViewBody("about"));
+  aboutPage.jsonLd = personJsonLd();
   for (const view of ["privacy", "terms"] as const) {
     push(view, VIEW_SEO[view].path, legalPageBody(view));
   }
@@ -325,7 +359,15 @@ export function buildStaticPages(): StaticPage[] {
   for (const article of publishedArticles) {
     const inner = article.body.map(articleText).join("");
     const bodyHtml = wrap(article.title, `${paragraph(article.description)}${inner}<p><a href="/blog">更多文章</a></p>`);
-    push("blog", `/blog/${article.slug}`, bodyHtml, undefined, article.slug);
+    const page = push("blog", `/blog/${article.slug}`, bodyHtml, undefined, article.slug);
+    page.jsonLd = articleJsonLd({
+      title: article.title,
+      description: article.description,
+      canonical: page.canonical,
+      datePublished: article.publishedAt
+    });
+    page.ogType = "article";
+    page.publishedTime = article.publishedAt;
   }
 
   return pages;

--- a/src/domain/prerender/structuredData.test.ts
+++ b/src/domain/prerender/structuredData.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { articleJsonLd, personJsonLd } from "./structuredData";
+
+const ARTICLE = {
+  title: "日本人吃東西不只說「おいしい」",
+  description: "整理あっさり、こってり等味道與口感日文。",
+  canonical: "https://jabiko.app/blog/japanese-taste-texture-expressions",
+  datePublished: "2026-07-13"
+};
+
+describe("articleJsonLd", () => {
+  const json = articleJsonLd(ARTICLE);
+  const parsed = JSON.parse(json);
+
+  it("is a BlogPosting with the article's headline/description/url", () => {
+    expect(parsed["@context"]).toBe("https://schema.org");
+    expect(parsed["@type"]).toBe("BlogPosting");
+    expect(parsed.headline).toBe(ARTICLE.title);
+    expect(parsed.description).toBe(ARTICLE.description);
+    expect(parsed.url).toBe(ARTICLE.canonical);
+    expect(parsed.mainEntityOfPage).toBe(ARTICLE.canonical);
+  });
+
+  it("carries the publish date and zh-Hant language", () => {
+    expect(parsed.datePublished).toBe("2026-07-13");
+    expect(parsed.inLanguage).toBe("zh-Hant");
+  });
+
+  it("attributes the article to the author and publisher", () => {
+    expect(parsed.author["@type"]).toBe("Person");
+    expect(parsed.author.name).toContain("花雪");
+    expect(parsed.author.url).toBe("https://jabiko.app/about");
+    expect(parsed.publisher.name).toBe("Jabiko");
+  });
+
+  it("is safe to embed inside a <script> tag (no raw '<')", () => {
+    expect(json).not.toMatch(/<\/script/i);
+    expect(json).not.toContain("<");
+  });
+});
+
+describe("personJsonLd", () => {
+  const json = personJsonLd();
+  const parsed = JSON.parse(json);
+
+  it("is a Person entity for the author at /about", () => {
+    expect(parsed["@context"]).toBe("https://schema.org");
+    expect(parsed["@type"]).toBe("Person");
+    expect(parsed.name).toContain("花雪");
+    expect(parsed.url).toBe("https://jabiko.app/about");
+  });
+
+  it("omits sameAs while no profile URLs are configured (never empty array)", () => {
+    // sameAs must be a non-empty array of real URLs or absent -- an empty
+    // array is a meaningless signal.
+    if ("sameAs" in parsed) {
+      expect(Array.isArray(parsed.sameAs)).toBe(true);
+      expect(parsed.sameAs.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("is safe to embed inside a <script> tag", () => {
+    expect(json).not.toContain("<");
+  });
+});

--- a/src/domain/prerender/structuredData.ts
+++ b/src/domain/prerender/structuredData.ts
@@ -1,0 +1,83 @@
+// Per-page JSON-LD structured data for the prerendered static pages (SEO;
+// remaining slice of the closed #584 bundle -- reopened as its own outcome).
+//
+// The SPA template ships one generic WebApplication schema (index.html). That
+// is right for the app views, but a blog article should identify itself as a
+// BlogPosting (headline / datePublished / author) and /about as a Person, so
+// search engines get article rich-results and a real author entity. applyHead
+// swaps the template's WebApplication block for a page's `jsonLd` when present.
+//
+// Build-time only (imported by staticPages.ts, never by the app), so it adds
+// zero bundle weight. Pure strings; no fs, no DOM.
+import { SITE_ORIGIN } from "../seo";
+
+const AUTHOR = {
+  "@type": "Person",
+  name: "花雪 (HanaYukii)",
+  url: `${SITE_ORIGIN}/about`
+} as const;
+
+const PUBLISHER = {
+  "@type": "Organization",
+  name: "Jabiko",
+  url: `${SITE_ORIGIN}/`,
+  logo: { "@type": "ImageObject", url: `${SITE_ORIGIN}/pwa-192x192.png` }
+} as const;
+
+// The author's cross-platform profile URLs (LinkedIn / GitHub / Codeforces …).
+// These disambiguate the real-world person for search + AI systems (sameAs),
+// but they are personal data the repo does not carry, so the list stays empty
+// until the author supplies them. An empty array is a meaningless signal, so
+// `sameAs` is OMITTED while this is empty rather than emitted as `[]`.
+const AUTHOR_SAME_AS: readonly string[] = [];
+
+/**
+ * Serialize a JSON-LD object for safe embedding in
+ * `<script type="application/ld+json">`. `<` is escaped to `<` so a
+ * value can never terminate the script element (`</script>`).
+ */
+function serialize(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export interface ArticleJsonLdInput {
+  title: string;
+  description: string;
+  /** Absolute canonical URL of the article. */
+  canonical: string;
+  /** ISO date (YYYY-MM-DD). */
+  datePublished: string;
+}
+
+export function articleJsonLd(input: ArticleJsonLdInput): string {
+  return serialize({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: input.title,
+    description: input.description,
+    url: input.canonical,
+    mainEntityOfPage: input.canonical,
+    datePublished: input.datePublished,
+    // No separate revision date is tracked; mirror datePublished so the field
+    // is present and never stale-forward.
+    dateModified: input.datePublished,
+    inLanguage: "zh-Hant",
+    author: AUTHOR,
+    publisher: PUBLISHER,
+    image: `${SITE_ORIGIN}/og-image.png`
+  });
+}
+
+export function personJsonLd(): string {
+  const person: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: "花雪 (HanaYukii)",
+    url: `${SITE_ORIGIN}/about`,
+    description: "Jabiko 的作者，親手打造這個免費、免註冊的 JLPT 日檢自習站。"
+  };
+  if (AUTHOR_SAME_AS.length > 0) {
+    person.sameAs = [...AUTHOR_SAME_AS];
+  }
+  return serialize(person);
+}


### PR DESCRIPTION
## 這個 PR 做什麼

診斷 Jabiko SEO 後發現的最高 CP 值小調：**每頁 JSON-LD 分型**。

在此之前，**所有預渲染路由（含 33 篇文章、/about）都共用 index.html 裡那一份 `WebApplication` schema**——搜尋引擎把文章和 /about 都當成「一個網頁應用」，拿不到文章 rich result，也沒有作者實體。

新增 `src/domain/prerender/structuredData.ts`：
- 文章頁 → **`BlogPosting`**（headline／description／url／datePublished／author→Person／publisher→Jabiko／image／inLanguage）
- `/about` → **`Person`**（每篇文章的 author 都 resolve 到這個作者實體）
- app 頁 → 維持 `WebApplication`

`applyHead` 在有 `jsonLd` 時把 template 的 WebApplication 換掉，文章頁另設 `og:type=article` ＋ `article:published_time`。

## 定位

這是 **#584 那個 bundle 關掉時說「需要哪項再單獨開票」的剩餘項**（Article JSON-LD）。build-time only、**零 bundle 影響**、index chunk 不變。

## ⚠ 待補一行：`Person.sameAs`

作者權威最關鍵的 `sameAs`（LinkedIn／GitHub／Codeforces…）需要真實個人檔案 URL，我沒有、不亂編，所以**先留空並省略該欄位**。花雪給網址後補一行即可（`AUTHOR_SAME_AS` 常數）。其餘結構已全部到位。

## 驗證

- TDD：`structuredData.test.ts`＋`staticPages.test.ts`（BlogPosting/Person 欄位、`<script>` 安全序列化、applyHead 置換、app 頁不受影響）
- **實測 build 後的 dist/**：文章 HTML 有 `BlogPosting`＋`og:type=article`；`about.html` 有 `Person`；`learn.html` 維持 `WebApplication`
- `pnpm test`：**1038/1038** ✅
- `pnpm build`：✅ examBlocks 仍 lazy、index 未膨脹
