### PR TITLE
fix(exam): 長句選項振假名換行(#652) ＋ romaji prompt 不交給 TTS(#653)

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExamPrompt } from "./ExamPrompt";
 import type { PracticeQuestion } from "../domain/types";
 import { FuriganaContext } from "./furiganaContext";
@@ -78,6 +78,47 @@ describe("ExamPrompt answer-leak guard", () => {
     const vocabRow = container.querySelector("p.reading");
     expect(vocabRow).not.toBeNull();
     expect(vocabRow?.textContent).toContain(cloze.vocabulary.surface);
+  });
+});
+
+describe("ExamPrompt TTS gate on non-Japanese prompts (#653)", () => {
+  // jsdom ships no SpeechSynthesis, so SpeakButton would null-render regardless.
+  // Stub a minimal engine so the button CAN appear -- then the only thing that
+  // suppresses it is our hasJapanese gate.
+  beforeEach(() => {
+    vi.stubGlobal("speechSynthesis", {
+      getVoices: () => [],
+      speak: () => {},
+      cancel: () => {},
+      speaking: false,
+      pending: false
+    });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        constructor(public text: string) {}
+        addEventListener() {}
+      }
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const base = examStyleQuestions[0];
+
+  it("shows the speak button on a Japanese prompt", () => {
+    const { container } = render(
+      <ExamPrompt question={{ ...base, promptText: "ここは学校だ。" }} language="zh-Hant" />
+    );
+    expect(container.querySelector(".speak-button")).not.toBeNull();
+  });
+
+  it("suppresses the speak button on a romaji prompt (kana pick), so ASCII never reaches a JA voice", () => {
+    const { container } = render(
+      <ExamPrompt question={{ ...base, promptText: "ne" }} language="zh-Hant" />
+    );
+    expect(container.querySelector(".speak-button")).toBeNull();
+    // the romaji prompt itself still renders as visible text
+    expect(container.querySelector(".exam-prompt")?.textContent).toContain("ne");
   });
 });
 

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -4,7 +4,7 @@ import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
 import { pickLocalized, pickLocalizedOptional } from "../domain/localizedContent";
 import { shuffleOrderFragments } from "../domain/wordOrder";
-import { isReadingPrompt } from "../domain/furigana";
+import { isReadingPrompt, hasJapanese } from "../domain/furigana";
 import { Ruby } from "./Ruby";
 import { SpeakButton } from "./SpeakButton";
 
@@ -81,7 +81,10 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
         {promptText ? (
           <>
             <Ruby text={promptText} plain={isReadingPrompt(question.promptLabel, question.targetForm)} />
-            <SpeakButton text={promptText} language={language} />
+            {/* A JA voice mangles ASCII, so don't offer TTS on a romaji prompt
+                (the kana "pick" question's prompt IS romaji). Speaking the kana
+                instead would leak the answer, so suppression is the only fix. */}
+            {hasJapanese(promptText) ? <SpeakButton text={promptText} language={language} /> : null}
           </>
         ) : null}
       </p>

--- a/src/domain/furigana.test.ts
+++ b/src/domain/furigana.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   kataToHira,
   hasKanji,
+  hasJapanese,
   alignToken,
   tokensToSegments,
   applyReadingOverrides,
@@ -12,6 +13,24 @@ import {
   splitQuotedTextForRuby,
   collectQuotedRubySources
 } from "./furigana";
+
+describe("hasJapanese", () => {
+  it("is true for hiragana, katakana and kanji", () => {
+    expect(hasJapanese("ね")).toBe(true);
+    expect(hasJapanese("ネ")).toBe(true);
+    expect(hasJapanese("学校")).toBe(true);
+    expect(hasJapanese("ここは学校だ。")).toBe(true);
+  });
+
+  it("is false for ASCII romaji / non-Japanese text (never send this to a JA voice)", () => {
+    // The kana "pick" question's promptText is Hepburn romaji ("ne"); a JA
+    // TTS voice mangles ASCII, so the speak button must be suppressed (#653).
+    expect(hasJapanese("ne")).toBe(false);
+    expect(hasJapanese("sha")).toBe(false);
+    expect(hasJapanese("")).toBe(false);
+    expect(hasJapanese("123 !?")).toBe(false);
+  });
+});
 
 describe("isReadingPrompt", () => {
   it("flags the 漢字読み prompt label (a reading question)", () => {

--- a/src/domain/furigana.ts
+++ b/src/domain/furigana.ts
@@ -39,6 +39,14 @@ function hasKana(value: string): boolean {
   return KANA_ONLY_RE.test(value);
 }
 
+// True when the text carries any Japanese script (kana or kanji). Used to
+// gate the TTS button: a JA voice mangles ASCII, so a romaji prompt (the kana
+// "pick" question's promptText IS Hepburn romaji, e.g. "ne") must not be sent
+// to speech synthesis (#653).
+export function hasJapanese(value: string): boolean {
+  return hasKanji(value) || hasKana(value);
+}
+
 // Hiragana / katakana / long-vowel mark / combining marks count as "kana"
 // for run-splitting. 々 is deliberately excluded (it repeats the preceding
 // kanji, so it groups WITH the kanji run).

--- a/src/styles/feedback.css
+++ b/src/styles/feedback.css
@@ -290,6 +290,13 @@
   min-height: 3.6rem;
   overflow-wrap: anywhere;
   padding: 0.7rem;
+  /* Options inherit the global button's `display: inline-flex`. With furigana
+     on, <Ruby> emits several <ruby>/text nodes that each become a flex item;
+     without wrapping, a long 用法 sentence option can't break across them and
+     overflows / squishes into a thin column (#652). flex-wrap lets the
+     word-level segments flow onto the next line -- single-word options (one
+     item) are unaffected and stay centred. */
+  flex-wrap: wrap;
 }
 
 .choice-option:hover:not(:disabled) {

--- a/src/styles/feedback.test.ts
+++ b/src/styles/feedback.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+// ?raw import (typed via vite/client), same trick as staticPages.test.ts.
+import css from "./feedback.css?raw";
+
+describe("choice-option layout (#652)", () => {
+  it("wraps long furigana option sentences (flex-wrap) instead of overflowing", () => {
+    // Options inherit the global button's inline-flex; with furigana on, <Ruby>
+    // makes each word a flex item. Without flex-wrap a long 用法 sentence option
+    // overflows / squishes into a thin column. This guards the wrap fix.
+    const start = css.indexOf(".choice-option {");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const rule = css.slice(start, css.indexOf("}", start));
+    expect(rule).toMatch(/flex-wrap:\s*wrap/);
+  });
+});


### PR DESCRIPTION
修兩個使用者回報的 exam 顯示 bug。原始回報都很模糊（「選項排版亂掉」「平假名 ne 發音怪怪的」），依 code 調查定位並實測。

## #652 長句選項＋振假名破版

選項按鈕繼承全域 `button { display: inline-flex }`；開振假名後 `<Ruby>` 把整句拆成一個一個 flex item，沒有 `flex-wrap` 時長句無法跨 item 換行 → **被壓成細高欄**。

**修法**：`.choice-option` 加 `flex-wrap: wrap`（單字選項只有一個 item、不受影響、仍置中）。

**瀏覽器實測**（真實 N2 詞彙用法題、四個長句選項、振假名開）：
| 寬度 | 強制 nowrap（＝原 bug） | `flex-wrap: wrap`（修法） |
|---|---|---|
| 320px | 四個選項高 172／142／202／231px（壓成細高欄） | 統一 105px、自然換行、無溢出 |
| 375px | — | 四個 overflowX=0、乾淨 |
| 768px（雙欄） | — | 統一 105px、無溢出 |

⚠ 這個 bug 我加的「詞彙用法」題型（整句選項）會讓它更常觸發，算我一起修掉。

## #653 羅馬字 prompt 交給日文 TTS

kana「pick」題（看 romaji→選假名）的 `promptText` 是 ASCII romaji（如 `ne`），ExamPrompt 無條件把它丟給 SpeakButton → 日文 voice 念 ASCII。

**修法**：新增 `hasJapanese()` helper，SpeakButton 只在 promptText 含日文時才顯示。
- ⚠ 原 issue 建議的「或改念假名」**會洩漏答案**（pick 題的答案就是那個假名），所以只能**隱藏播放鍵**。
- 正向 kana 題（「ね」）與 /kana 表仍正常朗讀假名。

## 驗證
- TDD：`hasJapanese` 單元測試；ExamPrompt TTS gate 測試（romaji→無播放鍵、日文→有，stub speech engine）；`feedback.css` flex-wrap 回歸守門。
- `pnpm test`：**1042/1042** ✅；`pnpm build` ✅。

Closes #652
Closes #653
