### PR TITLE
feat(blog): 文章單字表緊湊化＋工具文表格預設收合

### DIFF
--- a/src/components/BlogArticlePage.test.tsx
+++ b/src/components/BlogArticlePage.test.tsx
@@ -163,6 +163,72 @@ describe("BlogArticlePage", () => {
     ).toBeTruthy();
   });
 
+  it("renders collapsed vocab tables as <details> with the heading + word count as summary", () => {
+    const { container } = render(
+      <BlogArticlePage
+        slug="japanese-restaurant-ordering-phrases"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    const details = container.querySelectorAll("details.blog-vocab-details");
+    expect(details.length).toBeGreaterThan(0);
+    // Every vocab table in this tool article is collapsed (lives inside a details).
+    expect(container.querySelectorAll(".blog-vocab").length).toBe(details.length);
+
+    const first = details[0]!;
+    const summary = first.querySelector("summary.blog-vocab-summary");
+    expect(summary).not.toBeNull();
+    // Summary carries the section heading text plus the word count.
+    expect(summary!.textContent).toMatch(/個詞/);
+    expect(summary!.textContent!.length).toBeGreaterThan(3);
+    // The heading is consumed into the summary -- not duplicated as an <h2>.
+    expect(first.querySelector("h2")).toBeNull();
+    // Collapsed content still exists in the DOM (prerender/SEO + find-in-page).
+    expect(first.querySelector(".blog-vocab")).not.toBeNull();
+    expect(first.querySelectorAll(".blog-vocab-item").length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a generic 單字表 summary when the table is separated from its heading", () => {
+    const { container } = render(
+      <BlogArticlePage
+        slug="japanese-taste-texture-expressions"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    const details = container.querySelectorAll("details.blog-vocab-details");
+    // All six tables collapse; the last one follows prose, not a heading.
+    expect(details.length).toBe(6);
+    expect(container.querySelectorAll(".blog-vocab").length).toBe(6);
+    const titles = [...container.querySelectorAll(".blog-vocab-summary-title")].map(
+      (el) => el.textContent
+    );
+    expect(titles).toContain("單字表");
+    // Its section heading survives as a real <h2> above the prose.
+    expect(
+      [...container.querySelectorAll("h2")].some((el) => el.textContent?.includes("吃完"))
+    ).toBe(true);
+  });
+
+  it("keeps non-collapsed vocab tables as plain blocks", () => {
+    const { container } = render(
+      <BlogArticlePage
+        slug="sweet-steady-sweet-step"
+        language="zh-Hant"
+        onBack={vi.fn()}
+        onCta={vi.fn()}
+      />
+    );
+
+    expect(container.querySelectorAll("details.blog-vocab-details").length).toBe(0);
+    expect(container.querySelectorAll(".blog-vocab").length).toBeGreaterThan(0);
+  });
+
   it("passes the article CTA payload to the app-level handler", async () => {
     const user = userEvent.setup();
     const onCta = vi.fn();

--- a/src/components/BlogArticlePage.tsx
+++ b/src/components/BlogArticlePage.tsx
@@ -66,13 +66,48 @@ export function BlogArticlePage({
         <h1 className="blog-article-title">{article.title}</h1>
       </header>
 
-      <div className="blog-article-body">
-        {article.body.map((block, index) => (
-          <ArticleBlockView key={index} block={block} language={language} onCta={onCta} />
-        ))}
-      </div>
+      <div className="blog-article-body">{renderArticleBody(article.body, language, onCta)}</div>
     </section>
   );
+}
+
+// Render the body blocks, folding each `collapsed` vocab table into a closed
+// <details> with a word-count summary. A heading directly before the table
+// becomes the summary title; a table separated from its heading by prose
+// falls back to a generic 單字表 label (the blog view is zh-Hant-gated, so
+// the literal is safe). The table content stays in the DOM, so prerendered
+// SEO text and find-in-page are unaffected; only the scroll length shrinks.
+function renderArticleBody(
+  body: ReadonlyArray<ArticleBlock>,
+  language: Language,
+  onCta: (cta: ArticleCta) => void
+) {
+  const collapsedVocab = (title: string, block: ArticleBlock & { kind: "vocab" }, key: number) => (
+    <details key={key} className="blog-vocab-details">
+      <summary className="blog-vocab-summary">
+        <span className="blog-vocab-summary-title">{title}</span>
+        <span className="blog-vocab-summary-count">{block.items.length} 個詞</span>
+      </summary>
+      <ArticleBlockView block={block} language={language} onCta={onCta} />
+    </details>
+  );
+
+  const nodes = [];
+  for (let index = 0; index < body.length; index++) {
+    const block = body[index];
+    const next = body[index + 1];
+    if (block.kind === "heading" && next?.kind === "vocab" && next.collapsed) {
+      nodes.push(collapsedVocab(block.text, next, index));
+      index++;
+      continue;
+    }
+    if (block.kind === "vocab" && block.collapsed) {
+      nodes.push(collapsedVocab("單字表", block, index));
+      continue;
+    }
+    nodes.push(<ArticleBlockView key={index} block={block} language={language} onCta={onCta} />);
+  }
+  return nodes;
 }
 
 function ArticleBlockView({

--- a/src/domain/articleBodies/restaurantOrdering.ts
+++ b/src/domain/articleBodies/restaurantOrdering.ts
@@ -25,6 +25,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "剛進店，先處理人數、內用與座位" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "何名様ですか",
@@ -59,6 +60,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "還沒決定也沒關係，先讓店員知道" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "ご注文はお決まりですか",
@@ -107,6 +109,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "尺寸、套餐和拉麵硬度，都用「〜でお願いします」" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "サイズはどうしますか",
@@ -155,6 +158,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "店員問「要不要」，先別只丟一句大丈夫です" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "はい、お願いします",
@@ -196,6 +200,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "便利商店和咖啡店，最常多問這幾句" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "温めますか",
@@ -237,6 +242,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "沒聽懂時，讓對話停一下比亂猜安全" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "すみません、もう一度お願いします",
@@ -278,6 +284,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "去配料、餐點沒來或送錯時" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "ねぎ抜きにできますか",
@@ -319,6 +326,7 @@ export const restaurantOrderingBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "結帳方式不是每間店都一樣" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "お会計お願いします",

--- a/src/domain/articleBodies/tasteExpressions.ts
+++ b/src/domain/articleBodies/tasteExpressions.ts
@@ -20,6 +20,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "先別急著換掉「おいしい」" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "おいしい",
@@ -54,6 +55,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "甜、辣、鹹不難，容易搞混的是這幾個" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "甘い",
@@ -102,6 +104,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "清淡、濃郁與油脂感" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "味が濃い・味が薄い",
@@ -157,6 +160,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "很多口感，光聽聲音就有畫面" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "サクサク",
@@ -219,6 +223,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   { kind: "heading", text: "想把感想再說得像一點" },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "優しい味",
@@ -291,6 +296,7 @@ export const tasteExpressionsBody: ReadonlyArray<ArticleBlock> = [
   },
   {
     kind: "vocab",
+    collapsed: true,
     items: [
       {
         word: "ごちそうさまでした",

--- a/src/domain/articles.test.ts
+++ b/src/domain/articles.test.ts
@@ -154,6 +154,18 @@ describe("blog articles data guard", () => {
     expect(bodyText).toContain("お会計お願いします");
   });
 
+  it("collapses every vocab table in the two vocab-heavy tool articles", () => {
+    for (const slug of [
+      "japanese-restaurant-ordering-phrases",
+      "japanese-taste-texture-expressions"
+    ]) {
+      const article = articleBySlug(slug);
+      const vocab = (article?.body ?? []).filter((block) => block.kind === "vocab");
+      expect(vocab.length).toBeGreaterThan(0);
+      expect(vocab.every((block) => block.collapsed === true)).toBe(true);
+    }
+  });
+
   it("serves the country-names etymology article with honest hedges and fact anchors", () => {
     const article = articleBySlug("japanese-country-names");
     expect(article?.tag).toBe("日文冷知識");

--- a/src/domain/articles.ts
+++ b/src/domain/articles.ts
@@ -32,8 +32,15 @@ export type ArticleBlock =
   | { kind: "paragraph"; text: string }
   | { kind: "callout"; text: string }
   // A vocab table: word + reading + gloss + a usage note (may embed an
-  // original example sentence).
-  | { kind: "vocab"; items: ReadonlyArray<{ word: string; reading: string; meaning: string; note?: string }> }
+  // original example sentence). `collapsed: true` renders the table as a
+  // closed <details>; the heading directly before it (if any) becomes the
+  // summary title -- used by vocab-heavy tool articles so the teaching half
+  // doesn't dominate the scroll length.
+  | {
+      kind: "vocab";
+      collapsed?: boolean;
+      items: ReadonlyArray<{ word: string; reading: string; meaning: string; note?: string }>;
+    }
   // External resource links (opened in a new tab): the official YouTube MV,
   // a legal full-lyrics site (歌ネット / Uta-Net …), etc. We link OUT to full
   // lyrics rather than reproduce them.

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -253,8 +253,17 @@
   margin: 0;
 }
 
+/* Compact rows: word + reading + meaning share one baseline-aligned line and
+   the note wraps to its own tighter line below (the gloss <dd> contributes its
+   children directly via display: contents, which also drops the UA dd margin).
+   Long meanings simply wrap -- nothing is hidden. */
 .blog-vocab-item {
-  padding: 0.85rem 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 0.55rem;
+  row-gap: 0.15rem;
+  padding: 0.6rem 0;
   border-bottom: 1px solid var(--rule);
 }
 
@@ -266,7 +275,6 @@
   display: flex;
   align-items: baseline;
   gap: 0.3rem;
-  margin-bottom: 0.3rem;
 }
 
 .blog-vocab-word {
@@ -284,21 +292,72 @@
 
 .blog-vocab-gloss {
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  display: contents;
 }
 
 .blog-vocab-meaning {
   color: var(--ink);
   font-size: 0.93rem;
-  line-height: 1.7;
+  line-height: 1.6;
 }
 
 .blog-vocab-note {
+  flex-basis: 100%;
   color: var(--muted);
   font-size: 0.85rem;
-  line-height: 1.75;
+  line-height: 1.6;
+}
+
+/* Collapsed vocab tables (vocab-heavy tool articles): the section heading is
+   folded into a closed <details> summary with a word count, so the teaching
+   half stops dominating the scroll length. Content stays in the DOM. */
+.blog-vocab-details {
+  background: var(--paper);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+}
+
+.blog-vocab-summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.blog-vocab-summary::-webkit-details-marker {
+  display: none;
+}
+
+.blog-vocab-summary-title {
+  font-weight: 700;
+  font-size: 1.02rem;
+  color: var(--ink);
+}
+
+.blog-vocab-summary-count {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.blog-vocab-summary-count::after {
+  content: "▸";
+  display: inline-block;
+  margin-left: 0.4rem;
+  transition: transform 0.15s ease;
+}
+
+.blog-vocab-details[open] .blog-vocab-summary-count::after {
+  transform: rotate(90deg);
+}
+
+.blog-vocab-details > .blog-vocab {
+  border: none;
+  background: transparent;
+  padding-top: 0;
 }
 
 /* Lyric commentary */


### PR DESCRIPTION
花雪審版面回饋：文章整體太長。量測（375px 手機）發現長度都在教學單字表：點餐文 12.7 螢幕（表佔 11.3）、味道文 10.6（表佔 9.4），每條詞疊四行約 200px。

## 兩段修法（內容零刪減，花雪拍板 B＋A）
- **B 緊湊化（全部文章）**：word＋讀音＋意思同一行（dd 用 display:contents 併進 flex row）、note 收窄換行。短詞條 ~200px→~116px，長條目自然換行。
- **A 預設收合（工具文）**：vocab block 可標 collapsed:true → 渲染成 <details>，緊鄰的 heading 摺進 summary＋詞數；被說明文隔開的表 fallback 成「單字表」。內容仍在 DOM（prerender SEO／頁內搜尋不受影響）。點餐 8 表＋味道 6 表全收。

## 實測改善（375×812）
| 文章 | 改前 | 改後 |
|---|---|---|
| 點餐 | 12.7 螢幕 | **2.7** |
| 味道口感 | 10.6 | **2.5** |
| 國家名 | 9.9 | **3.3**（純緊湊化） |
| えびチリ | 11.7 | 10.9（紀錄型正文不動、只緊表格） |

## 驗證
TDD 先紅後綠（收合渲染／fallback summary／未收合不變／兩篇工具文全收 data guard）；瀏覽器實測開合互動、同行排版、長條目換行、深色模式（只用既有主題變數）。pnpm test 1058 綠、build 綠。