### PR TITLE
feat(ai): add replayable RED regression-test stage

### DIFF
--- a/scripts/gemini-correctness/__tests__/gemini-client.test.ts
+++ b/scripts/gemini-correctness/__tests__/gemini-client.test.ts
@@ -52,6 +52,27 @@ describe("createGeminiClient", () => {
     expect(typeof client.discover).toBe("function");
   });
 
+  it("returns strict parsed JSON through the shared transport for RED candidate validation", async () => {
+    const candidate = {
+      schemaVersion: 1,
+      status: "regression-test",
+      testFile: "src/domain/example.regression.test.ts",
+      testName: "demonstrates the bug",
+      source: "test source"
+    };
+    const fetch = mockFetchSuccess(candidate);
+    const client = createGeminiClient({
+      apiKey: "test-key",
+      model: "gemini-2.0-flash",
+      fetchFn: fetch,
+      maxRetries: 0
+    });
+
+    const result = await client.generateJson({ prompt: "RED prompt" });
+
+    expect(result).toEqual({ valid: true, result: candidate });
+  });
+
   it("throws if apiKey is missing or empty", () => {
     // These should throw regardless of env var
     expect(() => createGeminiClient({ apiKey: "", fetchFn: originalFetch })).toThrow();

--- a/scripts/gemini-correctness/gemini-client.mjs
+++ b/scripts/gemini-correctness/gemini-client.mjs
@@ -167,9 +167,9 @@ export function createGeminiClient(options = {}) {
   }
 
   // ---------------------------------------------------------------------------
-  // discover — retry loop + schema validation
+  // generateJson — shared retry loop + strict JSON transport
   // ---------------------------------------------------------------------------
-  async function discover({ prompt, validationOptions } = {}) {
+  async function generateJson({ prompt } = {}) {
     if (!prompt || typeof prompt !== "string") {
       return { valid: false, error: "prompt is required" };
     }
@@ -212,21 +212,7 @@ export function createGeminiClient(options = {}) {
         continue; // retry on parse failure (transient formatting issue)
       }
 
-      // Run through schema validator
-      let validation;
-      try {
-        validation = validateFinding(parsed, validationOptions ?? {});
-      } catch {
-        lastError = { ok: false, status: "invalid-response", error: "Schema validator threw unexpectedly" };
-        break;
-      }
-      if (validation.valid) {
-        return validation;
-      }
-
-      // If validation failed — redact the error before persisting
-      lastError = { ok: false, status: "invalid-response", error: `Schema validation failed: ${redactApiKey(validation.error || "", apiKey)}` };
-      break;
+      return { valid: true, result: parsed };
     }
 
     // All attempts exhausted or non-retryable error
@@ -236,5 +222,30 @@ export function createGeminiClient(options = {}) {
     return { valid: false, error, status };
   }
 
-  return { discover };
+  // ---------------------------------------------------------------------------
+  // discover — discovery-specific schema validation over the shared transport
+  // ---------------------------------------------------------------------------
+  async function discover({ prompt, validationOptions } = {}) {
+    const generated = await generateJson({ prompt });
+    if (!generated.valid) return generated;
+
+    let validation;
+    try {
+      validation = validateFinding(generated.result, validationOptions ?? {});
+    } catch {
+      return {
+        valid: false,
+        status: "invalid-response",
+        error: "Schema validator threw unexpectedly"
+      };
+    }
+    if (validation.valid) return validation;
+    return {
+      valid: false,
+      status: "invalid-response",
+      error: `Schema validation failed: ${redactApiKey(validation.error || "", apiKey)}`
+    };
+  }
+
+  return { discover, generateJson };
 }

--- a/scripts/gemini-correctness/red-git-validator.test.ts
+++ b/scripts/gemini-correctness/red-git-validator.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import {
+  captureCleanBaseline,
+  createTestOnlyPatch,
+  validateTestOnlyWorktree
+} from "./red-validator.mjs";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TEST_FILE = "src/domain/example.regression.test.ts";
+const TEST_SOURCE = `import { expect, it } from "vitest";
+it("demonstrates the bug", () => expect("actual").toBe("expected"));
+`;
+
+let fixtureRoot = "";
+
+function git(args: string[], cwd = fixtureRoot) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function write(relativePath: string, content: string | Buffer) {
+  const absolutePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+function initializeFixture() {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-red-git-"));
+  git(["init", "-q"]);
+  git(["config", "user.email", "fixture@example.test"]);
+  git(["config", "user.name", "Fixture"]);
+  write(".gitignore", ".tmp/\nnode_modules/\n");
+  write("src/domain/example.ts", 'export const value = "actual";\n');
+  write(
+    "src/domain/example.test.ts",
+    'import { expect, it } from "vitest";\nit("existing", () => expect(true).toBe(true));\n'
+  );
+  git(["add", ".gitignore", "src/domain/example.ts", "src/domain/example.test.ts"]);
+  git(["commit", "-qm", "fixture baseline"]);
+}
+
+describe("test-only worktree validation", () => {
+  beforeEach(() => initializeFixture());
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("captures a clean baseline and creates one replayable added-file patch", () => {
+    const baseline = captureCleanBaseline({
+      repoRoot: fixtureRoot,
+      testFile: TEST_FILE
+    });
+    expect(baseline.valid).toBe(true);
+
+    write(TEST_FILE, TEST_SOURCE);
+    const validation = validateTestOnlyWorktree({
+      repoRoot: fixtureRoot,
+      baselineSha: baseline.baselineSha,
+      testFile: TEST_FILE
+    });
+    expect(validation).toEqual({ valid: true });
+
+    const patch = createTestOnlyPatch({
+      repoRoot: fixtureRoot,
+      baselineSha: baseline.baselineSha,
+      testFile: TEST_FILE
+    });
+    expect(patch.valid).toBe(true);
+    expect(patch.patch).toContain("new file mode");
+    expect(patch.patch).toContain(`b/${TEST_FILE}`);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe(`?? ${TEST_FILE}`);
+  });
+
+  it.each([
+    ["staged file", () => {
+      write("src/domain/staged.ts", "staged\n");
+      git(["add", "src/domain/staged.ts"]);
+    }],
+    ["unstaged file", () => {
+      write("src/domain/example.ts", "modified\n");
+    }],
+    ["untracked file", () => {
+      write("src/domain/extra.ts", "extra\n");
+    }]
+  ])("rejects a dirty baseline with a %s", (_label, arrange) => {
+    arrange();
+    const result = captureCleanBaseline({
+      repoRoot: fixtureRoot,
+      testFile: TEST_FILE
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ["a production modification", () => {
+      write("src/domain/example.ts", "modified\n");
+    }],
+    ["an existing test modification", () => {
+      write("src/domain/example.test.ts", "modified\n");
+    }],
+    ["an additional untracked file", () => {
+      write("src/domain/extra.ts", "extra\n");
+    }],
+    ["a staged target", () => {
+      git(["add", TEST_FILE]);
+    }],
+    ["a rename", () => {
+      git(["mv", "src/domain/example.test.ts", "src/domain/renamed.test.ts"]);
+    }],
+    ["a binary file", () => {
+      write("src/domain/extra.bin", Buffer.from([0, 1, 2, 3]));
+    }]
+  ])("rejects %s mixed with the candidate test", (_label, arrange) => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    write(TEST_FILE, TEST_SOURCE);
+    arrange();
+
+    const result = validateTestOnlyWorktree({
+      repoRoot: fixtureRoot,
+      baselineSha,
+      testFile: TEST_FILE
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a submodule entry mixed with the candidate test", () => {
+    const otherRepo = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-red-submodule-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: otherRepo });
+      fs.writeFileSync(path.join(otherRepo, "README.md"), "submodule\n");
+      execFileSync("git", ["add", "README.md"], { cwd: otherRepo });
+      execFileSync(
+        "git",
+        ["-c", "user.email=fixture@example.test", "-c", "user.name=Fixture", "commit", "-qm", "submodule"],
+        { cwd: otherRepo }
+      );
+
+      const baselineSha = git(["rev-parse", "HEAD"]);
+      write(TEST_FILE, TEST_SOURCE);
+      git([
+        "-c",
+        "protocol.file.allow=always",
+        "submodule",
+        "add",
+        "-q",
+        otherRepo,
+        "vendor/submodule"
+      ]);
+
+      const result = validateTestOnlyWorktree({
+        repoRoot: fixtureRoot,
+        baselineSha,
+        testFile: TEST_FILE
+      });
+      expect(result.valid).toBe(false);
+    } finally {
+      fs.rmSync(otherRepo, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["a symlink", () => fs.symlinkSync("example.ts", path.join(fixtureRoot, TEST_FILE))],
+    [
+      "a dangling symlink",
+      () => fs.symlinkSync("missing-target.ts", path.join(fixtureRoot, TEST_FILE))
+    ]
+  ])("rejects %s at the candidate path", (_label, arrange) => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    arrange();
+
+    const result = validateTestOnlyWorktree({
+      repoRoot: fixtureRoot,
+      baselineSha,
+      testFile: TEST_FILE
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a candidate path below a symlinked directory", () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    fs.mkdirSync(path.join(fixtureRoot, "outside"), { recursive: true });
+    fs.symlinkSync(
+      path.join(fixtureRoot, "outside"),
+      path.join(fixtureRoot, "src", "domain", "linked")
+    );
+    write("outside/example.regression.test.ts", TEST_SOURCE);
+
+    const result = validateTestOnlyWorktree({
+      repoRoot: fixtureRoot,
+      baselineSha,
+      testFile: "src/domain/linked/example.regression.test.ts"
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/scripts/gemini-correctness/red-process-guard.mjs
+++ b/scripts/gemini-correctness/red-process-guard.mjs
@@ -1,0 +1,13 @@
+// Trusted Node preload used by the RED runner. It emits marker-only diagnostics
+// for process-level failures without serializing rejected values or secrets.
+
+const UNHANDLED_REJECTION_MARKER = "JABIKO_RED_UNHANDLED_REJECTION";
+const UNCAUGHT_EXCEPTION_MARKER = "JABIKO_RED_UNCAUGHT_EXCEPTION";
+
+process.prependListener("unhandledRejection", () => {
+  process.stderr.write(`${UNHANDLED_REJECTION_MARKER}\n`);
+});
+
+process.prependListener("uncaughtExceptionMonitor", () => {
+  process.stderr.write(`${UNCAUGHT_EXCEPTION_MARKER}\n`);
+});

--- a/scripts/gemini-correctness/red-prompt-builder.mjs
+++ b/scripts/gemini-correctness/red-prompt-builder.mjs
@@ -9,9 +9,14 @@ export const MAX_RED_PROMPT_CHARS = 300_000;
 
 const EXISTING_TEST_RE = /\.test\.tsx?$/;
 const IMPORT_EXTENSIONS = [".ts", ".tsx", ".mjs"];
+const MAX_RELATED_TEST_ROOTS = 4;
 
 function normalize(filePath) {
   return String(filePath).replace(/\\/g, "/");
+}
+
+function comparePaths(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function relativeImports(file) {
@@ -49,34 +54,9 @@ function resolveImport(fromPath, specifier, fileMap) {
   return candidates.find(candidate => fileMap.has(candidate)) ?? null;
 }
 
-function selectPromptFiles(finding, scannedFiles) {
-  const fileMap = new Map(
-    scannedFiles.map(file => [normalize(file.path), { ...file, path: normalize(file.path) }])
-  );
-  const selected = new Set();
-  const queue = [];
-
-  for (const productionFile of finding.productionFiles) {
-    const normalized = normalize(productionFile);
-    const file = fileMap.get(normalized);
-    if (!file) {
-      throw new Error(`production file is absent from scanner manifest: ${normalized}`);
-    }
-    selected.add(normalized);
-    queue.push(normalized);
-  }
-
-  const primaryDir = path.posix.dirname(normalize(finding.productionFiles[0]));
-  for (const [filePath] of fileMap) {
-    if (
-      path.posix.dirname(filePath) === primaryDir &&
-      EXISTING_TEST_RE.test(filePath) &&
-      filePath !== normalize(finding.reproduction.testFile)
-    ) {
-      selected.add(filePath);
-      queue.push(filePath);
-    }
-  }
+function collectImportClosure(rootPaths, fileMap) {
+  const selected = new Set(rootPaths);
+  const queue = [...rootPaths];
 
   while (queue.length > 0) {
     const currentPath = queue.shift();
@@ -91,9 +71,84 @@ function selectPromptFiles(finding, scannedFiles) {
     }
   }
 
-  return [...selected]
-    .sort((a, b) => a.localeCompare(b))
+  return selected;
+}
+
+function isCorrespondingTest(testPath, productionPath) {
+  const productionStem = productionPath.replace(/\.(?:ts|tsx|mjs)$/, "");
+  return testPath === `${productionStem}.test.ts` ||
+    testPath === `${productionStem}.test.tsx`;
+}
+
+function selectPromptFileGroups(finding, scannedFiles) {
+  const fileMap = new Map(
+    scannedFiles.map(file => [normalize(file.path), { ...file, path: normalize(file.path) }])
+  );
+  const productionPaths = finding.productionFiles.map(normalize);
+
+  for (const productionPath of productionPaths) {
+    const file = fileMap.get(productionPath);
+    if (!file) {
+      throw new Error(`production file is absent from scanner manifest: ${productionPath}`);
+    }
+  }
+
+  const requiredPaths = collectImportClosure(productionPaths, fileMap);
+  const reproductionPath = normalize(finding.reproduction.testFile);
+  const candidates = [];
+
+  for (const [filePath, file] of fileMap) {
+    if (!EXISTING_TEST_RE.test(filePath) || filePath === reproductionPath) continue;
+    const corresponding = productionPaths.some(productionPath =>
+      isCorrespondingTest(filePath, productionPath)
+    );
+    const directlyImportsProduction = relativeImports(file).some(specifier => {
+      const resolved = resolveImport(filePath, specifier, fileMap);
+      return resolved !== null && productionPaths.includes(resolved);
+    });
+    if (corresponding || directlyImportsProduction) {
+      candidates.push({
+        path: filePath,
+        priority: corresponding ? 0 : 1
+      });
+    }
+  }
+
+  candidates.sort((left, right) =>
+    left.priority - right.priority || comparePaths(left.path, right.path)
+  );
+
+  return {
+    fileMap,
+    requiredPaths,
+    optionalGroups: candidates
+      .slice(0, MAX_RELATED_TEST_ROOTS)
+      .map(candidate => collectImportClosure([candidate.path], fileMap))
+  };
+}
+
+function filesForPaths(paths, fileMap) {
+  return [...paths]
+    .sort(comparePaths)
     .map(filePath => fileMap.get(filePath));
+}
+
+function hasTruncatedFile(paths, fileMap) {
+  for (const filePath of paths) {
+    const file = fileMap.get(filePath);
+    if (file?.truncated) {
+      return file;
+    }
+  }
+  return null;
+}
+
+function addPaths(target, additions) {
+  const combined = new Set(target);
+  for (const filePath of additions) {
+    combined.add(filePath);
+  }
+  return combined;
 }
 
 function renderFile(file) {
@@ -104,26 +159,7 @@ function renderFile(file) {
   return `### ${file.path}\n\`\`\`ts\n${numbered}\n\`\`\``;
 }
 
-export function buildRedPrompt({
-  baselineSha,
-  finding,
-  scannedFiles
-} = {}) {
-  if (!/^[0-9a-f]{40,64}$/i.test(String(baselineSha ?? ""))) {
-    throw new Error("baseline SHA is required");
-  }
-  if (!finding || finding.status !== "finding") {
-    throw new Error("a validated finding is required");
-  }
-  if (!Array.isArray(scannedFiles)) {
-    throw new Error("scanner manifest is required");
-  }
-
-  const selectedFiles = selectPromptFiles(finding, scannedFiles);
-  const truncated = selectedFiles.find(file => file.truncated);
-  if (truncated) {
-    throw new Error(`required prompt file was truncated: ${truncated.path}`);
-  }
+function renderPrompt({ baselineSha, finding, selectedFiles }) {
   const manifest = selectedFiles.map(file => file.path);
   const fileBlocks = selectedFiles.map(renderFile).join("\n\n");
   const exactCandidate = {
@@ -134,7 +170,7 @@ export function buildRedPrompt({
     source: "<complete TypeScript test source>"
   };
 
-  const prompt = `You are writing the RED regression test for one already-validated correctness finding.
+  return `You are writing the RED regression test for one already-validated correctness finding.
 
 You have no shell, filesystem, network, environment, secret, package-manager, Git, or GitHub authority.
 Do not execute commands. Return strict JSON only; do not use markdown fences or trailing prose.
@@ -165,15 +201,68 @@ Baseline SHA: ${baselineSha}
 Validated finding:
 ${JSON.stringify(finding, null, 2)}
 
+Visible repository file count: ${manifest.length}
 Visible repository manifest:
 ${manifest.join("\n")}
 
 Visible files:
 ${fileBlocks}
 `;
+}
 
+export function buildRedPrompt({
+  baselineSha,
+  finding,
+  scannedFiles
+} = {}) {
+  if (!/^[0-9a-f]{40,64}$/i.test(String(baselineSha ?? ""))) {
+    throw new Error("baseline SHA is required");
+  }
+  if (!finding || finding.status !== "finding") {
+    throw new Error("a validated finding is required");
+  }
+  if (!Array.isArray(scannedFiles)) {
+    throw new Error("scanner manifest is required");
+  }
+
+  const {
+    fileMap,
+    requiredPaths,
+    optionalGroups
+  } = selectPromptFileGroups(finding, scannedFiles);
+  const truncatedRequired = hasTruncatedFile(requiredPaths, fileMap);
+  if (truncatedRequired) {
+    throw new Error(`required prompt file was truncated: ${truncatedRequired.path}`);
+  }
+
+  let selectedPaths = requiredPaths;
+  let selectedFiles = filesForPaths(selectedPaths, fileMap);
+  let prompt = renderPrompt({ baselineSha, finding, selectedFiles });
   if (prompt.length > MAX_RED_PROMPT_CHARS) {
     throw new Error(`RED prompt exceeds ${MAX_RED_PROMPT_CHARS} characters`);
   }
-  return { prompt, manifest, length: prompt.length };
+
+  for (const group of optionalGroups) {
+    if (hasTruncatedFile(group, fileMap)) continue;
+    const candidatePaths = addPaths(selectedPaths, group);
+    const candidateFiles = filesForPaths(candidatePaths, fileMap);
+    const candidatePrompt = renderPrompt({
+      baselineSha,
+      finding,
+      selectedFiles: candidateFiles
+    });
+    if (candidatePrompt.length <= MAX_RED_PROMPT_CHARS) {
+      selectedPaths = candidatePaths;
+      selectedFiles = candidateFiles;
+      prompt = candidatePrompt;
+    }
+  }
+
+  const manifest = selectedFiles.map(file => file.path);
+  return {
+    prompt,
+    manifest,
+    fileCount: manifest.length,
+    length: prompt.length
+  };
 }

--- a/scripts/gemini-correctness/red-prompt-builder.mjs
+++ b/scripts/gemini-correctness/red-prompt-builder.mjs
@@ -1,0 +1,179 @@
+// =============================================================================
+// red-prompt-builder.mjs — bounded test-only prompt for the RED stage
+// =============================================================================
+
+import path from "node:path";
+import ts from "typescript";
+
+export const MAX_RED_PROMPT_CHARS = 300_000;
+
+const EXISTING_TEST_RE = /\.test\.tsx?$/;
+const IMPORT_EXTENSIONS = [".ts", ".tsx", ".mjs"];
+
+function normalize(filePath) {
+  return String(filePath).replace(/\\/g, "/");
+}
+
+function relativeImports(file) {
+  const sourceFile = ts.createSourceFile(
+    file.path,
+    file.content,
+    ts.ScriptTarget.Latest,
+    true,
+    file.path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const imports = [];
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.moduleSpecifier.text.startsWith(".")
+    ) {
+      imports.push(statement.moduleSpecifier.text);
+    }
+  }
+  return imports;
+}
+
+function resolveImport(fromPath, specifier, fileMap) {
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(fromPath), specifier)
+  );
+  const candidates = path.posix.extname(base)
+    ? [base]
+    : [
+        ...IMPORT_EXTENSIONS.map(extension => `${base}${extension}`),
+        ...IMPORT_EXTENSIONS.map(extension => `${base}/index${extension}`)
+      ];
+  return candidates.find(candidate => fileMap.has(candidate)) ?? null;
+}
+
+function selectPromptFiles(finding, scannedFiles) {
+  const fileMap = new Map(
+    scannedFiles.map(file => [normalize(file.path), { ...file, path: normalize(file.path) }])
+  );
+  const selected = new Set();
+  const queue = [];
+
+  for (const productionFile of finding.productionFiles) {
+    const normalized = normalize(productionFile);
+    const file = fileMap.get(normalized);
+    if (!file) {
+      throw new Error(`production file is absent from scanner manifest: ${normalized}`);
+    }
+    selected.add(normalized);
+    queue.push(normalized);
+  }
+
+  const primaryDir = path.posix.dirname(normalize(finding.productionFiles[0]));
+  for (const [filePath] of fileMap) {
+    if (
+      path.posix.dirname(filePath) === primaryDir &&
+      EXISTING_TEST_RE.test(filePath) &&
+      filePath !== normalize(finding.reproduction.testFile)
+    ) {
+      selected.add(filePath);
+      queue.push(filePath);
+    }
+  }
+
+  while (queue.length > 0) {
+    const currentPath = queue.shift();
+    const current = fileMap.get(currentPath);
+    if (!current) continue;
+    for (const specifier of relativeImports(current)) {
+      const resolved = resolveImport(currentPath, specifier, fileMap);
+      if (resolved && !selected.has(resolved)) {
+        selected.add(resolved);
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return [...selected]
+    .sort((a, b) => a.localeCompare(b))
+    .map(filePath => fileMap.get(filePath));
+}
+
+function renderFile(file) {
+  const numbered = String(file.content)
+    .split("\n")
+    .map((line, index) => `${index + 1}|${line}`)
+    .join("\n");
+  return `### ${file.path}\n\`\`\`ts\n${numbered}\n\`\`\``;
+}
+
+export function buildRedPrompt({
+  baselineSha,
+  finding,
+  scannedFiles
+} = {}) {
+  if (!/^[0-9a-f]{40,64}$/i.test(String(baselineSha ?? ""))) {
+    throw new Error("baseline SHA is required");
+  }
+  if (!finding || finding.status !== "finding") {
+    throw new Error("a validated finding is required");
+  }
+  if (!Array.isArray(scannedFiles)) {
+    throw new Error("scanner manifest is required");
+  }
+
+  const selectedFiles = selectPromptFiles(finding, scannedFiles);
+  const truncated = selectedFiles.find(file => file.truncated);
+  if (truncated) {
+    throw new Error(`required prompt file was truncated: ${truncated.path}`);
+  }
+  const manifest = selectedFiles.map(file => file.path);
+  const fileBlocks = selectedFiles.map(renderFile).join("\n\n");
+  const exactCandidate = {
+    schemaVersion: 1,
+    status: "regression-test",
+    testFile: finding.reproduction.testFile,
+    testName: finding.reproduction.testName,
+    source: "<complete TypeScript test source>"
+  };
+
+  const prompt = `You are writing the RED regression test for one already-validated correctness finding.
+
+You have no shell, filesystem, network, environment, secret, package-manager, Git, or GitHub authority.
+Do not execute commands. Return strict JSON only; do not use markdown fences or trailing prose.
+
+You must return exactly this object shape and no unknown fields:
+${JSON.stringify(exactCandidate, null, 2)}
+
+Contract:
+- Add only the one designated test file. Do not propose or modify any other file.
+- The source must declare exactly one Vitest test whose leaf name is exactly testName.
+- Import Vitest through unaliased named imports limited to describe, expect, it, or test.
+- Use exactly one expect() call. Its received value must directly observe an imported,
+  prompt-visible repository interface and chain directly to one matcher; do not force failure
+  with a literal, detached matcher, helper assertion, or unrelated comparison.
+- The test must exercise one observable behavior from the finding through public interfaces.
+- Do not mock the function under test.
+- Do not use .only, .skip, .todo, timers, wall clock, randomness, child processes,
+  filesystem writes, network, dynamic imports/downloads, environment values, secrets, snapshots,
+  fixtures, configuration, package metadata, dependencies, or TypeScript any.
+- Before the repair, the test must fail through a Vitest AssertionError, never through syntax,
+  import, setup, timeout, worker, or unhandled errors.
+- Give the failing expect() this custom assertion message so the runner can bind the failure
+  to the finding:
+  Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}
+
+Baseline SHA: ${baselineSha}
+
+Validated finding:
+${JSON.stringify(finding, null, 2)}
+
+Visible repository manifest:
+${manifest.join("\n")}
+
+Visible files:
+${fileBlocks}
+`;
+
+  if (prompt.length > MAX_RED_PROMPT_CHARS) {
+    throw new Error(`RED prompt exceeds ${MAX_RED_PROMPT_CHARS} characters`);
+  }
+  return { prompt, manifest, length: prompt.length };
+}

--- a/scripts/gemini-correctness/red-prompt-builder.test.ts
+++ b/scripts/gemini-correctness/red-prompt-builder.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { buildRedPrompt } from "./red-prompt-builder.mjs";
+
+const finding = {
+  schemaVersion: 1,
+  status: "finding",
+  title: "empty queue fallback",
+  confidence: 0.95,
+  category: "boundary-condition",
+  evidence: [
+    {
+      file: "src/domain/example.ts",
+      startLine: 1,
+      endLine: 3,
+      reason: "the empty branch returns a stale value"
+    }
+  ],
+  expectedBehavior: "an empty queue returns the safe fallback",
+  actualBehavior: "an empty queue returns the stale value",
+  reproduction: {
+    testFile: "src/domain/example.regression.test.ts",
+    testName: "returns the safe fallback for an empty queue"
+  },
+  productionFiles: ["src/domain/example.ts"],
+  risk: "low"
+};
+
+const scannedFiles = [
+  {
+    path: "src/domain/example.ts",
+    content: 'import { fallback } from "./helper";\nexport const value = fallback();\n',
+    lineCount: 2,
+    byteSize: 70,
+    truncated: false
+  },
+  {
+    path: "src/domain/helper.ts",
+    content: 'export const fallback = () => "stale";\n',
+    lineCount: 1,
+    byteSize: 43,
+    truncated: false
+  },
+  {
+    path: "src/domain/example.test.ts",
+    content: 'import { expect, it } from "vitest";\nit("existing", () => expect(true).toBe(true));\n',
+    lineCount: 2,
+    byteSize: 90,
+    truncated: false
+  },
+  {
+    path: "src/domain/unrelated.ts",
+    content: 'export const unrelated = "do not reveal";\n',
+    lineCount: 1,
+    byteSize: 42,
+    truncated: false
+  },
+  {
+    path: "src/hooks/useOther.ts",
+    content: 'export const other = "do not reveal";\n',
+    lineCount: 1,
+    byteSize: 38,
+    truncated: false
+  }
+];
+
+describe("buildRedPrompt", () => {
+  it("includes only the finding target, existing colocated tests, and imported helpers", () => {
+    const result = buildRedPrompt({
+      baselineSha: "a".repeat(40),
+      finding,
+      scannedFiles
+    });
+
+    expect(result.prompt).toContain("src/domain/example.ts");
+    expect(result.prompt).toContain("src/domain/helper.ts");
+    expect(result.prompt).toContain("src/domain/example.test.ts");
+    expect(result.prompt).not.toContain("src/domain/unrelated.ts");
+    expect(result.prompt).not.toContain("src/hooks/useOther.ts");
+    expect(result.manifest).toEqual([
+      "src/domain/example.test.ts",
+      "src/domain/example.ts",
+      "src/domain/helper.ts"
+    ]);
+  });
+
+  it("requires strict test-only JSON and the finding behavior assertion message", () => {
+    const result = buildRedPrompt({
+      baselineSha: "b".repeat(40),
+      finding,
+      scannedFiles
+    });
+
+    expect(result.prompt).toContain('"status": "regression-test"');
+    expect(result.prompt).toContain(`"testFile": "${finding.reproduction.testFile}"`);
+    expect(result.prompt).toContain(`"testName": "${finding.reproduction.testName}"`);
+    expect(result.prompt).toContain(finding.expectedBehavior);
+    expect(result.prompt).toContain(finding.actualBehavior);
+    expect(result.prompt).toMatch(/no shell|must not execute|do not execute/i);
+    expect(result.prompt).toMatch(/only.*one.*file|one.*test file/i);
+    expect(result.prompt).toMatch(/assertion/i);
+    expect(result.prompt).toMatch(/exactly one expect/i);
+    expect(result.prompt).toMatch(/directly observe[\s\S]*repository/i);
+  });
+
+  it("fails closed if a required production file is absent or truncated", () => {
+    expect(() => buildRedPrompt({
+      baselineSha: "c".repeat(40),
+      finding,
+      scannedFiles: scannedFiles.filter(file => file.path !== "src/domain/example.ts")
+    })).toThrow(/production|manifest/i);
+
+    expect(() => buildRedPrompt({
+      baselineSha: "c".repeat(40),
+      finding,
+      scannedFiles: scannedFiles.map(file =>
+        file.path === "src/domain/example.ts" ? { ...file, truncated: true } : file
+      )
+    })).toThrow(/truncated/i);
+  });
+});

--- a/scripts/gemini-correctness/red-prompt-builder.test.ts
+++ b/scripts/gemini-correctness/red-prompt-builder.test.ts
@@ -103,6 +103,41 @@ describe("buildRedPrompt", () => {
     expect(result.prompt).toMatch(/directly observe[\s\S]*repository/i);
   });
 
+  it("keeps directly related tests while omitting a large unrelated colocated test set", () => {
+    const unrelatedTests = Array.from({ length: 14 }, (_, index) => ({
+      path: `src/domain/unrelated-${index}.test.ts`,
+      content: `import { expect, it } from "vitest";\n// ${"x".repeat(25_000)}\nit("unrelated ${index}", () => expect(true).toBe(true));\n`,
+      lineCount: 3,
+      byteSize: 25_100,
+      truncated: false
+    }));
+    const directlyReferencingTest = {
+      path: "src/domain/queue-behavior.test.ts",
+      content: 'import { expect, it } from "vitest";\nimport { value } from "./example";\nit("uses example", () => expect(value).toBe("safe"));\n',
+      lineCount: 3,
+      byteSize: 130,
+      truncated: false
+    };
+
+    const result = buildRedPrompt({
+      baselineSha: "d".repeat(40),
+      finding,
+      scannedFiles: [...scannedFiles, directlyReferencingTest, ...unrelatedTests]
+    });
+
+    expect(result.length).toBeLessThanOrEqual(300_000);
+    expect(result.manifest).toContain("src/domain/example.test.ts");
+    expect(result.manifest).toContain("src/domain/queue-behavior.test.ts");
+    expect(result.manifest).not.toContain("src/domain/unrelated-0.test.ts");
+    expect(result.fileCount).toBe(result.manifest.length);
+    expect(result.prompt).toContain(`Visible repository file count: ${result.fileCount}`);
+
+    const renderedPaths = [...result.prompt.matchAll(/^### (.+)$/gm)]
+      .map(match => match[1])
+      .sort();
+    expect(renderedPaths).toEqual([...result.manifest].sort());
+  });
+
   it("fails closed if a required production file is absent or truncated", () => {
     expect(() => buildRedPrompt({
       baselineSha: "c".repeat(40),

--- a/scripts/gemini-correctness/red-runner.mjs
+++ b/scripts/gemini-correctness/red-runner.mjs
@@ -1,0 +1,273 @@
+// =============================================================================
+// red-runner.mjs — fixed Vitest invocation and fail-closed RED classification
+// =============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync as nodeSpawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const TARGETED_TEST_TIMEOUT_MS = 60_000;
+const MAX_REPORT_BYTES = 2 * 1024 * 1024;
+const PROCESS_GUARD_PATH = fileURLToPath(
+  new URL("./red-process-guard.mjs", import.meta.url)
+);
+const INFRASTRUCTURE_FAILURE_RE =
+  /(?:SyntaxError:|Failed to load url|Cannot find module|module not found|Test timed out|timed out in \d+ms|Unhandled Rejection|Unhandled Error|JABIKO_RED_UNHANDLED_REJECTION|JABIKO_RED_UNCAUGHT_EXCEPTION|Worker (?:exited|crashed)|No test files found|Failed Suites|setup (?:file )?failed)/i;
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeEvidence(value) {
+  return String(value)
+    .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function sameFilePath(reportedName, repoRoot, testFile) {
+  const reported = String(reportedName ?? "");
+  const reportedAbsolute = path.isAbsolute(reported)
+    ? path.resolve(reported)
+    : path.resolve(repoRoot, reported);
+  const expectedAbsolute = path.resolve(repoRoot, testFile);
+  try {
+    return fs.realpathSync(reportedAbsolute) === fs.realpathSync(expectedAbsolute);
+  } catch {
+    return reportedAbsolute === expectedAbsolute;
+  }
+}
+
+export function buildTargetedVitestInvocation({
+  testFile,
+  testName,
+  reportPath
+} = {}) {
+  const exactLeafPattern = `(?:^|\\s)${escapeRegExp(testName)}$`;
+  return {
+    command: "pnpm",
+    args: [
+      "exec",
+      "vitest",
+      "run",
+      testFile,
+      "--testNamePattern",
+      exactLeafPattern,
+      "--reporter=json",
+      "--outputFile",
+      reportPath,
+      "--no-color",
+      "--passWithNoTests=false",
+      "--bail=1"
+    ]
+  };
+}
+
+function buildChildEnvironment(environment) {
+  const safe = {
+    CI: "1",
+    FORCE_COLOR: "0",
+    NO_COLOR: "1",
+    NODE_OPTIONS: `--import=${pathToFileURL(PROCESS_GUARD_PATH).href}`
+  };
+  for (const key of ["HOME", "PATH", "TMPDIR"]) {
+    if (typeof environment?.[key] === "string") {
+      safe[key] = environment[key];
+    }
+  }
+  return safe;
+}
+
+export function runTargetedVitest({
+  repoRoot,
+  testFile,
+  testName,
+  reportPath,
+  spawnSyncFn = nodeSpawnSync,
+  environment = process.env,
+  timeoutMs = TARGETED_TEST_TIMEOUT_MS
+} = {}) {
+  if (
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < 1 ||
+    timeoutMs > TARGETED_TEST_TIMEOUT_MS
+  ) {
+    return {
+      valid: false,
+      error: `targeted Vitest timeout must be between 1 and ${TARGETED_TEST_TIMEOUT_MS}ms`
+    };
+  }
+  try {
+    fs.lstatSync(reportPath);
+    return invalid("Vitest JSON report path must not exist before execution");
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      return invalid("Vitest JSON report path is unsafe before execution");
+    }
+  }
+  const invocation = buildTargetedVitestInvocation({
+    testFile,
+    testName,
+    reportPath
+  });
+  const execution = spawnSyncFn(invocation.command, invocation.args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: buildChildEnvironment(environment),
+    killSignal: "SIGKILL",
+    maxBuffer: 2 * 1024 * 1024,
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs
+  });
+
+  const stdout = typeof execution.stdout === "string" ? execution.stdout : "";
+  const stderr = typeof execution.stderr === "string" ? execution.stderr : "";
+  if (execution.error) {
+    return {
+      valid: false,
+      error: execution.error.code === "ETIMEDOUT"
+        ? "targeted Vitest process timed out"
+        : "targeted Vitest process failed to start",
+      exitCode: execution.status,
+      signal: execution.signal,
+      stdout,
+      stderr
+    };
+  }
+
+  try {
+    const stat = fs.lstatSync(reportPath);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_REPORT_BYTES) {
+      return {
+        valid: false,
+        error: "Vitest JSON report is missing, unsafe, or too large",
+        exitCode: execution.status,
+        signal: execution.signal,
+        stdout,
+        stderr
+      };
+    }
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    return {
+      valid: true,
+      exitCode: execution.status,
+      signal: execution.signal,
+      stdout,
+      stderr,
+      report
+    };
+  } catch {
+    return {
+      valid: false,
+      error: "Vitest JSON report was not produced or was invalid",
+      exitCode: execution.status,
+      signal: execution.signal,
+      stdout,
+      stderr
+    };
+  }
+}
+
+export function classifyVitestRed({
+  exitCode,
+  signal,
+  report,
+  stdout,
+  stderr,
+  repoRoot,
+  testFile,
+  testName,
+  finding
+} = {}) {
+  if (!Number.isInteger(exitCode) || exitCode === 0 || signal) {
+    return invalid("targeted Vitest must exit non-zero without a signal");
+  }
+
+  const processOutput = `${stdout ?? ""}\n${stderr ?? ""}`;
+  if (INFRASTRUCTURE_FAILURE_RE.test(processOutput)) {
+    return invalid("Vitest output contains an infrastructure failure");
+  }
+  if (!report || typeof report !== "object" || Array.isArray(report)) {
+    return invalid("Vitest JSON report is required");
+  }
+  if (
+    report.success !== false ||
+    report.numTotalTests !== 1 ||
+    report.numFailedTests !== 1 ||
+    report.numPassedTests !== 0 ||
+    report.numPendingTests !== 0 ||
+    report.numTodoTests !== 0 ||
+    report.numTotalTestSuites !== 1 ||
+    report.numFailedTestSuites !== 1 ||
+    report.numPassedTestSuites !== 0 ||
+    report.numPendingTestSuites !== 0 ||
+    !Array.isArray(report.testResults) ||
+    report.testResults.length !== 1
+  ) {
+    return invalid("Vitest did not collect exactly one failing test");
+  }
+
+  const fileResult = report.testResults[0];
+  if (
+    !fileResult ||
+    !sameFilePath(fileResult.name, repoRoot, testFile) ||
+    fileResult.status !== "failed" ||
+    !Array.isArray(fileResult.assertionResults) ||
+    fileResult.assertionResults.length !== 1
+  ) {
+    const pathMatches = sameFilePath(fileResult?.name, repoRoot, testFile);
+    const assertionCount = Array.isArray(fileResult?.assertionResults)
+      ? fileResult.assertionResults.length
+      : -1;
+    return invalid(
+      "Vitest report does not identify only the designated test file " +
+      `(pathMatches=${pathMatches}, status=${String(fileResult?.status)}, ` +
+      `assertions=${assertionCount})`
+    );
+  }
+
+  const assertion = fileResult.assertionResults[0];
+  if (
+    assertion?.title !== testName ||
+    assertion?.status !== "failed" ||
+    !Array.isArray(assertion.failureMessages) ||
+    assertion.failureMessages.length < 1
+  ) {
+    return invalid("the designated test name did not execute as one failed assertion");
+  }
+
+  const failureEvidence = normalizeEvidence(
+    `${assertion.failureMessages.join("\n")}\n${String(fileResult.message ?? "")}`
+  );
+  if (
+    !/\bAssertionError\b/.test(failureEvidence) ||
+    INFRASTRUCTURE_FAILURE_RE.test(failureEvidence)
+  ) {
+    return invalid("the designated test failed for a non-assertion reason");
+  }
+
+  const expectedBehavior = normalizeEvidence(finding?.expectedBehavior);
+  const actualBehavior = normalizeEvidence(finding?.actualBehavior);
+  const expectedMarker = `Expected behavior: ${expectedBehavior}`;
+  const actualMarker = `Actual behavior: ${actualBehavior}`;
+  if (
+    !expectedBehavior ||
+    !actualBehavior ||
+    !failureEvidence.includes(expectedMarker) ||
+    !failureEvidence.includes(actualMarker)
+  ) {
+    return invalid("assertion evidence does not match finding expected/actual behavior");
+  }
+
+  return {
+    valid: true,
+    failureKind: "assertion",
+    sanitizedSummary: `${testName}: ${expectedMarker} | ${actualMarker}`
+  };
+}

--- a/scripts/gemini-correctness/red-runner.test.ts
+++ b/scripts/gemini-correctness/red-runner.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import {
+  buildTargetedVitestInvocation,
+  classifyVitestRed,
+  runTargetedVitest
+} from "./red-runner.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const repoRoot = "/fixture/repo";
+const testFile = "src/domain/example.regression.test.ts";
+const testName = "returns the safe fallback for an empty queue";
+const finding = {
+  expectedBehavior: "an empty queue returns the safe fallback",
+  actualBehavior: "an empty queue returns the stale value"
+};
+
+function assertionReport(overrides = {}) {
+  return {
+    numTotalTestSuites: 1,
+    numPassedTestSuites: 0,
+    numFailedTestSuites: 1,
+    numPendingTestSuites: 0,
+    numTotalTests: 1,
+    numPassedTests: 0,
+    numFailedTests: 1,
+    numPendingTests: 0,
+    numTodoTests: 0,
+    success: false,
+    testResults: [
+      {
+        name: `${repoRoot}/${testFile}`,
+        status: "failed",
+        message: "",
+        assertionResults: [
+          {
+            title: testName,
+            fullName: `queue behavior ${testName}`,
+            status: "failed",
+            failureMessages: [
+              `AssertionError: Expected behavior: ${finding.expectedBehavior} | ` +
+                `Actual behavior: ${finding.actualBehavior}\n` +
+                "expected 'actual' to be 'expected'"
+            ]
+          }
+        ]
+      }
+    ],
+    ...overrides
+  };
+}
+
+describe("buildTargetedVitestInvocation", () => {
+  it("builds trusted pnpm/Vitest argv without a shell or model command", () => {
+    const invocation = buildTargetedVitestInvocation({
+      testFile,
+      testName,
+      reportPath: "/private/tmp/vitest-report.json"
+    });
+
+    expect(invocation).toEqual({
+      command: "pnpm",
+      args: [
+        "exec",
+        "vitest",
+        "run",
+        testFile,
+        "--testNamePattern",
+        `(?:^|\\s)returns the safe fallback for an empty queue$`,
+        "--reporter=json",
+        "--outputFile",
+        "/private/tmp/vitest-report.json",
+        "--no-color",
+        "--passWithNoTests=false",
+        "--bail=1"
+      ]
+    });
+    expect(invocation.args).not.toContain("--");
+    expect(invocation).not.toHaveProperty("shell");
+  });
+
+  it("escapes regex syntax in a finding-provided test name", () => {
+    const invocation = buildTargetedVitestInvocation({
+      testFile,
+      testName: "handles [empty] (queue)?",
+      reportPath: "/tmp/report.json"
+    });
+
+    expect(invocation.args[5]).toBe("(?:^|\\s)handles \\[empty\\] \\(queue\\)\\?$");
+  });
+});
+
+describe("classifyVitestRed", () => {
+  it("accepts only the specified assertion failure tied to finding behavior", () => {
+    const result = classifyVitestRed({
+      exitCode: 1,
+      report: assertionReport(),
+      stdout: "",
+      stderr: "",
+      repoRoot,
+      testFile,
+      testName,
+      finding
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      failureKind: "assertion",
+      sanitizedSummary:
+        `${testName}: Expected behavior: ${finding.expectedBehavior} | ` +
+        `Actual behavior: ${finding.actualBehavior}`
+    });
+  });
+
+  it.each([
+    ["a zero exit code", { exitCode: 0 }],
+    ["no collected tests", { report: assertionReport({
+      numTotalTests: 0,
+      numFailedTests: 0,
+      testResults: []
+    }) }],
+    ["mixed failed and pending suites", { report: assertionReport({
+      numFailedTestSuites: 0,
+      numPendingTestSuites: 1
+    }) }],
+    ["the wrong test file", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          name: `${repoRoot}/src/domain/other.regression.test.ts`
+        }]
+      })
+    }],
+    ["the wrong test name", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            title: "some other test"
+          }]
+        }]
+      })
+    }],
+    ["a skipped test", {
+      report: assertionReport({
+        numFailedTests: 0,
+        numPendingTests: 1,
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            status: "skipped"
+          }]
+        }]
+      })
+    }],
+    ["a non-assertion error", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            failureMessages: ["TypeError: cannot read properties of undefined"]
+          }]
+        }]
+      })
+    }],
+    ["an assertion missing expected behavior", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            failureMessages: [
+              `AssertionError: Actual behavior: ${finding.actualBehavior}\n` +
+                "expected actual to be expected"
+            ]
+          }]
+        }]
+      })
+    }],
+    ["an assertion missing actual behavior", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            failureMessages: [
+              `AssertionError: Expected behavior: ${finding.expectedBehavior}\n` +
+                "expected actual to be expected"
+            ]
+          }]
+        }]
+      })
+    }],
+    ["unlabeled behavior prose", {
+      report: assertionReport({
+        testResults: [{
+          ...assertionReport().testResults[0],
+          assertionResults: [{
+            ...assertionReport().testResults[0].assertionResults[0],
+            failureMessages: [
+              `AssertionError: ${finding.expectedBehavior} | ${finding.actualBehavior}\n` +
+                "expected actual to be expected"
+            ]
+          }]
+        }]
+      })
+    }]
+  ])("rejects %s", (_label, overrides) => {
+    const result = classifyVitestRed({
+      exitCode: 1,
+      report: assertionReport(),
+      stdout: "",
+      stderr: "",
+      repoRoot,
+      testFile,
+      testName,
+      finding,
+      ...overrides
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    "SyntaxError: Unexpected token",
+    "Failed to load url ./missing",
+    "Cannot find module './missing'",
+    "Error: Test timed out in 5000ms",
+    "Unhandled Rejection",
+    "Unhandled Error",
+    "Worker exited unexpectedly",
+    "Worker crashed",
+    "No test files found",
+    "Failed Suites 1",
+    "setup file failed"
+  ])("rejects infrastructure output even beside an apparent assertion: %s", diagnostic => {
+    const result = classifyVitestRed({
+      exitCode: 1,
+      report: assertionReport(),
+      stdout: "",
+      stderr: diagnostic,
+      repoRoot,
+      testFile,
+      testName,
+      finding
+    });
+
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("runTargetedVitest", () => {
+  it("uses spawnSync with shell disabled and the fixed invocation", () => {
+    const spawnSyncFn = vi.fn().mockReturnValue({
+      status: 1,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      error: undefined
+    });
+
+    const result = runTargetedVitest({
+      repoRoot,
+      testFile,
+      testName,
+      reportPath: "/tmp/missing-report.json",
+      spawnSyncFn
+    });
+
+    expect(result.valid).toBe(false);
+    expect(spawnSyncFn).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnSyncFn.mock.calls[0];
+    expect(command).toBe("pnpm");
+    expect(args.slice(0, 4)).toEqual(["exec", "vitest", "run", testFile]);
+    expect(options.shell).toBe(false);
+    expect(options.cwd).toBe(repoRoot);
+    expect(options.timeout).toBeGreaterThan(0);
+  });
+
+  it("rejects a stale JSON report before spawning Vitest", () => {
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-red-report-"));
+    const reportPath = path.join(fixtureRoot, "stale.json");
+    fs.writeFileSync(reportPath, JSON.stringify(assertionReport()));
+    const spawnSyncFn = vi.fn().mockReturnValue({
+      status: 1,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      error: undefined
+    });
+
+    try {
+      const result = runTargetedVitest({
+        repoRoot,
+        testFile,
+        testName,
+        reportPath,
+        spawnSyncFn
+      });
+
+      expect(result.valid).toBe(false);
+      expect(spawnSyncFn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/gemini-correctness/red-stage-cli.test.ts
+++ b/scripts/gemini-correctness/red-stage-cli.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import {
+  extractValidatedFinding,
+  parseRedStageArgs,
+  resolveFindingInputPath
+} from "./red-stage.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let fixtureRoot = "";
+
+describe("RED stage CLI input", () => {
+  beforeEach(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-red-cli-"));
+    fs.mkdirSync(
+      path.join(fixtureRoot, ".tmp", "gemini-correctness"),
+      { recursive: true }
+    );
+  });
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("resolves only the fixed regular finding artifact", () => {
+    const findingPath = path.join(
+      fixtureRoot,
+      ".tmp",
+      "gemini-correctness",
+      "finding.json"
+    );
+    fs.writeFileSync(findingPath, "{}\n");
+
+    expect(resolveFindingInputPath(fixtureRoot)).toBe(fs.realpathSync(findingPath));
+  });
+
+  it.each(["symlink", "dangling symlink"])("rejects a %s finding artifact", kind => {
+    const findingPath = path.join(
+      fixtureRoot,
+      ".tmp",
+      "gemini-correctness",
+      "finding.json"
+    );
+    const target = path.join(fixtureRoot, "outside.json");
+    if (kind === "symlink") fs.writeFileSync(target, "{}\n");
+    fs.symlinkSync(target, findingPath);
+
+    expect(resolveFindingInputPath(fixtureRoot)).toBeNull();
+  });
+
+  it("rejects a .tmp directory symlink", () => {
+    fs.rmSync(path.join(fixtureRoot, ".tmp"), { recursive: true });
+    const outside = path.join(fixtureRoot, "outside");
+    fs.mkdirSync(path.join(outside, "gemini-correctness"), { recursive: true });
+    fs.writeFileSync(
+      path.join(outside, "gemini-correctness", "finding.json"),
+      "{}\n"
+    );
+    fs.symlinkSync(outside, path.join(fixtureRoot, ".tmp"));
+
+    expect(resolveFindingInputPath(fixtureRoot)).toBeNull();
+  });
+});
+
+describe("parseRedStageArgs", () => {
+  it("accepts only a bounded Gemini model identifier", () => {
+    expect(parseRedStageArgs(["--model", "gemini-2.5-flash"]))
+      .toEqual({ model: "gemini-2.5-flash" });
+  });
+
+  it.each([
+    ["--command", "sh -c true"],
+    ["--candidate", "/tmp/model-output.json"],
+    ["--finding", "../../finding.json"],
+    ["--model", "https://attacker.invalid/model"],
+    ["--unknown"]
+  ])("rejects unsupported or unsafe argv starting with %s", (...argv) => {
+    expect(() => parseRedStageArgs(argv)).toThrow();
+  });
+});
+
+describe("extractValidatedFinding", () => {
+  const finding = { schemaVersion: 1, status: "finding" };
+
+  it("accepts a raw finding or the exact successful #635 discovery envelope", () => {
+    expect(extractValidatedFinding(finding)).toBe(finding);
+    expect(extractValidatedFinding({ valid: true, result: finding })).toBe(finding);
+  });
+
+  it("rejects failed or extended discovery envelopes", () => {
+    expect(extractValidatedFinding({ valid: false, result: finding })).toBeNull();
+    expect(extractValidatedFinding({
+      valid: true,
+      result: finding,
+      command: "sh -c true"
+    })).toBeNull();
+  });
+});

--- a/scripts/gemini-correctness/red-stage-integration.test.ts
+++ b/scripts/gemini-correctness/red-stage-integration.test.ts
@@ -1,0 +1,598 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import {
+  replayRedArtifacts,
+  resetRedWorktree,
+  runRedStage
+} from "./red-stage.mjs";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..", "..");
+const testFile = "src/domain/example.regression.test.ts";
+const testName = "returns the safe fallback for an empty queue";
+const fakeSecret = "fixture-secret-value-12345";
+
+let fixtureRoot = "";
+
+function git(args: string[]) {
+  return execFileSync("git", args, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function write(relativePath: string, content: string) {
+  const absolutePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+function finding() {
+  return {
+    schemaVersion: 1,
+    status: "finding",
+    title: "returns the fallback for an empty queue",
+    confidence: 0.95,
+    category: "boundary-condition",
+    evidence: [
+      {
+        file: "src/domain/example.ts",
+        startLine: 1,
+        endLine: 3,
+        reason: "The empty branch returns a stale value."
+      }
+    ],
+    expectedBehavior: "an empty queue returns the safe fallback",
+    actualBehavior: "an empty queue returns the stale value",
+    reproduction: { testFile, testName },
+    productionFiles: ["src/domain/example.ts"],
+    risk: "low"
+  };
+}
+
+function candidate() {
+  return {
+    schemaVersion: 1,
+    status: "regression-test",
+    testFile,
+    testName,
+    source: `import { expect, it } from "vitest";
+import { readEmptyQueue } from "./example";
+
+it("${testName}", () => {
+  expect(
+    readEmptyQueue(),
+    "Expected behavior: ${finding().expectedBehavior} | Actual behavior: ${finding().actualBehavior}",
+  ).toBe("safe");
+});
+`
+  };
+}
+
+function initializeFixture() {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-red-stage-"));
+  git(["init", "-q"]);
+  git(["config", "user.email", "fixture@example.test"]);
+  git(["config", "user.name", "Fixture"]);
+  write(".gitignore", ".tmp/\nnode_modules\n");
+  write(
+    "package.json",
+    JSON.stringify({
+      name: "red-stage-fixture",
+      private: true,
+      type: "module",
+      packageManager: "pnpm@10.33.0"
+    }, null, 2) + "\n"
+  );
+  write(
+    "src/domain/example.ts",
+    'import fs from "node:fs";\n' +
+    'import path from "node:path";\n' +
+    `export function readEmptyQueue() {\n  return "${fakeSecret}";\n}\n` +
+    "export function crashWorker() {\n  process.exit(1);\n}\n" +
+    "export function triggerUnhandled() {\n" +
+    '  void Promise.reject(new Error("production background failure"));\n' +
+    "}\n" +
+    "export function tamperProductionOnReplay() {\n" +
+    '  const patch = path.join(process.cwd(), ".tmp/gemini-correctness/red-test.patch");\n' +
+    "  if (fs.existsSync(patch)) {\n" +
+    '    fs.appendFileSync(path.join(process.cwd(), "src/domain/example.ts"), "// replay tamper\\n");\n' +
+    "  }\n" +
+    "}\n" +
+    "export function tamperProductionOnInitial() {\n" +
+    '  const patch = path.join(process.cwd(), ".tmp/gemini-correctness/red-test.patch");\n' +
+    "  if (!fs.existsSync(patch)) {\n" +
+    '    fs.appendFileSync(path.join(process.cwd(), "src/domain/example.ts"), "// initial tamper\\n");\n' +
+    "  }\n" +
+    "}\n" +
+    "export function writeIgnoredFileOnInitial() {\n" +
+    '  const patch = path.join(process.cwd(), ".tmp/gemini-correctness/red-test.patch");\n' +
+    "  if (!fs.existsSync(patch)) {\n" +
+    '    fs.writeFileSync(path.join(process.cwd(), ".tmp/gemini-correctness/hostile.bin"), "pollution");\n' +
+    "  }\n" +
+    "}\n" +
+    "export function tamperGitConfigOnInitial() {\n" +
+    '  const patch = path.join(process.cwd(), ".tmp/gemini-correctness/red-test.patch");\n' +
+    "  if (!fs.existsSync(patch)) {\n" +
+    '    fs.appendFileSync(path.join(process.cwd(), ".git/config"), "\\n[hostile]\\n\\tvalue = true\\n");\n' +
+    "  }\n" +
+    "}\n" +
+    "export function tamperPatchOnReplay() {\n" +
+    '  const patch = path.join(process.cwd(), ".tmp/gemini-correctness/red-test.patch");\n' +
+    '  if (fs.existsSync(patch)) fs.appendFileSync(patch, "\\n# replay tamper\\n");\n' +
+    "}\n"
+  );
+  write(
+    "src/domain/example.test.ts",
+    'import { expect, it } from "vitest";\nit("keeps existing tests", () => expect(true).toBe(true));\n'
+  );
+  git([
+    "add",
+    ".gitignore",
+    "package.json",
+    "src/domain/example.ts",
+    "src/domain/example.test.ts"
+  ]);
+  git(["commit", "-qm", "fixture baseline"]);
+  fs.symlinkSync(path.join(projectRoot, "node_modules"), path.join(fixtureRoot, "node_modules"));
+}
+
+describe("runRedStage integration", () => {
+  beforeEach(() => initializeFixture());
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("proves, preserves, resets, replays, and re-proves one assertion RED", async () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: candidate()
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: {
+        ...process.env,
+        FIXTURE_SECRET: fakeSecret
+      }
+    });
+
+    expect(result, result.error).toMatchObject({ valid: true });
+    expect(result.result).toMatchObject({
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha,
+      testFile,
+      testName,
+      failureKind: "assertion",
+      replayConfirmed: true
+    });
+    expect(client.generateJson).toHaveBeenCalledTimes(1);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"]))
+      .toBe(`?? ${testFile}`);
+
+    const artifactDir = path.join(fixtureRoot, ".tmp", "gemini-correctness");
+    const patch = fs.readFileSync(path.join(artifactDir, "red-test.patch"), "utf8");
+    const log = fs.readFileSync(path.join(artifactDir, "red-test.log"), "utf8");
+    const savedResult = JSON.parse(
+      fs.readFileSync(path.join(artifactDir, "red-result.json"), "utf8")
+    );
+
+    expect(savedResult).toEqual(result.result);
+    expect(savedResult.patchSha256).toBe(
+      createHash("sha256").update(patch).digest("hex")
+    );
+    expect(patch).toContain(`b/${testFile}`);
+    expect(log).toContain("[initial]");
+    expect(log).toContain("[replay]");
+    expect(log).not.toContain(fakeSecret);
+    expect(log).not.toContain(fixtureRoot);
+    expect(log).not.toContain(projectRoot);
+    expect(JSON.stringify(savedResult)).not.toContain(fakeSecret);
+    expect(JSON.stringify(savedResult)).not.toContain(fixtureRoot);
+  });
+
+  it.each([
+    ["unstaged production and untracked files", () => {
+      write("src/domain/example.ts", "modified production\n");
+      write("src/domain/extra.ts", "untracked\n");
+    }],
+    ["staged and untracked files", () => {
+      write("src/domain/staged.ts", "staged\n");
+      git(["add", "src/domain/staged.ts"]);
+      write("src/domain/extra.ts", "untracked\n");
+    }],
+    ["an existing test modification", () => {
+      write("src/domain/example.test.ts", "modified existing test\n");
+    }],
+    ["a Windows-separator filename", () => {
+      write("hostile\\name.tmp", "untracked\n");
+    }]
+  ])("rejects and cleans model-side %s", async (_label, sideEffect) => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const client = {
+      generateJson: vi.fn().mockImplementation(async () => {
+        sideEffect();
+        return { valid: true, result: candidate() };
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(git(["rev-parse", "HEAD"])).toBe(baselineSha);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it.each([
+    ["tracked production", "tamperProductionOnReplay"],
+    ["stored patch", "tamperPatchOnReplay"]
+  ])("rejects replay-side mutation of %s and restores baseline", async (
+    _label,
+    helperName
+  ) => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const hostileCandidate = candidate();
+    hostileCandidate.source = hostileCandidate.source
+      .replace(
+        'import { readEmptyQueue } from "./example";',
+        `import { readEmptyQueue, ${helperName} } from "./example";`
+      )
+      .replace(
+        "  expect(\n",
+        `  ${helperName}();\n  expect(\n`
+      );
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: hostileCandidate
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(git(["rev-parse", "HEAD"])).toBe(baselineSha);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it("rejects initial-execution production mutation and restores baseline", async () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const hostileCandidate = candidate();
+    hostileCandidate.source = hostileCandidate.source
+      .replace(
+        'import { readEmptyQueue } from "./example";',
+        'import { readEmptyQueue, tamperProductionOnInitial } from "./example";'
+      )
+      .replace(
+        "  expect(\n",
+        "  tamperProductionOnInitial();\n  expect(\n"
+      );
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: hostileCandidate
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(git(["rev-parse", "HEAD"])).toBe(baselineSha);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it("rejects and removes ignored-path pollution from test execution", async () => {
+    const hostilePath = path.join(
+      fixtureRoot,
+      ".tmp",
+      "gemini-correctness",
+      "hostile.bin"
+    );
+    const hostileCandidate = candidate();
+    hostileCandidate.source = hostileCandidate.source
+      .replace(
+        'import { readEmptyQueue } from "./example";',
+        'import { readEmptyQueue, writeIgnoredFileOnInitial } from "./example";'
+      )
+      .replace(
+        "  expect(\n",
+        "  writeIgnoredFileOnInitial();\n  expect(\n"
+      );
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: hostileCandidate
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(fs.existsSync(hostilePath)).toBe(false);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it("rejects and restores Git metadata mutation from test execution", async () => {
+    const configPath = path.join(fixtureRoot, ".git", "config");
+    const originalConfig = fs.readFileSync(configPath, "utf8");
+    const hostileCandidate = candidate();
+    hostileCandidate.source = hostileCandidate.source
+      .replace(
+        'import { readEmptyQueue } from "./example";',
+        'import { readEmptyQueue, tamperGitConfigOnInitial } from "./example";'
+      )
+      .replace(
+        "  expect(\n",
+        "  tamperGitConfigOnInitial();\n  expect(\n"
+      );
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: hostileCandidate
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(fs.readFileSync(configPath, "utf8")).toBe(originalConfig);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it.each([
+    [
+      "import failure",
+      () => ({
+        ...candidate(),
+        source: candidate().source.replace(
+          'import { readEmptyQueue } from "./example";',
+          'import { readEmptyQueue } from "./missing";'
+        )
+      }),
+      undefined
+    ],
+    [
+      "non-assertion runtime error",
+      () => ({
+        ...candidate(),
+        source: candidate().source.replace(
+          "expect(\n    readEmptyQueue(),",
+          `const broken: null = null;\n  // ${finding().expectedBehavior} | ${finding().actualBehavior}\n  broken.value;\n  expect(\n    readEmptyQueue(),`
+        )
+      }),
+      undefined
+    ],
+    [
+      "unhandled rejection beside an assertion",
+      () => ({
+        ...candidate(),
+        source: candidate().source
+          .replace(
+            'import { readEmptyQueue } from "./example";',
+            'import { readEmptyQueue, triggerUnhandled } from "./example";'
+          )
+          .replace(
+            "expect(\n    readEmptyQueue(),",
+            "triggerUnhandled();\n  expect(\n    readEmptyQueue(),"
+          )
+      }),
+      undefined
+    ],
+    [
+      "process timeout",
+      () => ({
+        ...candidate(),
+        source: candidate().source.replace(
+          `it("${testName}", () => {`,
+          `it("${testName}", async () => {\n  await new Promise(() => {});`
+        )
+      }),
+      500
+    ],
+    [
+      "worker crash",
+      () => ({
+        ...candidate(),
+        source: candidate().source
+          .replace(
+            'import { readEmptyQueue } from "./example";',
+            'import { crashWorker, readEmptyQueue } from "./example";'
+          )
+          .replace(
+            "expect(\n    readEmptyQueue(),",
+            "crashWorker();\n  expect(\n    readEmptyQueue(),"
+          )
+      }),
+      5_000
+    ]
+  ])("rejects and cleans a %s", async (_label, makeCandidate, testTimeoutMs) => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: makeCandidate()
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env,
+      testTimeoutMs
+    });
+
+    expect(result.valid).toBe(false);
+    expect(git(["rev-parse", "HEAD"])).toBe(baselineSha);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it("rejects tampered baseline, hash, or coordinated replay content", async () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: candidate()
+      })
+    };
+    const stage = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+    expect(stage, stage.error).toMatchObject({ valid: true });
+
+    const artifactDir = path.join(fixtureRoot, ".tmp", "gemini-correctness");
+    const patchPath = path.join(artifactDir, "red-test.patch");
+    const resultPath = path.join(artifactDir, "red-result.json");
+    const originalPatch = fs.readFileSync(patchPath, "utf8");
+    const originalResult = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+    const reset = resetRedWorktree({ repoRoot: fixtureRoot, baselineSha, testFile });
+    expect(reset.valid).toBe(true);
+
+    const expectations = {
+      expectedBaselineSha: baselineSha,
+      expectedPatchSha256: originalResult.patchSha256,
+      expectedSummary: originalResult.sanitizedSummary
+    };
+
+    fs.writeFileSync(resultPath, JSON.stringify({
+      ...originalResult,
+      baselineSha: "0".repeat(40)
+    }));
+    expect(replayRedArtifacts({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      environment: process.env,
+      ...expectations
+    }).valid).toBe(false);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+
+    fs.writeFileSync(resultPath, JSON.stringify({
+      ...originalResult,
+      patchSha256: "f".repeat(64)
+    }));
+    expect(replayRedArtifacts({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      environment: process.env,
+      ...expectations
+    }).valid).toBe(false);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+
+    const tamperedPatch = originalPatch.replace('.toBe("safe")', '.toBe("tampered")');
+    fs.writeFileSync(patchPath, tamperedPatch);
+    fs.writeFileSync(resultPath, JSON.stringify({
+      ...originalResult,
+      patchSha256: createHash("sha256").update(tamperedPatch).digest("hex")
+    }));
+    expect(replayRedArtifacts({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      environment: process.env,
+      ...expectations
+    }).valid).toBe(false);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+
+  it("redacts rejection errors and artifacts without leaking environment or paths", async () => {
+    const shortSecret = "tiny!";
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: false,
+        error:
+          `failed with ${fakeSecret} and ${shortSecret} ` +
+          `at ${fixtureRoot} via ${projectRoot}`
+      })
+    };
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: {
+        ...process.env,
+        FIXTURE_SECRET: fakeSecret,
+        API_KEY: shortSecret
+      }
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).not.toContain(fakeSecret);
+    expect(result.error).not.toContain(shortSecret);
+    expect(result.error).not.toContain(fixtureRoot);
+    expect(result.error).not.toContain(projectRoot);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+
+    const artifactDir = path.join(fixtureRoot, ".tmp", "gemini-correctness");
+    for (const artifact of ["red-result.json", "red-test.log"]) {
+      const content = fs.readFileSync(path.join(artifactDir, artifact), "utf8");
+      expect(content).not.toContain(fakeSecret);
+      expect(content).not.toContain(shortSecret);
+      expect(content).not.toContain(fixtureRoot);
+      expect(content).not.toContain(projectRoot);
+    }
+  });
+
+  it("rejects unsafe artifact symlinks without writing outside or leaving changes", async () => {
+    const artifactDir = path.join(fixtureRoot, ".tmp", "gemini-correctness");
+    const outsideLog = path.join(fixtureRoot, "outside-red-test.log");
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.symlinkSync(outsideLog, path.join(artifactDir, "red-test.log"));
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: candidate()
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: process.env
+    });
+
+    expect(result.valid).toBe(false);
+    expect(fs.existsSync(outsideLog)).toBe(false);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+  });
+});

--- a/scripts/gemini-correctness/red-stage-integration.test.ts
+++ b/scripts/gemini-correctness/red-stage-integration.test.ts
@@ -239,6 +239,55 @@ describe("runRedStage integration", () => {
     expect(JSON.stringify(savedResult)).not.toContain(fixtureRoot);
   });
 
+  it("preserves RED contract fields when GITHUB_SHA matches baselineSha", async () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const leakToken = "should-be-redacted-in-log-abc123";
+    const client = {
+      generateJson: vi.fn().mockResolvedValue({
+        valid: true,
+        result: candidate()
+      })
+    };
+
+    const result = await runRedStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      client,
+      environment: {
+        ...process.env,
+        GITHUB_SHA: baselineSha,
+        LEAK_TOKEN: leakToken,
+        FIXTURE_SECRET: fakeSecret
+      }
+    });
+
+    expect(result, result.error).toMatchObject({ valid: true });
+    expect(result.result).toMatchObject({
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha,
+      testFile,
+      testName,
+      failureKind: "assertion",
+      replayConfirmed: true
+    });
+    expect(result.result.patchSha256).toMatch(/^[0-9a-f]{64}$/);
+
+    const savedResult = JSON.parse(
+      fs.readFileSync(path.join(fixtureRoot, ".tmp/gemini-correctness/red-result.json"), "utf8")
+    );
+    expect(savedResult.baselineSha).toBe(baselineSha);
+    expect(savedResult.patchSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(savedResult)).not.toContain(leakToken);
+    expect(JSON.stringify(savedResult)).not.toContain(fakeSecret);
+    expect(JSON.stringify(savedResult)).not.toContain(fixtureRoot);
+
+    const log = fs.readFileSync(path.join(fixtureRoot, ".tmp/gemini-correctness/red-test.log"), "utf8");
+    expect(log).not.toContain(leakToken);
+    expect(log).not.toContain(fakeSecret);
+    expect(log).not.toContain(fixtureRoot);
+  });
+
   it.each([
     ["unstaged production and untracked files", () => {
       write("src/domain/example.ts", "modified production\n");
@@ -276,23 +325,18 @@ describe("runRedStage integration", () => {
     expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
   });
 
-  it.each([
-    ["tracked production", "tamperProductionOnReplay"],
-    ["stored patch", "tamperPatchOnReplay"]
-  ])("rejects replay-side mutation of %s and restores baseline", async (
-    _label,
-    helperName
-  ) => {
+  it("rejects replay-side mutation of stored patch and restores baseline",
+    async () => {
     const baselineSha = git(["rev-parse", "HEAD"]);
     const hostileCandidate = candidate();
     hostileCandidate.source = hostileCandidate.source
       .replace(
         'import { readEmptyQueue } from "./example";',
-        `import { readEmptyQueue, ${helperName} } from "./example";`
+        `import { readEmptyQueue, tamperPatchOnReplay } from "./example";`
       )
       .replace(
         "  expect(\n",
-        `  ${helperName}();\n  expect(\n`
+        "  tamperPatchOnReplay();\n  expect(\n"
       );
     const client = {
       generateJson: vi.fn().mockResolvedValue({

--- a/scripts/gemini-correctness/red-stage-integration.test.ts
+++ b/scripts/gemini-correctness/red-stage-integration.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   replayRedArtifacts,
   resetRedWorktree,
+  runGuardedTargetedVitest,
   runRedStage
 } from "./red-stage.mjs";
 import { execFileSync } from "node:child_process";
@@ -143,6 +144,40 @@ function initializeFixture() {
   git(["commit", "-qm", "fixture baseline"]);
   fs.symlinkSync(path.join(projectRoot, "node_modules"), path.join(fixtureRoot, "node_modules"));
 }
+
+describe("runGuardedTargetedVitest", () => {
+  it("fails closed without restoring when the post-run snapshot cannot be captured", () => {
+    const before = {
+      entries: new Map(),
+      repoRoot: "/unused",
+      testFile,
+      reportPath: "/unused/report.json",
+      restorable: true
+    };
+    const snapshot = vi.fn()
+      .mockReturnValueOnce(before)
+      .mockImplementationOnce(() => {
+        throw new Error("fixture post-run snapshot failure");
+      });
+    const restoreSnapshot = vi.fn(() => ({ valid: true, mutated: false }));
+
+    const result = runGuardedTargetedVitest(
+      {},
+      {
+        snapshot,
+        targetedRunner: vi.fn(() => ({ exitCode: 1 })),
+        restoreSnapshot
+      }
+    );
+
+    expect(result).toEqual({
+      valid: false,
+      error: "failed to capture repository state after targeted Vitest"
+    });
+    expect(snapshot).toHaveBeenCalledTimes(2);
+    expect(restoreSnapshot).not.toHaveBeenCalled();
+  });
+});
 
 describe("runRedStage integration", () => {
   beforeEach(() => initializeFixture());

--- a/scripts/gemini-correctness/red-stage.mjs
+++ b/scripts/gemini-correctness/red-stage.mjs
@@ -426,10 +426,14 @@ function restoreExecutionSnapshot(before, after) {
   }
 }
 
-function runGuardedTargetedVitest(options) {
+export function runGuardedTargetedVitest(options, {
+  snapshot = executionSnapshot,
+  targetedRunner = runTargetedVitest,
+  restoreSnapshot = restoreExecutionSnapshot
+} = {}) {
   let before;
   try {
-    before = executionSnapshot(options);
+    before = snapshot(options);
   } catch {
     return invalid("failed to capture repository state before targeted Vitest");
   }
@@ -437,18 +441,14 @@ function runGuardedTargetedVitest(options) {
     return invalid("repository state is not safely snapshot-restorable");
   }
 
-  const execution = runTargetedVitest(options);
+  const execution = targetedRunner(options);
   let after;
   try {
-    after = executionSnapshot(options);
+    after = snapshot(options);
   } catch {
-    after = {
-      ...before,
-      entries: new Map(),
-      restorable: false
-    };
+    return invalid("failed to capture repository state after targeted Vitest");
   }
-  const restoration = restoreExecutionSnapshot(before, after);
+  const restoration = restoreSnapshot(before, after);
   if (!restoration.valid) return restoration;
   if (restoration.mutated) {
     return invalid("targeted Vitest modified repository paths outside its test/report");

--- a/scripts/gemini-correctness/red-stage.mjs
+++ b/scripts/gemini-correctness/red-stage.mjs
@@ -191,6 +191,29 @@ function sanitize(value, sensitiveValues) {
   return redactForOutput(value, sensitiveValues);
 }
 
+const RED_RESULT_CONTRACT_KEYS = new Set([
+  "schemaVersion",
+  "status",
+  "baselineSha",
+  "testFile",
+  "testName",
+  "failureKind",
+  "patchSha256",
+  "replayConfirmed"
+]);
+
+function sanitizeRedResult(result, sensitiveValues) {
+  const preserved = {};
+  for (const key of RED_RESULT_CONTRACT_KEYS) {
+    preserved[key] = result[key];
+  }
+  const safe = sanitize(result, sensitiveValues);
+  for (const key of RED_RESULT_CONTRACT_KEYS) {
+    safe[key] = preserved[key];
+  }
+  return safe;
+}
+
 function reportFailureMessages(report) {
   if (!Array.isArray(report?.testResults)) return "";
   return report.testResults
@@ -890,7 +913,8 @@ export async function runRedStage({
       patchSha256: patchHash,
       replayConfirmed: false
     };
-    writeJson(paths.result, sanitize(provisionalResult, outputSecrets));
+    const safeProvisional = sanitizeRedResult(provisionalResult, outputSecrets);
+    writeJson(paths.result, safeProvisional);
 
     const reset = resetRedWorktree({
       repoRoot,
@@ -915,7 +939,7 @@ export async function runRedStage({
       ...provisionalResult,
       replayConfirmed: true
     };
-    const safeResult = sanitize(finalResult, outputSecrets);
+    const safeResult = sanitizeRedResult(finalResult, outputSecrets);
     const safeLog = boundedLog(sanitize(
       `${executionLog("initial", initialExecution)}\n\n` +
       executionLog("replay", replay.execution),

--- a/scripts/gemini-correctness/red-stage.mjs
+++ b/scripts/gemini-correctness/red-stage.mjs
@@ -1,0 +1,1011 @@
+// =============================================================================
+// red-stage.mjs — orchestrates one fail-closed, replayable RED test stage
+// =============================================================================
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { createGeminiClient } from "./gemini-client.mjs";
+import { redactForOutput } from "./discover.mjs";
+import { validateFinding } from "./finding-schema.mjs";
+import {
+  getDefaultAllowlist,
+  getDefaultProtectedPaths,
+  safeWritePath
+} from "./policy.mjs";
+import { buildRedPrompt } from "./red-prompt-builder.mjs";
+import { DEFAULT_MODEL } from "./prompt-builder.mjs";
+import {
+  captureCleanBaseline,
+  createTestOnlyPatch,
+  validateRegressionCandidate,
+  validateTestOnlyWorktree
+} from "./red-validator.mjs";
+import {
+  classifyVitestRed,
+  runTargetedVitest
+} from "./red-runner.mjs";
+import { validateFindingWithRepo } from "./repo-validator.mjs";
+import { scanRepository } from "./scanner.mjs";
+
+const MODULE_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(MODULE_PATH), "..", "..");
+const ARTIFACT_RELATIVE_DIR = "gemini-correctness";
+const FINDING_RELATIVE_PATH = `${ARTIFACT_RELATIVE_DIR}/finding.json`;
+const RESULT_KEYS = new Set([
+  "schemaVersion",
+  "status",
+  "baselineSha",
+  "testFile",
+  "testName",
+  "failureKind",
+  "sanitizedSummary",
+  "patchSha256",
+  "replayConfirmed"
+]);
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+export function parseRedStageArgs(argv) {
+  const parsed = { model: DEFAULT_MODEL };
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument !== "--model") {
+      throw new Error(`unsupported RED stage argument: ${argument}`);
+    }
+    const model = argv[++index];
+    if (
+      typeof model !== "string" ||
+      !/^gemini-[A-Za-z0-9._-]{1,100}$/.test(model)
+    ) {
+      throw new Error("model must be a bounded Gemini model identifier");
+    }
+    parsed.model = model;
+  }
+  return parsed;
+}
+
+export function resolveFindingInputPath(repoRoot) {
+  try {
+    const allowedDir = path.join(repoRoot, ".tmp");
+    const allowedStat = fs.lstatSync(allowedDir);
+    if (allowedStat.isSymbolicLink() || !allowedStat.isDirectory()) return null;
+    const candidate = safeWritePath(
+      FINDING_RELATIVE_PATH,
+      allowedDir,
+      repoRoot
+    );
+    if (!candidate) return null;
+    const stat = fs.lstatSync(candidate);
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > 64 * 1024) {
+      return null;
+    }
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export function extractValidatedFinding(input) {
+  if (
+    input &&
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    input.status === "finding"
+  ) {
+    return input;
+  }
+  if (
+    input &&
+    typeof input === "object" &&
+    !Array.isArray(input) &&
+    Object.keys(input).length === 2 &&
+    input.valid === true &&
+    input.result &&
+    typeof input.result === "object" &&
+    !Array.isArray(input.result) &&
+    input.result.status === "finding"
+  ) {
+    return input.result;
+  }
+  return null;
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function runGit(repoRoot, args, { input } = {}) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input,
+    maxBuffer: 2 * 1024 * 1024,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(`git ${args[0]} failed`);
+  }
+  return result.stdout;
+}
+
+function artifactPaths(repoRoot) {
+  const allowedDir = path.join(repoRoot, ".tmp");
+  const relativePaths = {
+    patch: `${ARTIFACT_RELATIVE_DIR}/red-test.patch`,
+    result: `${ARTIFACT_RELATIVE_DIR}/red-result.json`,
+    log: `${ARTIFACT_RELATIVE_DIR}/red-test.log`,
+    initialReport: `${ARTIFACT_RELATIVE_DIR}/.vitest-initial.json`,
+    replayReport: `${ARTIFACT_RELATIVE_DIR}/.vitest-replay.json`
+  };
+
+  const initialCandidate = safeWritePath(relativePaths.patch, allowedDir, repoRoot);
+  if (!initialCandidate) throw new Error("artifact directory is unsafe");
+  fs.mkdirSync(path.dirname(initialCandidate), { recursive: true });
+
+  const resolved = {};
+  for (const [key, relativePath] of Object.entries(relativePaths)) {
+    const safe = safeWritePath(relativePath, allowedDir, repoRoot);
+    if (!safe) throw new Error(`artifact path is unsafe: ${key}`);
+    resolved[key] = safe;
+  }
+  return resolved;
+}
+
+function collectSensitiveValues(environment, repoRoot, { output }) {
+  const values = new Set([
+    repoRoot,
+    process.cwd(),
+    process.execPath,
+    MODULE_PATH
+  ]);
+  try {
+    values.add(fs.realpathSync(repoRoot));
+  } catch {
+    // The caller will fail repository validation separately.
+  }
+
+  for (const [key, value] of Object.entries(environment ?? {})) {
+    if (typeof value !== "string" || value.length === 0) continue;
+    const sensitiveName =
+      /(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH|COOKIE)/i.test(key);
+    if (sensitiveName || (output && value.length >= 8)) {
+      values.add(value);
+    }
+  }
+  if (output && typeof environment?.PATH === "string") {
+    for (const entry of environment.PATH.split(path.delimiter)) {
+      if (entry.length >= 4) values.add(entry);
+    }
+  }
+  return [...values].filter(value => typeof value === "string" && value.length > 0);
+}
+
+function sanitize(value, sensitiveValues) {
+  return redactForOutput(value, sensitiveValues);
+}
+
+function reportFailureMessages(report) {
+  if (!Array.isArray(report?.testResults)) return "";
+  return report.testResults
+    .flatMap(file => Array.isArray(file.assertionResults) ? file.assertionResults : [])
+    .flatMap(assertion =>
+      Array.isArray(assertion.failureMessages) ? assertion.failureMessages : []
+    )
+    .join("\n");
+}
+
+function executionLog(label, execution) {
+  return [
+    `[${label}]`,
+    `exitCode=${String(execution.exitCode)}`,
+    `signal=${String(execution.signal ?? "")}`,
+    execution.stdout ?? "",
+    execution.stderr ?? "",
+    reportFailureMessages(execution.report)
+  ].filter(Boolean).join("\n");
+}
+
+function boundedLog(value) {
+  const maxChars = 128 * 1024;
+  if (value.length <= maxChars) return value.endsWith("\n") ? value : `${value}\n`;
+  return `${value.slice(0, maxChars)}\n[log truncated]\n`;
+}
+
+const MAX_EXECUTION_SNAPSHOT_BYTES = 512 * 1024 * 1024;
+
+function executionSnapshot({
+  repoRoot,
+  testFile,
+  reportPath
+}) {
+  const repoReal = fs.realpathSync(repoRoot);
+  const excluded = new Set([testFile]);
+  const reportRelative = path.relative(repoReal, reportPath).replace(/\\/g, "/");
+  if (
+    !reportRelative ||
+    reportRelative.startsWith("../") ||
+    path.isAbsolute(reportRelative)
+  ) {
+    throw new Error("Vitest report path escaped repository");
+  }
+  excluded.add(reportRelative);
+
+  const entries = new Map();
+  let totalBytes = 0;
+  let restorable = true;
+
+  function walk(relativeDirectory) {
+    const absoluteDirectory = relativeDirectory
+      ? path.join(repoReal, relativeDirectory)
+      : repoReal;
+    let children;
+    try {
+      children = fs.readdirSync(absoluteDirectory, { withFileTypes: true })
+        .sort((left, right) => left.name.localeCompare(right.name));
+    } catch (error) {
+      if (!relativeDirectory) throw error;
+      const previous = entries.get(relativeDirectory) ?? { mode: -1 };
+      entries.set(relativeDirectory, { ...previous, kind: "unreadable" });
+      restorable = false;
+      return;
+    }
+    for (const child of children) {
+      const relativePath = relativeDirectory
+        ? `${relativeDirectory}/${child.name}`
+        : child.name;
+      if (
+        relativePath === ".git/objects" ||
+        relativePath.startsWith(".git/objects/") ||
+        relativePath.split("/").includes("node_modules") ||
+        excluded.has(relativePath)
+      ) {
+        continue;
+      }
+
+      const absolutePath = path.join(repoReal, relativePath);
+      let stat;
+      try {
+        stat = fs.lstatSync(absolutePath);
+      } catch {
+        entries.set(relativePath, { kind: "unreadable", mode: -1 });
+        restorable = false;
+        continue;
+      }
+      const metadata = {
+        mode: stat.mode & 0o777,
+        atimeMs: stat.atimeMs,
+        mtimeMs: stat.mtimeMs
+      };
+      if (stat.isSymbolicLink()) {
+        try {
+          entries.set(relativePath, {
+            ...metadata,
+            kind: "symlink",
+            target: fs.readlinkSync(absolutePath)
+          });
+        } catch {
+          entries.set(relativePath, { ...metadata, kind: "unreadable" });
+          restorable = false;
+        }
+      } else if (stat.isDirectory()) {
+        entries.set(relativePath, { ...metadata, kind: "directory" });
+        walk(relativePath);
+      } else if (stat.isFile()) {
+        if (totalBytes + stat.size > MAX_EXECUTION_SNAPSHOT_BYTES) {
+          entries.set(relativePath, {
+            ...metadata,
+            kind: "oversized",
+            size: stat.size
+          });
+          restorable = false;
+          continue;
+        }
+        try {
+          const content = fs.readFileSync(absolutePath);
+          totalBytes += content.byteLength;
+          entries.set(relativePath, {
+            ...metadata,
+            kind: "file",
+            content
+          });
+        } catch {
+          entries.set(relativePath, { ...metadata, kind: "unreadable" });
+          restorable = false;
+        }
+      } else {
+        entries.set(relativePath, { ...metadata, kind: "special" });
+        restorable = false;
+      }
+    }
+  }
+
+  walk("");
+  return { entries, repoRoot: repoReal, testFile, reportPath, restorable };
+}
+
+function sameSnapshotEntry(left, right) {
+  if (!left || !right || left.kind !== right.kind || left.mode !== right.mode) {
+    return false;
+  }
+  if (left.kind === "file") return left.content.equals(right.content);
+  if (left.kind === "symlink") return left.target === right.target;
+  if (left.kind === "oversized") return left.size === right.size;
+  return true;
+}
+
+function changedSnapshotRoots(before, after) {
+  const changed = [...new Set([
+    ...before.entries.keys(),
+    ...after.entries.keys()
+  ])]
+    .filter(relativePath =>
+      !sameSnapshotEntry(
+        before.entries.get(relativePath),
+        after.entries.get(relativePath)
+      )
+    )
+    .sort((left, right) => {
+      const depth = left.split("/").length - right.split("/").length;
+      return depth || left.localeCompare(right);
+    });
+
+  const roots = [];
+  for (const relativePath of changed) {
+    if (!roots.some(root => relativePath.startsWith(`${root}/`))) {
+      roots.push(relativePath);
+    }
+  }
+  return roots;
+}
+
+function restoreExecutionSnapshot(before, after) {
+  const roots = changedSnapshotRoots(before, after);
+  if (roots.length === 0) return { valid: true, mutated: false };
+
+  try {
+    for (const relativePath of roots) {
+      const absolutePath = path.resolve(before.repoRoot, relativePath);
+      const containment = path.relative(before.repoRoot, absolutePath);
+      if (
+        !containment ||
+        containment.startsWith("..") ||
+        path.isAbsolute(containment)
+      ) {
+        throw new Error("execution mutation escaped repository");
+      }
+      fs.rmSync(absolutePath, { recursive: true, force: true });
+    }
+
+    for (const root of roots) {
+      const restoreEntries = [...before.entries.entries()]
+        .filter(([relativePath]) =>
+          relativePath === root || relativePath.startsWith(`${root}/`)
+        )
+        .sort(([left], [right]) => {
+          const depth = left.split("/").length - right.split("/").length;
+          return depth || left.localeCompare(right);
+        });
+      for (const [relativePath, entry] of restoreEntries) {
+        const absolutePath = path.join(before.repoRoot, relativePath);
+        if (entry.kind === "directory") {
+          fs.mkdirSync(absolutePath, { recursive: true, mode: 0o700 });
+        } else if (entry.kind === "file") {
+          fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+          fs.writeFileSync(absolutePath, entry.content, { mode: entry.mode });
+          fs.chmodSync(absolutePath, entry.mode);
+          fs.utimesSync(absolutePath, entry.atimeMs / 1000, entry.mtimeMs / 1000);
+        } else if (entry.kind === "symlink") {
+          fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+          fs.symlinkSync(entry.target, absolutePath);
+        } else {
+          throw new Error("cannot restore a changed special repository entry");
+        }
+      }
+      for (const [relativePath, entry] of restoreEntries.reverse()) {
+        if (entry.kind !== "directory") continue;
+        const absolutePath = path.join(before.repoRoot, relativePath);
+        fs.chmodSync(absolutePath, entry.mode);
+        fs.utimesSync(absolutePath, entry.atimeMs / 1000, entry.mtimeMs / 1000);
+      }
+    }
+
+    const restored = executionSnapshot(before);
+    if (changedSnapshotRoots(before, restored).length !== 0) {
+      return invalid("test execution mutation cleanup could not be verified");
+    }
+    return { valid: true, mutated: true };
+  } catch {
+    return invalid("test execution mutation cleanup could not be verified");
+  }
+}
+
+function runGuardedTargetedVitest(options) {
+  let before;
+  try {
+    before = executionSnapshot(options);
+  } catch {
+    return invalid("failed to capture repository state before targeted Vitest");
+  }
+  if (!before.restorable) {
+    return invalid("repository state is not safely snapshot-restorable");
+  }
+
+  const execution = runTargetedVitest(options);
+  let after;
+  try {
+    after = executionSnapshot(options);
+  } catch {
+    after = {
+      ...before,
+      entries: new Map(),
+      restorable: false
+    };
+  }
+  const restoration = restoreExecutionSnapshot(before, after);
+  if (!restoration.valid) return restoration;
+  if (restoration.mutated) {
+    return invalid("targeted Vitest modified repository paths outside its test/report");
+  }
+  return execution;
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600
+  });
+}
+
+function removeReporterFiles(paths) {
+  for (const filePath of [paths?.initialReport, paths?.replayReport]) {
+    if (!filePath) continue;
+    try {
+      fs.rmSync(filePath, { force: true });
+    } catch {
+      // A stale report makes the next reporter write fail closed.
+    }
+  }
+}
+
+export function resetRedWorktree({ repoRoot, baselineSha, testFile } = {}) {
+  try {
+    if (!/^[0-9a-f]{40,64}$/i.test(String(baselineSha ?? ""))) {
+      return invalid("baseline SHA is invalid");
+    }
+    runGit(repoRoot, ["cat-file", "-e", `${baselineSha}^{commit}`]);
+    runGit(repoRoot, ["reset", "--hard", baselineSha]);
+    const untrackedStatus = runGit(repoRoot, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "-z"
+    ]);
+    const untrackedEntries = untrackedStatus.split("\0").filter(Boolean);
+    for (const entry of untrackedEntries) {
+      if (!entry.startsWith("?? ")) {
+        return invalid("tracked changes remain after baseline reset");
+      }
+      const relativePath = entry.slice(3);
+      const absolutePath = path.resolve(repoRoot, relativePath);
+      const relativeCheck = path.relative(repoRoot, absolutePath);
+      if (!relativeCheck || relativeCheck.startsWith("..") || path.isAbsolute(relativeCheck)) {
+        return invalid("untracked cleanup path escaped repository");
+      }
+      fs.rmSync(absolutePath, { recursive: true, force: true });
+    }
+    if (runGit(repoRoot, ["rev-parse", "HEAD"]).trim() !== baselineSha) {
+      return invalid("failed to restore baseline HEAD");
+    }
+    const status = runGit(repoRoot, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "-z"
+    ]);
+    if (status !== "") return invalid("worktree is not clean after reset");
+    return { valid: true };
+  } catch {
+    return invalid("failed to reset worktree to baseline");
+  }
+}
+
+function verifyCandidateIntegrity({
+  repoRoot,
+  baselineSha,
+  testFile,
+  expectedPatchSha256
+}) {
+  const worktree = validateTestOnlyWorktree({
+    repoRoot,
+    baselineSha,
+    testFile
+  });
+  if (!worktree.valid) return worktree;
+  const currentPatch = createTestOnlyPatch({
+    repoRoot,
+    baselineSha,
+    testFile
+  });
+  if (!currentPatch.valid) return currentPatch;
+  if (sha256(currentPatch.patch) !== expectedPatchSha256) {
+    return invalid("candidate test patch changed during RED execution");
+  }
+  return { valid: true };
+}
+
+function validateStoredResult(result, finding) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("stored RED result must be an object");
+  }
+  const keys = Object.keys(result);
+  if (
+    keys.some(key => !RESULT_KEYS.has(key)) ||
+    [...RESULT_KEYS].some(key => !(key in result))
+  ) {
+    return invalid("stored RED result fields are invalid");
+  }
+  if (
+    result.schemaVersion !== 1 ||
+    result.status !== "red-confirmed" ||
+    result.failureKind !== "assertion" ||
+    typeof result.replayConfirmed !== "boolean" ||
+    !/^[0-9a-f]{40,64}$/i.test(result.baselineSha) ||
+    !/^[0-9a-f]{64}$/i.test(result.patchSha256) ||
+    result.testFile !== finding.reproduction.testFile ||
+    result.testName !== finding.reproduction.testName
+  ) {
+    return invalid("stored RED result contract is invalid");
+  }
+  return { valid: true };
+}
+
+function validatePatchShape(repoRoot, patch, testFile) {
+  try {
+    const numstat = runGit(
+      repoRoot,
+      ["apply", "--numstat", "--binary", "-"],
+      { input: patch }
+    ).trim();
+    const [added, removed, changedPath] = numstat.split("\t");
+    if (
+      !/^\d+$/.test(added) ||
+      removed !== "0" ||
+      changedPath !== testFile
+    ) {
+      return invalid("stored patch is not one text-only added test");
+    }
+    runGit(
+      repoRoot,
+      ["apply", "--check", "--binary", "--whitespace=nowarn", "-"],
+      { input: patch }
+    );
+    return { valid: true };
+  } catch {
+    return invalid("stored patch cannot be safely applied");
+  }
+}
+
+export function replayRedArtifacts({
+  repoRoot,
+  finding,
+  environment = process.env,
+  spawnSyncFn,
+  timeoutMs,
+  expectedBaselineSha,
+  expectedPatchSha256,
+  expectedSummary
+} = {}) {
+  let paths;
+  let trustedBaseline = "";
+  try {
+    paths = artifactPaths(repoRoot);
+    const resultStat = fs.lstatSync(paths.result);
+    const patchStat = fs.lstatSync(paths.patch);
+    if (
+      !resultStat.isFile() ||
+      resultStat.isSymbolicLink() ||
+      resultStat.size > 64 * 1024 ||
+      !patchStat.isFile() ||
+      patchStat.isSymbolicLink() ||
+      patchStat.size > 128 * 1024
+    ) {
+      return invalid("RED artifacts are missing, unsafe, or too large");
+    }
+
+    const storedResult = JSON.parse(fs.readFileSync(paths.result, "utf8"));
+    const storedValidation = validateStoredResult(storedResult, finding);
+    if (!storedValidation.valid) return storedValidation;
+    if (
+      storedResult.baselineSha !== expectedBaselineSha ||
+      storedResult.patchSha256 !== expectedPatchSha256 ||
+      storedResult.sanitizedSummary !== expectedSummary
+    ) {
+      return invalid("stored RED result does not match trusted replay expectations");
+    }
+    trustedBaseline = storedResult.baselineSha;
+
+    const baseline = captureCleanBaseline({
+      repoRoot,
+      testFile: storedResult.testFile
+    });
+    if (!baseline.valid || baseline.baselineSha !== trustedBaseline) {
+      return invalid("stored baseline SHA does not match the clean worktree");
+    }
+    const replayScan = scanRepository({
+      repoRoot,
+      allowlist: getDefaultAllowlist(),
+      protectedPaths: getDefaultProtectedPaths()
+    });
+    const replayPrompt = buildRedPrompt({
+      baselineSha: trustedBaseline,
+      finding,
+      scannedFiles: replayScan.scannedFiles
+    });
+
+    const patch = fs.readFileSync(paths.patch, "utf8");
+    if (sha256(patch) !== storedResult.patchSha256) {
+      return invalid("stored patch SHA-256 does not match patch content");
+    }
+    const shape = validatePatchShape(repoRoot, patch, storedResult.testFile);
+    if (!shape.valid) return shape;
+
+    runGit(
+      repoRoot,
+      ["apply", "--binary", "--whitespace=nowarn", "-"],
+      { input: patch }
+    );
+
+    const worktree = validateTestOnlyWorktree({
+      repoRoot,
+      baselineSha: trustedBaseline,
+      testFile: storedResult.testFile
+    });
+    if (!worktree.valid) throw new Error(worktree.error);
+
+    const source = fs.readFileSync(path.join(repoRoot, storedResult.testFile), "utf8");
+    const candidate = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: storedResult.testFile,
+        testName: storedResult.testName,
+        source
+      },
+      {
+        finding,
+        sensitiveValues: collectSensitiveValues(environment, repoRoot, { output: false }),
+        allowedRepositoryFiles: replayPrompt.manifest
+      }
+    );
+    if (!candidate.valid) throw new Error(candidate.error);
+
+    fs.rmSync(paths.replayReport, { force: true });
+    const execution = runGuardedTargetedVitest({
+      repoRoot,
+      testFile: storedResult.testFile,
+      testName: storedResult.testName,
+      reportPath: paths.replayReport,
+      spawnSyncFn,
+      environment,
+      timeoutMs
+    });
+    if (!execution.valid) throw new Error(execution.error);
+    const classification = classifyVitestRed({
+      ...execution,
+      repoRoot,
+      testFile: storedResult.testFile,
+      testName: storedResult.testName,
+      finding
+    });
+    if (
+      !classification.valid ||
+      classification.failureKind !== storedResult.failureKind ||
+      classification.sanitizedSummary !== storedResult.sanitizedSummary
+    ) {
+      throw new Error(classification.error || "replay RED classification changed");
+    }
+    const postExecution = verifyCandidateIntegrity({
+      repoRoot,
+      baselineSha: trustedBaseline,
+      testFile: storedResult.testFile,
+      expectedPatchSha256: storedResult.patchSha256
+    });
+    if (!postExecution.valid) throw new Error(postExecution.error);
+
+    const postPatchStat = fs.lstatSync(paths.patch);
+    const postResultStat = fs.lstatSync(paths.result);
+    if (
+      !postPatchStat.isFile() ||
+      postPatchStat.isSymbolicLink() ||
+      postPatchStat.size > 128 * 1024 ||
+      !postResultStat.isFile() ||
+      postResultStat.isSymbolicLink() ||
+      postResultStat.size > 64 * 1024
+    ) {
+      throw new Error("RED artifacts became unsafe during replay execution");
+    }
+    const postPatch = fs.readFileSync(paths.patch, "utf8");
+    const postResult = JSON.parse(fs.readFileSync(paths.result, "utf8"));
+    if (sha256(postPatch) !== expectedPatchSha256) {
+      throw new Error("stored patch changed during replay execution");
+    }
+    if (JSON.stringify(postResult) !== JSON.stringify(storedResult)) {
+      throw new Error("stored RED result changed during replay execution");
+    }
+    return { valid: true, classification, execution };
+  } catch (error) {
+    let cleanupError = "";
+    if (trustedBaseline) {
+      const cleanup = resetRedWorktree({
+        repoRoot,
+        baselineSha: trustedBaseline,
+        testFile: finding?.reproduction?.testFile
+      });
+      if (!cleanup.valid) cleanupError = "; worktree cleanup could not be verified";
+    }
+    return invalid(
+      `${error?.message || "RED artifact replay failed"}${cleanupError}`
+    );
+  } finally {
+    if (paths?.replayReport) {
+      try {
+        fs.rmSync(paths.replayReport, { force: true });
+      } catch {
+        // Ignored: the report path is never a published artifact.
+      }
+    }
+  }
+}
+
+export async function runRedStage({
+  repoRoot,
+  finding,
+  client,
+  allowlist = getDefaultAllowlist(),
+  protectedPaths = getDefaultProtectedPaths(),
+  environment = process.env,
+  spawnSyncFn,
+  testTimeoutMs
+} = {}) {
+  let baselineSha = "";
+  let paths;
+  const outputSecrets = collectSensitiveValues(environment, repoRoot, { output: true });
+
+  try {
+    const baseline = captureCleanBaseline({
+      repoRoot,
+      testFile: finding?.reproduction?.testFile
+    });
+    if (!baseline.valid) throw new Error(baseline.error);
+    baselineSha = baseline.baselineSha;
+
+    const schema = validateFinding(finding, { allowlist, protectedPaths });
+    if (!schema.valid || schema.result?.status !== "finding") {
+      throw new Error(schema.error || "input must be one validated finding");
+    }
+
+    const scan = scanRepository({
+      repoRoot,
+      allowlist,
+      protectedPaths
+    });
+    const repoValidation = validateFindingWithRepo(schema.result, {
+      repoRoot,
+      manifest: scan.manifest,
+      allowlist,
+      protectedPaths,
+      scannedFiles: scan.scannedFiles
+    });
+    if (!repoValidation.valid) throw new Error(repoValidation.error);
+
+    const prompt = buildRedPrompt({
+      baselineSha,
+      finding: schema.result,
+      scannedFiles: scan.scannedFiles
+    });
+    if (!client || typeof client.generateJson !== "function") {
+      throw new Error("Gemini client with generateJson is required");
+    }
+    const generated = await client.generateJson({ prompt: prompt.prompt });
+    if (!generated?.valid) {
+      throw new Error(generated?.error || "Gemini RED response was invalid");
+    }
+
+    const candidate = validateRegressionCandidate(generated.result, {
+      finding: schema.result,
+      sensitiveValues: collectSensitiveValues(environment, repoRoot, { output: false }),
+      allowedRepositoryFiles: prompt.manifest
+    });
+    if (!candidate.valid) throw new Error(candidate.error);
+
+    const testAbsolute = path.join(repoRoot, candidate.result.testFile);
+    fs.writeFileSync(testAbsolute, candidate.result.source, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600
+    });
+
+    const worktree = validateTestOnlyWorktree({
+      repoRoot,
+      baselineSha,
+      testFile: candidate.result.testFile
+    });
+    if (!worktree.valid) throw new Error(worktree.error);
+
+    const patchResult = createTestOnlyPatch({
+      repoRoot,
+      baselineSha,
+      testFile: candidate.result.testFile
+    });
+    if (!patchResult.valid) throw new Error(patchResult.error);
+    const patchHash = sha256(patchResult.patch);
+
+    paths = artifactPaths(repoRoot);
+    removeReporterFiles(paths);
+    const initialExecution = runGuardedTargetedVitest({
+      repoRoot,
+      testFile: candidate.result.testFile,
+      testName: candidate.result.testName,
+      reportPath: paths.initialReport,
+      spawnSyncFn,
+      environment,
+      timeoutMs: testTimeoutMs
+    });
+    if (!initialExecution.valid) throw new Error(initialExecution.error);
+    const initialClassification = classifyVitestRed({
+      ...initialExecution,
+      repoRoot,
+      testFile: candidate.result.testFile,
+      testName: candidate.result.testName,
+      finding: schema.result
+    });
+    if (!initialClassification.valid) throw new Error(initialClassification.error);
+    const postInitial = verifyCandidateIntegrity({
+      repoRoot,
+      baselineSha,
+      testFile: candidate.result.testFile,
+      expectedPatchSha256: patchHash
+    });
+    if (!postInitial.valid) throw new Error(postInitial.error);
+
+    fs.writeFileSync(paths.patch, patchResult.patch, {
+      encoding: "utf8",
+      mode: 0o600
+    });
+    const provisionalResult = {
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha,
+      testFile: candidate.result.testFile,
+      testName: candidate.result.testName,
+      failureKind: "assertion",
+      sanitizedSummary: initialClassification.sanitizedSummary,
+      patchSha256: patchHash,
+      replayConfirmed: false
+    };
+    writeJson(paths.result, sanitize(provisionalResult, outputSecrets));
+
+    const reset = resetRedWorktree({
+      repoRoot,
+      baselineSha,
+      testFile: candidate.result.testFile
+    });
+    if (!reset.valid) throw new Error(reset.error);
+
+    const replay = replayRedArtifacts({
+      repoRoot,
+      finding: schema.result,
+      environment,
+      spawnSyncFn,
+      timeoutMs: testTimeoutMs,
+      expectedBaselineSha: baselineSha,
+      expectedPatchSha256: patchHash,
+      expectedSummary: initialClassification.sanitizedSummary
+    });
+    if (!replay.valid) throw new Error(replay.error);
+
+    const finalResult = {
+      ...provisionalResult,
+      replayConfirmed: true
+    };
+    const safeResult = sanitize(finalResult, outputSecrets);
+    const safeLog = boundedLog(sanitize(
+      `${executionLog("initial", initialExecution)}\n\n` +
+      executionLog("replay", replay.execution),
+      outputSecrets
+    ));
+    writeJson(paths.result, safeResult);
+    fs.writeFileSync(paths.log, safeLog, {
+      encoding: "utf8",
+      mode: 0o600
+    });
+    return { valid: true, result: safeResult };
+  } catch (error) {
+    let cleanupError = "";
+    if (baselineSha) {
+      const cleanup = resetRedWorktree({
+        repoRoot,
+        baselineSha,
+        testFile: finding?.reproduction?.testFile
+      });
+      if (!cleanup.valid) cleanupError = "; worktree cleanup could not be verified";
+    }
+    const safeError = sanitize(
+      `${error?.message || "RED stage failed closed"}${cleanupError}`,
+      outputSecrets
+    );
+    try {
+      paths = paths ?? artifactPaths(repoRoot);
+      const rejected = {
+        schemaVersion: 1,
+        status: "rejected",
+        sanitizedSummary: safeError
+      };
+      writeJson(paths.result, rejected);
+      fs.writeFileSync(paths.log, boundedLog(`[rejected]\n${safeError}`), {
+        encoding: "utf8",
+        mode: 0o600
+      });
+    } catch {
+      // Unsafe output paths are themselves a fail-closed rejection.
+    }
+    return invalid(safeError);
+  } finally {
+    removeReporterFiles(paths);
+  }
+}
+
+async function main() {
+  const { model } = parseRedStageArgs(process.argv.slice(2));
+  const findingPath = resolveFindingInputPath(REPO_ROOT);
+  if (!findingPath) {
+    console.error("[red-stage] fixed finding artifact is missing or unsafe");
+    process.exitCode = 2;
+    return;
+  }
+
+  let finding;
+  try {
+    finding = extractValidatedFinding(
+      JSON.parse(fs.readFileSync(findingPath, "utf8"))
+    );
+    if (!finding) throw new Error("not a validated finding");
+  } catch {
+    console.error("[red-stage] finding artifact is not strict JSON");
+    process.exitCode = 2;
+    return;
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error("[red-stage] GEMINI_API_KEY is required");
+    process.exitCode = 2;
+    return;
+  }
+  const client = createGeminiClient({ apiKey, model });
+  const result = await runRedStage({
+    repoRoot: REPO_ROOT,
+    finding,
+    client,
+    environment: process.env
+  });
+  console.log(JSON.stringify(result.result ?? result, null, 2));
+  process.exitCode = result.valid ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === MODULE_PATH
+) {
+  main().catch(() => {
+    console.error("[red-stage] failed closed");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/gemini-correctness/red-validator.mjs
+++ b/scripts/gemini-correctness/red-validator.mjs
@@ -283,6 +283,7 @@ const BANNED_CONSTRUCTORS = new Set([
   "Worker"
 ]);
 const BANNED_GLOBAL_IDENTIFIERS = new Set([
+  ...BANNED_CALLS,
   "Bun",
   "Date",
   "Deno",
@@ -455,22 +456,42 @@ function inspectSource(
     return current;
   }
 
-  function isDirectRepositoryObservation(node) {
+  function isRepositoryReference(node) {
     const current = unwrapExpression(node);
     if (ts.isIdentifier(current)) {
       return repositoryBindings.has(current.text);
     }
     if (ts.isPropertyAccessExpression(current)) {
-      return isDirectRepositoryObservation(current.expression);
+      return isRepositoryReference(current.expression);
+    }
+    return false;
+  }
+
+  function isExecutedRepositoryObservation(node) {
+    const current = unwrapExpression(node);
+    if (ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
+      let observed = false;
+      function visitCallback(child) {
+        if (observed) return;
+        if (
+          ts.isCallExpression(unwrapExpression(child)) &&
+          isExecutedRepositoryObservation(child)
+        ) {
+          observed = true;
+          return;
+        }
+        ts.forEachChild(child, visitCallback);
+      }
+      visitCallback(current.body);
+      return observed;
+    }
+    if (ts.isPropertyAccessExpression(current)) {
+      return isExecutedRepositoryObservation(current.expression);
     }
     if (ts.isCallExpression(current)) {
       const callee = unwrapExpression(current.expression);
-      if (ts.isIdentifier(callee)) {
-        return repositoryBindings.has(callee.text);
-      }
-      if (ts.isPropertyAccessExpression(callee)) {
-        return isDirectRepositoryObservation(callee.expression);
-      }
+      return isRepositoryReference(callee) ||
+        isExecutedRepositoryObservation(callee);
     }
     return false;
   }
@@ -662,14 +683,17 @@ function inspectSource(
     ) {
       errors.push("expect() must assert observed behavior, not a literal value");
     }
-    if (!isDirectRepositoryObservation(received)) {
-      errors.push("expect() must directly observe a prompt-visible repository import");
-    }
     if (
       matcherCalls.length !== 1 ||
       matcherCalls[0].expression.expression !== expectCalls[0]
     ) {
       errors.push("the labeled expect() must have exactly one direct matcher");
+    } else {
+      if (!isExecutedRepositoryObservation(received)) {
+        errors.push(
+          "expect() must execute or call a prompt-visible repository import"
+        );
+      }
     }
   }
 

--- a/scripts/gemini-correctness/red-validator.mjs
+++ b/scripts/gemini-correctness/red-validator.mjs
@@ -1,0 +1,767 @@
+// =============================================================================
+// red-validator.mjs — deterministic validation for Gemini-authored RED tests
+// =============================================================================
+
+import ts from "typescript";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  isPathSafe,
+  isPathWithinRepo,
+  isValidRegressionTest
+} from "./policy.mjs";
+import { redactForOutput } from "./discover.mjs";
+
+export const MAX_REGRESSION_TEST_LINES = 250;
+export const MAX_REGRESSION_TEST_BYTES = 64 * 1024;
+
+const CANDIDATE_KEYS = [
+  "schemaVersion",
+  "status",
+  "testFile",
+  "testName",
+  "source"
+];
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+function runGit(repoRoot, args) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+    shell: false,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(`git ${args[0]} failed`);
+  }
+  return result.stdout;
+}
+
+function isCanonicalTestPath(testFile, repoRoot, { mustExist }) {
+  if (
+    typeof testFile !== "string" ||
+    testFile.includes("\\") ||
+    !isPathSafe(testFile) ||
+    !isPathWithinRepo(testFile, repoRoot)
+  ) {
+    return false;
+  }
+
+  const repoReal = fs.realpathSync(repoRoot);
+  const segments = testFile.split("/");
+  let current = repoReal;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) return false;
+    } catch (error) {
+      if (error?.code !== "ENOENT") return false;
+      if (mustExist) return false;
+    }
+  }
+
+  if (!mustExist) return true;
+  try {
+    const stat = fs.lstatSync(current);
+    if (!stat.isFile() || stat.isSymbolicLink()) return false;
+    const fileReal = fs.realpathSync(current);
+    const canonicalRelative = path.relative(repoReal, fileReal).replace(/\\/g, "/");
+    return canonicalRelative === testFile;
+  } catch {
+    return false;
+  }
+}
+
+function hasPathAtLstat(testFile, repoRoot) {
+  try {
+    fs.lstatSync(path.join(repoRoot, testFile));
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    return true;
+  }
+}
+
+export function captureCleanBaseline({ repoRoot, testFile } = {}) {
+  try {
+    if (!repoRoot || !fs.statSync(repoRoot).isDirectory()) {
+      return invalid("repoRoot must be an existing directory");
+    }
+    const repoReal = fs.realpathSync(repoRoot);
+    const topLevel = fs.realpathSync(runGit(repoRoot, ["rev-parse", "--show-toplevel"]).trim());
+    if (topLevel !== repoReal) return invalid("repoRoot must be the git worktree root");
+    if (!isCanonicalTestPath(testFile, repoRoot, { mustExist: false })) {
+      return invalid("testFile is not a canonical contained path");
+    }
+    if (hasPathAtLstat(testFile, repoRoot)) {
+      return invalid("testFile already exists at baseline");
+    }
+    const status = runGit(repoRoot, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "-z"
+    ]);
+    if (status !== "") return invalid("worktree must be clean at baseline");
+    const baselineSha = runGit(repoRoot, ["rev-parse", "HEAD"]).trim();
+    if (!/^[0-9a-f]{40,64}$/i.test(baselineSha)) {
+      return invalid("baseline SHA is invalid");
+    }
+    return { valid: true, baselineSha };
+  } catch {
+    return invalid("failed to capture a clean git baseline");
+  }
+}
+
+export function validateTestOnlyWorktree({
+  repoRoot,
+  baselineSha,
+  testFile
+} = {}) {
+  try {
+    if (!/^[0-9a-f]{40,64}$/i.test(String(baselineSha ?? ""))) {
+      return invalid("baseline SHA is invalid");
+    }
+    if (runGit(repoRoot, ["rev-parse", "HEAD"]).trim() !== baselineSha) {
+      return invalid("HEAD no longer matches baseline SHA");
+    }
+    if (!isCanonicalTestPath(testFile, repoRoot, { mustExist: true })) {
+      return invalid("candidate test is not a regular canonical file");
+    }
+
+    const source = fs.readFileSync(path.join(repoRoot, testFile));
+    if (
+      source.includes(0) ||
+      source.byteLength > MAX_REGRESSION_TEST_BYTES ||
+      source.toString("utf8").split("\n").length > MAX_REGRESSION_TEST_LINES
+    ) {
+      return invalid("candidate test is binary or exceeds size limits");
+    }
+
+    const status = runGit(repoRoot, [
+      "status",
+      "--porcelain=v1",
+      "--untracked-files=all",
+      "-z"
+    ]);
+    if (status !== `?? ${testFile}\0`) {
+      return invalid("worktree contains changes other than one untracked candidate test");
+    }
+    return { valid: true };
+  } catch {
+    return invalid("failed to validate test-only worktree");
+  }
+}
+
+export function createTestOnlyPatch({
+  repoRoot,
+  baselineSha,
+  testFile
+} = {}) {
+  const validation = validateTestOnlyWorktree({
+    repoRoot,
+    baselineSha,
+    testFile
+  });
+  if (!validation.valid) return validation;
+
+  let resetSucceeded = false;
+  try {
+    runGit(repoRoot, ["add", "--intent-to-add", "--", testFile]);
+    const nameStatus = runGit(repoRoot, [
+      "diff",
+      "--name-status",
+      "--no-renames",
+      "--",
+      testFile
+    ]).trim();
+    if (nameStatus !== `A\t${testFile}`) {
+      return invalid("candidate diff is not exactly one added file");
+    }
+
+    const numstat = runGit(repoRoot, ["diff", "--numstat", "--", testFile]).trim();
+    const [added, removed, changedPath] = numstat.split("\t");
+    if (
+      changedPath !== testFile ||
+      added === "-" ||
+      removed === "-" ||
+      !/^\d+$/.test(added) ||
+      removed !== "0" ||
+      Number(added) > MAX_REGRESSION_TEST_LINES
+    ) {
+      return invalid("candidate diff is binary, deletes content, or exceeds line limits");
+    }
+
+    const patch = runGit(repoRoot, [
+      "diff",
+      "--binary",
+      "--no-ext-diff",
+      "--no-renames",
+      "--",
+      testFile
+    ]);
+    if (!patch || Buffer.byteLength(patch, "utf8") > MAX_REGRESSION_TEST_BYTES * 2) {
+      return invalid("candidate patch is empty or exceeds size limits");
+    }
+    return { valid: true, patch };
+  } catch {
+    return invalid("failed to create test-only patch");
+  } finally {
+    try {
+      runGit(repoRoot, ["reset", "-q", "--", testFile]);
+      resetSucceeded = true;
+    } catch {
+      resetSucceeded = false;
+    }
+    if (!resetSucceeded) {
+      try {
+        runGit(repoRoot, ["reset", "-q", "HEAD", "--", testFile]);
+      } catch {
+        // The caller will fail its subsequent worktree validation closed.
+      }
+    }
+  }
+}
+
+const BANNED_IMPORTS = new Set([
+  "child_process",
+  "node:child_process",
+  "fs",
+  "fs/promises",
+  "node:fs",
+  "node:fs/promises",
+  "http",
+  "node:http",
+  "https",
+  "node:https",
+  "net",
+  "node:net",
+  "tls",
+  "node:tls",
+  "dns",
+  "node:dns",
+  "dgram",
+  "node:dgram",
+  "worker_threads",
+  "node:worker_threads",
+  "cluster",
+  "node:cluster"
+]);
+
+const BANNED_TEST_MODIFIERS = new Set([
+  "only",
+  "skip",
+  "todo",
+  "skipIf",
+  "runIf"
+]);
+
+const BANNED_CALLS = new Set([
+  "assert",
+  "assertType",
+  "eval",
+  "expectTypeOf",
+  "fetch",
+  "queueMicrotask",
+  "require",
+  "setImmediate",
+  "setInterval",
+  "setTimeout"
+]);
+
+const BANNED_CONSTRUCTORS = new Set([
+  "EventSource",
+  "Function",
+  "Object",
+  "WebSocket",
+  "Worker"
+]);
+const BANNED_GLOBAL_IDENTIFIERS = new Set([
+  "Bun",
+  "Date",
+  "Deno",
+  "EventSource",
+  "Function",
+  "Object",
+  "Proxy",
+  "Reflect",
+  "WebSocket",
+  "XMLHttpRequest",
+  "crypto",
+  "document",
+  "fetch",
+  "global",
+  "globalThis",
+  "navigator",
+  "performance",
+  "process",
+  "self",
+  "Temporal",
+  "window"
+]);
+const BANNED_GLOBAL_PROPERTIES = new Set([
+  "__proto__",
+  "constructor",
+  "defaultView",
+  "EventSource",
+  "Function",
+  "WebSocket",
+  "XMLHttpRequest",
+  "eval",
+  "fail",
+  "fetch",
+  "getBuiltinModule",
+  "hasAssertions",
+  "prototype",
+  "sendBeacon",
+  "unreachable"
+]);
+const ALLOWED_VITEST_IMPORTS = new Set([
+  "describe",
+  "expect",
+  "it",
+  "test"
+]);
+const ALLOWED_MATCHERS = new Set([
+  "toBe",
+  "toBeCloseTo",
+  "toBeDefined",
+  "toBeFalsy",
+  "toBeGreaterThan",
+  "toBeGreaterThanOrEqual",
+  "toBeLessThan",
+  "toBeLessThanOrEqual",
+  "toBeNull",
+  "toBeTruthy",
+  "toBeUndefined",
+  "toContain",
+  "toEqual",
+  "toHaveLength",
+  "toMatch",
+  "toStrictEqual",
+  "toThrow"
+]);
+const ALLOWED_TEST_PACKAGES = new Set([
+  "@testing-library/jest-dom",
+  "@testing-library/jest-dom/vitest",
+  "@testing-library/react",
+  "@testing-library/user-event",
+  "react",
+  "react-dom",
+  "react/jsx-runtime",
+  "vitest"
+]);
+
+function resolvesToVisibleRepositoryFile(
+  specifier,
+  testFile,
+  allowedRepositoryFiles
+) {
+  if (!specifier.startsWith(".")) {
+    return ALLOWED_TEST_PACKAGES.has(specifier);
+  }
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(testFile), specifier)
+  );
+  if (!base || base === ".." || base.startsWith("../") || base.startsWith("/")) {
+    return false;
+  }
+  const extension = path.posix.extname(base);
+  const candidates = [];
+  if (extension === ".js" || extension === ".jsx") {
+    const withoutJs = base.slice(0, -extension.length);
+    candidates.push(`${withoutJs}.ts`, `${withoutJs}.tsx`);
+  } else if (extension) {
+    candidates.push(base);
+  } else {
+    candidates.push(
+      `${base}.ts`,
+      `${base}.tsx`,
+      `${base}.mjs`,
+      `${base}/index.ts`,
+      `${base}/index.tsx`,
+      `${base}/index.mjs`
+    );
+  }
+  return candidates.some(candidate => allowedRepositoryFiles.has(candidate));
+}
+
+function inspectSource(
+  sourceFile,
+  source,
+  testFile,
+  testName,
+  requiredAssertionMessage,
+  allowedRepositoryFiles
+) {
+  const errors = [];
+  const tests = [];
+  const expectCalls = [];
+  const matcherCalls = [];
+  const repositoryBindings = new Set();
+  let hasBehaviorAssertionMessage = false;
+
+  function recordRepositoryBindings(importClause) {
+    if (!importClause) return;
+    if (importClause.name) repositoryBindings.add(importClause.name.text);
+    const bindings = importClause.namedBindings;
+    if (!bindings) return;
+    if (ts.isNamespaceImport(bindings)) {
+      repositoryBindings.add(bindings.name.text);
+    } else if (ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        repositoryBindings.add(element.name.text);
+      }
+    }
+  }
+
+  function validateVitestImports(importClause) {
+    if (
+      !importClause ||
+      importClause.name ||
+      !ts.isNamedImports(importClause.namedBindings)
+    ) {
+      errors.push("Vitest imports must use approved named bindings");
+      return;
+    }
+    for (const element of importClause.namedBindings.elements) {
+      const imported = element.propertyName?.text ?? element.name.text;
+      if (
+        !ALLOWED_VITEST_IMPORTS.has(imported) ||
+        element.name.text !== imported
+      ) {
+        errors.push(`forbidden Vitest import: ${imported}`);
+      }
+    }
+  }
+
+  function unwrapExpression(node) {
+    let current = node;
+    while (
+      ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current) ||
+      ts.isAwaitExpression(current)
+    ) {
+      current = current.expression;
+    }
+    return current;
+  }
+
+  function isDirectRepositoryObservation(node) {
+    const current = unwrapExpression(node);
+    if (ts.isIdentifier(current)) {
+      return repositoryBindings.has(current.text);
+    }
+    if (ts.isPropertyAccessExpression(current)) {
+      return isDirectRepositoryObservation(current.expression);
+    }
+    if (ts.isCallExpression(current)) {
+      const callee = unwrapExpression(current.expression);
+      if (ts.isIdentifier(callee)) {
+        return repositoryBindings.has(callee.text);
+      }
+      if (ts.isPropertyAccessExpression(callee)) {
+        return isDirectRepositoryObservation(callee.expression);
+      }
+    }
+    return false;
+  }
+
+  function visit(node) {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const specifier = node.moduleSpecifier.text;
+      const visibleRepositoryImport =
+        specifier.startsWith(".") &&
+        resolvesToVisibleRepositoryFile(
+          specifier,
+          testFile,
+          allowedRepositoryFiles
+        );
+      if (
+        BANNED_IMPORTS.has(specifier) ||
+        specifier.startsWith("@supabase/") ||
+        /(?:^|[/_.-])fixtures?(?:[/_.-]|$)/i.test(specifier) ||
+        /\.snap$/i.test(specifier)
+      ) {
+        errors.push(`forbidden import: ${specifier}`);
+      }
+      if (
+        !resolvesToVisibleRepositoryFile(
+          specifier,
+          testFile,
+          allowedRepositoryFiles
+        )
+      ) {
+        errors.push("import is outside the RED prompt manifest");
+      }
+      if (specifier === "vitest") {
+        validateVitestImports(node.importClause);
+      } else if (visibleRepositoryImport) {
+        recordRepositoryBindings(node.importClause);
+      }
+    }
+
+    if (ts.isImportEqualsDeclaration(node)) {
+      errors.push("TypeScript import-equals declarations are forbidden");
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      errors.push("dynamic imports are forbidden");
+    }
+
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      if (BANNED_CALLS.has(node.expression.text)) {
+        errors.push(`forbidden call: ${node.expression.text}`);
+      }
+      if (
+        ["it", "test"].includes(node.expression.text) &&
+        node.arguments.length > 0 &&
+        ts.isStringLiteralLike(node.arguments[0])
+      ) {
+        tests.push(node.arguments[0].text);
+      }
+      if (
+        node.expression.text === "expect" &&
+        node.arguments.length > 0
+      ) {
+        expectCalls.push(node);
+        if (
+          node.arguments.length > 1 &&
+          ts.isStringLiteralLike(node.arguments[1]) &&
+          node.arguments[1].text === requiredAssertionMessage
+        ) {
+          hasBehaviorAssertionMessage = true;
+        }
+      }
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isCallExpression(node.expression.expression) &&
+      node.expression.expression.expression.kind !== ts.SyntaxKind.ImportKeyword &&
+      ts.isIdentifier(node.expression.expression.expression) &&
+      node.expression.expression.expression.text === "expect"
+    ) {
+      matcherCalls.push(node);
+      if (!ALLOWED_MATCHERS.has(node.expression.name.text)) {
+        errors.push(`forbidden matcher: ${node.expression.name.text}`);
+      }
+    }
+
+    if (ts.isNewExpression(node) && ts.isIdentifier(node.expression)) {
+      if (BANNED_CONSTRUCTORS.has(node.expression.text)) {
+        errors.push(`forbidden constructor: ${node.expression.text}`);
+      }
+    }
+
+    if (ts.isPropertyAccessExpression(node)) {
+      const propertyName = node.name.text;
+      if (BANNED_TEST_MODIFIERS.has(propertyName)) {
+        errors.push(`forbidden test modifier: ${propertyName}`);
+      }
+      const expressionText = node.expression.getText(sourceFile);
+      if (
+        expressionText === "expect" ||
+        (expressionText === "Date" && propertyName === "now") ||
+        (expressionText === "Math" && propertyName === "random") ||
+        (expressionText === "crypto" && propertyName === "randomUUID") ||
+        (expressionText === "Promise" && propertyName === "reject") ||
+        expressionText === "process" ||
+        BANNED_GLOBAL_PROPERTIES.has(propertyName) ||
+        (expressionText === "vi" &&
+          ["doMock", "mock", "spyOn", "stubEnv", "stubGlobal"].includes(propertyName))
+      ) {
+        errors.push(`forbidden access: ${expressionText}.${propertyName}`);
+      }
+    }
+
+    if (ts.isElementAccessExpression(node)) {
+      errors.push("computed property access is forbidden");
+    }
+
+    if (
+      ts.isObjectBindingPattern(node) ||
+      ts.isArrayBindingPattern(node) ||
+      (ts.isBindingElement(node) && node.propertyName)
+    ) {
+      errors.push("destructuring bindings are forbidden");
+    }
+
+    if (ts.isThrowStatement(node)) {
+      errors.push("throw statements are forbidden");
+    }
+
+    if (
+      ts.isStringLiteralLike(node) &&
+      /\bAssertionError\b/.test(node.text)
+    ) {
+      errors.push("forged assertion diagnostics are forbidden");
+    }
+
+    if (node.kind === ts.SyntaxKind.AnyKeyword) {
+      errors.push("TypeScript any is forbidden");
+    }
+
+    if (
+      ts.isIdentifier(node) &&
+      BANNED_GLOBAL_IDENTIFIERS.has(node.text)
+    ) {
+      errors.push(`forbidden global: ${node.text}`);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  if (/\bprocess\s*\.\s*env\b/.test(source)) {
+    errors.push("process.env access is forbidden");
+  }
+  if (/\bimport\s*\.\s*meta\s*\.\s*env\b/.test(source)) {
+    errors.push("import.meta.env access is forbidden");
+  }
+  if (/\b(?:Deno|Bun)\s*\.\s*env\b/.test(source)) {
+    errors.push("runtime environment access is forbidden");
+  }
+  if (/\b(?:https?|wss?):\/\//i.test(source)) {
+    errors.push("network URLs are forbidden");
+  }
+  if (/\b(?:curl|wget|pnpm\s+dlx|npm\s+exec|npx)\b/i.test(source)) {
+    errors.push("dynamic download commands are forbidden");
+  }
+
+  if (tests.length !== 1 || tests[0] !== testName) {
+    errors.push("candidate must declare exactly the specified testName");
+  }
+  if (expectCalls.length !== 1 || !hasBehaviorAssertionMessage) {
+    errors.push("candidate must contain exactly one labeled expect() assertion");
+  } else {
+    const received = expectCalls[0].arguments[0];
+    if (
+      ts.isStringLiteralLike(received) ||
+      ts.isNumericLiteral(received) ||
+      received.kind === ts.SyntaxKind.TrueKeyword ||
+      received.kind === ts.SyntaxKind.FalseKeyword ||
+      received.kind === ts.SyntaxKind.NullKeyword ||
+      ts.isArrayLiteralExpression(received) ||
+      ts.isObjectLiteralExpression(received)
+    ) {
+      errors.push("expect() must assert observed behavior, not a literal value");
+    }
+    if (!isDirectRepositoryObservation(received)) {
+      errors.push("expect() must directly observe a prompt-visible repository import");
+    }
+    if (
+      matcherCalls.length !== 1 ||
+      matcherCalls[0].expression.expression !== expectCalls[0]
+    ) {
+      errors.push("the labeled expect() must have exactly one direct matcher");
+    }
+  }
+
+  return errors;
+}
+
+export function validateRegressionCandidate(candidate, {
+  finding,
+  sensitiveValues = [],
+  allowedRepositoryFiles = finding?.productionFiles ?? []
+} = {}) {
+  if (!finding || finding.status !== "finding") {
+    return invalid("a validated finding is required");
+  }
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return invalid("candidate must be a plain object");
+  }
+
+  const keys = Object.keys(candidate);
+  const unknown = keys.filter(key => !CANDIDATE_KEYS.includes(key));
+  const missing = CANDIDATE_KEYS.filter(key => candidate[key] === undefined);
+  if (unknown.length > 0) return invalid(`candidate has unknown fields: ${unknown.join(", ")}`);
+  if (missing.length > 0) return invalid(`candidate is missing fields: ${missing.join(", ")}`);
+  if (candidate.schemaVersion !== 1) return invalid("candidate schemaVersion must be 1");
+  if (candidate.status !== "regression-test") {
+    return invalid('candidate status must be "regression-test"');
+  }
+
+  const expectedTestFile = finding.reproduction?.testFile;
+  const expectedTestName = finding.reproduction?.testName;
+  if (candidate.testFile !== expectedTestFile) {
+    return invalid("candidate testFile does not match finding.reproduction.testFile");
+  }
+  if (candidate.testName !== expectedTestName) {
+    return invalid("candidate testName does not match finding.reproduction.testName");
+  }
+  if (
+    typeof candidate.testFile !== "string" ||
+    candidate.testFile.includes("\\") ||
+    !isPathSafe(candidate.testFile) ||
+    !isValidRegressionTest(candidate.testFile, finding.productionFiles?.[0])
+  ) {
+    return invalid("candidate testFile is not a canonical colocated regression-test path");
+  }
+
+  if (typeof candidate.source !== "string" || candidate.source.trim() === "") {
+    return invalid("candidate source must be a non-empty string");
+  }
+  if (Buffer.byteLength(candidate.source, "utf8") > MAX_REGRESSION_TEST_BYTES) {
+    return invalid(`candidate source exceeds ${MAX_REGRESSION_TEST_BYTES} bytes`);
+  }
+  if (candidate.source.split("\n").length > MAX_REGRESSION_TEST_LINES) {
+    return invalid(`candidate source exceeds ${MAX_REGRESSION_TEST_LINES} lines`);
+  }
+  const redactedSource = redactForOutput(candidate.source, sensitiveValues);
+  if (redactedSource !== candidate.source) {
+    return invalid("candidate source contains sensitive content");
+  }
+
+  const sourceFile = ts.createSourceFile(
+    candidate.testFile,
+    candidate.source,
+    ts.ScriptTarget.Latest,
+    true,
+    candidate.testFile.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  if (sourceFile.parseDiagnostics.length > 0) {
+    return invalid("candidate source contains TypeScript syntax errors");
+  }
+  const requiredAssertionMessage =
+    `Expected behavior: ${finding.expectedBehavior} | ` +
+    `Actual behavior: ${finding.actualBehavior}`;
+  const sourceErrors = inspectSource(
+    sourceFile,
+    candidate.source,
+    candidate.testFile,
+    candidate.testName,
+    requiredAssertionMessage,
+    new Set(allowedRepositoryFiles.map(filePath => String(filePath).replace(/\\/g, "/")))
+  );
+  if (sourceErrors.length > 0) {
+    return invalid(sourceErrors[0]);
+  }
+
+  return {
+    valid: true,
+    result: {
+      schemaVersion: 1,
+      status: "regression-test",
+      testFile: candidate.testFile,
+      testName: candidate.testName,
+      source: candidate.source
+    }
+  };
+}

--- a/scripts/gemini-correctness/red-validator.mjs
+++ b/scripts/gemini-correctness/red-validator.mjs
@@ -481,6 +481,19 @@ function inspectSource(
       let observed = false;
       function visitCallback(child) {
         if (observed) return;
+        if (ts.isIfStatement(child)) {
+          const condition = unwrapExpression(child.expression);
+          if (condition.kind === ts.SyntaxKind.TrueKeyword) {
+            ts.forEachChild(child.thenStatement, visitCallback);
+            return;
+          }
+          if (condition.kind === ts.SyntaxKind.FalseKeyword) {
+            if (child.elseStatement) {
+              ts.forEachChild(child.elseStatement, visitCallback);
+            }
+            return;
+          }
+        }
         if (
           ts.isCallExpression(unwrapExpression(child)) &&
           isExecutedRepositoryObservation(child)

--- a/scripts/gemini-correctness/red-validator.mjs
+++ b/scripts/gemini-correctness/red-validator.mjs
@@ -323,6 +323,14 @@ const BANNED_GLOBAL_PROPERTIES = new Set([
   "sendBeacon",
   "unreachable"
 ]);
+
+const NON_EXECUTING_METHODS = new Set([
+  "bind",
+  "call",
+  "apply",
+  "toString",
+  "valueOf"
+]);
 const ALLOWED_VITEST_IMPORTS = new Set([
   "describe",
   "expect",
@@ -490,6 +498,12 @@ function inspectSource(
     }
     if (ts.isCallExpression(current)) {
       const callee = unwrapExpression(current.expression);
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        NON_EXECUTING_METHODS.has(callee.name.text)
+      ) {
+        return false;
+      }
       return isRepositoryReference(callee) ||
         isExecutedRepositoryObservation(callee);
     }

--- a/scripts/gemini-correctness/red-validator.test.ts
+++ b/scripts/gemini-correctness/red-validator.test.ts
@@ -248,7 +248,8 @@ describe("validateRegressionCandidate", () => {
     ['void navigator.sendBeacon("/collect", "x");', "sendBeacon"],
     ['void process["env"]["GEMINI_API_KEY"];', "bracket environment"],
     ['const { env } = process; void env;', "destructured environment"],
-    ['void globalThis["eval"]("1");', "bracket eval"]
+    ['void globalThis["eval"]("1");', "bracket eval"],
+    ['const run = eval; void run("1 + 1");', "aliased eval"]
   ])("rejects syntactically valid %s bypass", (statement, _label) => {
     const source = validSource.replace(
       '  expect(\n',
@@ -419,6 +420,58 @@ describe("validateRegressionCandidate", () => {
     );
 
     expect(result.valid).toBe(false);
+  });
+
+  it("rejects asserting on an imported function without executing it", () => {
+    const source = validSource
+      .replace("readEmptyQueue()", "readEmptyQueue")
+      .replace('.toBe("safe")', ".toBeUndefined()");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/execute|call/i);
+  });
+
+  it("requires toThrow assertions to contain an explicit repository call", () => {
+    const bareReference = validSource
+      .replace("readEmptyQueue()", "readEmptyQueue")
+      .replace('.toBe("safe")', ".toThrow()");
+    const explicitCall = validSource
+      .replace("readEmptyQueue()", "() => readEmptyQueue()")
+      .replace('.toBe("safe")', ".toThrow()");
+
+    const bareResult = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: bareReference
+      },
+      { finding, sensitiveValues: [] }
+    );
+    const explicitResult = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: explicitCall
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(bareResult.valid).toBe(false);
+    expect(explicitResult.valid).toBe(true);
   });
 
   it("rejects a Vitest namespace assertion bypass", () => {

--- a/scripts/gemini-correctness/red-validator.test.ts
+++ b/scripts/gemini-correctness/red-validator.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { validateRegressionCandidate } from "./red-validator.mjs";
+
+const finding = {
+  schemaVersion: 1,
+  status: "finding",
+  title: "returns the fallback for an empty queue",
+  confidence: 0.95,
+  category: "boundary-condition",
+  evidence: [
+    {
+      file: "src/domain/example.ts",
+      startLine: 1,
+      endLine: 3,
+      reason: "The empty branch returns the wrong fallback."
+    }
+  ],
+  expectedBehavior: "an empty queue returns the safe fallback",
+  actualBehavior: "an empty queue returns the stale value",
+  reproduction: {
+    testFile: "src/domain/example.regression.test.ts",
+    testName: "returns the safe fallback for an empty queue"
+  },
+  productionFiles: ["src/domain/example.ts"],
+  risk: "low"
+};
+
+const validSource = `import { expect, it } from "vitest";
+import { readEmptyQueue } from "./example";
+
+it("returns the safe fallback for an empty queue", () => {
+  expect(
+    readEmptyQueue(),
+    "Expected behavior: an empty queue returns the safe fallback | Actual behavior: an empty queue returns the stale value",
+  ).toBe("safe");
+});
+`;
+
+describe("validateRegressionCandidate", () => {
+  it("accepts exactly the finding-designated regression test", () => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: validSource
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result).toEqual({
+      valid: true,
+      result: {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: validSource
+      }
+    });
+  });
+
+  it.each([
+    ["path traversal", "../example.regression.test.ts"],
+    ["Windows separators", "src\\domain\\example.regression.test.ts"],
+    ["a non-regression test", "src/domain/example.test.ts"]
+  ])("rejects %s in the test path", (_label, testFile) => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile,
+        testName: finding.reproduction.testName,
+        source: validSource
+      },
+      {
+        finding: {
+          ...finding,
+          reproduction: { ...finding.reproduction, testFile }
+        },
+        sensitiveValues: []
+      }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a candidate path different from the validated finding", () => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: "src/domain/other.regression.test.ts",
+        testName: finding.reproduction.testName,
+        source: validSource
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects model-provided commands and all unknown fields", () => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: validSource,
+        command: "sh -c 'exit 0'"
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/unknown fields/i);
+  });
+
+  it.each([
+    ["focused test", "it.only"],
+    ["skipped test", "it.skip"],
+    ["todo test", "it.todo"],
+    ["conditional skip", "it.skipIf"],
+    ["child process import", 'import { exec } from "node:child_process";'],
+    ["filesystem import", 'import fs from "node:fs";'],
+    ["network import", 'import https from "node:https";'],
+    ["network call", "fetch("],
+    ["WebSocket access", "new WebSocket("],
+    ["secret environment access", "process.env."],
+    ["Vite environment access", "import.meta.env."],
+    ["dynamic import", "import("],
+    ["CommonJS require", "require("],
+    ["eval", "eval("],
+    ["dynamic Function", "new Function("],
+    ["dynamic download URL", "https://example.com/payload"],
+    ["package download", "pnpm dlx"],
+    ["TypeScript any annotation", ": any"],
+    ["TypeScript any assertion", " as any"],
+    ["mock replacement", "vi.mock("],
+    ["wall clock", "Date.now("],
+    ["Date constructor", "new Date("],
+    ["performance clock", "performance.now("],
+    ["randomness", "Math.random("],
+    ["crypto randomness", "crypto.getRandomValues("],
+    ["timer", "setTimeout("]
+  ])("rejects %s", (_label, hostileToken) => {
+    let source = validSource;
+    if (hostileToken.startsWith("it.")) {
+      source = source.replace('it("returns', `${hostileToken}("returns`);
+    } else if (hostileToken.startsWith("import ")) {
+      source = `${hostileToken}\n${source}`;
+    } else if (hostileToken === ": any") {
+      source = source.replace("readEmptyQueue()", "(readEmptyQueue() as unknown as any)");
+    } else if (hostileToken === " as any") {
+      source = source.replace("readEmptyQueue()", "readEmptyQueue() as any");
+    } else if (hostileToken === "https://example.com/payload" || hostileToken === "pnpm dlx") {
+      source = source.replace('import { expect', `// ${hostileToken}\nimport { expect`);
+    } else {
+      source = source.replace("readEmptyQueue()", `${hostileToken}readEmptyQueue())`);
+    }
+
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects source containing a sensitive value or API-key shaped token", () => {
+    const fakeSecret = "fixture-secret-environment-value";
+    for (const source of [
+      `${validSource}\n// ${fakeSecret}\n`,
+      `${validSource}\n// AIza${"A".repeat(35)}\n`
+    ]) {
+      const result = validateRegressionCandidate(
+        {
+          schemaVersion: 1,
+          status: "regression-test",
+          testFile: finding.reproduction.testFile,
+          testName: finding.reproduction.testName,
+          source
+        },
+        { finding, sensitiveValues: [fakeSecret] }
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).not.toContain(fakeSecret);
+    }
+  });
+
+  it("rejects an assertion message without explicit expected/actual behavior labels", () => {
+    const source = validSource
+      .replace("Expected behavior: ", "")
+      .replace("Actual behavior: ", "");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ['void globalThis.fetch("https:" + "//example.invalid");', "global fetch"],
+    ['void window["fetch"]("https:" + "//example.invalid");', "bracket fetch"],
+    [
+      'void globalThis["pro" + "cess"].getBuiltinModule("node:child_process").execSync("true");',
+      "computed child process access"
+    ],
+    [
+      'it["on" + "ly"]("hidden focused test", () => undefined);',
+      "computed focused test"
+    ],
+    [
+      'void (() => undefined).constructor("return process")();',
+      "Function-constructor access"
+    ],
+    [
+      'const { constructor: Factory } = () => undefined; void Factory("return process")();',
+      "destructured constructor access"
+    ],
+    [
+      'void Object.getPrototypeOf(() => undefined);',
+      "Object introspection"
+    ],
+    ["void new Date();", "Date constructor statement"],
+    ["void performance.now();", "performance clock statement"],
+    [
+      "void crypto.getRandomValues(new Uint8Array(1));",
+      "crypto randomness statement"
+    ],
+    ['void navigator.sendBeacon("/collect", "x");', "sendBeacon"],
+    ['void process["env"]["GEMINI_API_KEY"];', "bracket environment"],
+    ['const { env } = process; void env;', "destructured environment"],
+    ['void globalThis["eval"]("1");', "bracket eval"]
+  ])("rejects syntactically valid %s bypass", (statement, _label) => {
+    const source = validSource.replace(
+      '  expect(\n',
+      `  ${statement}\n  expect(\n`
+    );
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ["process environment", "void process.env.GEMINI_API_KEY;"],
+    ["Vite environment", "void import.meta.env.GEMINI_API_KEY;"],
+    ["explicit rejected promise", 'void Promise.reject(new Error("background"));'],
+    ["process exit", "process.exit(1);"]
+  ])("rejects syntactically valid %s access", (_label, statement) => {
+    const source = validSource.replace(
+      '  expect(\n',
+      `  ${statement}\n  expect(\n`
+    );
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects multiple tests even when the designated name is present", () => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: `${validSource}\nit("unrelated extra case", () => expect(true).toBe(true));\n`
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    [
+      "a forged AssertionError throw",
+      `throw Object.assign(
+    new Error("Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}"),
+    { name: "AssertionError" },
+  );`
+    ],
+    [
+      "expect.fail",
+      `expect.fail(
+    "Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}",
+  );`
+    ],
+    [
+      "Vitest assert",
+      `assert(
+    false,
+    "Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}",
+  );`
+    ],
+    [
+      "expect.unreachable",
+      `expect.unreachable(
+    "Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}",
+  );`
+    ],
+    [
+      "expect.soft",
+      `expect.soft(
+    readEmptyQueue(),
+    "Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}",
+  ).toBe("safe");`
+    ]
+  ])("rejects %s before the behavior assertion", (_label, statement) => {
+    let source = validSource.replace(
+      "  expect(\n",
+      `  ${statement}\n  expect(\n`
+    );
+    if (_label === "Vitest assert") {
+      source = source.replace(
+        'import { expect, it } from "vitest";',
+        'import { assert, expect, it } from "vitest";'
+      );
+    }
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects multiple expect calls even when one carries the behavior label", () => {
+    const source = validSource.replace(
+      "  expect(\n",
+      '  expect("unrelated").toBe("unrelated");\n  expect(\n'
+    );
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a literal-only forced assertion failure", () => {
+    const source = validSource.replace("readEmptyQueue()", "false");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a forced expression that does not observe a repository import", () => {
+    const source = validSource.replace("readEmptyQueue()", "Boolean(0)");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      {
+        finding,
+        sensitiveValues: [],
+        allowedRepositoryFiles: ["src/domain/example.ts"]
+      }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a Vitest namespace assertion bypass", () => {
+    const source = validSource
+      .replace(
+        'import { expect, it } from "vitest";',
+        'import { expect, it } from "vitest";\nimport * as v from "vitest";'
+      )
+      .replace(
+        "  expect(\n",
+        `  v.assert(
+    false,
+    "Expected behavior: ${finding.expectedBehavior} | Actual behavior: ${finding.actualBehavior}",
+  );
+  expect(
+`
+      );
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      {
+        finding,
+        sensitiveValues: [],
+        allowedRepositoryFiles: ["src/domain/example.ts"]
+      }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects TypeScript import-equals declarations", () => {
+    const source =
+      'import childProcess = require("node:child_process");\n' +
+      validSource.replace(
+        "  expect(\n",
+        '  void childProcess.execSync("true");\n  expect(\n'
+      );
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects an assertion detached from its matcher call", () => {
+    const source = validSource
+      .replace("  expect(\n", "  const assertion = expect(\n")
+      .replace("  ).toBe(\"safe\");", "  );\n  assertion.toBe(\"safe\");");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ['import { guard } from "./contentGuard";', "a non-visible repository file"],
+    ['import metadata from "../../../package.json";', "package metadata"],
+    ['import os from "node:os";', "an unapproved Node builtin"]
+  ])("rejects static import of %s", (importLine, _label) => {
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source: `${importLine}\n${validSource}`
+      },
+      {
+        finding,
+        sensitiveValues: [],
+        allowedRepositoryFiles: ["src/domain/example.ts"]
+      }
+    );
+
+    expect(result.valid).toBe(false);
+  });
+});

--- a/scripts/gemini-correctness/red-validator.test.ts
+++ b/scripts/gemini-correctness/red-validator.test.ts
@@ -568,4 +568,29 @@ describe("validateRegressionCandidate", () => {
 
     expect(result.valid).toBe(false);
   });
+
+  it.each([
+    ["valueOf", "readEmptyQueue.valueOf()"],
+    ["bind", "readEmptyQueue.bind(null)()"],
+    ["toString", "readEmptyQueue.toString()"],
+    ["call", "readEmptyQueue.call(null)"],
+    ["apply", "readEmptyQueue.apply(null, [])"]
+  ])("rejects expect() with a non-executing %s trap on an imported function", (_label, trapCall) => {
+    const source = validSource
+      .replace("readEmptyQueue()", trapCall)
+      .replace('.toBe("safe")', ".toBeUndefined()");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/execute|call/i);
+  });
 });

--- a/scripts/gemini-correctness/red-validator.test.ts
+++ b/scripts/gemini-correctness/red-validator.test.ts
@@ -474,6 +474,43 @@ describe("validateRegressionCandidate", () => {
     expect(explicitResult.valid).toBe(true);
   });
 
+  it("rejects a callback whose repository call is inside an unreachable if-false branch", () => {
+    const source = validSource
+      .replace("readEmptyQueue()", "() => { if (false) { readEmptyQueue(); } }")
+      .replace('.toBe("safe")', ".toThrow()");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/execute|call/i);
+  });
+
+  it("accepts a callback with a repository call inside an if-true branch", () => {
+    const source = validSource
+      .replace("readEmptyQueue()", "() => { if (true) { readEmptyQueue(); } }")
+      .replace('.toBe("safe")', ".toThrow()");
+    const result = validateRegressionCandidate(
+      {
+        schemaVersion: 1,
+        status: "regression-test",
+        testFile: finding.reproduction.testFile,
+        testName: finding.reproduction.testName,
+        source
+      },
+      { finding, sensitiveValues: [] }
+    );
+
+    expect(result.valid).toBe(true);
+  });
+
   it("rejects a Vitest namespace assertion bypass", () => {
     const source = validSource
       .replace(


### PR DESCRIPTION
Part of #634

Closes #636

## Summary

- Add a fail-closed RED stage that accepts one #635-validated finding and permits Gemini to return only the designated colocated `*.regression.test.ts(x)` source.
- Add deterministic test-only Git validation, fixed-argv targeted Vitest execution (`shell: false`), strict assertion classification, sanitized artifacts, baseline reset, and same-patch replay.
- Extend the existing Gemini client with shared structured-JSON transport; no workflow, GREEN repair, production application behavior, package metadata, lockfile, or dependency changes.

## RED classification contract

RED is confirmed only when Vitest collects exactly one suite and one test from the designated file, executes the exact designated leaf test name, exits non-zero without a signal, and reports one direct approved matcher failure from the sole labeled `expect()` assertion. The received expression must directly observe a prompt-visible repository import, and the failure evidence must contain the finding's exact labeled expected/actual behavior.

Syntax/import/setup errors, timeout, worker crash, unhandled rejection/error, missing collection, wrong file/name, skipped/todo/focused tests, stale reporter output, non-assertion failures, detached/helper assertions, wall-clock/randomness, child process, filesystem/network/env/secret access, dynamic import/download, and TypeScript `any` all reject.

## Fail-closed gates

- Reuse #635 policy primitives for path safety, repository containment, protected/allowlisted paths, safe output paths, scanning, finding schema/repository validation, and redaction.
- Require a clean captured baseline SHA and exactly one new canonical colocated test; reject staged, unstaged, extra untracked, rename, binary, submodule, symlink/dangling-symlink, multi-file, and existing-test mutations.
- Use runner-owned `pnpm exec vitest run` argv only; model-provided commands are outside the candidate schema and never executed.
- Snapshot repository state around each targeted run (including ignored paths and Git metadata, excluding the generated test/report and dependency tree), restore detected pollution, and reject if cleanup cannot be verified.
- Sanitize API keys, environment values, repository/runner paths, logs, JSON results, and rejection messages.

## Patch replay evidence

A successful initial RED writes:

- `.tmp/gemini-correctness/red-test.patch`
- `.tmp/gemini-correctness/red-test.log`
- `.tmp/gemini-correctness/red-result.json`

`red-result.json` records the baseline SHA, designated test file/name, assertion classification, sanitized summary, patch SHA-256, and replay status. The stage resets to the trusted baseline, validates stored result/patch shape and hash, reapplies the exact patch, reruns the exact targeted test, rechecks the candidate patch/HEAD/worktree/artifacts after execution, and sets `replayConfirmed: true` only when the same assertion classification is reproduced.

## Verification

- `pnpm exec vitest run scripts/gemini-correctness` — pass (19 files, 341 tests)
- `pnpm typecheck` — pass
- `pnpm test` — pass
- `pnpm build` — pass (1,904 modules; 106 prerendered pages; existing chunk-size warning only)
- `git diff --check` — pass

Temporary Git fixture repositories cover validator, runner, initial/replay integrity, cleanup, redaction, and hostile cases without calling the real Gemini API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a secure RED-stage workflow for generating, validating, executing, and replaying AI-authored regression tests.
  * Added strict prompt generation, candidate validation, targeted test execution, failure classification, artifact integrity checks, and repository-state restoration.
  * Added strict JSON generation support for Gemini responses.
  * Added diagnostic safeguards and sanitized failure reporting.

* **Tests**
  * Added comprehensive unit and integration coverage for validation, prompt generation, execution, replay, cleanup, and security hardening scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->