### PR TITLE
feat(kanji): 漢字速查支援鍵盤 ← / → 切換卡片

### DIFF
--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -65,6 +65,85 @@ describe("KanjiOnyomiPanel (#195)", () => {
   });
 });
 
+// User request (2026-07): browsing a level or a search result meant clicking
+// every card. Desktop arrow keys now walk the grid in display order.
+describe("KanjiOnyomiPanel arrow-key browsing", () => {
+  const cells = () => Array.from(document.querySelectorAll<HTMLButtonElement>("button.kanji-cell"));
+  const selectedChar = () =>
+    document.querySelector(".kanji-cell.selected .kanji-cell-char")?.textContent ?? null;
+  const arrow = (key: "ArrowRight" | "ArrowLeft", init: KeyboardEventInit = {}) =>
+    fireEvent.keyDown(document, { key, ...init });
+
+  it("selects the first card on the first ArrowRight, then walks forward and back", () => {
+    renderNarrowed("高");
+    const chars = cells().map((cell) => cell.querySelector(".kanji-cell-char")?.textContent);
+    expect(chars.length).toBeGreaterThan(1);
+    expect(selectedChar()).toBeNull();
+
+    arrow("ArrowRight");
+    expect(selectedChar()).toBe(chars[0]);
+
+    arrow("ArrowRight");
+    expect(selectedChar()).toBe(chars[1]);
+
+    arrow("ArrowLeft");
+    expect(selectedChar()).toBe(chars[0]);
+  });
+
+  it("stops at both ends instead of wrapping around", () => {
+    renderNarrowed("高");
+    const chars = cells().map((cell) => cell.querySelector(".kanji-cell-char")?.textContent);
+
+    arrow("ArrowRight");
+    arrow("ArrowLeft");
+    expect(selectedChar()).toBe(chars[0]);
+
+    for (let i = 0; i < chars.length + 3; i++) arrow("ArrowRight");
+    expect(selectedChar()).toBe(chars[chars.length - 1]);
+  });
+
+  it("moves focus to the selected card so the grid stays keyboard-coherent", () => {
+    renderNarrowed("高");
+    arrow("ArrowRight");
+    expect(document.activeElement).toBe(cells()[0]);
+  });
+
+  it("never hijacks typing in the search box", () => {
+    renderNarrowed("高");
+    const search = screen.getByRole("searchbox");
+    search.focus();
+    fireEvent.keyDown(search, { key: "ArrowRight" });
+    expect(selectedChar()).toBeNull();
+  });
+
+  it("leaves browser and OS chords alone (Alt+Arrow is history navigation)", () => {
+    renderNarrowed("高");
+    arrow("ArrowRight", { altKey: true });
+    arrow("ArrowRight", { ctrlKey: true });
+    arrow("ArrowRight", { metaKey: true });
+    expect(selectedChar()).toBeNull();
+  });
+
+  it("reveals the next batch when arrowing past the load-more boundary (#608)", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const before = cells().length;
+    expect(screen.getByRole("button", { name: /載入更多/ })).toBeInTheDocument();
+
+    // Walk one step beyond the last rendered card.
+    for (let i = 0; i < before + 1; i++) arrow("ArrowRight");
+
+    expect(cells().length).toBeGreaterThan(before);
+    // The selection landed on the freshly revealed card, not stuck on the last.
+    const chars = cells().map((cell) => cell.querySelector(".kanji-cell-char")?.textContent);
+    expect(selectedChar()).toBe(chars[before]);
+  });
+
+  it("tells desktop learners the shortcut exists", () => {
+    renderNarrowed("高");
+    expect(screen.getByText(/← \/ →/)).toBeInTheDocument();
+  });
+});
+
 // Feedback 2026-07: hearing a kanji's reading used to require selecting the
 // cell, scrolling up to the detail card's TTS button, then scrolling back down
 // to pick the next kanji. The selected cell now grows an in-place speak button

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
@@ -86,6 +86,71 @@ export function KanjiOnyomiPanel({
   const totalEntries = families.reduce((sum, [, entries]) => sum + entries.length, 0);
   const remainingEntries = totalEntries - shownEntries;
 
+  // Every matched entry in display order (families first, then within a
+  // family) -- the sequence the arrow keys walk. Includes entries still behind
+  // the load-more boundary so stepping past it can reveal them.
+  const orderedEntries = useMemo(() => families.flatMap(([, entries]) => entries), [families]);
+  const cellRefs = useRef(new Map<string, HTMLButtonElement>());
+  const pendingFocus = useRef<string | null>(null);
+
+  // Desktop shortcut (user request 2026-07): ← / → walk the grid so browsing a
+  // level or a search result doesn't mean clicking every card. A GLOBAL
+  // document listener, like the drill's 1-9 shortcut: cards are not focused
+  // until one is picked, so a section-scoped handler would miss the first
+  // press. Skipped while a text field is focused (never hijack search typing)
+  // and whenever a modifier is held -- Alt+← is browser history.
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
+        return;
+      }
+      if (event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+      if (orderedEntries.length === 0) {
+        return;
+      }
+      const currentIndex = selected
+        ? orderedEntries.findIndex((entry) => entry.kanji === selected)
+        : -1;
+      // Nothing picked yet: the first press opens the first card.
+      const nextIndex = currentIndex < 0 ? 0 : currentIndex + (event.key === "ArrowRight" ? 1 : -1);
+      // Stop at both ends rather than wrapping -- silently jumping from the
+      // last of 671 back to the first would lose the learner's place.
+      if (nextIndex < 0 || nextIndex >= orderedEntries.length) {
+        return;
+      }
+      event.preventDefault();
+      // Stepping past the load-more boundary pulls the next batch in instead
+      // of dead-ending (one bump always covers the next whole family).
+      if (nextIndex >= shownEntries) {
+        setEntryBudget((budget) => budget + FAMILY_ENTRY_BUDGET);
+      }
+      pendingFocus.current = orderedEntries[nextIndex].kanji;
+      setSelected(orderedEntries[nextIndex].kanji);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [orderedEntries, selected, shownEntries]);
+
+  // Keyboard-driven selection follows the card: focus keeps the grid coherent
+  // for keyboard and screen-reader users, and `block: "nearest"` only scrolls
+  // when the card actually sits outside the viewport (so clicking never jumps).
+  useEffect(() => {
+    const kanji = pendingFocus.current;
+    if (!kanji) return;
+    const node = cellRefs.current.get(kanji);
+    if (!node) return; // just revealed; the next pass catches it
+    pendingFocus.current = null;
+    node.focus({ preventScroll: true });
+    node.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+  }, [selected, entryBudget]);
+
   const detail = selected ? kanjiOnyomi.find((entry) => entry.kanji === selected) ?? null : null;
   const examples = detail ? kanjiExamples(detail.kanji) : [];
   const detailSpeak = detail ? detail.onyomi[0] ?? detail.kunyomi[0] : "";
@@ -134,6 +199,9 @@ export function KanjiOnyomiPanel({
           ))}
         </div>
       </div>
+
+      {/* Hidden on touch devices (no keyboard to hint at) via CSS. */}
+      <p className="kanji-key-hint">{t.kanjiArrowHint}</p>
 
       {detail ? (
         <div className="kanji-card" aria-live="polite">
@@ -204,6 +272,10 @@ export function KanjiOnyomiPanel({
                   <div className="kanji-cell-wrap" key={entry.kanji}>
                     <button
                       type="button"
+                      ref={(node) => {
+                        if (node) cellRefs.current.set(entry.kanji, node);
+                        else cellRefs.current.delete(entry.kanji);
+                      }}
                       className={`kanji-cell${isSelected ? " selected" : ""}`}
                       aria-pressed={isSelected}
                       onClick={() => setSelected(entry.kanji)}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -169,6 +169,7 @@ export type Copy = {
   kanjiExamplesLabel: string;
   kanjiNoExamples: string;
   kanjiSearchEmpty: string;
+  kanjiArrowHint: string;
   // #608 batched kanji table: "load more (N left)" button label.
   kanjiLoadMore: (count: number) => string;
   // #619 standalone /kana reference page.

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -169,6 +169,7 @@ export const en: Copy = {
   kanjiExamplesLabel: "Example words",
   kanjiNoExamples: "(No example words yet)",
   kanjiSearchEmpty: "No matching kanji found.",
+  kanjiArrowHint: "Tip: use ← / → on your keyboard to step through the cards.",
   kanjiLoadMore: (count: number) => `Load more (${count} more)`,
   kanaPageTitle: "Kana chart",
   kanaPageIntro: "Hiragana and katakana side by side - tap any cell to hear it. Grouped into seion, dakuon/handakuon, and yoon.",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -169,6 +169,7 @@ export const id: Copy = {
   kanjiExamplesLabel: "Contoh kata",
   kanjiNoExamples: "（belum ada contoh kata）",
   kanjiSearchEmpty: "Tidak ditemukan kanji yang cocok.",
+  kanjiArrowHint: "Tips: gunakan ← / → pada keyboard untuk berpindah kartu.",
   kanjiLoadMore: (count: number) => `Muat lebih banyak (${count} lagi)`,
   kanaPageTitle: "Tabel kana",
   kanaPageIntro: "Hiragana dan katakana berdampingan - ketuk untuk mendengar pelafalan.",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -171,6 +171,7 @@ export const ja: Copy = {
   kanjiExamplesLabel: "例語",
   kanjiNoExamples: "（収録された例語はまだありません）",
   kanjiSearchEmpty: "該当する漢字が見つかりません。",
+  kanjiArrowHint: "ヒント：キーボードの ← / → でカードを次々に切り替えられます。",
   kanjiLoadMore: (count: number) => `もっと見る（あと${count}字）`,
   kanaPageTitle: "五十音表",
   kanaPageIntro: "ひらがな・カタカナの対照表。タップで発音を再生。清音・濁音・半濁音・拗音で区分。",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -169,6 +169,7 @@ export const ko: Copy = {
   kanjiExamplesLabel: "예시 단어",
   kanjiNoExamples: "(아직 예시 단어가 없어요)",
   kanjiSearchEmpty: "일치하는 한자를 찾을 수 없어요.",
+  kanjiArrowHint: "팁: 키보드 ← / → 로 카드를 연달아 넘길 수 있어요.",
   kanjiLoadMore: (count: number) => `더 보기 (${count}자 남음)`,
   kanaPageTitle: "오십음도",
   kanaPageIntro: "히라가나·가타카나 대조표. 셀을 누르면 발음이 재생됩니다.",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -169,6 +169,7 @@ export const my: Copy = {
   kanjiExamplesLabel: "နမူနာ စကားလုံးများ",
   kanjiNoExamples: "(နမူနာစကားလုံး မရှိသေးပါ)",
   kanjiSearchEmpty: "ကိုက်ညီသော ခန်းဂျိ မတွေ့ပါ။",
+  kanjiArrowHint: "အကြံပြုချက် - ကီးဘုတ်ရှိ ← / → ဖြင့် ကတ်များကို ဆက်တိုက် ပြောင်းနိုင်သည်။",
   kanjiLoadMore: (count: number) => `နောက်ထပ်ကြည့်ရန် (ကျန် ${count} လုံး)`,
   kanaPageTitle: "ကနာဇယား",
   kanaPageIntro: "ဟီရာဂနနှင့် ခတခန နှိုင်းယှဉ်ဇယား၊ အသံနားထောင်ရန် နှိပ်ပါ။",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -170,6 +170,7 @@ export const th: Copy = {
   kanjiExamplesLabel: "คำตัวอย่าง",
   kanjiNoExamples: "(ยังไม่มีคำตัวอย่าง)",
   kanjiSearchEmpty: "ไม่พบคันจิที่ตรงกัน",
+  kanjiArrowHint: "เคล็ดลับ: ใช้ปุ่ม ← / → บนคีย์บอร์ดเพื่อเลื่อนดูการ์ดต่อเนื่อง",
   kanjiLoadMore: (count: number) => `โหลดเพิ่ม (เหลืออีก ${count} ตัว)`,
   kanaPageTitle: "ตารางคานะ",
   kanaPageIntro: "ฮิรางานะและคาตากานะเทียบกัน แตะเพื่อฟังเสียง",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -169,6 +169,7 @@ export const vi: Copy = {
   kanjiExamplesLabel: "Từ ví dụ",
   kanjiNoExamples: "(Chưa có từ ví dụ)",
   kanjiSearchEmpty: "Không tìm thấy kanji phù hợp.",
+  kanjiArrowHint: "Mẹo: dùng phím ← / → trên bàn phím để chuyển thẻ liên tục.",
   kanjiLoadMore: (count: number) => `Tải thêm (còn ${count} chữ)`,
   kanaPageTitle: "Bảng kana",
   kanaPageIntro: "Bảng đối chiếu hiragana - katakana, chạm để nghe phát âm.",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -169,6 +169,7 @@ export const zhHant: Copy = {
   kanjiExamplesLabel: "例詞",
   kanjiNoExamples: "（暫無收錄例詞）",
   kanjiSearchEmpty: "找不到符合的漢字。",
+  kanjiArrowHint: "小技巧：用鍵盤 ← / → 可以連續切換卡片。",
   kanjiLoadMore: (count: number) => `載入更多（還有 ${count} 字）`,
   kanaPageTitle: "五十音表",
   kanaPageIntro: "平假名・片假名對照，每格可點發音；清音、濁音・半濁音、拗音分區。",

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -30,6 +30,21 @@
   color: var(--ink);
 }
 
+/* Arrow-key shortcut hint: only shown where a keyboard is likely (a mouse /
+   trackpad pointer). Touch devices get no dead advice. */
+.kanji-key-hint {
+  display: none;
+  margin: -0.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .kanji-key-hint {
+    display: block;
+  }
+}
+
 .kanji-card {
   border: 1px solid color-mix(in srgb, var(--matcha) 45%, var(--panel-border));
   background: color-mix(in srgb, var(--matcha) 10%, var(--paper));


### PR DESCRIPTION
﻿使用者來信建議（附了他自己寫 Chrome Extension 驗證過的邏輯）：桌面端連續瀏覽某個 N 級別或搜尋結果時，只能一張張點卡片。現在 ← / → 可以直接走。

## 實作
- **全域 document keydown listener**（與挑戰頁 1-9 快捷鍵同型：卡片在被選中前沒有焦點，section-scoped handler 會漏掉第一次按鍵）
- **保護**：輸入框（INPUT/TEXTAREA/SELECT/contenteditable）有焦點時不攔——搜尋打字不受干擾；**按住修飾鍵時完全不處理（Alt+← 是瀏覽器上一頁）**
- **走訪順序**＝所有符合篩選的字依畫面順序，**兩端停住不循環**（671 字從最後跳回第一個會弄丟閱讀位置）
- **跨過「載入更多」邊界會自動載入下一批**再選中（來信者的 DOM 版只看得到已渲染的卡片；#608 分批渲染讓清單比 DOM 長）
- 選中卡片**取得焦點**（鍵盤／輔助技術一致性）＋ scrollIntoView block:nearest（點擊時不會亂跳，只有鍵盤走到畫面外才捲動）
- **可發現性**：控制列下方一行提示，只在 hover/fine-pointer 裝置顯示（觸控裝置不給沒用的建議）；kanjiArrowHint 8 語系齊

## 驗證
TDD 先紅後綠 8 測（首次按鍵開第一張／前後走訪／兩端停住／焦點跟隨／搜尋打字免疫／Alt·Ctrl·Meta 不劫持／載入更多邊界自動展開／提示存在）。dev server 實機驗證：走訪、詳情卡同步、焦點、Alt+→ 保護、搜尋框保護皆正確。

⚠️ 附註：pnpm test 另有 11 個**既有**失敗在 scripts/gemini-correctness/__tests__（Windows 建 symlink 需管理員權限 EPERM），在乾淨 main 上完全相同、Linux CI 正常，與本 PR 無關。
