### PR TITLE
test(gemini): skip symlink fixtures where the OS can't create symlinks

### DIFF
--- a/scripts/gemini-correctness/__tests__/b2-blocks-integration.test.ts
+++ b/scripts/gemini-correctness/__tests__/b2-blocks-integration.test.ts
@@ -18,6 +18,20 @@ import { validateFindingWithRepo } from "../repo-validator.mjs";
 import fs from "node:fs";
 import path from "node:path";
 
+import { canCreateSymlinks, SYMLINK_SKIP_REASON } from "./symlink-support.js";
+
+// Building a symlink-escape fixture needs fs.symlinkSync, which Windows only
+// grants under Developer Mode / Administrator. Gate just the tests that create
+// one so they skip there rather than dying with EPERM before asserting
+// anything; every assertion is unchanged and still runs where symlinks work,
+// including CI. See symlink-support.ts.
+const symlinkFixturesSupported = canCreateSymlinks();
+if (!symlinkFixturesSupported) {
+  console.warn(
+    `[b2-blocks-integration] skipping symlink-escape tests: ${SYMLINK_SKIP_REASON}`
+  );
+}
+
 // =============================================================================
 // BLOCKER 1: safeWritePath must work on clean checkout (file doesn't exist)
 //            and must reject .tmp symlink to outside
@@ -46,7 +60,7 @@ describe("BLOCKER 1 — safeWritePath on clean checkout", () => {
     expect(fs.existsSync(tmpDir)).toBe(true);
   });
 
-  it("rejects when .tmp is a symlink outside the repo", () => {
+  it.skipIf(!symlinkFixturesSupported)("rejects when .tmp is a symlink outside the repo", () => {
     const tmpDir = path.join(REPO, ".tmp");
     if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.symlinkSync(OUTSIDE, tmpDir);
@@ -55,7 +69,7 @@ describe("BLOCKER 1 — safeWritePath on clean checkout", () => {
     expect(result).toBeNull();
   });
 
-  it("rejects when intermediate dir on output path is a symlink outside", () => {
+  it.skipIf(!symlinkFixturesSupported)("rejects when intermediate dir on output path is a symlink outside", () => {
     const tmpDir = path.join(REPO, ".tmp");
     if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
     const subDir = path.join(tmpDir, "sub");
@@ -65,7 +79,7 @@ describe("BLOCKER 1 — safeWritePath on clean checkout", () => {
     expect(result).toBeNull();
   });
 
-  it("rejects when .tmp is a symlink into a production directory", () => {
+  it.skipIf(!symlinkFixturesSupported)("rejects when .tmp is a symlink into a production directory", () => {
     const tmpDir = path.join(REPO, ".tmp");
     const productionDir = path.join(REPO, "src", "domain");
     fs.mkdirSync(productionDir, { recursive: true });
@@ -75,7 +89,7 @@ describe("BLOCKER 1 — safeWritePath on clean checkout", () => {
     expect(result).toBeNull();
   });
 
-  it("rejects a dangling final symlink whose target is outside the repo", () => {
+  it.skipIf(!symlinkFixturesSupported)("rejects a dangling final symlink whose target is outside the repo", () => {
     const tmpDir = path.join(REPO, ".tmp");
     fs.mkdirSync(tmpDir, { recursive: true });
     const outsideTarget = path.join(OUTSIDE, "not-created-yet.json");
@@ -254,7 +268,8 @@ describe("BLOCKER 3 — MAX_TOTAL_CHARS true hard cap", () => {
 // =============================================================================
 // BLOCKER 4: exact-file allowlist must re-verify after realpath resolution
 // =============================================================================
-describe("BLOCKER 4 — exact-file allowlist realpath re-verification", () => {
+// Whole suite: the symlink lives in beforeEach, so both tests depend on it.
+describe.skipIf(!symlinkFixturesSupported)("BLOCKER 4 — exact-file allowlist realpath re-verification", () => {
   const TMP = "/tmp/jabiko-b4-" + Date.now();
   const REPO = path.join(TMP, "repo");
 

--- a/scripts/gemini-correctness/__tests__/blocker-fixes.test.ts
+++ b/scripts/gemini-correctness/__tests__/blocker-fixes.test.ts
@@ -12,10 +12,25 @@ import { validateEvidenceLines, validateFindingWithRepo } from "../repo-validato
 import fs from "node:fs";
 import path from "node:path";
 
+import { canCreateSymlinks, SYMLINK_SKIP_REASON } from "./symlink-support.js";
+
+// The containment suites below prove that a symlink cannot be used to escape
+// the repo. Building those fixtures needs fs.symlinkSync, which Windows only
+// grants under Developer Mode / Administrator — without it the *fixture* dies
+// with EPERM before any assertion runs. Gate the suites on an actual probe so
+// they skip there instead of failing. The assertions are unchanged and still
+// run wherever symlinks work, including CI.
+const symlinkFixturesSupported = canCreateSymlinks();
+if (!symlinkFixturesSupported) {
+  console.warn(
+    `[blocker-fixes] skipping symlink-containment suites: ${SYMLINK_SKIP_REASON}`
+  );
+}
+
 // =============================================================================
 // 1. safeWritePath — .tmp symlink outside repo must be rejected
 // =============================================================================
-describe("safeWritePath — .tmp symlink containment", () => {
+describe.skipIf(!symlinkFixturesSupported)("safeWritePath — .tmp symlink containment", () => {
   const TEST_DIR = "/tmp/jabiko-safewrite-test-" + Date.now();
   const REPO_DIR = path.join(TEST_DIR, "repo");
   const OUTSIDE_DIR = path.join(TEST_DIR, "outside");
@@ -50,7 +65,7 @@ describe("safeWritePath — .tmp symlink containment", () => {
   });
 });
 
-describe("isPathWithinRepo — dangling symlink containment", () => {
+describe.skipIf(!symlinkFixturesSupported)("isPathWithinRepo — dangling symlink containment", () => {
   const TEST_DIR = "/tmp/jabiko-pathwithin-test-" + Date.now();
   const REPO_DIR = path.join(TEST_DIR, "repo");
   const OUTSIDE_TARGET = path.join(TEST_DIR, "outside", "missing.ts");
@@ -183,7 +198,7 @@ describe("scanRepository — protectedExcluded accuracy", () => {
 // =============================================================================
 // 5. scanner exact-file allowlist — symlink outside repo must be rejected
 // =============================================================================
-describe("scanRepository — exact-file allowlist symlink escape", () => {
+describe.skipIf(!symlinkFixturesSupported)("scanRepository — exact-file allowlist symlink escape", () => {
   const TEST_DIR = "/tmp/jabiko-exactfile-test-" + Date.now();
   const REPO_DIR = path.join(TEST_DIR, "repo");
   const OUTSIDE_FILE = path.join(TEST_DIR, "outside.ts");
@@ -214,7 +229,7 @@ describe("scanRepository — exact-file allowlist symlink escape", () => {
   });
 });
 
-describe("scanRepository — glob root canonical policy enforcement", () => {
+describe.skipIf(!symlinkFixturesSupported)("scanRepository — glob root canonical policy enforcement", () => {
   const TEST_DIR = "/tmp/jabiko-globroot-test-" + Date.now();
   const REPO_DIR = path.join(TEST_DIR, "repo");
 

--- a/scripts/gemini-correctness/__tests__/symlink-support.test.ts
+++ b/scripts/gemini-correctness/__tests__/symlink-support.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  canCreateSymlinks,
+  probeSymlinkSupport,
+  SYMLINK_SKIP_REASON
+} from "./symlink-support.js";
+
+/**
+ * These tests guard the capability probe that gates the symlink-containment
+ * security tests in blocker-fixes.test.ts. The probe must be *accurate*: a
+ * false negative would silently disable real security assertions on CI, which
+ * is far worse than the Windows EPERM noise it exists to remove.
+ */
+describe("probeSymlinkSupport", () => {
+  it("returns a boolean", () => {
+    expect(typeof probeSymlinkSupport()).toBe("boolean");
+  });
+
+  it("agrees with what fs.symlinkSync actually does on this machine", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-symlink-truth-"));
+    try {
+      const target = path.join(dir, "target.txt");
+      fs.writeFileSync(target, "truth");
+
+      let actuallyWorks: boolean;
+      try {
+        fs.symlinkSync(target, path.join(dir, "link.txt"));
+        actuallyWorks = true;
+      } catch {
+        actuallyWorks = false;
+      }
+
+      // The probe must never claim symlinks are unavailable on a machine that
+      // can create them — that is what would skip the security tests on CI.
+      expect(probeSymlinkSupport()).toBe(actuallyWorks);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects directory symlinks too, not just file symlinks", () => {
+    // blocker-fixes.test.ts symlinks directories (.tmp -> outside,
+    // src/domain -> supabase), so a file-only probe would under-detect.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-symlink-dir-"));
+    try {
+      const target = path.join(dir, "target-dir");
+      fs.mkdirSync(target);
+
+      let dirSymlinksWork: boolean;
+      try {
+        fs.symlinkSync(target, path.join(dir, "link-dir"), "dir");
+        dirSymlinksWork = true;
+      } catch {
+        dirSymlinksWork = false;
+      }
+
+      expect(probeSymlinkSupport()).toBe(dirSymlinksWork);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves no probe directories behind", () => {
+    const before = fs.readdirSync(os.tmpdir()).filter(isProbeArtifact);
+    probeSymlinkSupport();
+    probeSymlinkSupport();
+    const after = fs.readdirSync(os.tmpdir()).filter(isProbeArtifact);
+    expect(after).toEqual(before);
+  });
+
+  it("fails closed when the probe directory is unusable", () => {
+    const missing = path.join(os.tmpdir(), "jabiko-does-not-exist-" + process.pid);
+    expect(probeSymlinkSupport(missing)).toBe(false);
+  });
+});
+
+describe("canCreateSymlinks", () => {
+  it("matches a fresh probe", () => {
+    expect(canCreateSymlinks()).toBe(probeSymlinkSupport());
+  });
+
+  it("is stable across calls (cached)", () => {
+    expect(canCreateSymlinks()).toBe(canCreateSymlinks());
+  });
+});
+
+describe("SYMLINK_SKIP_REASON", () => {
+  it("explains why the tests are skipped and how to enable them", () => {
+    expect(SYMLINK_SKIP_REASON).toMatch(/symlink/i);
+    expect(SYMLINK_SKIP_REASON).toMatch(/developer mode|administrator/i);
+  });
+});
+
+function isProbeArtifact(name: string): boolean {
+  return name.startsWith("jabiko-symlink-probe-");
+}

--- a/scripts/gemini-correctness/__tests__/symlink-support.ts
+++ b/scripts/gemini-correctness/__tests__/symlink-support.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Symlink-capability detection for the containment tests in
+ * blocker-fixes.test.ts.
+ *
+ * Those tests build fixtures with fs.symlinkSync to prove that the scanner and
+ * write-path policy refuse symlink escapes. Creating a symlink on Windows needs
+ * SeCreateSymbolicLinkPrivilege — i.e. an elevated shell or Developer Mode —
+ * so on an ordinary Windows dev box the *fixture* dies with EPERM and the run
+ * is permanently red for a reason that has nothing to do with the code under
+ * test. Linux/macOS (and CI) create symlinks freely and run the assertions for
+ * real.
+ *
+ * This probe gates those suites so they skip instead of failing where the OS
+ * cannot host the fixture. It must never produce a false negative: a wrong
+ * "no symlinks here" would silently disable real security assertions on CI.
+ * Hence an actual create-a-symlink probe rather than a platform sniff.
+ */
+
+/** Guidance printed / attached wherever the containment suites are skipped. */
+export const SYMLINK_SKIP_REASON =
+  "this machine cannot create symlinks (on Windows, enable Developer Mode or " +
+  "run as Administrator); the symlink-containment assertions still run on CI";
+
+/**
+ * Actually create a symlink in a throwaway directory and report whether it
+ * worked. Both a file and a directory symlink are attempted because the
+ * containment fixtures use both, and Windows treats them as separate calls.
+ *
+ * @param baseDir directory to create the throwaway probe dir in.
+ * @returns true only if both symlink kinds were created successfully.
+ */
+export function probeSymlinkSupport(baseDir: string = os.tmpdir()): boolean {
+  let probeDir: string | undefined;
+  try {
+    probeDir = fs.mkdtempSync(path.join(baseDir, "jabiko-symlink-probe-"));
+
+    const fileTarget = path.join(probeDir, "target.txt");
+    fs.writeFileSync(fileTarget, "probe");
+    fs.symlinkSync(fileTarget, path.join(probeDir, "link.txt"), "file");
+
+    const dirTarget = path.join(probeDir, "target-dir");
+    fs.mkdirSync(dirTarget);
+    fs.symlinkSync(dirTarget, path.join(probeDir, "link-dir"), "dir");
+
+    return true;
+  } catch {
+    // Fail closed: EPERM (no privilege), EACCES, ENOENT (unusable baseDir), or
+    // a filesystem that has no symlinks at all all mean "cannot build the
+    // fixture here".
+    return false;
+  } finally {
+    if (probeDir !== undefined) {
+      try {
+        fs.rmSync(probeDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup; a leftover temp dir must not fail a test run.
+      }
+    }
+  }
+}
+
+let cached: boolean | undefined;
+
+/**
+ * probeSymlinkSupport(), evaluated once per process. Suites call this at
+ * collection time, so it needs to be cheap on repeat.
+ */
+export function canCreateSymlinks(): boolean {
+  if (cached === undefined) cached = probeSymlinkSupport();
+  return cached;
+}


### PR DESCRIPTION
## Problem

`pnpm test` is permanently red on Windows. **11 tests** across two files fail with
`EPERM: operation not permitted, symlink` — creating a symlink on Windows requires
`SeCreateSymbolicLinkPrivilege` (Developer Mode or an elevated shell).

The failures are in the *fixture setup*, not the assertions: `fs.symlinkSync` throws
before a single `expect` runs. They pass on Linux CI, which is why #635 merged green.
Local-developer-experience problem only.

- `blocker-fixes.test.ts` — 5 tests (the ones reported)
- `b2-blocks-integration.test.ts` — 6 more, same root cause, found by running the full suite

## Fix

New `scripts/gemini-correctness/__tests__/symlink-support.ts`:

- `probeSymlinkSupport(baseDir?)` — actually creates a **file** symlink *and* a
  **directory** symlink in a throwaway temp dir, cleans up, returns whether both
  worked. Both kinds are probed because the fixtures use both and Windows treats
  them as separate privileged calls. Fails closed on any error.
- `canCreateSymlinks()` — the same, cached per process (suites call it at collection time).
- `SYMLINK_SKIP_REASON` — the message logged once per file when skipping.

Suites are gated with `describe.skipIf(...)` / `it.skipIf(...)`. In BLOCKER 1 only the
four symlink-creating tests are gated — its symlink-free `clean checkout` sibling still
runs everywhere.

## No security assertion is weakened

- Fixture bodies and `expect` calls are **byte-identical** — the diff only adds the gate.
- All 11 test names are unchanged.
- The gate is a **real capability probe**, not a `process.platform === "win32"` sniff,
  so it cannot silently disable these checks on a machine that can create symlinks.
- `symlink-support.test.ts` asserts the probe's result **equals what `fs.symlinkSync`
  actually does** on the running machine, in both directions. On CI that test fails if
  the probe ever under-reports — i.e. it guards against exactly the false negative that
  would skip security tests on CI.

## Verification

| Gate | Result |
|---|---|
| `pnpm test` (Windows) | 114 files, **1281 passed, 11 skipped, 0 failed** |
| `pnpm check:exam` | 20 passed |
| `pnpm build` | ✅, `examBlocks` still its own lazy chunk |

**Do the gated tests still run when symlinks are available?** Yes — verified by
temporarily forcing the probe to return `true` and re-running both files: **22 tests
collected, 0 skipped**, all 11 symlink tests executed (and failed with EPERM, since this
machine genuinely cannot create symlinks). That confirms the `skipIf` gate is the only
thing suppressing them. The override was reverted before committing. CI on Linux runs
them for real and must stay green.

Skip output on Windows:

```
stderr | scripts/gemini-correctness/__tests__/blocker-fixes.test.ts
[blocker-fixes] skipping symlink-containment suites: this machine cannot create
symlinks (on Windows, enable Developer Mode or run as Administrator); the
symlink-containment assertions still run on CI
```

TDD: `symlink-support.test.ts` was written first and observed failing
(`Cannot find module './symlink-support.js'`) before the helper existed.
