### PR TITLE
feat(kanji): 記住級別篩選與上次看到的漢字

### DIFF
--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -1,6 +1,17 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { KanjiOnyomiPanel } from "./KanjiOnyomiPanel";
+import {
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "../domain/kanjiPreferences";
+
+// The panel persists the level filter and the last card opened
+// (kanjiPreferences), so every test must start from an empty store -- without
+// this, one test's selection becomes the next test's resume point.
+afterEach(() => window.localStorage.clear());
 
 // The default view renders the whole table (~hundreds of cells), which makes
 // testing-library's accessible-name scans slow in jsdom (not in a real
@@ -141,6 +152,96 @@ describe("KanjiOnyomiPanel arrow-key browsing", () => {
   it("tells desktop learners the shortcut exists", () => {
     renderNarrowed("高");
     expect(screen.getByText(/← \/ →/)).toBeInTheDocument();
+  });
+});
+
+// User request (2026-07, scsnake): the page forgot both the level you were
+// filtering on and the card you were reading, so every visit restarted the
+// browse from the top of your band.
+describe("KanjiOnyomiPanel remembers where you were", () => {
+  const cells = () => Array.from(document.querySelectorAll<HTMLButtonElement>("button.kanji-cell"));
+  const selectedChar = () =>
+    document.querySelector(".kanji-cell.selected .kanji-cell-char")?.textContent ?? null;
+  const charOf = (cell: Element) => cell.querySelector(".kanji-cell-char")?.textContent ?? "";
+
+  it("restores the level picked last time under the same band", () => {
+    writeKanjiLevel("N2", "N5");
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
+    expect(screen.getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "N2" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("persists a level pick so the next visit opens on it", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
+    fireEvent.click(screen.getByRole("button", { name: "N4" }));
+    expect(readKanjiLevel("N2")).toBe("N4");
+  });
+
+  it("goes back to the band default when the learner's target level changed", () => {
+    writeKanjiLevel("N2", "N5");
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N1" />);
+    expect(screen.getByRole("button", { name: "N1" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("stores the card you open as the last one read", () => {
+    renderNarrowed("高");
+    const first = cells()[0];
+    fireEvent.click(first);
+    expect(readLastReadKanji()).toBe(charOf(first));
+  });
+
+  it("marks the last-read card on return, without opening or scrolling to it", () => {
+    // Learn which card sits second in this view, then come back to it.
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const target = charOf(cells()[1]);
+    cleanup();
+
+    writeLastReadKanji(target);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const marked = document.querySelectorAll(".kanji-cell.last-read");
+    expect(marked).toHaveLength(1);
+    expect(charOf(marked[0])).toBe(target);
+    // Marked, not selected: no detail card pops open on load.
+    expect(selectedChar()).toBeNull();
+    expect(document.querySelector(".kanji-card")).toBeNull();
+  });
+
+  it("drops the mark once the learner picks a card this session", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const target = charOf(cells()[1]);
+    cleanup();
+
+    writeLastReadKanji(target);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    fireEvent.click(cells()[0]);
+    expect(document.querySelectorAll(".kanji-cell.last-read")).toHaveLength(0);
+  });
+
+  it("resumes arrow browsing from the last-read card", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const chars = cells().map(charOf);
+    cleanup();
+
+    writeLastReadKanji(chars[1]);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    // Continues past the card you already read, rather than restarting at 0.
+    expect(selectedChar()).toBe(chars[2]);
+
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(selectedChar()).toBe(chars[1]);
+  });
+
+  it("ignores a last-read card that the current filter hides", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N5" />);
+    const n5Chars = cells().map(charOf);
+    cleanup();
+
+    writeLastReadKanji("鬱"); // not in the N5 view
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N5" />);
+    expect(document.querySelectorAll(".kanji-cell.last-read")).toHaveLength(0);
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(selectedChar()).toBe(n5Chars[0]);
   });
 });
 

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -2,6 +2,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
+import {
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "../domain/kanjiPreferences";
 import { kanjiMeaning } from "../domain/kanjiOnyomi.i18n";
 import { pickLocalized } from "../domain/localizedContent";
 import { SpeakButton } from "./SpeakButton";
@@ -33,9 +39,23 @@ export function KanjiOnyomiPanel({
 }) {
   const t = copy[language];
   const [query, setQuery] = useState("");
-  const [level, setLevel] = useState<JlptLevel | "all">(defaultLevel);
+  // A level picked ON THIS PAGE outlives the visit, but only within the band
+  // the learner's target level puts them in (see kanjiPreferences) -- so
+  // browsing sticks, while changing your target level still moves the page.
+  const [level, setLevel] = useState<JlptLevel | "all">(
+    () => readKanjiLevel(defaultLevel) ?? defaultLevel
+  );
   const [readingType, setReadingType] = useState<ReadingType>("on");
   const [selected, setSelected] = useState<string | null>(null);
+  // Where the learner stopped last time. Read once on mount: it marks that
+  // card and gives the arrow keys a starting point, but nothing scrolls or
+  // opens on load -- returning to the page should look exactly as before.
+  const [lastRead] = useState<string | null>(() => readLastReadKanji());
+
+  const selectKanji = (kanji: string) => {
+    setSelected(kanji);
+    writeLastReadKanji(kanji);
+  };
   const [entryBudget, setEntryBudget] = useState(FAMILY_ENTRY_BUDGET);
   useEffect(() => {
     // Any filter change starts a fresh batched view.
@@ -115,10 +135,12 @@ export function KanjiOnyomiPanel({
       if (orderedEntries.length === 0) {
         return;
       }
-      const currentIndex = selected
-        ? orderedEntries.findIndex((entry) => entry.kanji === selected)
+      // Nothing picked yet: carry on from the card the learner last read (so a
+      // return visit resumes rather than restarting), else from the top.
+      const position = selected ?? lastRead;
+      const currentIndex = position
+        ? orderedEntries.findIndex((entry) => entry.kanji === position)
         : -1;
-      // Nothing picked yet: the first press opens the first card.
       const nextIndex = currentIndex < 0 ? 0 : currentIndex + (event.key === "ArrowRight" ? 1 : -1);
       // Stop at both ends rather than wrapping -- silently jumping from the
       // last of 671 back to the first would lose the learner's place.
@@ -126,17 +148,19 @@ export function KanjiOnyomiPanel({
         return;
       }
       event.preventDefault();
-      // Stepping past the load-more boundary pulls the next batch in instead
-      // of dead-ending (one bump always covers the next whole family).
+      // Reveal the target when it sits behind the load-more boundary. Budget
+      // is family-granular, so asking for index+1 entries always pulls in the
+      // whole family holding it -- covers both a single step past the edge and
+      // a resume that lands deep in the list.
       if (nextIndex >= shownEntries) {
-        setEntryBudget((budget) => budget + FAMILY_ENTRY_BUDGET);
+        setEntryBudget((budget) => Math.max(budget, nextIndex + 1));
       }
       pendingFocus.current = orderedEntries[nextIndex].kanji;
-      setSelected(orderedEntries[nextIndex].kanji);
+      selectKanji(orderedEntries[nextIndex].kanji);
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [orderedEntries, selected, shownEntries]);
+  }, [orderedEntries, selected, lastRead, shownEntries]);
 
   // Keyboard-driven selection follows the card: focus keeps the grid coherent
   // for keyboard and screen-reader users, and `block: "nearest"` only scrolls
@@ -192,7 +216,10 @@ export function KanjiOnyomiPanel({
               type="button"
               className={level === option ? "selected" : ""}
               aria-pressed={level === option}
-              onClick={() => setLevel(option)}
+              onClick={() => {
+                setLevel(option);
+                writeKanjiLevel(defaultLevel, option);
+              }}
             >
               {option === "all" ? t.kanjiLevelAll : option}
             </button>
@@ -259,6 +286,10 @@ export function KanjiOnyomiPanel({
             <div className="kanji-grid">
               {entries.map((entry) => {
                 const isSelected = selected === entry.kanji;
+                // Where the learner stopped last time, shown only until they
+                // pick something this session -- after that the selection is
+                // the position and a second marker would just be noise.
+                const isLastRead = selected === null && lastRead === entry.kanji;
                 // Feedback 2026-07: listening used to mean scrolling back up to
                 // the detail card's TTS button after every selection. The
                 // selected cell grows an in-place speak button instead; it reads
@@ -276,9 +307,9 @@ export function KanjiOnyomiPanel({
                         if (node) cellRefs.current.set(entry.kanji, node);
                         else cellRefs.current.delete(entry.kanji);
                       }}
-                      className={`kanji-cell${isSelected ? " selected" : ""}`}
+                      className={`kanji-cell${isSelected ? " selected" : ""}${isLastRead ? " last-read" : ""}`}
                       aria-pressed={isSelected}
-                      onClick={() => setSelected(entry.kanji)}
+                      onClick={() => selectKanji(entry.kanji)}
                     >
                       <span className="kanji-cell-char">{entry.kanji}</span>
                       <span className="kanji-cell-read">

--- a/src/domain/kanjiPreferences.test.ts
+++ b/src/domain/kanjiPreferences.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  KANJI_LAST_READ_KEY,
+  KANJI_LEVEL_KEY,
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "./kanjiPreferences";
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("kanji level preference", () => {
+  it("returns null before the learner has picked a level on the page", () => {
+    expect(readKanjiLevel("N2")).toBeNull();
+  });
+
+  it("remembers a pick made under the same band default", () => {
+    writeKanjiLevel("N2", "N5");
+    expect(readKanjiLevel("N2")).toBe("N5");
+  });
+
+  // The page default follows the learner's target level (kanjiDefaultLevel).
+  // A manual pick is scoped to the band it was made under, so changing the
+  // target level moves the page to the NEW band instead of pinning the old
+  // pick forever.
+  it("drops the pick once the band default changes", () => {
+    writeKanjiLevel("N2", "N5");
+    expect(readKanjiLevel("N1")).toBeNull();
+  });
+
+  it("ignores a stored value that is not a level", () => {
+    window.localStorage.setItem(KANJI_LEVEL_KEY, "N2|banana");
+    expect(readKanjiLevel("N2")).toBeNull();
+  });
+
+  it("survives unreadable storage", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readKanjiLevel("N2")).toBeNull();
+  });
+
+  it("survives unwritable storage", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => writeKanjiLevel("N2", "N5")).not.toThrow();
+  });
+});
+
+describe("last-read kanji", () => {
+  it("round-trips the last card the learner opened", () => {
+    expect(readLastReadKanji()).toBeNull();
+    writeLastReadKanji("校");
+    expect(readLastReadKanji()).toBe("校");
+  });
+
+  it("keeps only the newest card", () => {
+    writeLastReadKanji("校");
+    writeLastReadKanji("考");
+    expect(readLastReadKanji()).toBe("考");
+  });
+
+  it("ignores a stored value that is not a single character", () => {
+    window.localStorage.setItem(KANJI_LAST_READ_KEY, "not a kanji");
+    expect(readLastReadKanji()).toBeNull();
+  });
+
+  it("survives unreadable storage", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readLastReadKanji()).toBeNull();
+  });
+});

--- a/src/domain/kanjiPreferences.ts
+++ b/src/domain/kanjiPreferences.ts
@@ -1,0 +1,55 @@
+import { readStored, writeStored } from "./safeStorage";
+import type { JlptLevel } from "./types";
+
+// Page-scoped preferences for the 漢字音讀速查 table (#195), asked for by a
+// learner who browses one band card by card: the page used to forget both the
+// level filter and the card they were on, so every visit restarted from the
+// top of their band.
+//
+// Deliberately tiny and crash-safe (readStored/writeStored swallow blocked
+// storage): losing persistence must never cost the page.
+
+export const KANJI_LEVEL_KEY = "jabiko.kanjiLevel";
+export const KANJI_LAST_READ_KEY = "jabiko.kanjiLastRead";
+
+export type KanjiLevelFilter = JlptLevel | "all";
+
+const LEVEL_FILTERS: readonly string[] = ["all", "N5", "N4", "N3", "N2", "N1"];
+
+function isLevelFilter(value: string): value is KanjiLevelFilter {
+  return LEVEL_FILTERS.includes(value);
+}
+
+// The manual pick is stored WITH the band default it was made under
+// ("<band>|<pick>"). The page default follows the learner's target level
+// (kanjiDefaultLevel), so scoping the pick this way means changing the target
+// level moves the page to the new band instead of pinning an old pick for
+// good -- while browsing within one band still remembers where you were.
+export function readKanjiLevel(bandDefault: KanjiLevelFilter): KanjiLevelFilter | null {
+  const raw = readStored(KANJI_LEVEL_KEY);
+  if (raw === null) return null;
+  const separator = raw.indexOf("|");
+  if (separator < 0) return null;
+  const band = raw.slice(0, separator);
+  const pick = raw.slice(separator + 1);
+  if (band !== bandDefault) return null;
+  return isLevelFilter(pick) ? pick : null;
+}
+
+export function writeKanjiLevel(bandDefault: KanjiLevelFilter, pick: KanjiLevelFilter): void {
+  writeStored(KANJI_LEVEL_KEY, `${bandDefault}|${pick}`);
+}
+
+// The last card opened, so a return visit can mark where the learner stopped
+// and let the arrow keys carry on from there. One character by definition --
+// anything else is stale or tampered data and reads back as "none".
+export function readLastReadKanji(): string | null {
+  const raw = readStored(KANJI_LAST_READ_KEY);
+  if (raw === null || [...raw].length !== 1) return null;
+  return raw;
+}
+
+export function writeLastReadKanji(kanji: string): void {
+  if ([...kanji].length !== 1) return;
+  writeStored(KANJI_LAST_READ_KEY, kanji);
+}

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -231,6 +231,14 @@
   background: color-mix(in srgb, var(--matcha) 12%, var(--paper));
 }
 
+/* Where the learner stopped last visit: a dashed rim only, no fill -- it must
+   read as a bookmark, not as the current selection (which owns the filled
+   style above). Cleared as soon as a card is picked this session. */
+.kanji-cell.last-read {
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--matcha) 60%, var(--rule));
+}
+
 .kanji-cell-char {
   font-size: 1.6rem;
   line-height: 1;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -88,6 +88,7 @@ export default defineConfig({
           ],
           exclude: [
             "src/domain/bookmarks.test.ts",
+            "src/domain/kanjiPreferences.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
             "src/domain/diagnostics.test.ts"
@@ -107,6 +108,7 @@ export default defineConfig({
             "src/i18n.test.ts",
             "src/lib/**/*.test.{ts,tsx}",
             "src/domain/bookmarks.test.ts",
+            "src/domain/kanjiPreferences.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
             "src/domain/diagnostics.test.ts"


### PR DESCRIPTION
﻿承接 #669 同一位使用者的建議（他 repo 裡的 P2＋last-read 追蹤）：他習慣一張一張刷某個級別，但頁面既不記得篩選的級別、也不記得看到哪張卡，每次進來都要從那一段的開頭重來。

## 做法
- **新 `src/domain/kanjiPreferences.ts`**（crash-safe，沿用 safeStorage）
  - **級別選擇連同「當時的 band 預設」一起存**（`"<band>|<pick>"`）。頁面預設是跟著目標級別走的（`kanjiDefaultLevel`），這樣分域的效果是：**同一個 band 內瀏覽會記住，但改了目標級別就會跟著搬到新的 band**，不會被舊選擇永久釘住。
  - **last-read 漢字**：定義上就是單一字元，其他值（過期／被亂改）一律讀成「沒有」，不可能選到幽靈卡片。
- **KanjiOnyomiPanel**：初始級別＝儲存的選擇 → band 預設；每次點級別、每次開卡都寫入。回訪時上次那張卡加**虛線框**（書籤感，跟「選中」的實心樣式區隔），**方向鍵從它接續**——按 → 是走到**下一張**而不是從第 0 張重來。**載入時不捲動、不展開詳情卡**（花雪選的方案：只標記），回到頁面看起來跟離開時一樣。一旦這次 session 選了任何卡，標記就消失（此時選中狀態本身就是位置）。
- 方向鍵的邊界展開從「加一批」改成 `max(budget, index + 1)`，讓「接續到清單深處」一步就渲染得夠遠（原本跨一格的行為不變）。

## 驗證
TDD 先紅後綠：**10 個 domain 測試**（band 分域、無效／過期值、storage 被封鎖）＋**8 個元件測試**（恢復、寫入、換 band、標記、標記消失、方向鍵接續、last-read 被篩選掉時的行為）。

⚠️ 過程中有兩個**既有**的方向鍵測試在第一次跑綠時失敗——因為頁面現在會記住選擇，同檔案的後續測試就繼承了前一個測試的接續點。這正是該被抓到的耦合，改用檔案層級清 storage 解決（頁面有記憶之後，這才是正確的隔離）。`kanjiPreferences.test.ts` 併入 jsdom project（需要 localStorage），與 bookmarks／levelPreference 同一慣例。

pnpm test **1299 passed / 11 skipped**、typecheck、build 全綠。**實機驗證**：點 N4 → 存 `all|N4`；開「心」→ 寫入；重載後 N4 恢復、「心」虛線框、不捲動不開詳情；按 → 接續到下一張並清除標記；把目標級別設成 n1n2 後舊選擇失效、頁面開在 N1，新選擇重新分域成 `N1|N3`。
