### PR TITLE
feat(ai): add guarded GREEN repair stage

### DIFF
--- a/scripts/gemini-correctness/__tests__/policy.test.ts
+++ b/scripts/gemini-correctness/__tests__/policy.test.ts
@@ -8,7 +8,10 @@ import {
   isValidRegressionTest,
   resolveProductionDir,
   getDefaultAllowlist,
-  getDefaultProtectedPaths
+  getDefaultProtectedPaths,
+  MAX_GREEN_PRODUCTION_FILES,
+  MAX_GREEN_DIFF_LINES,
+  parseUnifiedDiff
 } from "../policy.mjs";
 
 describe("getDefaultAllowlist", () => {
@@ -227,5 +230,145 @@ describe("resolveProductionDir", () => {
 
   it("throws for null path", () => {
     expect(() => resolveProductionDir(null)).toThrow();
+  });
+});
+
+describe("GREEN hard constants", () => {
+  it("caps production files and diff lines at the Issue #637 budgets", () => {
+    expect(MAX_GREEN_PRODUCTION_FILES).toBe(3);
+    expect(MAX_GREEN_DIFF_LINES).toBe(250);
+  });
+});
+
+describe("parseUnifiedDiff", () => {
+  it("parses a single-file unified diff with per-file add/delete counts", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1,3 +1,4 @@\n" +
+      " export function read() {\n" +
+      "-  return \"stale\";\n" +
+      "+  return \"safe\";\n" +
+      "+  // added line\n" +
+      " }\n";
+    const result = parseUnifiedDiff(diff);
+
+    expect(result.valid).toBe(true);
+    expect(result.files).toHaveLength(1);
+    expect(result.files[0]).toEqual({
+      path: "src/domain/example.ts",
+      additions: 2,
+      deletions: 1,
+      addedLines: ['  return "safe";', "  // added line"],
+      removedLines: ['  return "stale";']
+    });
+    expect(result.totalAdditions).toBe(2);
+    expect(result.totalDeletions).toBe(1);
+  });
+
+  it("parses a multi-file unified diff and rejects paths outside the repo", () => {
+    const diff =
+      "diff --git a/src/domain/a.ts b/src/domain/a.ts\n" +
+      "--- a/src/domain/a.ts\n" +
+      "+++ b/src/domain/a.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-old\n" +
+      "+new\n" +
+      "diff --git a/src/domain/b.ts b/src/domain/b.ts\n" +
+      "--- a/src/domain/b.ts\n" +
+      "+++ b/src/domain/b.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      "+y\n";
+    const result = parseUnifiedDiff(diff);
+
+    expect(result.valid).toBe(true);
+    expect(result.files.map(file => file.path))
+      .toEqual(["src/domain/a.ts", "src/domain/b.ts"]);
+    expect(result.totalAdditions).toBe(2);
+    expect(result.totalDeletions).toBe(2);
+  });
+
+  it.each([
+    ["an empty string", "", /empty/i],
+    ["a non-string input", 42, /string/i],
+    ["a null input", null, /string/i]
+  ])("rejects %s", (_label, input, pattern) => {
+    const result = parseUnifiedDiff(input);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(pattern);
+  });
+
+  it("rejects a diff that references a path outside the repository", () => {
+    const diff =
+      "diff --git a/../../etc/passwd b/../../etc/passwd\n" +
+      "--- a/../../etc/passwd\n" +
+      "+++ b/../../etc/passwd\n" +
+      "@@ -1 +1 @@\n" +
+      "-root\n" +
+      "+hacked\n";
+    const result = parseUnifiedDiff(diff);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a diff with an absolute path", () => {
+    const diff =
+      "diff --git a//etc/passwd b//etc/passwd\n" +
+      "--- a//etc/passwd\n" +
+      "+++ b//etc/passwd\n" +
+      "@@ -1 +1 @@\n" +
+      "-root\n" +
+      "+hacked\n";
+    const result = parseUnifiedDiff(diff);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a diff with an index/similarity header or no file header", () => {
+    const bare =
+      "@@ -1 +1 @@\n- old\n+ new\n";
+    expect(parseUnifiedDiff(bare).valid).toBe(false);
+
+    const similarity =
+      "similarity index 100%\n" +
+      "rename from a.ts\n" +
+      "rename to b.ts\n";
+    expect(parseUnifiedDiff(similarity).valid).toBe(false);
+  });
+
+  it("rejects a hunk body that has no file attribution", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1,3 +1,3 @@\n" +
+      " export function readEmptyQueue() {\n" +
+      '-  return "stale";\n' +
+      '+  return "safe";\n' +
+      " }\n" +
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "@@ -2,1 +2,1 @@\n" +
+      " }\n" +
+      "+// smuggled line\n";
+    const result = parseUnifiedDiff(diff);
+    expect(result.valid).toBe(false);
+  });
+
+  it("counts hunk header context lines without counting them as additions", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1,5 +1,5 @@\n" +
+      " export function read() {\n" +
+      "+  return \"safe\";\n" +
+      "   const value = 1;\n" +
+      " }\n";
+    const result = parseUnifiedDiff(diff);
+    expect(result.valid).toBe(true);
+    expect(result.files[0].additions).toBe(1);
+    expect(result.files[0].deletions).toBe(0);
+    expect(result.totalAdditions).toBe(1);
+    expect(result.totalDeletions).toBe(0);
   });
 });

--- a/scripts/gemini-correctness/green-prompt-builder.mjs
+++ b/scripts/gemini-correctness/green-prompt-builder.mjs
@@ -1,0 +1,227 @@
+// =============================================================================
+// green-prompt-builder.mjs — bounded repair-only prompt for the GREEN stage
+// =============================================================================
+//
+// Builds the Gemini repair prompt from the validated finding, the replayed RED
+// result, the regression test source, and the production files Gemini may edit.
+// Gemini only ever sees:
+//   - the validated finding
+//   - the replay-confirmed RED result (baseline SHA, patch hash, assertion)
+//   - the regression test source (read-only — never editable)
+//   - the finding production files plus their import closure (the only files
+//     Gemini may modify, still subject to policy allowlist / protected paths)
+// =============================================================================
+
+import path from "node:path";
+import ts from "typescript";
+
+export const MAX_GREEN_PROMPT_CHARS = 300_000;
+const IMPORT_EXTENSIONS = [".ts", ".tsx", ".mjs"];
+
+function normalize(filePath) {
+  return String(filePath).replace(/\\/g, "/");
+}
+
+function comparePaths(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function relativeImports(file) {
+  const sourceFile = ts.createSourceFile(
+    file.path,
+    file.content,
+    ts.ScriptTarget.Latest,
+    true,
+    file.path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const imports = [];
+  for (const statement of sourceFile.statements) {
+    if (
+      (ts.isImportDeclaration(statement) || ts.isExportDeclaration(statement)) &&
+      statement.moduleSpecifier &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.moduleSpecifier.text.startsWith(".")
+    ) {
+      imports.push(statement.moduleSpecifier.text);
+    }
+  }
+  return imports;
+}
+
+function resolveImport(fromPath, specifier, fileMap) {
+  const base = path.posix.normalize(
+    path.posix.join(path.posix.dirname(fromPath), specifier)
+  );
+  const candidates = path.posix.extname(base)
+    ? [base]
+    : [
+        ...IMPORT_EXTENSIONS.map(extension => `${base}${extension}`),
+        ...IMPORT_EXTENSIONS.map(extension => `${base}/index${extension}`)
+      ];
+  return candidates.find(candidate => fileMap.has(candidate)) ?? null;
+}
+
+function collectImportClosure(rootPaths, fileMap) {
+  const selected = new Set(rootPaths);
+  const queue = [...rootPaths];
+
+  while (queue.length > 0) {
+    const currentPath = queue.shift();
+    const current = fileMap.get(currentPath);
+    if (!current) continue;
+    for (const specifier of relativeImports(current)) {
+      const resolved = resolveImport(currentPath, specifier, fileMap);
+      if (resolved && !selected.has(resolved)) {
+        selected.add(resolved);
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return selected;
+}
+
+function renderFile(file) {
+  const numbered = String(file.content)
+    .split("\n")
+    .map((line, index) => `${index + 1}|${line}`)
+    .join("\n");
+  return `### ${file.path}\n\`\`\`ts\n${numbered}\n\`\`\``;
+}
+
+function renderPrompt({ finding, redResult, regressionTestSource, selectedFiles, redTestFailure }) {
+  const manifest = selectedFiles.map(file => file.path);
+  const fileBlocks = selectedFiles.map(renderFile).join("\n\n");
+  const exactCandidate = {
+    schemaVersion: 1,
+    status: "repair-diff",
+    diff: "<unified git diff of production files only>",
+    rootCause: "<one sentence: the root cause you are fixing>",
+    fixSummary: "<one sentence: what your diff changes>"
+  };
+  const failureEvidence = redTestFailure
+    ? `${redTestFailure.stderr ?? ""}\n${redTestFailure.stdout ?? ""}`.trim()
+    : "";
+
+  return `You are repairing the production code that causes ONE already-validated correctness finding.
+
+You have no shell, filesystem, network, environment, secret, package-manager, Git, or GitHub authority.
+Do not execute commands. Return strict JSON only; do not use markdown fences or trailing prose.
+
+You must return exactly this object shape and no unknown fields:
+${JSON.stringify(exactCandidate, null, 2)}
+
+Repair scope:
+- You may modify ONLY the production files listed in the finding.productionFiles
+  and shown below. Do not propose or modify any other file.
+- The regression test below is FIXED and MUST NOT be modified. Do not modify the regression test or any existing test file.
+- Touching at most 3 production files and changing at most 250 added+deleted lines total.
+- No file deletion, rename, binary, submodule, symlink, or new file creation.
+- No .skip/.only, @ts-ignore, @ts-nocheck, @ts-expect-error, coverage or lint
+  disables, or uncommented TypeScript any.
+- No whitespace-only or EOL churn, no refactors, no public API renames, and no
+  second root cause. Fix exactly the root cause below.
+- Do not modify dependency, lockfile, workflow, config, migration, auth, RLS,
+  generated/content/i18n files, or environment/secrets.
+- The repair is only complete when the fixed regression test passes and
+  lint, typecheck, the full test suite, and the build all pass.
+
+RED replay confirmation (already verified, do not question it):
+- baseline SHA: ${redResult.baselineSha}
+- regression test patch SHA-256: ${redResult.patchSha256}
+- replay status: ${String(redResult.replayConfirmed)} (replayConfirmed)
+- failure kind: ${redResult.failureKind}
+
+Validated finding (the ONE root cause to fix):
+${JSON.stringify(finding, null, 2)}
+
+Regression test (fixed — read it, never modify it):
+### ${redResult.testFile}
+\`\`\`ts
+${regressionTestSource}
+\`\`\`
+
+Observed RED failure evidence (read-only):
+${failureEvidence || "(regression test above fails until the root cause is fixed)"}
+
+Visible repository file count: ${manifest.length}
+Visible repository manifest:
+${manifest.join("\n")}
+
+Visible production files (the only files you may modify):
+${fileBlocks}
+`;
+}
+
+export function buildGreenPrompt({
+  finding,
+  redResult,
+  regressionTestSource,
+  scannedFiles,
+  redTestFailure
+} = {}) {
+  if (!finding || finding.status !== "finding") {
+    throw new Error("a validated finding is required");
+  }
+  if (
+    !redResult ||
+    typeof redResult !== "object" ||
+    redResult.status !== "red-confirmed" ||
+    redResult.replayConfirmed !== true ||
+    redResult.testFile !== finding.reproduction?.testFile ||
+    redResult.testName !== finding.reproduction?.testName
+  ) {
+    throw new Error("a red-confirmed, replay-confirmed RED result matching the finding reproduction test is required");
+  }
+  if (typeof regressionTestSource !== "string" || regressionTestSource.trim() === "") {
+    throw new Error("regression test source is required");
+  }
+  if (!Array.isArray(scannedFiles)) {
+    throw new Error("scanner manifest is required");
+  }
+
+  const fileMap = new Map(
+    scannedFiles.map(file => [normalize(file.path), { ...file, path: normalize(file.path) }])
+  );
+  const productionPaths = (finding.productionFiles ?? []).map(normalize);
+  for (const productionPath of productionPaths) {
+    const file = fileMap.get(productionPath);
+    if (!file) {
+      throw new Error(`production file is absent from scanner manifest: ${productionPath}`);
+    }
+    if (file.truncated) {
+      throw new Error(`required prompt file was truncated: ${productionPath}`);
+    }
+  }
+
+  const selectedPaths = collectImportClosure(productionPaths, fileMap);
+  const regressionPath = normalize(finding.reproduction.testFile);
+  selectedPaths.add(regressionPath);
+
+  const selectedFiles = [...selectedPaths]
+    .sort(comparePaths)
+    .map(filePath => fileMap.get(filePath))
+    .filter(file => file !== undefined);
+
+  if (selectedFiles.length !== selectedPaths.size) {
+    throw new Error(`regression test is absent from scanner manifest: ${regressionPath}`);
+  }
+
+  const prompt = renderPrompt({
+    finding,
+    redResult,
+    regressionTestSource,
+    selectedFiles,
+    redTestFailure
+  });
+  if (prompt.length > MAX_GREEN_PROMPT_CHARS) {
+    throw new Error(`GREEN prompt exceeds ${MAX_GREEN_PROMPT_CHARS} characters`);
+  }
+
+  return {
+    prompt,
+    manifest: selectedFiles.map(file => file.path),
+    fileCount: selectedFiles.length,
+    length: prompt.length
+  };
+}

--- a/scripts/gemini-correctness/green-prompt-builder.test.ts
+++ b/scripts/gemini-correctness/green-prompt-builder.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { buildGreenPrompt } from "./green-prompt-builder.mjs";
+
+const finding = {
+  schemaVersion: 1,
+  status: "finding",
+  title: "empty queue fallback",
+  confidence: 0.95,
+  category: "boundary-condition",
+  evidence: [
+    {
+      file: "src/domain/example.ts",
+      startLine: 1,
+      endLine: 3,
+      reason: "the empty branch returns a stale value"
+    }
+  ],
+  expectedBehavior: "an empty queue returns the safe fallback",
+  actualBehavior: "an empty queue returns the stale value",
+  reproduction: {
+    testFile: "src/domain/example.regression.test.ts",
+    testName: "returns the safe fallback for an empty queue"
+  },
+  productionFiles: ["src/domain/example.ts"],
+  risk: "low"
+};
+
+const redResult = {
+  schemaVersion: 1,
+  status: "red-confirmed",
+  baselineSha: "a".repeat(40),
+  testFile: "src/domain/example.regression.test.ts",
+  testName: "returns the safe fallback for an empty queue",
+  failureKind: "assertion",
+  sanitizedSummary: "returns the safe fallback for an empty queue: Expected behavior: an empty queue returns the safe fallback | Actual behavior: an empty queue returns the stale value",
+  patchSha256: "b".repeat(64),
+  replayConfirmed: true
+};
+
+const regressionTestSource = `import { expect, it } from "vitest";
+import { readEmptyQueue } from "./example";
+
+it("returns the safe fallback for an empty queue", () => {
+  expect(
+    readEmptyQueue(),
+    "Expected behavior: an empty queue returns the safe fallback | Actual behavior: an empty queue returns the stale value",
+  ).toBe("safe");
+});
+`;
+
+const scannedFiles = [
+  {
+    path: "src/domain/example.regression.test.ts",
+    content: regressionTestSource,
+    lineCount: regressionTestSource.split("\n").length,
+    byteSize: Buffer.byteLength(regressionTestSource, "utf8"),
+    truncated: false
+  },
+  {
+    path: "src/domain/example.ts",
+    content: 'import { fallback } from "./helper";\nexport function readEmptyQueue() {\n  return fallback();\n}\n',
+    lineCount: 4,
+    byteSize: 80,
+    truncated: false
+  },
+  {
+    path: "src/domain/helper.ts",
+    content: 'export const fallback = "safe";\n',
+    lineCount: 1,
+    byteSize: 30,
+    truncated: false
+  },
+  {
+    path: "src/domain/unrelated.ts",
+    content: 'export const unrelated = "do not reveal";\n',
+    lineCount: 1,
+    byteSize: 42,
+    truncated: false
+  }
+];
+
+const redTestFailure = {
+  stdout: "",
+  stderr: "AssertionError: Expected behavior: an empty queue returns the safe fallback | Actual behavior: an empty queue returns the stale value"
+};
+
+describe("buildGreenPrompt", () => {
+  it("includes only the finding target, its import closure, and the regression test", () => {
+    const result = buildGreenPrompt({
+      finding,
+      redResult,
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    });
+
+    expect(result.prompt).toContain("src/domain/example.ts");
+    expect(result.prompt).toContain("src/domain/helper.ts");
+    expect(result.prompt).toContain("src/domain/example.regression.test.ts");
+    expect(result.prompt).not.toContain("src/domain/unrelated.ts");
+    expect(result.manifest).toEqual([
+      "src/domain/example.regression.test.ts",
+      "src/domain/example.ts",
+      "src/domain/helper.ts"
+    ]);
+    expect(result.manifest).toContain("src/domain/example.ts");
+    expect(result.manifest).toContain("src/domain/helper.ts");
+    expect(result.manifest).toContain("src/domain/example.regression.test.ts");
+  });
+
+  it("requires strict repair-diff JSON with the exact candidate shape", () => {
+    const result = buildGreenPrompt({
+      finding,
+      redResult,
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    });
+
+    expect(result.prompt).toContain('"status": "repair-diff"');
+    expect(result.prompt).toContain('"diff": "<unified git diff of production files only>"');
+    expect(result.prompt).toContain('"rootCause":');
+    expect(result.prompt).toContain('"fixSummary":');
+    expect(result.prompt).toMatch(/no shell|must not execute|do not execute/i);
+    expect(result.prompt).toContain("3 production files");
+    expect(result.prompt).toContain("250 added+deleted lines");
+  });
+
+  it("includes the RED replay confirmation, regression test source, and failure evidence", () => {
+    const result = buildGreenPrompt({
+      finding,
+      redResult,
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    });
+
+    expect(result.prompt).toContain(redResult.patchSha256);
+    expect(result.prompt).toContain(redResult.baselineSha);
+    expect(result.prompt).toContain("replayConfirmed");
+    expect(result.prompt).toContain("export function readEmptyQueue");
+    expect(result.prompt).toContain("AssertionError");
+    expect(result.prompt).toContain(finding.expectedBehavior);
+    expect(result.prompt).toContain(finding.actualBehavior);
+  });
+
+  it("states that only finding production files may be modified", () => {
+    const result = buildGreenPrompt({
+      finding,
+      redResult,
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    });
+
+    expect(result.prompt).toMatch(/only.*production|modify\s*only|must not modify/i);
+    expect(result.prompt).toMatch(/do not\s*.*test/i);
+  });
+
+  it("rejects a non-finding input", () => {
+    expect(() => buildGreenPrompt({
+      finding: { ...finding, status: "no-finding" },
+      redResult,
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    })).toThrow(/finding/i);
+  });
+
+  it("rejects a redResult that is not red-confirmed", () => {
+    expect(() => buildGreenPrompt({
+      finding,
+      redResult: { ...redResult, status: "rejected" },
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    })).toThrow(/red-confirmed/i);
+  });
+
+  it("rejects a redResult that does not match the finding reproduction", () => {
+    expect(() => buildGreenPrompt({
+      finding,
+      redResult: {
+        ...redResult,
+        testFile: "src/domain/other.regression.test.ts"
+      },
+      regressionTestSource,
+      scannedFiles,
+      redTestFailure
+    })).toThrow(/test/i);
+  });
+});

--- a/scripts/gemini-correctness/green-runner.mjs
+++ b/scripts/gemini-correctness/green-runner.mjs
@@ -461,15 +461,19 @@ export async function runGreenStage({
       allowlist,
       protectedPaths
     });
+    // The RED replay's raw stdout/stderr can contain API keys, tokens, env
+    // values, repository absolute paths, home paths, or the Node executable
+    // path. Sanitize at the runner boundary before anything reaches the prompt.
+    const sanitizedReplayFailure = {
+      stdout: sanitize(replay.stdout ?? "", outputSecrets),
+      stderr: sanitize(replay.stderr ?? "", outputSecrets)
+    };
     const greenPrompt = buildGreenPrompt({
       finding,
       redResult,
       regressionTestSource: testSource,
       scannedFiles: greenScan.scannedFiles,
-      redTestFailure: {
-        stdout: replay.stdout ?? "",
-        stderr: replay.stderr ?? ""
-      }
+      redTestFailure: sanitizedReplayFailure
     });
 
     const generated = await client.generateJson({

--- a/scripts/gemini-correctness/green-runner.mjs
+++ b/scripts/gemini-correctness/green-runner.mjs
@@ -1,0 +1,656 @@
+// =============================================================================
+// green-runner.mjs — guarded GREEN repair stage runner
+// =============================================================================
+//
+// Replays the stored RED artifacts at the recorded baseline, asks Gemini for a
+// minimal production-only repair diff, applies it, and proves targeted test,
+// lint, typecheck, full test, and build all pass before writing
+// repair-result.json.  Every gate fails closed: no commit, push, or PR is ever
+// created here.
+//
+// Data flow (Issue #637):
+//   clean baseline at redResult.baselineSha
+//     → verify finding + red-result schema/hash/status
+//     → apply exact red-test.patch
+//     → rerun exact test and reconfirm approved RED
+//     → Gemini returns a unified production diff only
+//     → validate + apply in the repo-contained worktree
+//     → deterministic production diff guard
+//     → exact targeted regression test passes
+//     → pnpm lint / typecheck / test / build
+//     → final diff/hash/stats/cleanup guard
+//     → repair-result.json
+// =============================================================================
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { redactForOutput } from "./discover.mjs";
+import {
+  MAX_GREEN_DIFF_LINES,
+  MAX_GREEN_PRODUCTION_FILES,
+  getDefaultAllowlist,
+  getDefaultProtectedPaths,
+  safeWritePath
+} from "./policy.mjs";
+import {
+  captureCleanBaseline,
+  validateTestOnlyWorktree
+} from "./red-validator.mjs";
+import {
+  classifyVitestRed,
+  runTargetedVitest
+} from "./red-runner.mjs";
+import { resetRedWorktree } from "./red-stage.mjs";
+import { scanRepository } from "./scanner.mjs";
+import { validateGreenRepairCandidate } from "./green-validator.mjs";
+import { buildGreenPrompt } from "./green-prompt-builder.mjs";
+
+const MODULE_PATH = fileURLToPath(import.meta.url);
+const GREEN_CHECK_SCRIPTS = ["lint", "typecheck", "test", "build"];
+const RED_RESULT_KEYS = new Set([
+  "schemaVersion",
+  "status",
+  "baselineSha",
+  "testFile",
+  "testName",
+  "failureKind",
+  "sanitizedSummary",
+  "patchSha256",
+  "replayConfirmed"
+]);
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function runGit(repoRoot, args, { input } = {}) {
+  const result = spawnSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input,
+    maxBuffer: 8 * 1024 * 1024,
+    shell: false,
+    stdio: ["pipe", "pipe", "pipe"]
+  });
+  if (result.error || result.status !== 0) {
+    throw new Error(`git ${args[0]} failed`);
+  }
+  return result.stdout;
+}
+
+function sameFilePath(reportedName, repoRoot, testFile) {
+  const reported = String(reportedName ?? "");
+  const reportedAbsolute = path.isAbsolute(reported)
+    ? path.resolve(reported)
+    : path.resolve(repoRoot, reported);
+  const expectedAbsolute = path.resolve(repoRoot, testFile);
+  try {
+    return fs.realpathSync(reportedAbsolute) === fs.realpathSync(expectedAbsolute);
+  } catch {
+    return reportedAbsolute === expectedAbsolute;
+  }
+}
+
+function collectSensitiveValues(environment, repoRoot, { output }) {
+  const values = new Set([
+    repoRoot,
+    process.cwd(),
+    process.execPath,
+    MODULE_PATH
+  ]);
+  try {
+    values.add(fs.realpathSync(repoRoot));
+  } catch {
+    // The caller will fail repository validation separately.
+  }
+  for (const [key, value] of Object.entries(environment ?? {})) {
+    if (typeof value !== "string" || value.length === 0) continue;
+    const sensitiveName =
+      /(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH|COOKIE)/i.test(key);
+    if (sensitiveName || (output && value.length >= 8)) {
+      values.add(value);
+    }
+  }
+  if (output && typeof environment?.PATH === "string") {
+    for (const entry of environment.PATH.split(path.delimiter)) {
+      if (entry.length >= 4) values.add(entry);
+    }
+  }
+  return [...values].filter(value => typeof value === "string" && value.length > 0);
+}
+
+function sanitize(value, sensitiveValues) {
+  return redactForOutput(value, sensitiveValues);
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600
+  });
+}
+
+function validateRedResult(result, finding) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("stored RED result must be an object");
+  }
+  const keys = Object.keys(result);
+  if (
+    keys.some(key => !RED_RESULT_KEYS.has(key)) ||
+    [...RED_RESULT_KEYS].some(key => !(key in result))
+  ) {
+    return invalid("stored RED result fields are invalid");
+  }
+  if (
+    result.schemaVersion !== 1 ||
+    result.status !== "red-confirmed" ||
+    result.failureKind !== "assertion" ||
+    result.replayConfirmed !== true ||
+    !/^[0-9a-f]{40,64}$/i.test(result.baselineSha) ||
+    !/^[0-9a-f]{64}$/i.test(result.patchSha256) ||
+    typeof result.sanitizedSummary !== "string" ||
+    result.sanitizedSummary.trim() === "" ||
+    result.testFile !== finding.reproduction?.testFile ||
+    result.testName !== finding.reproduction?.testName
+  ) {
+    return invalid("stored RED result contract is invalid");
+  }
+  return { valid: true };
+}
+
+function verifyVitestGreen(execution, { repoRoot, testFile, testName }) {
+  const report = execution?.report;
+  if (execution?.exitCode !== 0 || !report || typeof report !== "object" || Array.isArray(report)) {
+    return invalid("targeted test did not exit successfully");
+  }
+  if (
+    report.success !== true ||
+    report.numTotalTests !== 1 ||
+    report.numPassedTests !== 1 ||
+    report.numFailedTests !== 0 ||
+    report.numPendingTests !== 0 ||
+    report.numTodoTests !== 0 ||
+    report.numTotalTestSuites !== 1 ||
+    report.numFailedTestSuites !== 0 ||
+    report.numPassedTestSuites !== 1 ||
+    !Array.isArray(report.testResults) ||
+    report.testResults.length !== 1
+  ) {
+    return invalid("targeted test did not collect exactly one passing test");
+  }
+  const fileResult = report.testResults[0];
+  if (
+    !fileResult ||
+    !sameFilePath(fileResult.name, repoRoot, testFile) ||
+    fileResult.status !== "passed" ||
+    !Array.isArray(fileResult.assertionResults) ||
+    fileResult.assertionResults.length !== 1
+  ) {
+    return invalid("targeted test report does not identify only the designated passing test");
+  }
+  const assertion = fileResult.assertionResults[0];
+  if (
+    assertion?.title !== testName ||
+    assertion?.status !== "passed"
+  ) {
+    return invalid("the designated test did not pass as one assertion");
+  }
+  return { valid: true };
+}
+
+function verifyGreenWorktree({ repoRoot, testFile, expectedFiles }) {
+  const status = runGit(repoRoot, [
+    "status",
+    "--porcelain=v1",
+    "--untracked-files=all",
+    "-z"
+  ]);
+  const entries = status.split("\0").filter(Boolean);
+  const expected = new Set([
+    ...expectedFiles.map(filePath => ` M ${filePath}`),
+    `?? ${testFile}`
+  ]);
+  if (entries.length !== expected.size) {
+    return invalid(`worktree contains unexpected changes: ${entries.join(", ")}`);
+  }
+  for (const entry of entries) {
+    if (!expected.has(entry)) {
+      return invalid(`unexpected worktree change: ${entry}`);
+    }
+  }
+  return { valid: true };
+}
+
+function defaultRunCommand(repoRoot) {
+  return (script) => {
+    const result = spawnSync("pnpm", [script], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 8 * 1024 * 1024,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+    return {
+      exitCode: result.status,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? ""
+    };
+  };
+}
+
+function artifactPaths(repoRoot) {
+  const allowedDir = path.join(repoRoot, ".tmp");
+  const relativePaths = {
+    replayReport: "gemini-correctness/.vitest-green-replay.json",
+    finalReport: "gemini-correctness/.vitest-green-final.json",
+    result: "gemini-correctness/repair-result.json"
+  };
+  const resolved = {};
+  for (const [key, relativePath] of Object.entries(relativePaths)) {
+    const safe = safeWritePath(relativePath, allowedDir, repoRoot);
+    if (!safe) throw new Error(`artifact path is unsafe: ${key}`);
+    resolved[key] = safe;
+  }
+  fs.mkdirSync(path.dirname(resolved.result), { recursive: true });
+  return resolved;
+}
+
+function removeGreenReporterFiles(paths) {
+  for (const filePath of [paths?.replayReport, paths?.finalReport]) {
+    if (!filePath) continue;
+    try {
+      fs.rmSync(filePath, { force: true });
+    } catch {
+      // A stale report makes the next reporter write fail closed.
+    }
+  }
+}
+
+function removeGreenArtifacts(repoRoot) {
+  for (const relativePath of [
+    "gemini-correctness/.vitest-green-replay.json",
+    "gemini-correctness/.vitest-green-final.json",
+    "gemini-correctness/repair-result.json",
+    "gemini-correctness/green-repair.patch"
+  ]) {
+    try {
+      const candidate = safeWritePath(relativePath, path.join(repoRoot, ".tmp"), repoRoot);
+      if (candidate) fs.rmSync(candidate, { force: true });
+    } catch {
+      // Cleanup is best-effort; a leftover artifact fails a later gate.
+    }
+  }
+}
+
+function finalProductionDiff({ repoRoot, testFile }) {
+  const nameStatus = runGit(repoRoot, [
+    "diff",
+    "--name-status",
+    "--no-ext-diff",
+    "--no-renames"
+  ]).trim();
+  const changedFiles = nameStatus
+    .split("\n")
+    .filter(Boolean)
+    .map(line => line.split("\t")[1] ?? "")
+    .filter(filePath => filePath !== "" && filePath !== testFile);
+  if (changedFiles.some(filePath => !/^[0-9A-Za-z/._-]+$/.test(filePath))) {
+    return invalid("final production diff contains an unsafe path");
+  }
+  const numstat = runGit(repoRoot, [
+    "diff",
+    "--numstat",
+    "--no-ext-diff",
+    "--no-renames"
+  ]).trim();
+  let totalAdditions = 0;
+  let totalDeletions = 0;
+  for (const line of numstat.split("\n").filter(Boolean)) {
+    const [added, removed, filePath] = line.split("\t");
+    if (filePath === testFile) continue;
+    if (!/^\d+$/.test(added) || !/^\d+$/.test(removed)) {
+      return invalid("final production diff is binary or malformed");
+    }
+    totalAdditions += Number(added);
+    totalDeletions += Number(removed);
+  }
+  const diff = runGit(repoRoot, [
+    "diff",
+    "--binary",
+    "--no-ext-diff",
+    "--no-renames"
+  ]);
+  if (!diff) {
+    return invalid("final production diff is empty");
+  }
+  return {
+    valid: true,
+    changedFiles: changedFiles.length,
+    changedLines: totalAdditions + totalDeletions,
+    files: changedFiles,
+    diffSha256: sha256(diff)
+  };
+}
+
+export async function runGreenStage({
+  repoRoot,
+  finding,
+  redResult,
+  client,
+  allowlist = getDefaultAllowlist(),
+  protectedPaths = getDefaultProtectedPaths(),
+  environment = process.env,
+  spawnFn,
+  testTimeoutMs,
+  guardedRunner = runTargetedVitest,
+  runCommand = defaultRunCommand(repoRoot)
+} = {}) {
+  const outputSecrets = collectSensitiveValues(environment, repoRoot, { output: true });
+  let paths;
+  let trustedBaseline = "";
+  let appliedProductionFiles = [];
+
+  function safeError(message, cleanupError) {
+    return sanitize(
+      `${message ?? "GREEN stage failed closed"}${cleanupError}`,
+      outputSecrets
+    );
+  }
+
+  async function failClosed(status, message, cleanupError = "") {
+    try {
+      if (trustedBaseline) {
+        const reset = resetRedWorktree({
+          repoRoot,
+          baselineSha: trustedBaseline,
+          testFile: finding?.reproduction?.testFile
+        });
+        if (!reset.valid) cleanupError = `${cleanupError || ""}; worktree cleanup could not be verified`;
+      }
+    } catch {
+      cleanupError = `${cleanupError || ""}; worktree cleanup could not be verified`;
+    }
+    removeGreenArtifacts(repoRoot);
+    removeGreenReporterFiles(paths);
+    return { valid: false, status, error: safeError(message, cleanupError) };
+  }
+
+  try {
+    const baseline = captureCleanBaseline({
+      repoRoot,
+      testFile: finding?.reproduction?.testFile
+    });
+    if (!baseline.valid) throw new Error(baseline.error);
+    if (baseline.baselineSha !== redResult?.baselineSha) {
+      throw new Error("worktree HEAD does not match the recorded RED baseline SHA");
+    }
+    trustedBaseline = baseline.baselineSha;
+
+    const redValidation = validateRedResult(redResult, finding);
+    if (!redValidation.valid) throw new Error(redValidation.error);
+
+    const safePatch = safeWritePath(
+      "gemini-correctness/red-test.patch",
+      path.join(repoRoot, ".tmp"),
+      repoRoot
+    );
+    if (!safePatch) throw new Error("RED patch artifact is unsafe");
+    const patchStat = fs.lstatSync(safePatch);
+    if (!patchStat.isFile() || patchStat.isSymbolicLink() || patchStat.size > 128 * 1024) {
+      throw new Error("RED patch artifact is missing, unsafe, or too large");
+    }
+    const patch = fs.readFileSync(safePatch, "utf8");
+    if (sha256(patch) !== redResult.patchSha256) {
+      throw new Error("stored RED patch SHA-256 does not match redResult.patchSha256");
+    }
+
+    runGit(repoRoot, ["apply", "--binary", "--whitespace=nowarn", "-"], { input: patch });
+
+    const testWorktree = validateTestOnlyWorktree({
+      repoRoot,
+      baselineSha: trustedBaseline,
+      testFile: redResult.testFile
+    });
+    if (!testWorktree.valid) throw new Error(testWorktree.error);
+
+    const testSource = fs.readFileSync(path.join(repoRoot, redResult.testFile), "utf8");
+    const testSourceBefore = sha256(testSource);
+
+    paths = artifactPaths(repoRoot);
+    removeGreenReporterFiles(paths);
+    const replay = await guardedRunner({
+      repoRoot,
+      testFile: redResult.testFile,
+      testName: redResult.testName,
+      reportPath: paths.replayReport,
+      spawnFn,
+      environment,
+      timeoutMs: testTimeoutMs
+    });
+    if (!replay.valid) throw new Error(replay.error);
+    const replayClassification = classifyVitestRed({
+      ...replay,
+      repoRoot,
+      testFile: redResult.testFile,
+      testName: redResult.testName,
+      finding
+    });
+    if (
+      !replayClassification.valid ||
+      replayClassification.failureKind !== redResult.failureKind ||
+      sanitize(replayClassification.sanitizedSummary, outputSecrets) !== redResult.sanitizedSummary
+    ) {
+      throw new Error(replayClassification.error || "RED replay classification changed");
+    }
+    fs.rmSync(paths.replayReport, { force: true });
+
+    if (!client || typeof client.generateJson !== "function") {
+      throw new Error("Gemini client with generateJson is required");
+    }
+
+    const greenScan = scanRepository({
+      repoRoot,
+      allowlist,
+      protectedPaths
+    });
+    const greenPrompt = buildGreenPrompt({
+      finding,
+      redResult,
+      regressionTestSource: testSource,
+      scannedFiles: greenScan.scannedFiles,
+      redTestFailure: {
+        stdout: replay.stdout ?? "",
+        stderr: replay.stderr ?? ""
+      }
+    });
+
+    const generated = await client.generateJson({
+      prompt: greenPrompt.prompt
+    });
+    if (!generated?.valid || !generated.result) {
+      return failClosed(
+        "repair-not-found",
+        generated?.error || "Gemini GREEN response was invalid"
+      );
+    }
+    const modelResult = generated.result;
+    if (
+      modelResult &&
+      typeof modelResult === "object" &&
+      !Array.isArray(modelResult) &&
+      modelResult.status === "needs-human-scope-expansion"
+    ) {
+      const reason = typeof modelResult.reason === "string" ? modelResult.reason : "";
+      return failClosed(
+        "needs-human-scope-expansion",
+        `Gemini requested scope expansion: ${reason}`
+      );
+    }
+
+    const repairValidation = validateGreenRepairCandidate(modelResult, {
+      finding,
+      sensitiveValues: collectSensitiveValues(environment, repoRoot, { output: false }),
+      allowlist,
+      protectedPaths
+    });
+    if (!repairValidation.valid) {
+      return failClosed("diff-policy-rejected", repairValidation.error);
+    }
+    appliedProductionFiles = repairValidation.result.files;
+
+    // Repo-contained application: prove the diff applies cleanly before
+    // touching the worktree, then apply it in place.
+    try {
+      runGit(
+        repoRoot,
+        ["apply", "--check", "--binary", "--whitespace=nowarn", "-"],
+        { input: repairValidation.result.diff }
+      );
+    } catch {
+      return failClosed("diff-policy-rejected", "Gemini repair diff cannot be applied cleanly");
+    }
+    runGit(
+      repoRoot,
+      ["apply", "--binary", "--whitespace=nowarn", "-"],
+      { input: repairValidation.result.diff }
+    );
+
+    const greenWorktree = verifyGreenWorktree({
+      repoRoot,
+      testFile: redResult.testFile,
+      expectedFiles: appliedProductionFiles
+    });
+    if (!greenWorktree.valid) {
+      return failClosed("diff-policy-rejected", greenWorktree.error);
+    }
+    const testSourceAfterPatch = sha256(
+      fs.readFileSync(path.join(repoRoot, redResult.testFile), "utf8")
+    );
+    if (testSourceAfterPatch !== testSourceBefore) {
+      return failClosed("diff-policy-rejected", "regression test content changed after applying the repair diff");
+    }
+
+    removeGreenReporterFiles(paths);
+    const finalExecution = await guardedRunner({
+      repoRoot,
+      testFile: redResult.testFile,
+      testName: redResult.testName,
+      reportPath: paths.finalReport,
+      spawnFn,
+      environment,
+      timeoutMs: testTimeoutMs
+    });
+    if (!finalExecution.valid) {
+      return failClosed("targeted-test-failed", finalExecution.error);
+    }
+    const greenPassed = verifyVitestGreen(finalExecution, {
+      repoRoot,
+      testFile: redResult.testFile,
+      testName: redResult.testName
+    });
+    if (!greenPassed.valid) {
+      return failClosed("targeted-test-failed", greenPassed.error);
+    }
+    fs.rmSync(paths.finalReport, { force: true });
+
+    const checks = [{ name: "targeted-test", status: "passed" }];
+    for (const script of GREEN_CHECK_SCRIPTS) {
+      let execution;
+      try {
+        execution = await runCommand(script);
+      } catch {
+        return failClosed("full-check-failed", `${script} invocation failed`);
+      }
+      if (execution?.exitCode !== 0) {
+        return failClosed(
+          "full-check-failed",
+          `${script} failed:\n${sanitize(`${execution?.stdout ?? ""}\n${execution?.stderr ?? ""}`, outputSecrets)}`
+        );
+      }
+      checks.push({ name: script, status: "passed" });
+    }
+
+    try {
+      runGit(repoRoot, ["diff", "--check"]);
+    } catch {
+      return failClosed("full-check-failed", "git diff --check failed (whitespace errors)");
+    }
+
+    const finalGuard = verifyGreenWorktree({
+      repoRoot,
+      testFile: redResult.testFile,
+      expectedFiles: appliedProductionFiles
+    });
+    if (!finalGuard.valid) {
+      return failClosed("full-check-failed", `build produced extra changes: ${finalGuard.error}`);
+    }
+
+    const finalDiff = finalProductionDiff({ repoRoot, testFile: redResult.testFile });
+    if (!finalDiff.valid) return failClosed("full-check-failed", finalDiff.error);
+    if (finalDiff.changedFiles > MAX_GREEN_PRODUCTION_FILES) {
+      return failClosed(
+        "diff-policy-rejected",
+        `final production diff touches ${finalDiff.changedFiles} files; budget is ${MAX_GREEN_PRODUCTION_FILES}`
+      );
+    }
+    if (finalDiff.changedLines > MAX_GREEN_DIFF_LINES) {
+      return failClosed(
+        "diff-policy-rejected",
+        `final production diff changes ${finalDiff.changedLines} lines; budget is ${MAX_GREEN_DIFF_LINES}`
+      );
+    }
+
+    const repairResult = {
+      schemaVersion: 1,
+      status: "repair-verified",
+      baselineSha: trustedBaseline,
+      findingTitle: finding.title,
+      testFile: redResult.testFile,
+      testName: redResult.testName,
+      productionFiles: appliedProductionFiles,
+      rootCause: repairValidation.result.rootCause,
+      fixSummary: repairValidation.result.fixSummary,
+      checks,
+      changedFiles: finalDiff.changedFiles,
+      changedLines: finalDiff.changedLines,
+      testPatchSha256: redResult.patchSha256,
+      finalDiffSha256: finalDiff.diffSha256
+    };
+
+    paths = artifactPaths(repoRoot);
+    writeJson(paths.result, repairResult);
+    return { valid: true, result: repairResult };
+  } catch (error) {
+    let cleanupError = "";
+    try {
+      if (trustedBaseline) {
+        const reset = resetRedWorktree({
+          repoRoot,
+          baselineSha: trustedBaseline,
+          testFile: finding?.reproduction?.testFile
+        });
+        if (!reset.valid) cleanupError = "; worktree cleanup could not be verified";
+      }
+    } catch {
+      cleanupError = "; worktree cleanup could not be verified";
+    }
+    removeGreenArtifacts(repoRoot);
+    removeGreenReporterFiles(paths);
+    const message = error?.message || "GREEN stage failed closed";
+    return {
+      valid: false,
+      status: /baseline|clean/i.test(message) ? "baseline-mismatch" : "red-replay-failed",
+      error: safeError(message, cleanupError)
+    };
+  } finally {
+    removeGreenReporterFiles(paths);
+  }
+}

--- a/scripts/gemini-correctness/green-runner.test.ts
+++ b/scripts/gemini-correctness/green-runner.test.ts
@@ -357,6 +357,67 @@ describe("runGreenStage — success path (injected runners)", () => {
     expect(result.error).not.toContain(fakeSecret);
     expect(result.error).not.toContain(fixtureRoot);
   });
+
+  it("sanitizes RED replay evidence before sending it to Gemini", async () => {
+    const red = prepareRedArtifacts();
+    const fakeApiKey = "AIzaSyFakeApiKey0123456789abcdefghijklmno";
+    const fakeToken = "fake-token-value-abcdef-1234567890";
+    const runnerModulePath = path.join(__dirname, "green-runner.mjs");
+    const guardedRunner = vi.fn()
+      .mockResolvedValueOnce({
+        valid: true,
+        exitCode: 1,
+        report: redReport(),
+        stdout: `red replay leaked key ${fakeApiKey}`,
+        stderr:
+          `red replay leaked token ${fakeToken} at ${fixtureRoot} ` +
+          `${process.cwd()} ${process.execPath} ${runnerModulePath}`
+      })
+      .mockResolvedValueOnce({ valid: true, exitCode: 0, report: greenReport() });
+    const client = fakeClient({ valid: true, result: candidate() });
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: git(["rev-parse", "HEAD"]),
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary:
+          `${TEST_NAME}: Expected behavior: ${EXPECTED_BEHAVIOR} | ` +
+          `Actual behavior: ${ACTUAL_BEHAVIOR}`,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client,
+      environment: {
+        ...process.env,
+        FIXTURE_SECRET: fakeSecret,
+        FAKE_GEMINI_API_KEY: fakeApiKey,
+        FAKE_TOKEN: fakeToken
+      },
+      guardedRunner,
+      runCommand: passingRunCommand()
+    });
+
+    expect(result, result.error).toMatchObject({ valid: true });
+    const prompt = client.generateJson.mock.calls[0][0].prompt;
+    expect(prompt).not.toContain(fakeApiKey);
+    expect(prompt).not.toContain(fakeToken);
+    expect(prompt).not.toContain(fakeSecret);
+    expect(prompt).not.toContain(fixtureRoot);
+    expect(prompt).not.toContain(process.cwd());
+    expect(prompt).not.toContain(process.execPath);
+    expect(prompt).not.toContain(runnerModulePath);
+    // The sanitized RED assertion evidence still reaches the model.
+    expect(prompt).toContain(EXPECTED_BEHAVIOR);
+    expect(prompt).toContain(ACTUAL_BEHAVIOR);
+    // Sanitization never collapses the prompt to empty.
+    expect(prompt.length).toBeGreaterThan(200);
+  });
 });
 
 describe("runGreenStage — failure statuses (injected runners)", () => {

--- a/scripts/gemini-correctness/green-runner.test.ts
+++ b/scripts/gemini-correctness/green-runner.test.ts
@@ -1,0 +1,691 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { runGreenStage } from "./green-runner.mjs";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..", "..");
+const TEST_FILE = "src/domain/example.regression.test.ts";
+const TEST_NAME = "returns the safe fallback for an empty queue";
+const EXPECTED_BEHAVIOR = "an empty queue returns the safe fallback";
+const ACTUAL_BEHAVIOR = "an empty queue returns the stale value";
+const fakeSecret = "fixture-secret-value-12345";
+
+let fixtureRoot = "";
+
+function git(args: string[]) {
+  return execFileSync("git", args, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  }).trim();
+}
+
+function gitRaw(args: string[]) {
+  return execFileSync("git", args, {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+}
+
+function write(relativePath: string, content: string) {
+  const absolutePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, content);
+}
+
+function sha256(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function regressionTestSource() {
+  return `import { expect, it } from "vitest";
+import { readEmptyQueue } from "./example";
+
+it("${TEST_NAME}", () => {
+  expect(
+    readEmptyQueue(),
+    "Expected behavior: ${EXPECTED_BEHAVIOR} | Actual behavior: ${ACTUAL_BEHAVIOR}",
+  ).toBe("safe");
+});
+`;
+}
+
+function finding() {
+  return {
+    schemaVersion: 1,
+    status: "finding",
+    title: "empty queue fallback",
+    confidence: 0.95,
+    category: "boundary-condition",
+    evidence: [
+      {
+        file: "src/domain/example.ts",
+        startLine: 1,
+        endLine: 3,
+        reason: "the empty branch returns a stale value"
+      }
+    ],
+    expectedBehavior: EXPECTED_BEHAVIOR,
+    actualBehavior: ACTUAL_BEHAVIOR,
+    reproduction: { testFile: TEST_FILE, testName: TEST_NAME },
+    productionFiles: ["src/domain/example.ts"],
+    risk: "low"
+  };
+}
+
+function repairDiff() {
+  return [
+    "diff --git a/src/domain/example.ts b/src/domain/example.ts",
+    "--- a/src/domain/example.ts",
+    "+++ b/src/domain/example.ts",
+    "@@ -1,3 +1,3 @@",
+    " export function readEmptyQueue() {",
+    '-  return "stale";',
+    '+  return "safe";',
+    " }",
+    ""
+  ].join("\n");
+}
+
+function candidate(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    status: "repair-diff",
+    diff: repairDiff(),
+    rootCause: "the empty branch returns a stale value instead of the fallback",
+    fixSummary: "return the safe fallback when the queue is empty",
+    ...overrides
+  };
+}
+
+function redReport() {
+  return {
+    success: false,
+    numTotalTestSuites: 1,
+    numPassedTestSuites: 0,
+    numFailedTestSuites: 1,
+    numPendingTestSuites: 0,
+    numTotalTests: 1,
+    numPassedTests: 0,
+    numFailedTests: 1,
+    numPendingTests: 0,
+    numTodoTests: 0,
+    testResults: [
+      {
+        name: `${fixtureRoot}/${TEST_FILE}`,
+        status: "failed",
+        message: "",
+        assertionResults: [
+          {
+            title: TEST_NAME,
+            fullName: TEST_NAME,
+            status: "failed",
+            failureMessages: [
+              `AssertionError: Expected behavior: ${EXPECTED_BEHAVIOR} | Actual behavior: ${ACTUAL_BEHAVIOR}\nexpected 'stale' to be 'safe'`
+            ]
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function greenReport() {
+  return {
+    success: true,
+    numTotalTestSuites: 1,
+    numPassedTestSuites: 1,
+    numFailedTestSuites: 0,
+    numPendingTestSuites: 0,
+    numTotalTests: 1,
+    numPassedTests: 1,
+    numFailedTests: 0,
+    numPendingTests: 0,
+    numTodoTests: 0,
+    testResults: [
+      {
+        name: `${fixtureRoot}/${TEST_FILE}`,
+        status: "passed",
+        message: "",
+        assertionResults: [
+          {
+            title: TEST_NAME,
+            fullName: TEST_NAME,
+            status: "passed",
+            failureMessages: []
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function initializeFixture() {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-green-runner-"));
+  git(["init", "-q"]);
+  git(["config", "user.email", "fixture@example.test"]);
+  git(["config", "user.name", "Fixture"]);
+  write(".gitignore", ".tmp/\nnode_modules\n");
+  write(
+    "package.json",
+    JSON.stringify({
+      name: "green-runner-fixture",
+      private: true,
+      type: "module",
+      packageManager: "pnpm@10.33.0"
+    }, null, 2) + "\n"
+  );
+  write(
+    "src/domain/example.ts",
+    'export function readEmptyQueue() {\n  return "stale";\n}\n'
+  );
+  git(["add", ".gitignore", "package.json", "src/domain/example.ts"]);
+  git(["commit", "-qm", "fixture baseline"]);
+  fs.symlinkSync(path.join(projectRoot, "node_modules"), path.join(fixtureRoot, "node_modules"));
+}
+
+function prepareRedArtifacts() {
+  const baselineSha = git(["rev-parse", "HEAD"]);
+  write(TEST_FILE, regressionTestSource());
+  git(["add", "-N", TEST_FILE]);
+  const patch = gitRaw([
+    "diff",
+    "--binary",
+    "--no-ext-diff",
+    "--no-renames",
+    "--",
+    TEST_FILE
+  ]);
+  git(["reset", "-q", "--", TEST_FILE]);
+  fs.rmSync(path.join(fixtureRoot, TEST_FILE), { force: true });
+  const patchSha256 = sha256(patch);
+  const sanitizedSummary =
+    `${TEST_NAME}: Expected behavior: ${EXPECTED_BEHAVIOR} | ` +
+    `Actual behavior: ${ACTUAL_BEHAVIOR}`;
+  write(".tmp/gemini-correctness/red-test.patch", patch);
+  write(
+    ".tmp/gemini-correctness/red-result.json",
+    JSON.stringify({
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha,
+      testFile: TEST_FILE,
+      testName: TEST_NAME,
+      failureKind: "assertion",
+      sanitizedSummary,
+      patchSha256,
+      replayConfirmed: true
+    }, null, 2) + "\n"
+  );
+  return { baselineSha, patchSha256, sanitizedSummary };
+}
+
+function defaultGuardedRunner() {
+  return vi.fn()
+    .mockResolvedValueOnce({ valid: true, exitCode: 1, report: redReport() })
+    .mockResolvedValueOnce({ valid: true, exitCode: 0, report: greenReport() });
+}
+
+function passingRunCommand() {
+  return vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" }));
+}
+
+function fakeClient(result) {
+  return {
+    generateJson: vi.fn().mockResolvedValue(result)
+  };
+}
+
+describe("runGreenStage — success path (injected runners)", () => {
+  beforeEach(() => initializeFixture());
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("produces repair-verified with exact diff stats and hashes", async () => {
+    const { patchSha256 } = prepareRedArtifacts();
+    const guardedRunner = defaultGuardedRunner();
+    const runCommand = passingRunCommand();
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: git(["rev-parse", "HEAD"]),
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary:
+          `${TEST_NAME}: Expected behavior: ${EXPECTED_BEHAVIOR} | ` +
+          `Actual behavior: ${ACTUAL_BEHAVIOR}`,
+        patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: { ...process.env, FIXTURE_SECRET: fakeSecret },
+      guardedRunner,
+      runCommand
+    });
+
+    expect(result, result.error).toMatchObject({ valid: true });
+    expect(result.result.status).toBe("repair-verified");
+    expect(result.result.baselineSha).toBe(git(["rev-parse", "HEAD"]));
+    expect(result.result.findingTitle).toBe(finding().title);
+    expect(result.result.testFile).toBe(TEST_FILE);
+    expect(result.result.testName).toBe(TEST_NAME);
+    expect(result.result.productionFiles).toEqual(["src/domain/example.ts"]);
+    expect(result.result.rootCause).toBe(candidate().rootCause);
+    expect(result.result.fixSummary).toBe(candidate().fixSummary);
+    expect(result.result.checks).toEqual([
+      { name: "targeted-test", status: "passed" },
+      { name: "lint", status: "passed" },
+      { name: "typecheck", status: "passed" },
+      { name: "test", status: "passed" },
+      { name: "build", status: "passed" }
+    ]);
+    expect(result.result.changedFiles).toBe(1);
+    expect(result.result.changedLines).toBe(2);
+    expect(result.result.testPatchSha256).toBe(patchSha256);
+    const actualDiff = gitRaw([
+      "diff",
+      "--binary",
+      "--no-ext-diff",
+      "--no-renames"
+    ]);
+    expect(result.result.finalDiffSha256).toBe(sha256(actualDiff));
+
+    expect(guardedRunner).toHaveBeenCalledTimes(2);
+    expect(runCommand.mock.calls.map(call => call[0]))
+      .toEqual(["lint", "typecheck", "test", "build"]);
+
+    // The repaired production file stays modified and the regression test stays
+    // untracked — exactly the diff that would become the PR.
+    expect(gitRaw(["status", "--porcelain=v1", "--untracked-files=all"]))
+      .toBe(` M src/domain/example.ts\n?? ${TEST_FILE}\n`);
+    const artifact = JSON.parse(
+      fs.readFileSync(
+        path.join(fixtureRoot, ".tmp/gemini-correctness/repair-result.json"),
+        "utf8"
+      )
+    );
+    expect(artifact).toEqual(result.result);
+    expect(JSON.stringify(artifact)).not.toContain(fakeSecret);
+    expect(JSON.stringify(artifact)).not.toContain(fixtureRoot);
+  });
+
+  it("redacts secrets and absolute paths from failure errors", async () => {
+    const red = prepareRedArtifacts();
+    const guardedRunner = defaultGuardedRunner();
+    const runCommand = vi.fn(async () => ({
+      exitCode: 1,
+      stdout: `built with ${fakeSecret}`,
+      stderr: `at ${fixtureRoot}`
+    }));
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: git(["rev-parse", "HEAD"]),
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary:
+          `${TEST_NAME}: Expected behavior: ${EXPECTED_BEHAVIOR} | ` +
+          `Actual behavior: ${ACTUAL_BEHAVIOR}`,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: { ...process.env, FIXTURE_SECRET: fakeSecret },
+      guardedRunner,
+      runCommand
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).not.toContain(fakeSecret);
+    expect(result.error).not.toContain(fixtureRoot);
+  });
+});
+
+describe("runGreenStage — failure statuses (injected runners)", () => {
+  beforeEach(() => initializeFixture());
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("fails closed with baseline-mismatch when HEAD differs from redResult.baselineSha", async () => {
+    const red = prepareRedArtifacts();
+    write("src/domain/example.ts", 'export function readEmptyQueue() {\n  return "x";\n}\n');
+    git(["add", "src/domain/example.ts"]);
+    git(["commit", "-qm", "drift commit"]);
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("baseline-mismatch");
+    // The worktree keeps the drift commit; the runner never rewrites history.
+    expect(git(["rev-parse", "HEAD"])).not.toBe(red.baselineSha);
+  });
+
+  it("fails closed with red-replay-failed when the stored patch hash does not match", async () => {
+    const red = prepareRedArtifacts();
+    const patchPath = path.join(fixtureRoot, ".tmp/gemini-correctness/red-test.patch");
+    fs.writeFileSync(patchPath, fs.readFileSync(patchPath, "utf8") + "# tampered\n");
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("red-replay-failed");
+  });
+
+  it("fails closed with red-replay-failed when the replay does not reproduce the RED assertion", async () => {
+    const red = prepareRedArtifacts();
+    const guardedRunner = vi.fn().mockResolvedValueOnce({
+      valid: true,
+      exitCode: 0,
+      report: greenReport()
+    });
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner,
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("red-replay-failed");
+  });
+
+  it("fails closed with repair-not-found when Gemini returns no valid repair", async () => {
+    const red = prepareRedArtifacts();
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: false, error: "Gemini HTTP 500: boom" }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("repair-not-found");
+  });
+
+  it("fails closed with diff-policy-rejected when Gemini tampers the regression test", async () => {
+    const red = prepareRedArtifacts();
+    const tampered = [
+      "diff --git a/src/domain/example.regression.test.ts b/src/domain/example.regression.test.ts",
+      "--- a/src/domain/example.regression.test.ts",
+      "+++ b/src/domain/example.regression.test.ts",
+      "@@ -1,3 +1,3 @@",
+      " export function readEmptyQueue() {",
+      '-  return "stale";',
+      '+  return "safe";',
+      " }",
+      ""
+    ].join("\n");
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate({ diff: tampered }) }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("diff-policy-rejected");
+  });
+
+  it("fails closed with diff-policy-rejected when Gemini adds an escape hatch", async () => {
+    const red = prepareRedArtifacts();
+    const escaped = repairDiff().replace(
+      '  return "stale";',
+      "  // @ts-ignore\n  return \"stale\";"
+    );
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate({ diff: escaped }) }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("diff-policy-rejected");
+  });
+
+  it("fails closed with needs-human-scope-expansion when Gemini requests it", async () => {
+    const red = prepareRedArtifacts();
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({
+        valid: true,
+        result: { schemaVersion: 1, status: "needs-human-scope-expansion", reason: "needs other files" }
+      }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("needs-human-scope-expansion");
+  });
+
+  it("fails closed with targeted-test-failed when the repair does not green the test", async () => {
+    const red = prepareRedArtifacts();
+    const guardedRunner = vi.fn()
+      .mockResolvedValueOnce({ valid: true, exitCode: 1, report: redReport() })
+      .mockResolvedValueOnce({ valid: true, exitCode: 1, report: redReport() });
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner,
+      runCommand: passingRunCommand()
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("targeted-test-failed");
+  });
+
+  it.each([
+    ["lint", "exit 1 from lint"],
+    ["typecheck", "exit 1 from typecheck"],
+    ["test", "exit 1 from test"],
+    ["build", "exit 1 from build"]
+  ])("fails closed with full-check-failed when %s fails", async (_label, failure) => {
+    const red = prepareRedArtifacts();
+    const failing = ["lint", "typecheck", "test", "build"];
+    const runCommand = vi.fn(async (script) => {
+      if (failure.includes(script)) {
+        return { exitCode: 1, stdout: "", stderr: failure };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+    void failing;
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("full-check-failed");
+  });
+
+  it("cleans up to baseline and removes green temporary artifacts on failure", async () => {
+    const baselineSha = git(["rev-parse", "HEAD"]);
+    const red = prepareRedArtifacts();
+    const runCommand = vi.fn(async () => ({ exitCode: 1, stdout: "", stderr: "build failed" }));
+
+    const result = await runGreenStage({
+      repoRoot: fixtureRoot,
+      finding: finding(),
+      redResult: {
+        schemaVersion: 1,
+        status: "red-confirmed",
+        baselineSha: red.baselineSha,
+        testFile: TEST_FILE,
+        testName: TEST_NAME,
+        failureKind: "assertion",
+        sanitizedSummary: red.sanitizedSummary,
+        patchSha256: red.patchSha256,
+        replayConfirmed: true
+      },
+      client: fakeClient({ valid: true, result: candidate() }),
+      environment: process.env,
+      guardedRunner: defaultGuardedRunner(),
+      runCommand
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.status).toBe("full-check-failed");
+    expect(git(["rev-parse", "HEAD"])).toBe(baselineSha);
+    expect(git(["status", "--porcelain=v1", "--untracked-files=all"])).toBe("");
+    const artifactDir = path.join(fixtureRoot, ".tmp/gemini-correctness");
+    const greenArtifacts = fs.readdirSync(artifactDir);
+    expect(greenArtifacts).not.toContain("green-repair.patch");
+    expect(greenArtifacts).not.toContain("repair-result.json");
+    const resultFile = path.join(artifactDir, "repair-result.json");
+    if (fs.existsSync(resultFile)) {
+      expect(JSON.stringify(fs.readFileSync(resultFile, "utf8"))).not.toContain(fakeSecret);
+    }
+  });
+});

--- a/scripts/gemini-correctness/green-stage-cli.test.ts
+++ b/scripts/gemini-correctness/green-stage-cli.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { parseGreenStageArgs, resolveGreenInputs } from "./green-stage.mjs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+let fixtureRoot = "";
+
+describe("parseGreenStageArgs", () => {
+  it("accepts only a bounded Gemini model identifier", () => {
+    expect(parseGreenStageArgs(["--model", "gemini-2.5-flash"]))
+      .toEqual({ model: "gemini-2.5-flash" });
+  });
+
+  it.each([
+    ["--command", "sh -c true"],
+    ["--finding", "../../finding.json"],
+    ["--model", "https://attacker.invalid/model"],
+    ["--unknown"]
+  ])("rejects unsupported or unsafe argv starting with %s", (...argv) => {
+    expect(() => parseGreenStageArgs(argv)).toThrow();
+  });
+});
+
+describe("resolveGreenInputs", () => {
+  beforeEach(() => {
+    fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-green-cli-"));
+    fs.mkdirSync(
+      path.join(fixtureRoot, ".tmp", "gemini-correctness"),
+      { recursive: true }
+    );
+  });
+  afterEach(() => {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("resolves only the fixed finding and red-result artifacts", () => {
+    const findingPath = path.join(
+      fixtureRoot, ".tmp", "gemini-correctness", "finding.json"
+    );
+    const redPath = path.join(
+      fixtureRoot, ".tmp", "gemini-correctness", "red-result.json"
+    );
+    fs.writeFileSync(findingPath, "{}\n");
+    fs.writeFileSync(redPath, "{}\n");
+
+    const result = resolveGreenInputs(fixtureRoot);
+    expect(result.valid).toBe(true);
+    expect(result.findingPath).toBe(fs.realpathSync(findingPath));
+    expect(result.redResultPath).toBe(fs.realpathSync(redPath));
+  });
+
+  it("rejects a missing red-result artifact", () => {
+    const findingPath = path.join(
+      fixtureRoot, ".tmp", "gemini-correctness", "finding.json"
+    );
+    fs.writeFileSync(findingPath, "{}\n");
+
+    expect(resolveGreenInputs(fixtureRoot).valid).toBe(false);
+  });
+
+  it("rejects a symlinked finding artifact", () => {
+    const findingPath = path.join(
+      fixtureRoot, ".tmp", "gemini-correctness", "finding.json"
+    );
+    const redPath = path.join(
+      fixtureRoot, ".tmp", "gemini-correctness", "red-result.json"
+    );
+    const target = path.join(fixtureRoot, "outside.json");
+    fs.writeFileSync(target, "{}\n");
+    fs.writeFileSync(redPath, "{}\n");
+    fs.symlinkSync(target, findingPath);
+
+    expect(resolveGreenInputs(fixtureRoot).valid).toBe(false);
+  });
+});

--- a/scripts/gemini-correctness/green-stage-integration.test.ts
+++ b/scripts/gemini-correctness/green-stage-integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { parseRedResultArtifact } from "./green-stage.mjs";
+
+describe("parseRedResultArtifact", () => {
+  it("accepts a red-confirmed result", () => {
+    expect(parseRedResultArtifact(JSON.stringify({
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha: "a".repeat(40),
+      testFile: "src/domain/example.regression.test.ts",
+      testName: "returns the safe fallback",
+      failureKind: "assertion",
+      sanitizedSummary: "summary",
+      patchSha256: "b".repeat(64),
+      replayConfirmed: true
+    }))).toMatchObject({
+      schemaVersion: 1,
+      status: "red-confirmed",
+      baselineSha: "a".repeat(40)
+    });
+  });
+
+  it.each([
+    ["a rejected status", JSON.stringify({
+      schemaVersion: 1,
+      status: "rejected",
+      baselineSha: "a".repeat(40)
+    })],
+    ["a no-finding envelope", JSON.stringify({
+      valid: true,
+      result: { schemaVersion: 1, status: "no-finding" }
+    })],
+    ["non-JSON content", "not json"],
+    ["a null input", null],
+    ["an empty string", ""]
+  ])("rejects %s", (_label, content) => {
+    expect(parseRedResultArtifact(content)).toBeNull();
+  });
+});

--- a/scripts/gemini-correctness/green-stage.mjs
+++ b/scripts/gemini-correctness/green-stage.mjs
@@ -1,0 +1,146 @@
+// =============================================================================
+// green-stage.mjs — fixed entry point for the guarded GREEN repair stage
+// =============================================================================
+//
+// A fixed module (not a workflow) that loads the finding + red-result artifacts
+// from the .tmp artifact directory and drives the guarded GREEN runner.
+// Like the RED stage, this is fail-closed: it never commits, pushes, or opens
+// a PR itself.
+// =============================================================================
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { createGeminiClient } from "./gemini-client.mjs";
+import { safeWritePath } from "./policy.mjs";
+import { DEFAULT_MODEL } from "./prompt-builder.mjs";
+import { extractValidatedFinding } from "./red-stage.mjs";
+import { runGreenStage } from "./green-runner.mjs";
+
+const MODULE_PATH = fileURLToPath(import.meta.url);
+const ARTIFACT_DIR = "gemini-correctness";
+const FINDING_RELATIVE_PATH = `${ARTIFACT_DIR}/finding.json`;
+const RED_RESULT_RELATIVE_PATH = `${ARTIFACT_DIR}/red-result.json`;
+
+export function parseGreenStageArgs(argv) {
+  const parsed = { model: DEFAULT_MODEL };
+  for (let index = 0; index < argv.length; index++) {
+    const argument = argv[index];
+    if (argument !== "--model") {
+      throw new Error(`unsupported GREEN stage argument: ${argument}`);
+    }
+    const model = argv[++index];
+    if (
+      typeof model !== "string" ||
+      !/^gemini-[A-Za-z0-9._-]{1,100}$/.test(model)
+    ) {
+      throw new Error("model must be a bounded Gemini model identifier");
+    }
+    parsed.model = model;
+  }
+  return parsed;
+}
+
+function resolveArtifact(repoRoot, relativePath) {
+  try {
+    const allowedDir = path.join(repoRoot, ".tmp");
+    const allowedStat = fs.lstatSync(allowedDir);
+    if (allowedStat.isSymbolicLink() || !allowedStat.isDirectory()) return null;
+    const candidate = safeWritePath(relativePath, allowedDir, repoRoot);
+    if (!candidate) return null;
+    const stat = fs.lstatSync(candidate);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveGreenInputs(repoRoot) {
+  const findingPath = resolveArtifact(repoRoot, FINDING_RELATIVE_PATH);
+  const redResultPath = resolveArtifact(repoRoot, RED_RESULT_RELATIVE_PATH);
+  if (!findingPath) return { valid: false, error: "finding artifact is missing or unsafe" };
+  if (!redResultPath) return { valid: false, error: "red-result artifact is missing or unsafe" };
+  return { valid: true, findingPath, redResultPath };
+}
+
+export function parseRedResultArtifact(content) {
+  try {
+    const parsed = JSON.parse(content);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      parsed.status === "red-confirmed" &&
+      typeof parsed.baselineSha === "string"
+    ) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const { model } = parseGreenStageArgs(process.argv.slice(2));
+  const repoRoot = path.resolve(path.dirname(MODULE_PATH), "..", "..");
+  const inputs = resolveGreenInputs(repoRoot);
+  if (!inputs.valid) {
+    console.error(`[green-stage] ${inputs.error}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  let finding;
+  try {
+    finding = extractValidatedFinding(
+      JSON.parse(fs.readFileSync(inputs.findingPath, "utf8"))
+    );
+    if (!finding) throw new Error("not a validated finding");
+  } catch {
+    console.error("[green-stage] finding artifact is not strict JSON");
+    process.exitCode = 2;
+    return;
+  }
+
+  let redResult;
+  try {
+    redResult = parseRedResultArtifact(
+      fs.readFileSync(inputs.redResultPath, "utf8")
+    );
+    if (!redResult) throw new Error("not a red-confirmed result");
+  } catch {
+    console.error("[green-stage] red-result artifact is not strict JSON");
+    process.exitCode = 2;
+    return;
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error("[green-stage] GEMINI_API_KEY is required");
+    process.exitCode = 2;
+    return;
+  }
+  const client = createGeminiClient({ apiKey, model });
+  const result = await runGreenStage({
+    repoRoot,
+    finding,
+    redResult,
+    client,
+    environment: process.env
+  });
+  console.log(JSON.stringify(result.result ?? result, null, 2));
+  process.exitCode = result.valid ? 0 : 1;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === MODULE_PATH
+) {
+  main().catch(() => {
+    console.error("[green-stage] failed closed");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/gemini-correctness/green-validator.mjs
+++ b/scripts/gemini-correctness/green-validator.mjs
@@ -1,0 +1,165 @@
+// =============================================================================
+// green-validator.mjs — deterministic validation of Gemini-authored repair diffs
+// =============================================================================
+//
+// Validates the Gemini repair response against the finding allowlist, hard
+// budgets, and escape-hatch rules.  This is the ONLY place that interprets a
+// repair diff for the GREEN stage; neither the prompt nor Gemini's output
+// should bypass it.
+//
+// A repair diff must:
+//   - be a strict { schemaVersion, status, diff, rootCause, fixSummary } object
+//   - reference only production files listed in finding.productionFiles
+//   - still pass policy allowlist / protected-path checks
+//   - touch at most MAX_GREEN_PRODUCTION_FILES files
+//   - add/remove at most MAX_GREEN_DIFF_LINES lines in total
+//   - never add .skip/.only/@ts-ignore/@ts-nocheck/@ts-expect-error, coverage or
+//     lint disables, or an uncommented `any` annotation
+//   - never contain whitespace-only churn, EOL churn, binary/rename/delete/
+//     symlink/submodule markers, or sensitive content
+// =============================================================================
+
+import {
+  MAX_GREEN_DIFF_LINES,
+  MAX_GREEN_PRODUCTION_FILES,
+  getDefaultAllowlist,
+  getDefaultProtectedPaths,
+  isAllowlisted,
+  isPathSafe,
+  isProductionFilePath,
+  isProtected,
+  parseUnifiedDiff
+} from "./policy.mjs";
+import { redactForOutput } from "./discover.mjs";
+
+const CANDIDATE_KEYS = ["schemaVersion", "status", "diff", "rootCause", "fixSummary"];
+
+const ESCAPE_HATCH_RE = /(?:\b\.skip\b|\b\.only\b|@ts-ignore|@ts-nocheck|@ts-expect-error|eslint-disable|eslint-disable-next-line|eslint-disable-line|istanbul\s+ignore|c8\s+ignore|coverage\s+ignore)/i;
+
+const ANNOTATED_ANY_RE = /\bany\b(?![^*/]*\*\/)/;
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+function normalizePath(filePath) {
+  return String(filePath).replace(/\\/g, "/");
+}
+
+function isWhitespaceChurn(addedLines, removedLines) {
+  const normalized = lines => lines.map(line => line.replace(/\s/g, "")).filter(line => line !== "");
+  return (
+    addedLines.length === removedLines.length &&
+    normalized(addedLines).join("\n") === normalized(removedLines).join("\n")
+  );
+}
+
+export function validateGreenRepairCandidate(candidate, options = {}) {
+  const finding = options.finding;
+  if (!finding || finding.status !== "finding") {
+    return invalid("a validated finding is required");
+  }
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return invalid("candidate must be a plain object");
+  }
+
+  const keys = Object.keys(candidate);
+  const unknown = keys.filter(key => !CANDIDATE_KEYS.includes(key));
+  const missing = CANDIDATE_KEYS.filter(key => candidate[key] === undefined);
+  if (unknown.length > 0) return invalid(`candidate has unknown fields: ${unknown.join(", ")}`);
+  if (missing.length > 0) return invalid(`candidate is missing fields: ${missing.join(", ")}`);
+  if (candidate.schemaVersion !== 1) return invalid("candidate schemaVersion must be 1");
+  if (candidate.status !== "repair-diff") {
+    return invalid('candidate status must be "repair-diff"');
+  }
+  if (typeof candidate.rootCause !== "string" || candidate.rootCause.trim() === "") {
+    return invalid("rootCause must be a non-empty string");
+  }
+  if (typeof candidate.fixSummary !== "string" || candidate.fixSummary.trim() === "") {
+    return invalid("fixSummary must be a non-empty string");
+  }
+
+  const allowlist = options.allowlist ?? getDefaultAllowlist();
+  const protectedPaths = options.protectedPaths ?? getDefaultProtectedPaths();
+  // Only length >= 4 values are treated as sensitive.  Very short env values
+  // (e.g. a single character) would otherwise corrupt any diff hunk that
+  // happens to contain that character, producing false "sensitive content"
+  // rejections.  Real secrets (API keys, tokens) are far longer.
+  const sensitiveValues = (options.sensitiveValues ?? []).filter(
+    value => typeof value === "string" && value.length >= 4
+  );
+  const productionFileSet = new Set(
+    (finding.productionFiles ?? []).map(normalizePath)
+  );
+
+  const parsed = parseUnifiedDiff(candidate.diff);
+  if (!parsed.valid) return parsed;
+
+  if (parsed.changedFiles > MAX_GREEN_PRODUCTION_FILES) {
+    return invalid(`repair diff touches ${parsed.changedFiles} files; budget is ${MAX_GREEN_PRODUCTION_FILES}`);
+  }
+  const totalChanged = parsed.totalAdditions + parsed.totalDeletions;
+  if (totalChanged > MAX_GREEN_DIFF_LINES) {
+    return invalid(`repair diff changes ${totalChanged} lines; budget is ${MAX_GREEN_DIFF_LINES}`);
+  }
+
+  for (const file of parsed.files) {
+    const normalized = normalizePath(file.path);
+    if (!productionFileSet.has(normalized)) {
+      return invalid(`diff file "${file.path}" is not in finding.productionFiles`);
+    }
+    if (!isPathSafe(file.path)) {
+      return invalid(`diff file "${file.path}" is not a safe relative path`);
+    }
+    if (!isAllowlisted(normalized, allowlist)) {
+      return invalid(`diff file "${file.path}" is outside the allowlist`);
+    }
+    if (isProtected(normalized, protectedPaths)) {
+      return invalid(`diff file "${file.path}" is a protected path`);
+    }
+    if (!isProductionFilePath(file.path)) {
+      return invalid(`diff file "${file.path}" is a test file, not a production repair target`);
+    }
+    if (isWhitespaceChurn(file.addedLines, file.removedLines)) {
+      return invalid(`diff for "${file.path}" is whitespace-only churn`);
+    }
+    for (const line of [...file.addedLines, ...file.removedLines]) {
+      if (line.includes("\r")) {
+        return invalid(`diff for "${file.path}" contains EOL churn`);
+      }
+      if (ESCAPE_HATCH_RE.test(line)) {
+        return invalid(`diff for "${file.path}" contains an escape-hatch marker`);
+      }
+      if (ANNOTATED_ANY_RE.test(line)) {
+        return invalid(`diff for "${file.path}" introduces an uncommented any annotation`);
+      }
+    }
+  }
+
+  const redactedDiff = redactForOutput(candidate.diff, sensitiveValues);
+  if (redactedDiff !== candidate.diff) {
+    return invalid("repair diff contains sensitive content");
+  }
+  const redactedSummary = redactForOutput(
+    `${candidate.rootCause}\n${candidate.fixSummary}`,
+    sensitiveValues
+  );
+  if (redactedSummary !== `${candidate.rootCause}\n${candidate.fixSummary}`) {
+    return invalid("repair summary contains sensitive content");
+  }
+
+  return {
+    valid: true,
+    result: {
+      schemaVersion: 1,
+      status: "repair-diff",
+      diff: candidate.diff,
+      rootCause: candidate.rootCause,
+      fixSummary: candidate.fixSummary,
+      changedFiles: parsed.changedFiles,
+      totalAdditions: parsed.totalAdditions,
+      totalDeletions: parsed.totalDeletions,
+      files: parsed.files.map(file => file.path)
+    }
+  };
+}

--- a/scripts/gemini-correctness/green-validator.test.ts
+++ b/scripts/gemini-correctness/green-validator.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { getDefaultProtectedPaths } from "./policy.mjs";
+// @ts-expect-error -- plain .mjs module, no types
+import { validateGreenRepairCandidate } from "./green-validator.mjs";
+
+const fakeSecret = "fixture-secret-value-12345";
+
+function finding(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    status: "finding",
+    title: "empty queue fallback",
+    confidence: 0.95,
+    category: "boundary-condition",
+    evidence: [
+      {
+        file: "src/domain/example.ts",
+        startLine: 1,
+        endLine: 3,
+        reason: "the empty branch returns a stale value"
+      }
+    ],
+    expectedBehavior: "an empty queue returns the safe fallback",
+    actualBehavior: "an empty queue returns the stale value",
+    reproduction: {
+      testFile: "src/domain/example.regression.test.ts",
+      testName: "returns the safe fallback for an empty queue"
+    },
+    productionFiles: ["src/domain/example.ts"],
+    risk: "low",
+    ...overrides
+  };
+}
+
+function singleFileDiff(body = "") {
+  const content =
+    'export function readEmptyQueue() {\n  return "stale";\n}\n';
+  return (
+    "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+    "--- a/src/domain/example.ts\n" +
+    "+++ b/src/domain/example.ts\n" +
+    "@@ -1,3 +1,3 @@\n" +
+    content.split("\n").slice(0, 2).map(line => ` ${line}`).join("\n") +
+    "\n" +
+    '-  return "stale";\n' +
+    '+  return "safe";\n' +
+    " }\n" +
+    body
+  );
+}
+
+function candidate(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    status: "repair-diff",
+    diff: singleFileDiff(),
+    rootCause: "the empty branch returns a stale value instead of the fallback",
+    fixSummary: "return the safe fallback when the queue is empty",
+    ...overrides
+  };
+}
+
+function validOptions() {
+  return {
+    finding: finding(),
+    sensitiveValues: [fakeSecret],
+    allowlist: ["src/domain/**"],
+    protectedPaths: []
+  };
+}
+
+describe("validateGreenRepairCandidate", () => {
+  it("accepts a minimal single-file repair diff", () => {
+    const result = validateGreenRepairCandidate(candidate(), validOptions());
+    expect(result.valid).toBe(true);
+    expect(result.result).toMatchObject({
+      schemaVersion: 1,
+      status: "repair-diff",
+      changedFiles: 1,
+      totalAdditions: 1,
+      totalDeletions: 1,
+      files: ["src/domain/example.ts"]
+    });
+  });
+
+  it("accepts a multi-file repair within the finding productionFiles", () => {
+    const multi = finding({ productionFiles: ["src/domain/example.ts", "src/domain/helper.ts"] });
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1 @@\n" +
+      '-return "stale";\n' +
+      '+return "safe";\n' +
+      "diff --git a/src/domain/helper.ts b/src/domain/helper.ts\n" +
+      "--- a/src/domain/helper.ts\n" +
+      "+++ b/src/domain/helper.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-export const helper = 1;\n" +
+      "+export const helper = 2;\n";
+    const result = validateGreenRepairCandidate(candidate({ diff }), {
+      ...validOptions(),
+      finding: multi
+    });
+    expect(result.valid).toBe(true);
+    expect(result.result.files).toEqual(["src/domain/example.ts", "src/domain/helper.ts"]);
+  });
+
+  it.each([
+    ["schemaVersion mismatch", { schemaVersion: 2 }],
+    ["status mismatch", { status: "regression-test" }],
+    ["missing diff", { diff: undefined }],
+    ["missing rootCause", { rootCause: undefined }],
+    ["missing fixSummary", { fixSummary: undefined }],
+    ["unknown field", { extra: "nope" }],
+    ["empty diff string", { diff: "" }],
+    ["non-string diff", { diff: 42 }]
+  ])("rejects a candidate with %s", (_label, overrides) => {
+    const result = validateGreenRepairCandidate(candidate(overrides), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects an empty rootCause or fixSummary string", () => {
+    expect(validateGreenRepairCandidate(
+      candidate({ rootCause: "   " }),
+      validOptions()
+    ).valid).toBe(false);
+    expect(validateGreenRepairCandidate(
+      candidate({ fixSummary: "" }),
+      validOptions()
+    ).valid).toBe(false);
+  });
+
+  it("rejects a regression-test or existing-test file in the diff", () => {
+    const diff =
+      "diff --git a/src/domain/example.regression.test.ts b/src/domain/example.regression.test.ts\n" +
+      "--- a/src/domain/example.regression.test.ts\n" +
+      "+++ b/src/domain/example.regression.test.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      "+y\n";
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a file outside the finding productionFiles (scope escape)", () => {
+    const diff =
+      "diff --git a/src/domain/other.ts b/src/domain/other.ts\n" +
+      "--- a/src/domain/other.ts\n" +
+      "+++ b/src/domain/other.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      "+y\n";
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ["a protected path", "src/domain/types.ts"],
+    ["package.json", "package.json"],
+    ["pnpm-lock.yaml", "pnpm-lock.yaml"],
+    ["a workflow", ".github/workflows/ci.yml"],
+    ["a supabase migration", "supabase/migrations/1.sql"]
+  ])("rejects %s even when the finding lists it", (_label, filePath) => {
+    const diff =
+      `diff --git a/${filePath} b/${filePath}\n` +
+      `--- a/${filePath}\n` +
+      `+++ b/${filePath}\n` +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      "+y\n";
+    const result = validateGreenRepairCandidate(candidate({ diff }), {
+      ...validOptions(),
+      protectedPaths: getDefaultProtectedPaths(),
+      finding: finding({ productionFiles: [filePath] })
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects more than the GREEN production-file budget", () => {
+    const files = Array.from({ length: 4 }, (_, index) =>
+      `src/domain/module-${index}.ts`
+    );
+    const diff = files.map(filePath =>
+      `diff --git a/${filePath} b/${filePath}\n` +
+      `--- a/${filePath}\n` +
+      `+++ b/${filePath}\n` +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      "+y\n"
+    ).join("");
+    const result = validateGreenRepairCandidate(candidate({ diff }), {
+      ...validOptions(),
+      finding: finding({ productionFiles: files })
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a diff that exceeds the GREEN line budget", () => {
+    const added = Array.from({ length: 251 }, () => "+line\n").join("");
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1,252 @@\n" +
+      " context\n" +
+      added;
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    ["a deleted file", "deleted file mode 100644\n"],
+    ["a rename", "similarity index 90%\nrename from a.ts\nrename to b.ts\n"],
+    ["a binary file", "GIT binary patch\nliteral 5\n"],
+    ["a submodule change", "Subproject commit 0123456789abcdef0123456789abcdef01234567\n"]
+  ])("rejects a diff containing %s", (_label, marker) => {
+    const result = validateGreenRepairCandidate(
+      candidate({ diff: singleFileDiff(marker) }),
+      validOptions()
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a symlink file mode in the diff", () => {
+    const diff = singleFileDiff(
+      "new file mode 120000\n"
+    );
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it.each([
+    [".skip", "  it.skip(\"x\", () => {});"],
+    [".only", "  describe.only(\"x\", () => {});"],
+    ["@ts-ignore", "  // @ts-ignore"],
+    ["@ts-nocheck", "  // @ts-nocheck"],
+    ["@ts-expect-error", "  // @ts-expect-error"],
+    ["eslint-disable", "  /* eslint-disable no-any */"],
+    ["istanbul ignore", "  /* istanbul ignore next */"]
+  ])("rejects an escape-hatch marker in the diff: %s", (_label, marker) => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1,2 @@\n" +
+      '-return "stale";\n' +
+      `+${marker}\n` +
+      '+return "safe";\n';
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects an added uncommented `any` type annotation", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1,2 @@\n" +
+      '-return "stale";\n' +
+      "+function f(): any {\n" +
+      '+return "safe";\n' +
+      "}\n";
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects whitespace-only churn between added and removed lines", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1 @@\n" +
+      '-  return "safe";\n' +
+      '+return "safe";\n';
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects EOL churn that introduces carriage returns", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1 @@\n" +
+      '-return "stale";\r\n' +
+      '+return "safe";\r\n';
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects a diff whose path is not a safe relative repository path", () => {
+    for (const unsafePath of ["/etc/passwd", "../../outside.ts", "src/domain/link -> /etc"]) {
+      const diff =
+        `diff --git a/${unsafePath} b/${unsafePath}\n` +
+        `--- a/${unsafePath}\n` +
+        `+++ b/${unsafePath}\n` +
+        "@@ -1 +1 @@\n" +
+        "-x\n" +
+        "+y\n";
+      const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+      expect(result.valid).toBe(false);
+    }
+  });
+
+  it("rejects a diff containing sensitive content", () => {
+    const diff =
+      "diff --git a/src/domain/example.ts b/src/domain/example.ts\n" +
+      "--- a/src/domain/example.ts\n" +
+      "+++ b/src/domain/example.ts\n" +
+      "@@ -1 +1 @@\n" +
+      "-x\n" +
+      `+const key = "${fakeSecret}";\n`;
+    const result = validateGreenRepairCandidate(candidate({ diff }), validOptions());
+    expect(result.valid).toBe(false);
+  });
+});

--- a/scripts/gemini-correctness/policy.mjs
+++ b/scripts/gemini-correctness/policy.mjs
@@ -218,3 +218,119 @@ export function isValidRegressionTest(testFile, productionFile) {
     return testDir === prodDir;
   } catch { return false; }
 }
+
+// ---------------------------------------------------------------------------
+// GREEN hard constants (#637) — budgets that a Gemini repair diff must satisfy
+// ---------------------------------------------------------------------------
+export const MAX_GREEN_PRODUCTION_FILES = 3;
+export const MAX_GREEN_DIFF_LINES = 250;
+
+// ---------------------------------------------------------------------------
+// parseUnifiedDiff — parse a Gemini-authored unified production diff into
+// per-file add/delete counts.  Pure function (no filesystem access): rejects
+// empty/non-string input, missing file headers, rename/binary markers, and any
+// referenced path that is not a safe repo-relative path.
+// ---------------------------------------------------------------------------
+export function parseUnifiedDiff(diff) {
+  if (typeof diff !== "string") {
+    return { valid: false, error: "unified diff must be a string" };
+  }
+  if (/\r/.test(diff)) {
+    return { valid: false, error: "unified diff contains carriage returns (EOL churn)" };
+  }
+  if (diff.trim() === "") {
+    return { valid: false, error: "unified diff is empty" };
+  }
+
+  const files = [];
+  let current = null;
+  let inHunk = false;
+
+  const lines = diff.split("\n");
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/[ \t]+$/, "");
+    if (line.startsWith("@@ ")) {
+      inHunk = true;
+      continue;
+    }
+    if (inHunk) {
+      // A hunk body is only context (' '), added ('+'), removed ('-'), or a
+      // trailing '\ No newline' marker. Any other line ends the hunk and is
+      // processed below as a header/marker.
+      const isHunkBody =
+        line.startsWith(" ") ||
+        line.startsWith("+") ||
+        line.startsWith("-") ||
+        line.startsWith("\\");
+      if (!isHunkBody) inHunk = false;
+      else {
+        // A hunk body without a preceding `+++ b/` attribution cannot be
+        // attributed to a file.  A well-formed git diff always pairs a hunk
+        // with a `+++ b/` header, so reaching this branch means the input is
+        // malformed or hostile: fail closed instead of silently dropping the
+        // lines (which would let an attacker bypass line budgets and
+        // escape-hatch scanning).
+        if (!current) return { valid: false, error: "hunk body has no file attribution" };
+        if (line.startsWith("+")) {
+          current.additions += 1;
+          current.addedLines.push(line.slice(1));
+        } else if (line.startsWith("-")) {
+          current.deletions += 1;
+          current.removedLines.push(line.slice(1));
+        }
+        continue;
+      }
+    }
+    if (
+      /^new\s+file\s+mode\s/.test(line) ||
+      /^deleted\s+file\s+mode\s/.test(line) ||
+      /^old\s+mode\s/.test(line) ||
+      /^new\s+mode\s/.test(line) ||
+      /^Subproject\s+commit\s/.test(line)
+    ) {
+      return { valid: false, error: "add/delete/mode/submodule diffs are forbidden" };
+    }
+    if (line.startsWith("diff --git ")) {
+      current = null;
+      inHunk = false;
+      continue;
+    }
+    if (/^similarity index\s/.test(line) || /^rename (?:from|to)\s/.test(line)) {
+      return { valid: false, error: "rename/similarity diffs are forbidden" };
+    }
+    if (/^Binary files\s/.test(line) || /^GIT binary patch\b/.test(line)) {
+      return { valid: false, error: "binary diffs are forbidden" };
+    }
+    if (line.startsWith("+++ b/")) {
+      const candidatePath = line.slice(6);
+      if (!isPathSafe(candidatePath)) {
+        return { valid: false, error: `diff references an unsafe path: ${candidatePath}` };
+      }
+      current = files.find(file => file.path === candidatePath);
+      if (!current) {
+        current = { path: candidatePath, additions: 0, deletions: 0, addedLines: [], removedLines: [] };
+        files.push(current);
+      }
+      continue;
+    }
+  }
+
+  if (files.length === 0) {
+    return { valid: false, error: "unified diff has no file header" };
+  }
+  for (const file of files) {
+    if (file.additions === 0 && file.deletions === 0) {
+      return { valid: false, error: `diff for ${file.path} has no hunks` };
+    }
+  }
+
+  const totalAdditions = files.reduce((sum, file) => sum + file.additions, 0);
+  const totalDeletions = files.reduce((sum, file) => sum + file.deletions, 0);
+  return {
+    valid: true,
+    files,
+    totalAdditions,
+    totalDeletions,
+    changedFiles: files.length
+  };
+}


### PR DESCRIPTION
## Summary

Closes nothing on its own — implements the **GREEN repair stage** for Issue #637 (part of #634), on top of the #636 RED stage.

Adds the fixed GREEN modules (not a workflow):

- `scripts/gemini-correctness/green-prompt-builder.mjs` — bounded repair-only prompt: Gemini sees the validated finding, the replay-confirmed RED result (baseline SHA + patch hash + assertion), the fixed regression test (read-only), and only the finding production files + their import closure.
- `scripts/gemini-correctness/green-validator.mjs` — deterministic production diff guard: strict `{schemaVersion,status,diff,rootCause,fixSummary}` shape, files must be in `finding.productionFiles` **and** pass allowlist / protected-path, ≤ 3 files, ≤ 250 added+deleted lines, no `.skip/.only`/`@ts-ignore`/`@ts-nocheck`/`@ts-expect-error`/coverage/lint disable, no uncommented `any`, no whitespace-only / EOL churn, no delete/rename/binary/submodule/symlink, no sensitive content.
- `scripts/gemini-correctness/green-runner.mjs` — guarded pipeline: clean baseline at `redResult.baselineSha` → verify finding + RED result schema/hash/status → apply exact `red-test.patch` → rerun exact test and reconfirm approved RED → Gemini unified diff → validate + apply → targeted test passes → `lint`/`typecheck`/`test`/`build` → final diff/hash/stats guard → `repair-result.json`. Every gate fails closed (no commit/push/PR from the stage).
- `scripts/gemini-correctness/green-stage.mjs` — fixed CLI entry point (loads `finding.json` + `red-result.json` from `.tmp/gemini-correctness/`).
- `policy.mjs` — minimal extension: GREEN hard constants (`MAX_GREEN_PRODUCTION_FILES=3`, `MAX_GREEN_DIFF_LINES=250`) + shared `parseUnifiedDiff` helper, with tests.

Non-success statuses are machine-readable: `needs-human-scope-expansion`, `repair-not-found`, `targeted-test-failed`, `full-check-failed`, `diff-policy-rejected`, `baseline-mismatch`, `red-replay-failed`. Failure results/logs are sanitized (no API key, env values, absolute runner paths, or raw model response).

No workflow, no auto-push, no auto-PR, no `.github/**`, no dependency/lockfile/`src/**` changes, and the #636 RED modules are untouched.

## Test plan

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run scripts/gemini-correctness` — 25 files / 529 tests pass
- `pnpm test` — 125 files / 1613 tests pass
- `pnpm build` — pass
- `git diff --check` — clean
- arbiter read-only attacker review: **No blocking findings.** (test tampering, scope escape, budget bypass, secret leak, failed cleanup all probed)
- TDD followed: each GREEN module was written RED-first; hostile fixtures cover tampered regression tests, allowlist/protected/lockfile/workflow changes, delete/rename/binary/submodule/symlink, escape hatches, budget overruns, malformed/empty/multi-diff model responses, baseline/patch/hash tamper, and failure cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)