### PR TITLE
feat(mock): define N4 and N5 section blueprints

### DIFF
--- a/src/domain/mockExam.test.ts
+++ b/src/domain/mockExam.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { getMockExamBlueprint, N1_BLUEPRINT, N2_BLUEPRINT, N3_BLUEPRINT, sectionSubtitle } from "./mockExam";
+import {
+  getMockExamBlueprint,
+  N1_BLUEPRINT,
+  N2_BLUEPRINT,
+  N3_BLUEPRINT,
+  N4_BLUEPRINT,
+  N5_BLUEPRINT,
+  sectionSubtitle,
+  type MockExamBlueprint,
+  type MockExamLevel,
+} from "./mockExam";
+
+/** Compact (id, promptLabel, targetCount) projection used to pin the tables. */
+function sectionTuples(bp: MockExamBlueprint): Array<[string, string, number]> {
+  return bp.sections.map((s) => [s.id, s.promptLabel, s.targetCount]);
+}
 
 // 模擬考 is now a section picker built on these blueprints (the timed
 // full-paper composer was removed). These tests pin the section metadata:
@@ -56,6 +71,104 @@ describe("getMockExamBlueprint", () => {
         expect(sectionSubtitle(section, "en")).toBe(section.labelEn);
         // zh-Hant returns the Chinese subtitle
         expect(sectionSubtitle(section, "zh-Hant")).toBe(section.labelZh);
+      }
+    }
+  });
+});
+
+describe("N4 / N5 blueprints (#702)", () => {
+  it("getMockExamBlueprint returns every one of the five levels with the right level tag", () => {
+    for (const level of ["N1", "N2", "N3", "N4", "N5"] as const) {
+      const bp = getMockExamBlueprint(level);
+      expect(bp.level).toBe(level);
+      expect(bp.sections.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("matches the N4 section table exactly", () => {
+    expect(sectionTuples(N4_BLUEPRINT)).toEqual([
+      ["kanji-yomi", "漢字読み", 7],
+      ["hyoki", "表記", 5],
+      ["bunmyaku-kitei", "詞彙填空", 8],
+      ["iikae-ruigi", "類義替換", 4],
+      ["yohou", "詞彙用法", 4],
+      ["bun-bunpou-1", "文法形式選擇", 13],
+      ["bun-bunpou-2", "語順組合", 4],
+      ["bunshou-bunpou", "文章脈絡", 4],
+      ["dokkai-short", "内容理解（短文）", 3],
+      ["dokkai-mid", "内容理解（中文）", 3],
+      ["joho-kensaku", "情報検索", 2],
+    ]);
+  });
+
+  it("matches the N5 section table exactly", () => {
+    expect(sectionTuples(N5_BLUEPRINT)).toEqual([
+      ["kanji-yomi", "漢字読み", 7],
+      ["hyoki", "表記", 5],
+      ["bunmyaku-kitei", "詞彙填空", 6],
+      ["iikae-ruigi", "類義替換", 3],
+      ["bun-bunpou-1", "文法形式選擇", 9],
+      ["bun-bunpou-2", "語順組合", 4],
+      ["bunshou-bunpou", "文章脈絡", 4],
+      ["dokkai-short", "内容理解（短文）", 2],
+      ["dokkai-mid", "内容理解（中文）", 2],
+      ["joho-kensaku", "情報検索", 1],
+    ]);
+  });
+
+  it("fixes totalMinutes at N4 80 and N5 60", () => {
+    expect(N4_BLUEPRINT.totalMinutes).toBe(80);
+    expect(N5_BLUEPRINT.totalMinutes).toBe(60);
+  });
+
+  it("forbids N5 詞彙用法 and both N4/N5 語形成 / 長文 / 統合理解 / 主張理解", () => {
+    const n5Ids = N5_BLUEPRINT.sections.map((s) => s.id);
+    const n4Ids = N4_BLUEPRINT.sections.map((s) => s.id);
+    const n4Labels = N4_BLUEPRINT.sections.map((s) => s.promptLabel);
+    const n5Labels = N5_BLUEPRINT.sections.map((s) => s.promptLabel);
+
+    expect(n5Ids).not.toContain("yohou"); // N5 無詞彙用法
+    for (const ids of [n4Ids, n5Ids]) {
+      expect(ids).not.toContain("go-keisei"); // 語形成
+      expect(ids).not.toContain("dokkai-long"); // 内容理解（長文）
+      expect(ids).not.toContain("togo"); // 統合理解
+      expect(ids).not.toContain("shucho"); // 主張理解
+    }
+    expect(n4Labels).not.toContain("内容理解（長文）");
+    expect(n5Labels).not.toContain("内容理解（長文）");
+  });
+
+  it("keeps N1–N3 blueprints byte-identical to the existing baseline", () => {
+    expect(getMockExamBlueprint("N1")).toBe(N1_BLUEPRINT);
+    expect(getMockExamBlueprint("N2")).toBe(N2_BLUEPRINT);
+    expect(getMockExamBlueprint("N3")).toBe(N3_BLUEPRINT);
+  });
+
+  it("never falls back to another level for unknown/unsafe levels", () => {
+    const seen = new Set<MockExamLevel>();
+    const levels: MockExamLevel[] = ["N1", "N2", "N3", "N4", "N5"];
+    for (const level of levels) {
+      const bp = getMockExamBlueprint(level);
+      expect(bp.level).toBe(level);
+      expect(seen.has(bp.level)).toBe(false);
+      seen.add(bp.level);
+    }
+    // Runtime junk is rejected at the type boundary, but the runtime lookup
+    // must also not silently map garbage to a valid level.
+    expect(() => getMockExamBlueprint("N6" as MockExamLevel)).toThrow();
+    expect(() => getMockExamBlueprint("" as MockExamLevel)).toThrow();
+  });
+
+  it("gives every N4/N5 section a non-empty promptLabel and stable unique id", () => {
+    for (const bp of [N4_BLUEPRINT, N5_BLUEPRINT]) {
+      const ids = bp.sections.map((s) => s.id);
+      expect(new Set(ids).size).toBe(ids.length);
+      for (const section of bp.sections) {
+        expect(section.promptLabel.length).toBeGreaterThan(0);
+        expect(section.labelJa.length).toBeGreaterThan(0);
+        expect(section.labelZh.length).toBeGreaterThan(0);
+        expect(section.labelEn.length).toBeGreaterThan(0);
+        expect(section.targetCount).toBeGreaterThan(0);
       }
     }
   });

--- a/src/domain/mockExam.ts
+++ b/src/domain/mockExam.ts
@@ -13,7 +13,7 @@
 // full-paper mode is ever wanted again.)
 import type { JlptLevel } from "./types";
 
-export type MockExamLevel = Extract<JlptLevel, "N1" | "N2" | "N3">;
+export type MockExamLevel = Extract<JlptLevel, "N1" | "N2" | "N3" | "N4" | "N5">;
 
 export interface MockExamSection {
   /** Stable id used internally (e.g. "kanji-yomi"). */
@@ -126,7 +126,63 @@ export const N3_BLUEPRINT: MockExamBlueprint = {
 };
 
 export function getMockExamBlueprint(level: MockExamLevel): MockExamBlueprint {
-  if (level === "N1") return N1_BLUEPRINT;
-  if (level === "N3") return N3_BLUEPRINT;
-  return N2_BLUEPRINT;
+  switch (level) {
+    case "N1":
+      return N1_BLUEPRINT;
+    case "N2":
+      return N2_BLUEPRINT;
+    case "N3":
+      return N3_BLUEPRINT;
+    case "N4":
+      return N4_BLUEPRINT;
+    case "N5":
+      return N5_BLUEPRINT;
+    default:
+      // No catch-all: an unknown/unsafe level must not silently fall back to
+      // a valid level's blueprint (#702).
+      throw new Error(`Unknown JLPT mock-exam level: ${level}`);
+  }
 }
+
+// N4 / N5 言語知識（文字・語彙）・文法・読解 blueprints (#702). Per the JLPT
+// official guide, the lowest two levels have no 語形成, no 統合理解 / 主張理解
+// (those are N1/N2 only), and no 内容理解（長文）(that is N3 only) -- N4/N5
+// reading ends at 内容理解（中文）. N4 keeps 語彙用法 (詞彙用法); N5 drops it.
+// Like N1–N3, these list the 言語知識・読解 paper only (聴解 is out of scope),
+// so totalMinutes is the combined 文字・語彙 + 文法・読解 duration, not the
+// full-paper time. Counts taken from the JLPT official guide; treat them as
+// the contract -- if 国際交流基金 ever revises, update here.
+export const N4_BLUEPRINT: MockExamBlueprint = {
+  level: "N4",
+  totalMinutes: 80,
+  sections: [
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelEn: "Kanji reading", promptLabel: "漢字読み", targetCount: 7 },
+    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelEn: "Orthography (kanji writing)", promptLabel: "表記", targetCount: 5 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelEn: "Vocabulary in context", promptLabel: "詞彙填空", targetCount: 8 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelEn: "Paraphrase (synonyms)", promptLabel: "類義替換", targetCount: 4 },
+    { id: "yohou", labelJa: "用法", labelZh: "詞彙用法", labelEn: "Word usage", promptLabel: "詞彙用法", targetCount: 4 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelEn: "Grammar form selection", promptLabel: "文法形式選擇", targetCount: 13 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelEn: "Sentence assembly (★)", promptLabel: "語順組合", targetCount: 4 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelEn: "Passage cloze", promptLabel: "文章脈絡", targetCount: 4 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelEn: "Reading: short passages", promptLabel: "内容理解（短文）", targetCount: 3 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelEn: "Reading: mid-length passages", promptLabel: "内容理解（中文）", targetCount: 3 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelEn: "Information retrieval", promptLabel: "情報検索", targetCount: 2 }
+  ]
+};
+
+export const N5_BLUEPRINT: MockExamBlueprint = {
+  level: "N5",
+  totalMinutes: 60,
+  sections: [
+    { id: "kanji-yomi", labelJa: "漢字読み", labelZh: "漢字讀音", labelEn: "Kanji reading", promptLabel: "漢字読み", targetCount: 7 },
+    { id: "hyoki", labelJa: "表記", labelZh: "漢字書寫", labelEn: "Orthography (kanji writing)", promptLabel: "表記", targetCount: 5 },
+    { id: "bunmyaku-kitei", labelJa: "文脈規定", labelZh: "詞彙填空", labelEn: "Vocabulary in context", promptLabel: "詞彙填空", targetCount: 6 },
+    { id: "iikae-ruigi", labelJa: "言い換え類義", labelZh: "類義替換", labelEn: "Paraphrase (synonyms)", promptLabel: "類義替換", targetCount: 3 },
+    { id: "bun-bunpou-1", labelJa: "文の文法 1（文法形式の判断）", labelZh: "文法形式判斷", labelEn: "Grammar form selection", promptLabel: "文法形式選擇", targetCount: 9 },
+    { id: "bun-bunpou-2", labelJa: "文の文法 2（文の組み立て）", labelZh: "句子組合（★ 題）", labelEn: "Sentence assembly (★)", promptLabel: "語順組合", targetCount: 4 },
+    { id: "bunshou-bunpou", labelJa: "文章の文法", labelZh: "文章脈絡填空", labelEn: "Passage cloze", promptLabel: "文章脈絡", targetCount: 4 },
+    { id: "dokkai-short", labelJa: "内容理解（短文）", labelZh: "短文閱讀", labelEn: "Reading: short passages", promptLabel: "内容理解（短文）", targetCount: 2 },
+    { id: "dokkai-mid", labelJa: "内容理解（中文）", labelZh: "中文閱讀", labelEn: "Reading: mid-length passages", promptLabel: "内容理解（中文）", targetCount: 2 },
+    { id: "joho-kensaku", labelJa: "情報検索", labelZh: "資訊檢索", labelEn: "Information retrieval", promptLabel: "情報検索", targetCount: 1 }
+  ]
+};


### PR DESCRIPTION
Closes #702

## Summary

- Extend `MockExamLevel` to all five JLPT levels (`N1`–`N5`).
- Add `N4_BLUEPRINT` (totalMinutes 80, 11 sections) and `N5_BLUEPRINT` (totalMinutes 60, 10 sections) with the exact section tables from the issue.
- `getMockExamBlueprint` now handles each level explicitly via switch; `default` throws (no catch-all fallback).
- N5 omits 詞彙用法; N4/N5 omit 語形成 / 内容理解（長文）/ 統合理解 / 主張理解.
- N1–N3 blueprints untouched (same references).

## Scope

Only `src/domain/mockExam.ts` and `src/domain/mockExam.test.ts`. No UI, session wiring, content, or copy changes — the section picker still lists N3/N2/N1 only, so N4/N5 are not exposed to users yet.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/domain/mockExam.test.ts` — 13/13 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test`: only pre-existing flaky failures in git-heavy tests (`red-stage-integration`, `App.test`) that also fail on a clean `origin/main` control run — unrelated to this change.

## Reviewer verdict

```
Blocking findings:
- 無

Non-blocking findings:
- baseline 既有（非本變更引入）的結尾 newline 缺失

Verdict:
No blocking findings.
```