### PR TITLE
refactor(sync): derive pending login sync status

### DIFF
--- a/src/hooks/useProgressAttempts.test.tsx
+++ b/src/hooks/useProgressAttempts.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { User } from "@supabase/supabase-js";
@@ -111,6 +112,35 @@ describe("useProgressAttempts -- anon (no user)", () => {
     const first = result.current.recordAttempt;
     rerender();
     expect(result.current.recordAttempt).toBe(first);
+  });
+
+  it("anon -> logout-idle is DERIVED: no sync setState in the login effect, no supabase call", async () => {
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+
+    expect(result.current.syncStatus).toBe("idle");
+    expect(getSupabase).not.toHaveBeenCalled();
+
+    // A user who logs in and back out (logout) leaves syncStatus DERIVED idle
+    // -- no effect-time setState("idle") required, and the local store survives.
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    const storeAtLogin = readStore();
+
+    rerender({ user: null });
+    expect(result.current.syncStatus).toBe("idle");
+    expect(readStore()).toEqual(storeAtLogin);
+  });
+
+  it("already-logged-in first render exposes syncing immediately (no effect-time setState)", async () => {
+    // Login is already the INITIAL render (the effect runs AFTER the first
+    // paint), so the very first exposed syncStatus is the derived "syncing" --
+    // the hook must not synchronously setState("syncing") inside the effect.
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+    expect(result.current.syncStatus).toBe("syncing");
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
   });
 });
 
@@ -412,5 +442,115 @@ describe("useProgressAttempts -- login sync commit safety (codex review)", () =>
       remoteOnly,
       recordedDuringSync
     ]);
+  });
+
+  // Derived-status semantics: while A's sync is still in flight, B must read
+  // "syncing" (A's terminal result must not leak into B's status), and once B
+  // completes, A's late terminal write must stay inert.
+  it("A->B switch mid-sync: B reads syncing until its own merge completes", async () => {
+    const aFetch = deferred<Attempt[]>();
+    const bFetch = deferred<Attempt[]>();
+    fetchRemoteAttempts
+      .mockReturnValueOnce(aFetch.promise) // user A
+      .mockReturnValueOnce(bFetch.promise); // user B
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: makeUser("user-A") as User | null } }
+    );
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    // Switch to B while A is still parked on its fetch.
+    rerender({ user: makeUser("user-B") });
+    expect(result.current.syncStatus).toBe("syncing");
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-B"));
+    // Still syncing -- B has not completed yet.
+    expect(result.current.syncStatus).toBe("syncing");
+
+    // Resolve A's stale fetch. A's terminal result must NOT surface on B.
+    await act(async () => {
+      aFetch.resolve([makeAttempt({ timestamp: 30, submittedAnswer: "A-late" })]);
+      await aFetch.promise;
+    });
+    expect(result.current.syncStatus).toBe("syncing");
+
+    // B completes -> synced.
+    await act(async () => {
+      bFetch.resolve([]);
+      await bFetch.promise;
+    });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+  });
+
+  // Derived-status semantics: A's late success must not flip B's status, and
+  // the (stale, resolved) A generation must not mutate the store.
+  it("A late success after B completed -> B stays synced, store unchanged", async () => {
+    const aRemote = makeAttempt({ timestamp: 40, submittedAnswer: "A-remote" });
+    const bRemote = makeAttempt({ timestamp: 41, submittedAnswer: "B-remote" });
+
+    const aFetch = deferred<Attempt[]>();
+    const bFetch = deferred<Attempt[]>();
+    fetchRemoteAttempts
+      .mockReturnValueOnce(aFetch.promise) // user A
+      .mockReturnValueOnce(bFetch.promise); // user B
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: makeUser("user-A") as User | null } }
+    );
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    rerender({ user: makeUser("user-B") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-B"));
+
+    // B completes first (its merge lands).
+    await act(async () => {
+      bFetch.resolve([bRemote]);
+      await bFetch.promise;
+    });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    expect(readStore() ?? []).toContainEqual(bRemote);
+
+    // Now A's stale run resolves: its terminal write must be a no-op.
+    await act(async () => {
+      aFetch.resolve([aRemote]);
+      await aFetch.promise;
+    });
+    expect(result.current.syncStatus).toBe("synced");
+    expect(readStore() ?? []).not.toContainEqual(aRemote);
+    expect(result.current.progressAttempts).not.toContainEqual(aRemote);
+  });
+
+  // StrictMode: the effect runs -> unmounts -> re-runs (double-invoke). The
+  // second (replay) run must be the only one that mutates remote/local: no
+  // duplicate fetch/push of the same delta, no duplicate local replace.
+  it("StrictMode replay -> second generation is the only one that commits (no dup push / replace)", async () => {
+    const localOnly = makeAttempt({ timestamp: 50, submittedAnswer: "local" });
+
+    // Seed the local store while anon, under a StrictMode wrapper.
+    const { result: anon } = renderHook(() => useProgressAttempts(null), {
+      wrapper: StrictMode
+    });
+    act(() => {
+      anon.current.recordAttempt(localOnly);
+    });
+
+    fetchRemoteAttempts.mockResolvedValue([]);
+
+    // Login is the INITIAL render under StrictMode: the effect double-invokes
+    // (run -> teardown -> replay), and the replay generation is the one that
+    // may commit.
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")), {
+      wrapper: StrictMode
+    });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    // The replay's effect teardown must have invalidated the first run, so
+    // only the replay generation pushed (exactly one push of the delta).
+    const user1Pushes = pushAttempts.mock.calls.filter(([, id]) => id === "user-1");
+    expect(user1Pushes).toHaveLength(1);
+    expect(user1Pushes[0][2]).toEqual([localOnly]);
+    expect(fetchRemoteAttempts.mock.calls.filter(([, id]) => id === "user-1")).toHaveLength(1);
+    expect(readStore()).toEqual([localOnly]);
   });
 });

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -16,6 +16,16 @@ const attemptStore = createAttemptStore();
 //   error   -- the last login merge failed; local was left untouched
 export type SyncStatus = "idle" | "syncing" | "synced" | "error";
 
+// The terminal outcome of a single login-sync generation, keyed to the user
+// whose merge it belongs to. React state stores ONLY the latest completed
+// result; `syncStatus` is derived from it (never set synchronously in the
+// login effect -- see below), so an expired result for a previous user can
+// never surface on the current one.
+type SyncResult = {
+  userId: string;
+  status: "synced" | "error";
+};
+
 // Owns the lifetime attempt history (loaded from storage on mount,
 // appended on every answer). Lifted OUT of usePracticeSession so it can
 // live in the always-mounted App shell: the home/learn dashboards read
@@ -30,9 +40,25 @@ export type SyncStatus = "idle" | "syncing" | "synced" | "error";
 // local only, never cleared, and the Supabase SDK stays in its lazy chunk.
 export function useProgressAttempts(user: User | null) {
   const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
-  const [syncStatus, setSyncStatus] = useState<SyncStatus>("idle");
+  // Only the last COMPLETED sync result is held in state; "in flight" and
+  // "logged out" are derived, so the login effect never needs to set state
+  // synchronously (it just starts the async flow, which writes the terminal
+  // result once a generation finishes).
+  const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
 
   const userId = user?.id ?? null;
+
+  // Derived syncStatus (pure function of {lastSyncResult, current userId}):
+  //   no user        -> idle            (logout needs no setState; local kept)
+  //   result missing -> syncing         (login effect is starting a merge)
+  //   result for the CURRENT user -> its terminal status (synced | error)
+  //   result for a PREVIOUS user -> syncing (A's outcome must not leak to B)
+  const syncStatus: SyncStatus =
+    userId === null
+      ? "idle"
+      : lastSyncResult === null || lastSyncResult.userId !== userId
+        ? "syncing"
+        : lastSyncResult.status;
 
   // Keep the latest userId for recordAttempt's best-effort push without
   // making the callback's identity depend on it (identity must stay stable
@@ -43,16 +69,18 @@ export function useProgressAttempts(user: User | null) {
   }, [userId]);
 
   // Login sync: runs when the user id transitions to a non-null value.
+  // NOTE: no synchronous setState in the effect body (react-hooks v7
+  // `set-state-in-effect`). "syncing" is DERIVED while the merge is in flight;
+  // only the async terminal outcome writes state, and only while this
+  // generation is still active.
   useEffect(() => {
     if (!userId) {
-      // Logout / anon: behaviour exactly as before -- local untouched,
-      // status back to idle.
-      setSyncStatus("idle");
+      // Logout / anon: behaviour exactly as before -- local untouched.
+      // No setState("idle") needed: derived syncStatus is naturally idle.
       return;
     }
 
     let active = true;
-    setSyncStatus("syncing");
 
     (async () => {
       // Re-check `active` after EVERY await: if the effect went stale
@@ -89,14 +117,14 @@ export function useProgressAttempts(user: User | null) {
       const merged = mergeAttempts(attemptStore.list(), remote);
       attemptStore.replace(merged);
       setProgressAttempts(merged);
-      setSyncStatus("synced");
+      setLastSyncResult({ userId, status: "synced" });
     })().catch(() => {
       // Any failure (offline, RLS, push conflict, etc.): the local store is
       // left untouched because mutation only happens after fetch + push both
       // succeed and the effect is still active. Nothing is lost; the next
       // login retries.
       if (active) {
-        setSyncStatus("error");
+        setLastSyncResult({ userId, status: "error" });
       }
     });
 


### PR DESCRIPTION
Closes #681

## Summary

- Remove the synchronous `setSyncStatus("idle"/"syncing")` calls from the login effect so `useProgressAttempts` passes React Hooks v7 `set-state-in-effect`.
- State now holds only the last completed `SyncResult { userId, status }`; `syncStatus` is purely derived: `userId === null` → idle, result for a previous user or in-flight → syncing, current user's terminal result → synced/error.
- A→B account switching keeps A's late result inert (stale generation guard + derived status), and logout leaves the local store untouched.

## Scope

Only `src/hooks/useProgressAttempts.ts` and `src/hooks/useProgressAttempts.test.tsx`. Remote-first mutation order, per-await active guards, `userIdRef` live-push contract, and `recordAttempt` stable identity are unchanged.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/hooks/useProgressAttempts.test.tsx` — 17/17 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test`: only pre-existing flaky failures in git-heavy tests (also fail on clean `origin/main` control) — unrelated to this change.

## Reviewer verdict

```
Blocking findings:
- 無。

Non-blocking findings:
- 同使用者重新登入時第一幀 derived 顯示先前 terminal status（非 syncing），屬 spec-faithful 設計必然結果，建議補註記/測試。
- set-state-in-effect 規則目前尚未在 eslint.config.js 啟用（本變更結構性合規）。

Verdict:
No blocking findings.
```