### PR TITLE
chore(i18n): add AST overlay audit core

### DIFF
--- a/scripts/i18n-overlay-audit.mjs
+++ b/scripts/i18n-overlay-audit.mjs
@@ -1,0 +1,423 @@
+// =============================================================================
+// i18n-overlay-audit.mjs -- reusable TypeScript-AST overlay audit core (#695)
+// =============================================================================
+//
+// This module is the CORE of the #422 overlay audit pipeline. It deliberately
+// knows NOTHING about Jabiko content file paths or field mappings: content
+// adapters are pure functions injected via `runOverlayAdapters`, and each one
+// returns `OverlayAuditRecord[]` for a single system+locale by supplying the
+// source key set and the overlay key set.
+//
+// Design rules (from the issue):
+//   - Parsing uses the repo's `typescript` compiler API. Regex is NEVER used to
+//     parse nested TypeScript object shapes.
+//   - The locale registry is parsed from `src/i18n.ts`'s `LAUNCHED_LANGUAGES`
+//     array literal at runtime. There is deliberately NO second hardcoded
+//     locale list in this module.
+//   - Any shape that cannot be statically resolved (computed key, spread,
+//     dynamic call, template interpolation, ...) THROWS a deterministic error
+//     carrying file / line / context. Nothing is silently skipped.
+//   - The core performs zero filesystem writes, console output, network access
+//     and never calls process.exit. Reports are returned, not emitted.
+//   - No Date.* / runtime imports: everything is deterministic.
+// =============================================================================
+
+import ts from "typescript";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** One audit finding: a source key missing from an overlay, or an overlay key
+ *  with no matching source key. Sorted deterministically by the report layer. */
+// NOTE: this module is plain .mjs -- the contract types are documented here and
+// mirrored in the issue; the actual records are plain JS objects at runtime.
+//
+// OverlayAuditRecord = {
+//   system: "exam" | "learningBlocks" | "grammarNotes" | "sentencePatterns" |
+//           "kanjiOnyomi";
+//   locale: string;
+//   sourceKey: string;   // "" for dangling
+//   overlayKey: string;  // "" for missing
+//   status: "missing" | "dangling";
+// }
+
+const OVERLAY_SYSTEMS = [
+  "exam",
+  "learningBlocks",
+  "grammarNotes",
+  "sentencePatterns",
+  "kanjiOnyomi"
+];
+
+// ---------------------------------------------------------------------------
+// Deterministic error type
+// ---------------------------------------------------------------------------
+
+/** Error thrown when the AST audit meets a shape it cannot statically resolve.
+ *  Carries file / line / context so the report can stay deterministic without
+ *  dumping raw source text into the payload. */
+export class AuditParseError extends Error {
+  /** @type {string} */
+  file;
+  /** @type {number | null} */
+  line;
+  /** @type {string} */
+  context;
+
+  constructor(message, { file, line, context } = {}) {
+    super(message);
+    this.name = "AuditParseError";
+    this.file = file ?? "";
+    this.line = Number.isInteger(line) ? line : null;
+    this.context = context ?? "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source file parsing
+// ---------------------------------------------------------------------------
+
+/** Parse a TypeScript file into a ts.SourceFile carrying its real path. */
+export function parseTypeScriptFile(filePath) {
+  const text = ts.sys.readFile(filePath);
+  if (text === undefined) {
+    throw new AuditParseError(`unable to read TypeScript file: ${filePath}`, { file: filePath });
+  }
+  return ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+/** Fall back to a SourceFile from raw text (used in tests / dry-runs where the
+ *  file may not exist on disk). */
+export function parseTypeScriptSource(text, fileName = "inline.ts") {
+  return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+// ---------------------------------------------------------------------------
+// Locale registry parsing (src/i18n.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the launched-locale registry from a SourceFile. The registry is the
+ * array literal of `LAUNCHED_LANGUAGES` in src/i18n.ts -- the single source of
+ * truth. `sourceLocale` is fixed to the zh-Hant source; `targetLocales` keeps
+ * the remaining entries in source order.
+ *
+ * A missing / non-array-literal registry fails closed (no second hardcoded
+ * locale list is ever consulted).
+ */
+export function parseLaunchedLocales(sourceFile) {
+  const sourceLocale = "zh-Hant";
+  const targetLocales = [];
+
+  let found = false;
+  const visit = (node) => {
+    if (
+      !found &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList) &&
+      node.declarationList.declarations.some(
+        (d) => ts.isIdentifier(d.name) && d.name.text === "LAUNCHED_LANGUAGES"
+      )
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "LAUNCHED_LANGUAGES") continue;
+        const init = d.initializer;
+        if (!ts.isArrayLiteralExpression(init)) {
+          throw new AuditParseError(
+            "LAUNCHED_LANGUAGES must be an array literal so the audit can resolve locales statically",
+            { file: sourceFile.fileName, line: getLine(sourceFile, d) }
+          );
+        }
+        for (const element of init.elements) {
+          const locale = staticStringValue(element, sourceFile, "LAUNCHED_LANGUAGES element");
+          if (locale !== sourceLocale) targetLocales.push(locale);
+        }
+        found = true;
+        break;
+      }
+    }
+    if (!found) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  if (!found) {
+    throw new AuditParseError(
+      "LAUNCHED_LANGUAGES registry not found; cannot resolve the launched locale set",
+      { file: sourceFile.fileName }
+    );
+  }
+
+  return { sourceLocale, targetLocales };
+}
+
+// ---------------------------------------------------------------------------
+// Static key resolution
+// ---------------------------------------------------------------------------
+
+/** Read a static property-name node (identifier, quoted string, number, or a
+ *  no-substitution template literal) into its literal text. Computed names and
+ *  template interpolations throw a deterministic AuditParseError. */
+export function readStaticPropertyName(node, sourceFile = undefined) {
+  if (ts.isIdentifier(node) || ts.isPrivateIdentifier(node)) return node.text;
+  if (ts.isStringLiteral(node) || ts.isNumericLiteral(node)) return node.text;
+  if (ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (ts.isComputedPropertyName(node)) {
+    throw new AuditParseError(
+      `computed property name cannot be resolved statically: ${node.getText()}`,
+      { file: sourceFile?.fileName, line: getLine(sourceFile, node), context: node.getText() }
+    );
+  }
+  throw new AuditParseError(
+    `unsupported property-name node kind ${ts.SyntaxKind[node.kind]} (${node.getText()})`,
+    { file: sourceFile?.fileName, line: getLine(sourceFile, node), context: node.getText() }
+  );
+}
+
+/** Resolve a string literal that must hold a static string value (used for
+ *  registry entries). Throws on anything that cannot be statically resolved. */
+function staticStringValue(node, sourceFile, what) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  throw new AuditParseError(
+    `${what} must be a static string literal: ${node.getText()}`,
+    { file: sourceFile.fileName, line: getLine(sourceFile, node), context: node.getText() }
+  );
+}
+
+/**
+ * Collect the static property keys of an object literal into a flat array, in
+ * declaration order. Only identifier / quoted / numeric / no-substitution
+ * template keys are accepted; computed keys, spreads and any other member kind
+ * THROW (fail closed, no silent skipping).
+ *
+ * `context` is passed through (adapter context) but unused by the core so that
+ * signature stays stable; the caller selects which node to audit, so nested
+ * objects are NOT flattened and same-name keys at different depths never mix.
+ */
+export function collectStaticObjectKeys(node, context) {
+  const sf = node.getSourceFile?.();
+  void context; // adapter context is part of the contract signature; core is context-agnostic
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new AuditParseError(
+      `collectStaticObjectKeys expected an ObjectLiteralExpression, got ${ts.SyntaxKind[node.kind]}`,
+      { file: sf?.fileName, line: getLine(sf, node) }
+    );
+  }
+  const keys = [];
+  for (const member of node.properties) {
+    if (ts.isPropertyAssignment(member)) {
+      keys.push(readStaticPropertyName(member.name, sf));
+      continue;
+    }
+    if (ts.isShorthandPropertyAssignment(member)) {
+      keys.push(readStaticPropertyName(member.name, sf));
+      continue;
+    }
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file: sf?.fileName, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (ts.isMethodDeclaration(member)) {
+      keys.push(readStaticPropertyName(member.name, sf));
+      continue;
+    }
+    if (ts.isGetAccessorDeclaration(member) || ts.isSetAccessorDeclaration(member)) {
+      keys.push(readStaticPropertyName(member.name, sf));
+      continue;
+    }
+    throw new AuditParseError(
+      `unsupported object member kind ${ts.SyntaxKind[member.kind]}: ${member.getText()}`,
+      { file: sf?.fileName, line: getLine(sf, member), context: member.getText() }
+    );
+  }
+  return keys;
+}
+
+// ---------------------------------------------------------------------------
+// Key-set comparison
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare a source key set against an overlay key set for one system+locale.
+ *   - source key missing from overlay  -> { status: "missing" }
+ *   - overlay key absent from source   -> { status: "dangling" }
+ *
+ * Duplicate keys are rejected deterministically (never silently deduped).
+ * Explicit invalid options fail closed instead of guessing.
+ */
+export function auditKeySets({ system, locale, sourceKeys, overlayKeys }) {
+  if (!OVERLAY_SYSTEMS.includes(system)) {
+    throw new Error(`unknown overlay system: ${system}`);
+  }
+  if (typeof locale !== "string" || locale.length === 0) {
+    throw new Error("audit locale must be a non-empty string");
+  }
+  if (!Array.isArray(sourceKeys) || !sourceKeys.every((k) => typeof k === "string")) {
+    throw new Error("sourceKeys must be an array of strings");
+  }
+  if (!Array.isArray(overlayKeys) || !overlayKeys.every((k) => typeof k === "string")) {
+    throw new Error("overlayKeys must be an array of strings");
+  }
+
+  const sourceSet = new Set();
+  for (let i = 0; i < sourceKeys.length; i++) {
+    if (sourceSet.has(sourceKeys[i])) {
+      throw new Error(`duplicate source key "${sourceKeys[i]}" at index ${i}`);
+    }
+    sourceSet.add(sourceKeys[i]);
+  }
+
+  const overlaySet = new Set();
+  for (let i = 0; i < overlayKeys.length; i++) {
+    if (overlaySet.has(overlayKeys[i])) {
+      throw new Error(`duplicate overlay key "${overlayKeys[i]}" at index ${i}`);
+    }
+    overlaySet.add(overlayKeys[i]);
+  }
+
+  // Emit dangling (overlay-only) records first: they carry sourceKey "" which
+  // sorts ahead of any missing record's non-empty sourceKey, so this matches the
+  // canonical report ordering (system -> locale -> sourceKey -> overlayKey).
+  const records = [];
+  for (const overlayKey of overlayKeys) {
+    if (!sourceSet.has(overlayKey)) {
+      records.push({ system, locale, sourceKey: "", overlayKey, status: "dangling" });
+    }
+  }
+  for (const sourceKey of sourceKeys) {
+    if (!overlaySet.has(sourceKey)) {
+      records.push({ system, locale, sourceKey, overlayKey: "", status: "missing" });
+    }
+  }
+  return records;
+}
+
+// ---------------------------------------------------------------------------
+// Sorting
+// ---------------------------------------------------------------------------
+
+const STATUS_RANK = { missing: 0, dangling: 1 };
+const SYSTEM_RANK = Object.fromEntries(OVERLAY_SYSTEMS.map((s, i) => [s, i]));
+
+/**
+ * Sort records deterministically by
+ *   system -> locale -> sourceKey -> overlayKey -> status
+ * (not by filesystem or object-traversal order). The input array is NOT
+ * mutated.
+ */
+export function sortAuditRecords(records) {
+  return [...records].sort((a, b) => {
+    const sysA = SYSTEM_RANK[a.system] ?? Number.MAX_SAFE_INTEGER;
+    const sysB = SYSTEM_RANK[b.system] ?? Number.MAX_SAFE_INTEGER;
+    if (sysA !== sysB) return sysA - sysB;
+    if (a.locale !== b.locale) return a.locale < b.locale ? -1 : 1;
+    if (a.sourceKey !== b.sourceKey) return a.sourceKey < b.sourceKey ? -1 : 1;
+    if (a.overlayKey !== b.overlayKey) return a.overlayKey < b.overlayKey ? -1 : 1;
+    return (STATUS_RANK[a.status] ?? 0) - (STATUS_RANK[b.status] ?? 0);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Report assembly
+// ---------------------------------------------------------------------------
+
+function makeEmptyCounts() {
+  return { total: 0, missing: 0, dangling: 0 };
+}
+
+function countRecord(counts, record) {
+  counts.total += 1;
+  if (record.status === "missing") counts.missing += 1;
+  else if (record.status === "dangling") counts.dangling += 1;
+}
+
+/** Cap the error-context excerpt so a report never dumps unbounded source text. */
+function boundedContext(text) {
+  if (text.length <= 200) return text;
+  return text.slice(0, 197) + "...";
+}
+
+/**
+ * Run a set of pure adapter functions (each returning OverlayAuditRecord[])
+ * over a shared context and assemble a sorted report with:
+ *   - records: sorted by system -> locale -> sourceKey -> overlayKey -> status
+ *   - counts: per-system and per-locale { total, missing, dangling }
+ *   - diagnostics: parse failures captured as { file, line, message, context }
+ *
+ * Adapter errors never abort the run: they are captured into diagnostics so the
+ * report stays complete and deterministic. Nothing is written, logged or exited.
+ */
+export function runOverlayAdapters(adapters, context) {
+  const records = [];
+  const counts = { bySystem: {}, byLocale: {} };
+  const diagnostics = [];
+
+  for (const adapter of adapters) {
+    let adapterRecords;
+    try {
+      adapterRecords = adapter(context);
+    } catch (e) {
+      if (e instanceof AuditParseError) {
+        diagnostics.push({
+          file: e.file,
+          line: e.line,
+          message: e.message,
+          context: boundedContext(e.context)
+        });
+        continue;
+      }
+      diagnostics.push({
+        file: typeof e?.file === "string" ? e.file : "",
+        line: Number.isInteger(e?.line) ? e.line : null,
+        message: e instanceof Error ? e.message : String(e),
+        context: boundedContext(typeof e?.context === "string" ? e.context : "")
+      });
+      continue;
+    }
+    if (!Array.isArray(adapterRecords)) {
+      diagnostics.push({
+        file: "",
+        line: null,
+        message: "adapter must return an array of overlay audit records",
+        context: ""
+      });
+      continue;
+    }
+    for (const record of adapterRecords) {
+      records.push(record);
+      const systemCounts = (counts.bySystem[record.system] ??= makeEmptyCounts());
+      countRecord(systemCounts, record);
+      const localeCounts = (counts.byLocale[record.locale] ??= makeEmptyCounts());
+      countRecord(localeCounts, record);
+    }
+  }
+
+  return {
+    records: sortAuditRecords(records),
+    counts: {
+      // Sort keys so the serialized report is byte-equivalent regardless of the
+      // order adapters ran in.
+      bySystem: sortedObject(counts.bySystem),
+      byLocale: sortedObject(counts.byLocale)
+    },
+    diagnostics
+  };
+}
+
+/** Rebuild an object with its keys sorted so JSON serialization is stable. */
+function sortedObject(obj) {
+  return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => (a < b ? -1 : 1)));
+}
+
+// ---------------------------------------------------------------------------
+// Line-number helper
+// ---------------------------------------------------------------------------
+
+/** 1-based line of a node, or null when no source file / line break is known. */
+function getLine(sourceFile, node) {
+  if (!sourceFile || !ts.isSourceFile(sourceFile)) return null;
+  const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return line + 1;
+}

--- a/scripts/i18n-overlay-audit.test.ts
+++ b/scripts/i18n-overlay-audit.test.ts
@@ -1,0 +1,422 @@
+// scripts/i18n-overlay-audit.test.ts
+// TDD coverage for the reusable TypeScript-AST overlay audit core (#695).
+// Fixtures are created at test runtime in a temp dir and never committed.
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import ts from "typescript";
+// @ts-expect-error -- plain .mjs tooling module, no types
+import {
+  AuditParseError,
+  auditKeySets,
+  collectStaticObjectKeys,
+  parseLaunchedLocales,
+  parseTypeScriptFile,
+  readStaticPropertyName,
+  runOverlayAdapters,
+  sortAuditRecords
+} from "./i18n-overlay-audit.mjs";
+
+let tmpDir: string;
+let fixtureCounter = 0;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "jabiko-i18n-audit-"));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeFixture(text: string): string {
+  const p = path.join(tmpDir, `fixture-${fixtureCounter++}.ts`);
+  fs.writeFileSync(p, text);
+  return p;
+}
+
+function allObjectLiterals(sf: ts.SourceFile): ts.ObjectLiteralExpression[] {
+  const out: ts.ObjectLiteralExpression[] = [];
+  const visit = (n: ts.Node): void => {
+    if (ts.isObjectLiteralExpression(n)) out.push(n);
+    ts.forEachChild(n, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+function firstObjectLiteral(sf: ts.SourceFile): ts.ObjectLiteralExpression | undefined {
+  return allObjectLiterals(sf)[0];
+}
+
+function smallestObjectLiteralContaining(
+  sf: ts.SourceFile,
+  text: string
+): ts.ObjectLiteralExpression {
+  const candidates = allObjectLiterals(sf).filter((n) => n.getText().includes(text));
+  candidates.sort((a, b) => a.getText().length - b.getText().length);
+  if (candidates.length === 0) throw new Error(`no object literal containing ${text}`);
+  return candidates[0];
+}
+
+function firstPropertyAssignments(sf: ts.SourceFile): ts.PropertyAssignment[] {
+  const obj = firstObjectLiteral(sf);
+  if (!obj) throw new Error("no object literal in fixture");
+  return obj.properties.filter((p): p is ts.PropertyAssignment => ts.isPropertyAssignment(p));
+}
+
+function expectParseError(fn: () => unknown): {
+  file: unknown;
+  line: unknown;
+  context: unknown;
+  message: string;
+} {
+  try {
+    fn();
+  } catch (e) {
+    if (e instanceof AuditParseError) {
+      return { file: e.file, line: e.line, context: e.context, message: e.message };
+    }
+    throw e;
+  }
+  throw new Error("expected the function to throw an AuditParseError");
+}
+
+describe("parseTypeScriptFile", () => {
+  it("parses a file into a SourceFile carrying the given path", () => {
+    const fixture = writeFixture("export const A = 1;");
+    const sf = parseTypeScriptFile(fixture);
+    expect(ts.isSourceFile(sf)).toBe(true);
+    expect(sf.fileName).toBe(fixture);
+  });
+});
+
+describe("parseLaunchedLocales", () => {
+  it("resolves launched locales in source order, excluding zh-Hant", () => {
+    const sf = parseTypeScriptFile(
+      writeFixture('export const LAUNCHED_LANGUAGES: readonly string[] = ["zh-Hant", "ja", "en"];')
+    );
+    expect(parseLaunchedLocales(sf)).toEqual({ sourceLocale: "zh-Hant", targetLocales: ["ja", "en"] });
+  });
+
+  it("automatically reflects added and removed locales", () => {
+    const added = parseTypeScriptFile(writeFixture('export const LAUNCHED_LANGUAGES = ["ja", "zh-Hant", "ko"];'));
+    expect(parseLaunchedLocales(added).targetLocales).toEqual(["ja", "ko"]);
+    const removed = parseTypeScriptFile(writeFixture('export const LAUNCHED_LANGUAGES = ["zh-Hant"];'));
+    expect(parseLaunchedLocales(removed).targetLocales).toEqual([]);
+    const noSource = parseTypeScriptFile(writeFixture('export const LAUNCHED_LANGUAGES = ["ja"];'));
+    expect(parseLaunchedLocales(noSource).targetLocales).toEqual(["ja"]);
+  });
+
+  it("fails closed when LAUNCHED_LANGUAGES is missing or not an array literal", () => {
+    const missing = parseTypeScriptFile(writeFixture("export const COPY = {};"));
+    expect(() => parseLaunchedLocales(missing)).toThrowError(/LAUNCHED_LANGUAGES/);
+    const notArray = parseTypeScriptFile(writeFixture('export const LAUNCHED_LANGUAGES = "zh-Hant";'));
+    expect(() => parseLaunchedLocales(notArray)).toThrowError(/array literal/);
+  });
+});
+
+describe("readStaticPropertyName", () => {
+  it("reads identifier, single/double-quoted, numeric and no-substitution template names", () => {
+    const sf = parseTypeScriptFile(
+      writeFixture('const x = { ident: 1, "double": 2, \'single\': 3, [`tpl`]: 4, 42: 5 };')
+    );
+    const props = firstPropertyAssignments(sf);
+    expect(readStaticPropertyName(props[0].name)).toBe("ident");
+    expect(readStaticPropertyName(props[1].name)).toBe("double");
+    expect(readStaticPropertyName(props[2].name)).toBe("single");
+    const computed = props[3].name as ts.ComputedPropertyName;
+    expect(readStaticPropertyName(computed.expression)).toBe("tpl");
+    expect(readStaticPropertyName(props[4].name)).toBe("42");
+  });
+
+  it("fails closed on computed and interpolated property names", () => {
+    const sf = parseTypeScriptFile(writeFixture("const x = { [key]: 1, [`k${x}`]: 2 };"));
+    const props = firstPropertyAssignments(sf);
+    const e1 = expectParseError(() => readStaticPropertyName(props[0].name));
+    expect(e1.message).toMatch(/computed/);
+    const e2 = expectParseError(() => readStaticPropertyName(props[1].name));
+    expect(e2.message).toMatch(/computed/);
+  });
+});
+
+describe("collectStaticObjectKeys", () => {
+  it("collects identifier, quoted, trailing-comma and multiline keys", () => {
+    const sf = parseTypeScriptFile(
+      writeFixture(
+        "const x = {\n" +
+          "  ident: 1,\n" +
+          '  "double-quoted": 2,\n' +
+          "  'single-quoted': 3,\n" +
+          '  "escaped\\nkey": 4,\n' +
+          "  trailing: 5,\n" +
+          "};"
+      )
+    );
+    expect(collectStaticObjectKeys(firstObjectLiteral(sf)!, {})).toEqual([
+      "ident",
+      "double-quoted",
+      "single-quoted",
+      "escaped\nkey",
+      "trailing"
+    ]);
+  });
+
+  it("lets the caller target a nested object node without flattening same-name keys", () => {
+    const sf = parseTypeScriptFile(writeFixture("const x = { outer: { a: 1 }, inner: { a: 2, b: 3 } };"));
+    expect(collectStaticObjectKeys(smallestObjectLiteralContaining(sf, "b"), {})).toEqual(["a", "b"]);
+    expect(collectStaticObjectKeys(firstObjectLiteral(sf)!, {})).toEqual(["outer", "inner"]);
+  });
+
+  it("fails closed on spread with file, line and context", () => {
+    const fixture = writeFixture("const x = {\n  a: 1,\n  ...other,\n};");
+    const err = expectParseError(() =>
+      collectStaticObjectKeys(firstObjectLiteral(parseTypeScriptFile(fixture))!, {})
+    );
+    expect(err.file).toBe(fixture);
+    expect(err.line).toBe(3);
+    expect(err.context).toContain("...other");
+  });
+
+  it("fails closed on computed / dynamic keys with file, line and context", () => {
+    const fixture = writeFixture("const x = {\n  [key]: 1,\n};");
+    const err = expectParseError(() =>
+      collectStaticObjectKeys(firstObjectLiteral(parseTypeScriptFile(fixture))!, {})
+    );
+    expect(err.file).toBe(fixture);
+    expect(err.line).toBe(2);
+    expect(err.context).toContain("[key]");
+
+    const dynamic = writeFixture("const x = {\n  [getKey()]: 1,\n};");
+    const err2 = expectParseError(() =>
+      collectStaticObjectKeys(firstObjectLiteral(parseTypeScriptFile(dynamic))!, {})
+    );
+    expect(err2.file).toBe(dynamic);
+    expect(err2.line).toBe(2);
+  });
+
+  it("fails closed on malformed input (non-object node)", () => {
+    const sf = parseTypeScriptFile(writeFixture("const x = 42;"));
+    expect(() => collectStaticObjectKeys(sf, {})).toThrowError(/ObjectLiteralExpression/);
+  });
+});
+
+describe("auditKeySets", () => {
+  it("classifies valid / missing / dangling key sets", () => {
+    const records = auditKeySets({
+      system: "exam",
+      locale: "en",
+      sourceKeys: ["a", "b", "c"],
+      overlayKeys: ["b", "c", "d"]
+    });
+    expect(records).toEqual([
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "d", status: "dangling" },
+      { system: "exam", locale: "en", sourceKey: "a", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("rejects duplicate source keys deterministically", () => {
+    expect(() =>
+      auditKeySets({ system: "exam", locale: "en", sourceKeys: ["a", "a"], overlayKeys: [] })
+    ).toThrowError(/duplicate source key "a" at index 1/);
+  });
+
+  it("rejects duplicate overlay keys deterministically", () => {
+    expect(() =>
+      auditKeySets({ system: "exam", locale: "en", sourceKeys: [], overlayKeys: ["b", "b"] })
+    ).toThrowError(/duplicate overlay key "b" at index 1/);
+  });
+
+  it("treats empty source and overlay sets as a valid empty audit", () => {
+    expect(auditKeySets({ system: "exam", locale: "en", sourceKeys: [], overlayKeys: [] })).toEqual([]);
+  });
+
+  it("flags every overlay key as dangling when source is empty", () => {
+    expect(
+      auditKeySets({ system: "exam", locale: "en", sourceKeys: [], overlayKeys: ["x", "y"] })
+    ).toEqual([
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "x", status: "dangling" },
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "y", status: "dangling" }
+    ]);
+  });
+
+  it("flags every source key as missing when overlay is empty", () => {
+    expect(
+      auditKeySets({ system: "exam", locale: "en", sourceKeys: ["x", "y"], overlayKeys: [] })
+    ).toEqual([
+      { system: "exam", locale: "en", sourceKey: "x", overlayKey: "", status: "missing" },
+      { system: "exam", locale: "en", sourceKey: "y", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("rejects invalid explicit options rather than guessing", () => {
+    expect(() =>
+      auditKeySets({ system: "nope", locale: "en", sourceKeys: [], overlayKeys: [] })
+    ).toThrowError(/unknown overlay system/);
+    expect(() =>
+      auditKeySets({ system: "exam", locale: "", sourceKeys: [], overlayKeys: [] })
+    ).toThrowError(/locale/);
+    expect(() =>
+      auditKeySets({ system: "exam", locale: "en", sourceKeys: "nope", overlayKeys: [] })
+    ).toThrowError(/sourceKeys must be an array/);
+  });
+});
+
+describe("sortAuditRecords", () => {
+  it("sorts by system -> locale -> sourceKey -> overlayKey -> status without mutating input", () => {
+    const records = [
+      { system: "exam", locale: "en", sourceKey: "z", overlayKey: "", status: "missing" },
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "a", status: "dangling" },
+      { system: "grammarNotes", locale: "en", sourceKey: "a", overlayKey: "", status: "missing" },
+      { system: "exam", locale: "ja", sourceKey: "a", overlayKey: "", status: "missing" }
+    ];
+    const sorted = sortAuditRecords(records);
+    expect(
+      sorted.map((r) => `${r.system}:${r.locale}:${r.sourceKey}:${r.overlayKey}:${r.status}`)
+    ).toEqual([
+      "exam:en::a:dangling",
+      "exam:en:z::missing",
+      "exam:ja:a::missing",
+      "grammarNotes:en:a::missing"
+    ]);
+    expect(records.map((r) => r.sourceKey)).toEqual(["z", "", "a", "a"]);
+  });
+});
+
+describe("runOverlayAdapters", () => {
+  it("aggregates adapter records into a sorted report with counts and diagnostics", () => {
+    const report = runOverlayAdapters(
+      [
+        () => auditKeySets({ system: "grammarNotes", locale: "ja", sourceKeys: ["x"], overlayKeys: ["y"] }),
+        () => auditKeySets({ system: "exam", locale: "en", sourceKeys: ["a", "b"], overlayKeys: ["b"] })
+      ],
+      {}
+    );
+    expect(report.records).toEqual([
+      { system: "exam", locale: "en", sourceKey: "a", overlayKey: "", status: "missing" },
+      { system: "grammarNotes", locale: "ja", sourceKey: "", overlayKey: "y", status: "dangling" },
+      { system: "grammarNotes", locale: "ja", sourceKey: "x", overlayKey: "", status: "missing" }
+    ]);
+    expect(report.counts).toEqual({
+      bySystem: {
+        exam: { total: 1, missing: 1, dangling: 0 },
+        grammarNotes: { total: 2, missing: 1, dangling: 1 }
+      },
+      byLocale: {
+        en: { total: 1, missing: 1, dangling: 0 },
+        ja: { total: 2, missing: 1, dangling: 1 }
+      }
+    });
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  it("passes context through to each adapter", () => {
+    const seen: unknown[] = [];
+    const context = { file: "src/x.ts", sourceFile: null };
+    runOverlayAdapters([(c: unknown) => { seen.push(c); return []; }], context);
+    expect(seen).toEqual([context]);
+  });
+
+  it("captures parse diagnostics with file, line and bounded context (no source dump)", () => {
+    const fixture = writeFixture("const x = {\n  a: 1,\n  ...other,\n};");
+    const adapter = () => {
+      const sf = parseTypeScriptFile(fixture);
+      collectStaticObjectKeys(firstObjectLiteral(sf)!, {});
+      return [];
+    };
+    const report = runOverlayAdapters([adapter], {});
+    expect(report.diagnostics).toHaveLength(1);
+    const d = report.diagnostics[0];
+    expect(d.file).toBe(fixture);
+    expect(d.line).toBe(3);
+    expect(d.message).toMatch(/spread/);
+    expect(typeof d.context).toBe("string");
+    expect(d.context.length).toBeLessThanOrEqual(200);
+  });
+
+  it("produces byte-equivalent reports regardless of adapter / input order", () => {
+    const build = (adapters: Array<() => unknown>) => runOverlayAdapters(adapters, {});
+    const adapters = [
+      () => auditKeySets({ system: "exam", locale: "en", sourceKeys: ["a", "b"], overlayKeys: ["b"] }),
+      () => auditKeySets({ system: "exam", locale: "en", sourceKeys: ["b", "c"], overlayKeys: ["b"] }),
+      () => auditKeySets({ system: "learningBlocks", locale: "ja", sourceKeys: [], overlayKeys: ["q"] })
+    ];
+    const reportA = JSON.stringify(build(adapters));
+    const reportB = JSON.stringify(build([...adapters].reverse()));
+    const reportC = JSON.stringify(build([adapters[1], adapters[2], adapters[0]]));
+    expect(reportA).toBe(reportB);
+    expect(reportA).toBe(reportC);
+  });
+
+  it("produces byte-equivalent reports when an adapter throws in any position", () => {
+    const fixture = writeFixture("const x = {\n  ...boom,\n};");
+    const throwing = () => {
+      const sf = parseTypeScriptFile(fixture);
+      collectStaticObjectKeys(firstObjectLiteral(sf)!, {});
+      return [];
+    };
+    const ok = () => auditKeySets({ system: "exam", locale: "en", sourceKeys: ["a"], overlayKeys: ["a"] });
+    const a = JSON.stringify(runOverlayAdapters([throwing, ok], {}));
+    const b = JSON.stringify(runOverlayAdapters([ok, throwing], {}));
+    expect(a).toBe(b);
+    expect(JSON.parse(a).diagnostics).toHaveLength(1);
+  });
+
+  it("report contains no absolute temp path or source text dump", () => {
+    const fixture = writeFixture("const source = { a: 1, b: 2 };\nconst overlay = { a: 1 };");
+    const adapter = () => {
+      const sf = parseTypeScriptFile(fixture);
+      const [sourceNode, overlayNode] = allObjectLiterals(sf);
+      return auditKeySets({
+        system: "exam",
+        locale: "en",
+        sourceKeys: collectStaticObjectKeys(sourceNode, {}),
+        overlayKeys: collectStaticObjectKeys(overlayNode, {})
+      });
+    };
+    const json = JSON.stringify(runOverlayAdapters([adapter], {}));
+    expect(json).not.toContain(tmpDir);
+    expect(json).not.toContain("const source");
+    expect(json).toContain('"sourceKey":"b"');
+  });
+});
+
+describe("core side-effect discipline", () => {
+  it("performs zero filesystem writes, console output, network and process.exit", () => {
+    const fixture = writeFixture("const source = { a: 1 };\nconst overlay = { a: 1 };");
+    const localesFixture = writeFixture('export const LAUNCHED_LANGUAGES = ["zh-Hant"];');
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const logSpy = vi.spyOn(console, "log");
+    const errorSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const adapter = () => {
+        const sf = parseTypeScriptFile(fixture);
+        const [sourceNode, overlayNode] = allObjectLiterals(sf);
+        return auditKeySets({
+          system: "exam",
+          locale: "en",
+          sourceKeys: collectStaticObjectKeys(sourceNode, {}),
+          overlayKeys: collectStaticObjectKeys(overlayNode, {})
+        });
+      };
+      runOverlayAdapters([adapter], {});
+      parseLaunchedLocales(parseTypeScriptFile(localesFixture));
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes #695

## Summary

- Add `scripts/i18n-overlay-audit.mjs`: a reusable TypeScript-AST overlay audit core using the repo's existing `typescript` dependency (no regex parsing of object shapes).
- Exports: `parseLaunchedLocales` (resolves the locale registry from `src/i18n.ts` `LAUNCHED_LANGUAGES`, excludes `zh-Hant`, no second hardcoded list), `parseTypeScriptFile`, `readStaticPropertyName`, `collectStaticObjectKeys`, `auditKeySets`, `sortAuditRecords`, `runOverlayAdapters`.
- Fail-closed: computed/spread/dynamic/template keys throw `AuditParseError` with file/line/context.
- Reports are sorted (`system → locale → sourceKey → overlayKey → status`) with per-system/per-locale counts and parse diagnostics; zero filesystem writes / console / network / `process.exit`.
- No content adapters and no `check:i18n` wiring (per issue scope).

## Scope

Only the two new files: `scripts/i18n-overlay-audit.mjs` and `scripts/i18n-overlay-audit.test.ts`.

## Verification

- `node --check` on the .mjs — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run scripts/i18n-overlay-audit.test.ts` — 26/26 pass
- `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- None.

Non-blocking findings:
- runOverlayAdapters 未驗證 adapter 回傳 record 的 shape（健壯性 gap，非 contract break）。
- diagnostics 未排序（multi-throw 時 byte-equivalence 差異；issue 未指定 diagnostics 順序）。
- parseTypeScriptSource 為未測試的 public helper（非 issue contract）。
- parseLaunchedLocales 未直接以真實 src/i18n.ts 測試（parser 已正確處理真實宣告）。

Verdict:
No blocking findings.
```