### PR TITLE
refactor(exam): reset hint state by question key

### DIFF
--- a/src/components/ExamPrompt.test.tsx
+++ b/src/components/ExamPrompt.test.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react";
+import { StrictMode } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -327,5 +328,94 @@ describe("ExamPrompt content localization (#400)", () => {
     expect(container.querySelector(".hint-toggle")).toBeNull();
     expect(screen.queryByText("English context")).not.toBeInTheDocument();
     expect(screen.queryByText("情境中文")).not.toBeInTheDocument();
+  });
+
+  it("keeps the hint expanded and re-localizes its text when only the language changes", async () => {
+    // Same question.id across the rerender: the keyed hint subtree must NOT
+    // remount, so the expanded state survives and only the shown copy updates.
+    const user = userEvent.setup();
+    const { container, rerender } = render(
+      <ExamPrompt question={makeQuestion()} language="zh-Hant" />
+    );
+    await user.click(container.querySelector(".hint-toggle") as HTMLElement);
+    expect(screen.getByText("提示中文")).toBeInTheDocument();
+
+    rerender(<ExamPrompt question={makeQuestion()} language="en" />);
+    expect(container.querySelector(".hint-toggle")).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("English hint")).toBeInTheDocument();
+    expect(screen.queryByText("提示中文")).not.toBeInTheDocument();
+  });
+
+  it("renders no toggle when neither a hint nor a context exists", () => {
+    const { container } = render(
+      <ExamPrompt
+        question={makeQuestion({
+          hintZh: undefined,
+          hintI18n: undefined,
+          promptContextZh: undefined,
+          promptContextI18n: undefined
+        })}
+        language="zh-Hant"
+      />
+    );
+    expect(container.querySelector(".hint-toggle")).toBeNull();
+  });
+});
+
+describe("ExamPrompt keyed hint state (#685)", () => {
+  const first = () =>
+    examStyleQuestions.find((question) => question.id === "n3-grammar-tahougaii");
+  const second = () =>
+    examStyleQuestions.find(
+      (question) => question.id !== first()!.id && (question.hintZh ?? question.promptContextZh)
+    );
+
+  it("keeps the hint expanded across a same-question re-render", async () => {
+    const user = userEvent.setup();
+    const item = first();
+    const { rerender } = render(<ExamPrompt question={item!} language="zh-Hant" />);
+    await user.click(screen.getByRole("button", { name: "提示" }));
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+
+    rerender(<ExamPrompt question={item!} language="zh-Hant" />);
+    expect(screen.getByRole("button", { name: "隱藏提示" })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+  });
+
+  it("starts collapsed when returning to a previously-expanded question (fresh mount)", async () => {
+    // The new mount for A after A->B->A must NOT restore the old expanded
+    // state: only the question id keys the hint, never the prior interaction.
+    const user = userEvent.setup();
+    const a = first();
+    const b = second();
+    expect(b).toBeDefined();
+    const { rerender } = render(<ExamPrompt question={a!} language="zh-Hant" />);
+    await user.click(screen.getByRole("button", { name: "提示" }));
+    expect(screen.getByText("發燒時對就醫安排的判斷。")).toBeInTheDocument();
+
+    rerender(<ExamPrompt question={b!} language="zh-Hant" />);
+    rerender(<ExamPrompt question={a!} language="zh-Hant" />);
+    expect(screen.getByRole("button", { name: "提示" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("發燒時對就醫安排的判斷。")).not.toBeInTheDocument();
+  });
+
+  it("toggles and resets under StrictMode without effect-driven state updates", async () => {
+    const user = userEvent.setup();
+    const a = first();
+    const b = second();
+    const { rerender } = render(
+      <StrictMode>
+        <ExamPrompt question={a!} language="zh-Hant" />
+      </StrictMode>
+    );
+    await user.click(screen.getByRole("button", { name: "提示" }));
+    expect(screen.getByRole("button", { name: "隱藏提示" })).toHaveAttribute("aria-expanded", "true");
+
+    rerender(
+      <StrictMode>
+        <ExamPrompt question={b!} language="zh-Hant" />
+      </StrictMode>
+    );
+    expect(screen.getByRole("button", { name: "提示" })).toHaveAttribute("aria-expanded", "false");
   });
 });

--- a/src/components/ExamPrompt.tsx
+++ b/src/components/ExamPrompt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { GraduationCap } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { PracticeQuestion } from "../domain/types";
@@ -8,19 +8,42 @@ import { isReadingPrompt, hasJapanese } from "../domain/furigana";
 import { Ruby } from "./Ruby";
 import { SpeakButton } from "./SpeakButton";
 
+// The pre-answer hint toggle. It owns the only mutable piece of the prompt --
+// whether the hint is expanded -- and is keyed by question id in ExamPrompt so
+// a question change unmounts/remounts it and naturally resets to hidden,
+// without an effect-driven setState. It reads nothing but the hint copy and
+// the two toggle labels; all question/answer/vocabulary logic stays in the
+// parent.
+function ExamHint({
+  hint,
+  showLabel,
+  hideLabel
+}: {
+  hint: string;
+  showLabel: string;
+  hideLabel: string;
+}) {
+  const [showHint, setShowHint] = useState(false);
+  return (
+    <div className="hint-block">
+      <button
+        type="button"
+        className="hint-toggle"
+        aria-expanded={showHint}
+        onClick={() => setShowHint((shown) => !shown)}
+      >
+        {showHint ? hideLabel : showLabel}
+      </button>
+      {showHint ? <p className="meaning">{hint}</p> : null}
+    </div>
+  );
+}
+
 // Renders an exam/cloze/pattern question's prompt: instruction, the
 // sentence with the blank, a neutral pre-answer hint, and (when safe) a
 // surface・reading・meaning vocab row.
 export function ExamPrompt({ question, language }: { question: PracticeQuestion; language: Language }) {
   const t = copy[language];
-  // The pre-answer hint sits behind a toggle so the learner attempts the
-  // question first and reveals the hint only when stuck. Reset to hidden
-  // on every question change (keyed by id) so each new question starts
-  // collapsed.
-  const [showHint, setShowHint] = useState(false);
-  useEffect(() => {
-    setShowHint(false);
-  }, [question.id]);
 
   // Sentence-pattern items use placeholder surface/reading (the pattern
   // id) which would render as a meaningless "te-kudasai・te-kudasai・..."
@@ -97,17 +120,7 @@ export function ExamPrompt({ question, language }: { question: PracticeQuestion;
         ) : null}
       </p>
       {preAnswerHint ? (
-        <div className="hint-block">
-          <button
-            type="button"
-            className="hint-toggle"
-            aria-expanded={showHint}
-            onClick={() => setShowHint((shown) => !shown)}
-          >
-            {showHint ? t.hideHint : t.showHint}
-          </button>
-          {showHint ? <p className="meaning">{preAnswerHint}</p> : null}
-        </div>
+        <ExamHint key={question.id} hint={preAnswerHint} showLabel={t.showHint} hideLabel={t.hideHint} />
       ) : null}
       {showVocabRow ? (
         <p className="reading">


### PR DESCRIPTION
Closes #685

## Summary

- Remove the `useEffect(() => setShowHint(false), [question.id])` synchronous setState in `ExamPrompt`.
- Extract an internal `ExamHint` component that owns the `showHint` state and is mounted with `key={question.id}`, so a question change unmounts/remounts and naturally resets to hidden.
- Same-question re-renders and language switches keep the expanded state; `ExamHint` reads only the hint copy and two labels.
- Answer-leak guard, word-order shuffle, Ruby, TTS, and vocab-row logic untouched.

## Scope

Only `src/components/ExamPrompt.tsx` and `src/components/ExamPrompt.test.tsx`.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/components/ExamPrompt.test.tsx` — 24/24 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test` — pass (1668 tests)

## Reviewer verdict

```
Blocking findings:
- 無。

Non-blocking findings:
- 既有測試註解仍寫「useEffect keyed by question.id」，實作已改為 key remount，註解過時（僅註解不同步）。

Verdict:
No blocking findings.
```