### PR TITLE
refactor(pwa): sync safe view ref after commit

### DIFF
--- a/src/hooks/usePwaUpdate.test.tsx
+++ b/src/hooks/usePwaUpdate.test.tsx
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
+// Raw import (typed via vite/client) lets the #678 regression test read the
+// hook source without pulling @types/node into the app build — same trick as
+// src/domain/prerender/staticPages.test.ts.
+import usePwaUpdateSource from "./usePwaUpdate.ts?raw";
 
 // Capture registerSW's options + hand back a spy updateSW, so tests can fire
 // onNeedRefresh / onRegisteredSW like the real virtual:pwa-register would.
@@ -113,5 +117,34 @@ describe("usePwaUpdate safe-window auto apply", () => {
     registration.update.mockClear();
     fireVisibilityChange(false);
     expect(registration.update).toHaveBeenCalled();
+  });
+});
+
+// #678: React Hooks v7 `refs` rule forbids writing a ref during render. The SW
+// callbacks and visibilitychange listener read safeKeyRef.current (the
+// latest-value bridge), so it must be synced from safeViewKey in a layout
+// effect after commit — never in the component body. This asserts that
+// structural contract directly; a stray render-phase write regresses the ESLint
+// `react-hooks/refs` gate even though the observable behaviour is unchanged.
+describe("usePwaUpdate ref-sync contract (#678)", () => {
+  it("never writes safeKeyRef.current in the component body", () => {
+    const fnIdx = usePwaUpdateSource.indexOf("function usePwaUpdate");
+    // The component body is everything up to the first effect; safeKeyRef must
+    // only be written inside the layout effect, never during render.
+    const layoutIdx = usePwaUpdateSource.indexOf("useLayoutEffect", fnIdx);
+    const body = usePwaUpdateSource.slice(
+      fnIdx,
+      layoutIdx === -1
+        ? usePwaUpdateSource.indexOf("useEffect(() => {", fnIdx)
+        : layoutIdx
+    );
+    expect(body).not.toContain("safeKeyRef.current =");
+  });
+
+  it("syncs safeKeyRef from safeViewKey in a layout effect after commit", () => {
+    const fnIdx = usePwaUpdateSource.indexOf("function usePwaUpdate");
+    expect(usePwaUpdateSource.slice(fnIdx)).toMatch(
+      /useLayoutEffect\(\(\) => \{\s*safeKeyRef\.current = safeViewKey;\s*\}, \[safeViewKey\]\)/
+    );
   });
 });

--- a/src/hooks/usePwaUpdate.ts
+++ b/src/hooks/usePwaUpdate.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { registerSW } from "virtual:pwa-register";
 
 // Service-worker update lifecycle (#327). registerType is "prompt", so a new
@@ -35,12 +35,18 @@ export function usePwaUpdate(safeViewKey: string | null) {
   // Refs mirror the reactive values so the SW callbacks and the (single)
   // visibilitychange listener always read the current state.
   const needRefreshRef = useRef(false);
-  const safeKeyRef = useRef(safeViewKey);
-  safeKeyRef.current = safeViewKey;
+  // safeKeyRef is the latest-value bridge for the external SW callbacks and the
+  // visibilitychange listener. It must never be written during render (#678);
+  // the layout effect below syncs it from safeViewKey after every commit.
+  const safeKeyRef = useRef<string | null>(null);
 
   const updateApp = useCallback(() => {
     void updateRef.current?.(true);
   }, []);
+
+  useLayoutEffect(() => {
+    safeKeyRef.current = safeViewKey;
+  }, [safeViewKey]);
 
   useEffect(() => {
     updateRef.current = registerSW({


### PR DESCRIPTION
Closes #678

## Summary

- Remove the render-phase `safeKeyRef.current = safeViewKey` write in `usePwaUpdate`.
- `safeKeyRef` is initialized to `null` and synced in a `useLayoutEffect([safeViewKey])` after commit — never in the component body.
- SW callbacks and the visibilitychange listener still read the latest key; registerSW options, hourly polling, safe-view determination, and reload timing are unchanged.
- Passes React Hooks v7 `refs` diagnostics.

## Scope

Only `src/hooks/usePwaUpdate.ts` and `src/hooks/usePwaUpdate.test.tsx`.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/hooks/usePwaUpdate.test.tsx` — 10/10 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test` — pass (1665 tests)

## Reviewer verdict

```
Blocking findings:
- 無。

Non-blocking findings:
- 兩個新增測試為 source-scan（?raw），對排版變動較脆弱；沿用 staticPages.test.ts 前例，風險低。
- ESLint react-hooks/refs gate 目前尚未啟用（前瞻性）；實際鎖 contract 的是測試本身。

Verdict:
No blocking findings.
```