### PR TITLE
refactor(menu): choose roving focus in open events

### DIFF
--- a/src/components/MoreMenu.test.tsx
+++ b/src/components/MoreMenu.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { MoreMenu, type MoreMenuNavItem, type MoreMenuTools } from "./MoreMenu";
 
@@ -39,7 +40,7 @@ function makeTools(overrides: Partial<MoreMenuTools> = {}): MoreMenuTools {
 }
 
 function renderMenu(items = makeItems(), tools = makeTools()) {
-  render(
+  const view = render(
     <MoreMenu
       triggerLabel="更多"
       triggerCurrentLabel={(page) => `更多（目前：${page}）`}
@@ -47,7 +48,7 @@ function renderMenu(items = makeItems(), tools = makeTools()) {
       tools={tools}
     />
   );
-  return { items, tools };
+  return { items, tools, view };
 }
 
 function menuItems(): HTMLButtonElement[] {
@@ -249,5 +250,151 @@ describe("MoreMenu (#608)", () => {
     expect(within(menu).queryByRole("menuitem", { name: "登入" })).not.toBeInTheDocument();
     expect(within(menu).getByText(/花雪/)).toBeInTheDocument();
     expect(within(menu).getByText("已同步")).toBeInTheDocument();
+  });
+
+  // #684: MoreMenu must not synchronously call setFocusKey() inside the open
+  // effect -- the React Hooks v7 `set-state-in-effect` rule flags any state
+  // write from an effect. Opening is an event-driven transition, so focusKey
+  // is seeded by the same event handlers that flip `open`. These tests pin the
+  // behaviour contract (first entry focused + roving tabindex, focus returned
+  // on close, outside-close without swallowing the press, action-before-close)
+  // so the refactor to event-sourced focus stays behaviour-neutral.
+
+  it("seeds the first entry as the roving key and focuses it on trigger click (#684)", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items.slice(1).every((item) => item.tabIndex === -1)).toBe(true);
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("opens on ArrowDown from the closed trigger with the first entry focused (#684)", () => {
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    const items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("clears the focus key and returns focus to the trigger on close (#684)", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    await user.click(trigger);
+    expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+
+    // Re-opening must seed a fresh roving key, never a stale one.
+    await user.click(trigger);
+    const items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items.slice(1).every((item) => item.tabIndex === -1)).toBe(true);
+  });
+
+  it("closes on Tab without preventing default traversal (#684)", () => {
+    renderMenu();
+
+    const trigger = screen.getByRole("button", { name: "更多" });
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Tab" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("closes on an outside pointer press and does not swallow the press (#684)", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    fireEvent.pointerDown(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("runs the nav/tool action first, then closes (#684)", async () => {
+    const user = userEvent.setup();
+    const { items, tools } = renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    await user.click(screen.getByRole("menuitem", { name: "深色模式" }));
+    expect(tools.theme.onToggle).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    await user.click(screen.getByRole("menuitem", { name: "關於" }));
+    expect(items[2].onSelect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("keeps exactly one tabbable entry when items change while open and the current key disappears (#684)", async () => {
+    const user = userEvent.setup();
+    const { view } = renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus();
+
+    // Remove the currently-focused first entry mid-open: the effective roving
+    // key falls back to the first still-legal key.
+    view.rerender(
+      <MoreMenu
+        triggerLabel="更多"
+        triggerCurrentLabel={(page) => `更多（目前：${page}）`}
+        items={makeItems().slice(1)}
+        tools={makeTools()}
+      />
+    );
+    const items = menuItems();
+    expect(items[0].tabIndex).toBe(0);
+    expect(items.filter((item) => item.tabIndex === 0)).toHaveLength(1);
+  });
+
+  it("wraps roving with ArrowDown/ArrowUp and honours Home/End (#684)", async () => {
+    const user = userEvent.setup();
+    renderMenu();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const items = menuItems();
+    const last = items[items.length - 1];
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowUp" });
+    expect(last).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "ArrowDown" });
+    expect(items[0]).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "End" });
+    expect(last).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: "Home" });
+    expect(items[0]).toHaveFocus();
+  });
+
+  it("does not double-focus or warn under StrictMode (#684)", async () => {
+    const user = userEvent.setup();
+    render(
+      <StrictMode>
+        <MoreMenu
+          triggerLabel="更多"
+          triggerCurrentLabel={(page) => `更多（目前：${page}）`}
+          items={makeItems()}
+          tools={makeTools()}
+        />
+      </StrictMode>
+    );
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus();
   });
 });

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState, type ReactNode } from "react";
+import { useCallback, useId, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { ChevronDown, Globe, Languages, LogIn, LogOut, MessageCircle, SunMoon } from "lucide-react";
 
 // #608: the mobile nav keeps five primary entries; the rest of the site lives
@@ -57,49 +57,81 @@ export function MoreMenu({
 
   const selectedItem = items.find((item) => item.selected) ?? null;
 
-  // Focus the first entry once the panel is in the DOM (menu-button pattern).
-  useEffect(() => {
-    if (!open) {
-      setFocusKey(null);
-      return;
-    }
-    const first = rootRef.current?.querySelector<HTMLButtonElement>("[role^='menuitem']");
-    if (first) {
-      setFocusKey(first.dataset.menuKey ?? null);
-      first.focus();
-    }
-  }, [open]);
+  // The menu's focusables in the exact order they are rendered (items first,
+  // then the tools block). Opening and roving both derive their keys from this
+  // so a key always resolves to the same DOM element.
+  const toolKeys: string[] = [
+    tools.language ? "tool-language" : null,
+    "tool-furigana",
+    "tool-theme",
+    "tool-feedback",
+    tools.auth ? "tool-auth" : null
+  ].filter((key): key is string => key !== null);
+
+  const allKeys = useCallback(() => [...items.map((item) => item.key), ...toolKeys], [items, toolKeys]);
+
+  // Opening is an event-driven transition: the event handler seeds the first
+  // key and flips `open` together, so the focus effect never has to write
+  // state (the Hooks v7 set-state-in-effect rule).
+  const openMenu = useCallback(
+    (options: { focus: boolean }) => {
+      const first = allKeys()[0] ?? null;
+      setFocusKey(first);
+      setOpen(true);
+      if (options.focus && first) {
+        requestAnimationFrame(() =>
+          document.querySelector<HTMLElement>(`[data-menu-key="${first}"]`)?.focus()
+        );
+      }
+    },
+    [allKeys]
+  );
+
+  // Every close path (click, Escape, Tab, outside press, action select) funnels
+  // through here so the focus key is always cleared with `open`.
+  const closeMenu = useCallback((options: { returnFocus: boolean }) => {
+    setOpen(false);
+    setFocusKey(null);
+    if (options.returnFocus) triggerRef.current?.focus();
+  }, []);
+
+  // Menu-button pattern: the open effect only moves focus once the panel has
+  // committed -- it never writes state.
+  useLayoutEffect(() => {
+    if (!open) return;
+    const focused = rootRef.current?.querySelector<HTMLButtonElement>(
+      `[data-menu-key="${focusKey}"]`
+    );
+    if (focused) focused.focus();
+  }, [open, focusKey]);
 
   // A press anywhere outside closes the menu without swallowing the press.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
       if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
-        setOpen(false);
+        closeMenu({ returnFocus: false });
       }
     };
     document.addEventListener("pointerdown", onPointerDown);
     return () => document.removeEventListener("pointerdown", onPointerDown);
-  }, [open]);
+  }, [open, closeMenu]);
 
-  const close = () => setOpen(false);
   const closeAnd = (action: () => void) => () => {
     action();
-    close();
+    closeMenu({ returnFocus: false });
   };
 
   const onPanelKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "Escape") {
       event.preventDefault();
-      close();
-      triggerRef.current?.focus();
+      closeMenu({ returnFocus: true });
       return;
     }
     if (event.key === "Tab") {
       // Menu pattern: Tab leaves the menu. Close and put focus back on the
       // trigger so the default Tab continues from there (no preventDefault).
-      close();
-      triggerRef.current?.focus();
+      closeMenu({ returnFocus: true });
       return;
     }
     if (event.key !== "ArrowDown" && event.key !== "ArrowUp" && event.key !== "Home" && event.key !== "End") {
@@ -126,8 +158,14 @@ export function MoreMenu({
     }
   };
 
+  // Effective roving key for rendering: the tracked key while it still exists,
+  // otherwise the first legal key. Read from props/state only -- never written
+  // back to state from an effect, so a key that disappears mid-open falls back
+  // cleanly to the first legal key on the next render.
+  const effectiveFocusKey = focusKey && allKeys().includes(focusKey) ? focusKey : (allKeys()[0] ?? null);
+
   // Roving-tabindex helper: only the focused entry is tabbable.
-  const rove = (key: string) => (focusKey === key ? 0 : -1);
+  const rove = (key: string) => (effectiveFocusKey === key ? 0 : -1);
 
   return (
     <div className="nav-more" ref={rootRef}>
@@ -139,11 +177,17 @@ export function MoreMenu({
         aria-expanded={open}
         aria-controls={open ? panelId : undefined}
         aria-label={selectedItem ? triggerCurrentLabel(selectedItem.label) : undefined}
-        onClick={() => setOpen((value) => !value)}
+        onClick={() => {
+          if (open) {
+            closeMenu({ returnFocus: false });
+          } else {
+            openMenu({ focus: true });
+          }
+        }}
         onKeyDown={(event) => {
           if (event.key === "ArrowDown" && !open) {
             event.preventDefault();
-            setOpen(true);
+            openMenu({ focus: true });
           }
         }}
       >


### PR DESCRIPTION
Closes #684

## Summary

- Move focus-key seeding out of the open effect into event handlers: a single `openMenu()` sets the first focus key then opens; a single `closeMenu({returnFocus})` clears `open` + `focusKey` on every close path (trigger click, Escape, Tab, outside press, action select).
- Effects only focus the committed panel (`useLayoutEffect`), never write state.
- `effectiveFocusKey` falls back to the first legal key in render when the tracked key disappears mid-open.
- Roving tabindex, focus return, outside-close (without swallowing the press), and action-before-close are unchanged.

## Scope

Only `src/components/MoreMenu.tsx` and `src/components/MoreMenu.test.tsx`.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/components/MoreMenu.test.tsx` — 21/21 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test` — pass (1672 tests)

## Reviewer verdict

```
Blocking findings:
- none

Non-blocking findings:
- rAF focus call in openMenu is additive/unguarded (menu closing before the rAF tick targets a detached node — harmless no-op); the layout effect independently satisfies the contract.
- allKeys() recomputed per call; negligible for a nav menu.

Verdict:
No blocking findings.
```