### PR TITLE
feat(ai): orchestrate guarded correctness stages

### DIFF
--- a/scripts/gemini-correctness/workflow-orchestrator.mjs
+++ b/scripts/gemini-correctness/workflow-orchestrator.mjs
@@ -1,0 +1,513 @@
+// =============================================================================
+// workflow-orchestrator.mjs — GitHub-independent deterministic orchestration
+// state machine (Issue #688)
+// =============================================================================
+//
+// Serializes the already-merged discovery / RED / GREEN stages (#635/#636/#637)
+// into a deterministic, GitHub-independent state machine that produces a
+// sanitized machine-readable WorkflowResult.  This module never creates a
+// workflow, never opens a PR, never commits/pushes, and never calls a real
+// GitHub write API.
+//
+// Public contract:
+//   runWorkflowOrchestration({ mode, baselineSha, adapters, limits })
+//     => Promise<WorkflowResult>
+//
+// adapters is the fixed injection boundary — tests always use fakes:
+//   openAiPrGate({ baselineSha, limits }) -> { valid, openPrs? } | throws
+//   baseline({ baselineSha, limits })     -> { valid, baselineSha?, checks }
+//   discovery({ baselineSha, limits })    -> { valid, result? } | throws
+//   red({ baselineSha, finding, limits }) -> { valid, result? } | throws
+//   green({ baselineSha, finding, redResult, limits }) -> { valid, result? }
+//   cleanup({ baselineSha, redResult })   -> { valid } | throws
+//   clock()                               -> number (completion timestamp)
+//
+// The orchestrator never spawns a model-provided command, never reads a secret
+// on its own (an injected environment is only used for result redaction, and is
+// never forwarded to adapters), and never calls a GitHub write command.  Every
+// stage hand-off carries only the validated contract of the previous stage;
+// raw model responses never reach the next stage or the summary.
+//
+// Modes:
+//   off     — immediate safe skip; zero baseline/Gemini/repository writes.
+//   observe — open-PR gate -> baseline -> discovery/validation -> sanitized
+//             result.  Never enters RED/GREEN.
+//   repair  — open-PR gate -> baseline -> discovery -> RED -> clean reset ->
+//             GREEN -> deterministic result.  Even a verified repair only
+//             returns a publication candidate; it is never published here.
+// =============================================================================
+
+import { validateFinding } from "./finding-schema.mjs";
+import { redactForOutput } from "./discover.mjs";
+import path from "node:path";
+
+const REQUIRED_BASELINE_CHECKS = ["lint", "typecheck", "test", "build", "diff-check"];
+const BASELINE_SHA_RE = /^[0-9a-f]{40,64}$/i;
+const HEX64_RE = /^[0-9a-f]{64}$/i;
+const GEMINI_AI_PR_PREFIX = "gemini/auto-fix-";
+const MODES = new Set(["off", "observe", "repair"]);
+const REQUIRED_ADAPTERS = [
+  "openAiPrGate",
+  "baseline",
+  "discovery",
+  "red",
+  "green",
+  "cleanup",
+  "clock"
+];
+
+export const WORKFLOW_STATUS = Object.freeze({
+  OFF_SKIP: "off-skip",
+  OPEN_PR_BLOCKED: "open-pr-blocked",
+  BASELINE_BLOCKED: "baseline-blocked",
+  NO_FINDING: "no-finding",
+  FINDING_REJECTED: "finding-rejected",
+  QUOTA_API_ERROR: "quota-api-error",
+  OBSERVED: "observed",
+  RED_FAILED: "red-failed",
+  CLEANUP_FAILED: "cleanup-failed",
+  GREEN_FAILED: "green-failed",
+  REPAIR_VERIFIED: "repair-verified",
+  CONFIG_ERROR: "config-error"
+});
+
+function invalid(message) {
+  return { valid: false, error: message };
+}
+
+function errorMessage(error) {
+  return error?.message ?? "unknown error";
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive-value collection from an injected environment.  The orchestrator
+// never reads a secret store or process.env on its own; the caller decides what
+// to inject for result redaction.  These values are used only for scrubbing the
+// result and are never forwarded to any stage adapter.
+// ---------------------------------------------------------------------------
+function collectSensitiveValues(environment) {
+  const values = new Set();
+  for (const [key, value] of Object.entries(environment ?? {})) {
+    if (typeof value !== "string" || value.length === 0) continue;
+    if (
+      /(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH|COOKIE)/i.test(key) ||
+      value.length >= 8
+    ) {
+      values.add(value);
+    }
+  }
+  if (typeof environment?.PATH === "string") {
+    for (const entry of environment.PATH.split(path.delimiter)) {
+      if (entry.length >= 4) values.add(entry);
+    }
+  }
+  return [...values].filter((value) => typeof value === "string" && value.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Unified result redaction.  Starts from the shared redactForOutput (AIza keys
+// + exact secrets), then applies deterministic scrub patterns for common leak
+// shapes: GitHub/OpenAI/AWS tokens, env-dump assignments, and absolute POSIX
+// paths.  The result must never contain a raw prompt/response, an env dump, or
+// an absolute path.
+// ---------------------------------------------------------------------------
+function scrubResult(value, sensitiveValues) {
+  const base = redactForOutput(value, sensitiveValues);
+  let json = JSON.stringify(base);
+  json = json
+    .replace(/ghp_[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/sk-[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/AKIA[0-9A-Z]{16}/g, "REDACTED_KEY")
+    .replace(/\b[A-Z][A-Z0-9_]{2,}=[^\s,;"']{4,}/g, "REDACTED_KEY")
+    .replace(/\/[A-Za-z0-9._~-]+(?:\/[A-Za-z0-9._~-]+)+/g, "REDACTED_KEY");
+  try {
+    return JSON.parse(json);
+  } catch {
+    // The result is always JSON-safe; this is an unreachable safety net.
+    return value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stage contract validators — every hand-off must be a validated contract.
+// ---------------------------------------------------------------------------
+function validateBaselineResult(result, expectedBaselineSha) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("baseline result must be an object");
+  }
+  if (
+    result.baselineSha !== undefined &&
+    result.baselineSha !== expectedBaselineSha
+  ) {
+    return invalid("baseline SHA does not match the trusted baseline");
+  }
+  if (!Array.isArray(result.checks)) {
+    return invalid("baseline checks must be an array");
+  }
+  for (const name of REQUIRED_BASELINE_CHECKS) {
+    const check = result.checks.find(
+      (entry) => entry && typeof entry === "object" && entry.name === name
+    );
+    if (!check || check.status !== "passed") {
+      return invalid(`baseline check ${name} did not pass`);
+    }
+  }
+  return { valid: true, checks: result.checks };
+}
+
+function validateRedResult(result, trustedBaseline) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("RED result must be an object");
+  }
+  if (result.schemaVersion !== 1) return invalid("RED schemaVersion must be 1");
+  if (result.status !== "red-confirmed") {
+    return invalid("RED status must be red-confirmed");
+  }
+  if (!BASELINE_SHA_RE.test(String(result.baselineSha ?? ""))) {
+    return invalid("RED baselineSha is invalid");
+  }
+  if (result.baselineSha !== trustedBaseline) {
+    return invalid("RED baselineSha does not match the trusted baseline");
+  }
+  if (!HEX64_RE.test(String(result.patchSha256 ?? ""))) {
+    return invalid("RED patchSha256 is invalid");
+  }
+  if (result.replayConfirmed !== true) {
+    return invalid("RED must be replay-confirmed");
+  }
+  if (typeof result.testFile !== "string" || result.testFile.trim() === "") {
+    return invalid("RED testFile is invalid");
+  }
+  if (typeof result.testName !== "string" || result.testName.trim() === "") {
+    return invalid("RED testName is invalid");
+  }
+  return { valid: true, result };
+}
+
+function validateGreenResult(result, trustedBaseline) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return invalid("GREEN result must be an object");
+  }
+  if (result.schemaVersion !== 1) return invalid("GREEN schemaVersion must be 1");
+  if (result.status !== "repair-verified") {
+    return invalid("GREEN status must be repair-verified");
+  }
+  if (!BASELINE_SHA_RE.test(String(result.baselineSha ?? ""))) {
+    return invalid("GREEN baselineSha is invalid");
+  }
+  if (result.baselineSha !== trustedBaseline) {
+    return invalid("GREEN baselineSha does not match the trusted baseline");
+  }
+  if (!Number.isFinite(result.changedFiles) || result.changedFiles < 0) {
+    return invalid("GREEN changedFiles is invalid");
+  }
+  if (!Number.isFinite(result.changedLines) || result.changedLines < 0) {
+    return invalid("GREEN changedLines is invalid");
+  }
+  if (!HEX64_RE.test(String(result.finalDiffSha256 ?? ""))) {
+    return invalid("GREEN finalDiffSha256 is invalid");
+  }
+  if (!Array.isArray(result.checks)) {
+    return invalid("GREEN checks must be an array");
+  }
+  return { valid: true, result };
+}
+
+// ---------------------------------------------------------------------------
+// runWorkflowOrchestration
+// ---------------------------------------------------------------------------
+export async function runWorkflowOrchestration({
+  mode,
+  baselineSha,
+  adapters = {},
+  limits = {}
+} = {}) {
+  const sensitiveValues = collectSensitiveValues(limits?.environment);
+  const now = () => {
+    const value = typeof adapters.clock === "function" ? adapters.clock() : undefined;
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  };
+
+  const failClosed = (status, reasonCode, message) =>
+    scrubResult(
+      {
+        schemaVersion: 1,
+        mode: String(mode ?? ""),
+        status,
+        reasonCode,
+        reason: String(message ?? ""),
+        publicationAllowed: false,
+        baselineSha: typeof baselineSha === "string" ? baselineSha : undefined,
+        completedAt: now()
+      },
+      sensitiveValues
+    );
+
+  // --- Bounded configuration validation --------------------------------
+  if (!MODES.has(mode)) {
+    return failClosed(
+      WORKFLOW_STATUS.CONFIG_ERROR,
+      "invalid-mode",
+      "mode must be one of off|observe|repair"
+    );
+  }
+  if (!BASELINE_SHA_RE.test(String(baselineSha ?? ""))) {
+    return failClosed(
+      WORKFLOW_STATUS.CONFIG_ERROR,
+      "invalid-baseline-sha",
+      "baselineSha must be a git commit SHA"
+    );
+  }
+  if (!limits || typeof limits !== "object" || Array.isArray(limits)) {
+    return failClosed(
+      WORKFLOW_STATUS.CONFIG_ERROR,
+      "invalid-limits",
+      "limits must be a plain object"
+    );
+  }
+  for (const adapterName of REQUIRED_ADAPTERS) {
+    if (typeof adapters[adapterName] !== "function") {
+      return failClosed(
+        WORKFLOW_STATUS.CONFIG_ERROR,
+        "missing-adapter",
+        `adapter ${adapterName} is required`
+      );
+    }
+  }
+
+  // --- off: immediate safe skip, zero adapter calls --------------------
+  if (mode === "off") {
+    return {
+      schemaVersion: 1,
+      mode,
+      status: WORKFLOW_STATUS.OFF_SKIP,
+      reasonCode: "safe-skip",
+      reason: "safe skip",
+      publicationAllowed: false,
+      baselineSha
+    };
+  }
+
+  // The injected environment is only for result redaction; adapters never see
+  // it, so no secret value can leak into a stage invocation.
+  const forwardableLimits = {};
+  for (const [key, value] of Object.entries(limits)) {
+    if (key !== "environment") forwardableLimits[key] = value;
+  }
+
+  // --- Stage 1: open-AI-PR read gate ----------------------------------
+  let gate;
+  try {
+    gate = await adapters.openAiPrGate({ baselineSha, limits: forwardableLimits });
+  } catch (error) {
+    return failClosed(WORKFLOW_STATUS.OPEN_PR_BLOCKED, "open-pr-blocked", errorMessage(error));
+  }
+  if (!gate || gate.valid !== true) {
+    return failClosed(
+      WORKFLOW_STATUS.OPEN_PR_BLOCKED,
+      "open-pr-blocked",
+      gate?.error ?? "open AI PR gate failed closed"
+    );
+  }
+  const openPrs = Array.isArray(gate.openPrs) ? gate.openPrs : [];
+  const hasAiPr = openPrs.some(
+    (pr) => pr && typeof pr.ref === "string" && pr.ref.startsWith(GEMINI_AI_PR_PREFIX)
+  );
+  if (hasAiPr) {
+    return failClosed(
+      WORKFLOW_STATUS.OPEN_PR_BLOCKED,
+      "open-pr-blocked",
+      "open AI PR exists; skipping before baseline and Gemini"
+    );
+  }
+
+  // --- Stage 2: baseline (lint/typecheck/test/build/diff-check) --------
+  let baselineOutcome;
+  try {
+    baselineOutcome = await adapters.baseline({ baselineSha, limits: forwardableLimits });
+  } catch (error) {
+    return failClosed(WORKFLOW_STATUS.BASELINE_BLOCKED, "baseline-blocked", errorMessage(error));
+  }
+  if (!baselineOutcome || baselineOutcome.valid !== true) {
+    return failClosed(
+      WORKFLOW_STATUS.BASELINE_BLOCKED,
+      "baseline-blocked",
+      baselineOutcome?.error ?? "baseline failed closed"
+    );
+  }
+  const baselineCheck = validateBaselineResult(baselineOutcome, baselineSha);
+  if (!baselineCheck.valid) {
+    return failClosed(
+      WORKFLOW_STATUS.BASELINE_BLOCKED,
+      "baseline-blocked",
+      baselineCheck.error
+    );
+  }
+
+  // --- Stage 3: discovery + finding validation -------------------------
+  let discoveryOutcome;
+  try {
+    discoveryOutcome = await adapters.discovery({ baselineSha, limits: forwardableLimits });
+  } catch (error) {
+    return failClosed(
+      WORKFLOW_STATUS.QUOTA_API_ERROR,
+      "quota-api-error",
+      errorMessage(error)
+    );
+  }
+  if (!discoveryOutcome || discoveryOutcome.valid !== true) {
+    return failClosed(
+      WORKFLOW_STATUS.FINDING_REJECTED,
+      "finding-rejected",
+      discoveryOutcome?.error ?? "discovery failed closed"
+    );
+  }
+  // The orchestrator only accepts a re-validated finding contract; a tampered
+  // schema (unknown fields, bad hashes, non-finding status) is rejected here.
+  // The no-finding path is also validated before it is trusted.
+  const schemaCheck = validateFinding(discoveryOutcome.result);
+  if (!schemaCheck.valid) {
+    return failClosed(
+      WORKFLOW_STATUS.FINDING_REJECTED,
+      "finding-rejected",
+      schemaCheck.error ?? "finding schema rejected"
+    );
+  }
+  if (schemaCheck.result.status === "no-finding") {
+    return failClosed(
+      WORKFLOW_STATUS.NO_FINDING,
+      "no-finding",
+      schemaCheck.result.reason ?? "no finding"
+    );
+  }
+  const finding = schemaCheck.result;
+
+  if (mode === "observe") {
+    return scrubResult(
+      {
+        schemaVersion: 1,
+        mode,
+        status: WORKFLOW_STATUS.OBSERVED,
+        reasonCode: "observed",
+        reason: "discovery validated a finding; observation complete",
+        publicationAllowed: false,
+        baselineSha,
+        checks: baselineCheck.checks,
+        findingTitle: finding.title,
+        findingCategory: finding.category,
+        completedAt: now()
+      },
+      sensitiveValues
+    );
+  }
+
+  // --- Stage 4 (repair): RED -------------------------------------------
+  let redOutcome;
+  try {
+    redOutcome = await adapters.red({ baselineSha, finding, limits: forwardableLimits });
+  } catch (error) {
+    return failClosed(WORKFLOW_STATUS.RED_FAILED, "red-failed", errorMessage(error));
+  }
+  if (!redOutcome || redOutcome.valid !== true) {
+    const signal = redOutcome?.signal ? ` (signal: ${redOutcome.signal})` : "";
+    return failClosed(
+      WORKFLOW_STATUS.RED_FAILED,
+      "red-failed",
+      `${redOutcome?.error ?? "RED stage failed closed"}${signal}`
+    );
+  }
+  const redCheck = validateRedResult(redOutcome.result, baselineSha);
+  if (!redCheck.valid) {
+    return failClosed(WORKFLOW_STATUS.RED_FAILED, "red-failed", redCheck.error);
+  }
+  const redResult = redCheck.result;
+
+  // --- Stage 5 (repair): clean reset -----------------------------------
+  let cleanupOutcome;
+  try {
+    cleanupOutcome = await adapters.cleanup({ baselineSha, redResult });
+  } catch (error) {
+    return failClosed(
+      WORKFLOW_STATUS.CLEANUP_FAILED,
+      "cleanup-failed",
+      errorMessage(error)
+    );
+  }
+  if (!cleanupOutcome || cleanupOutcome.valid !== true) {
+    return failClosed(
+      WORKFLOW_STATUS.CLEANUP_FAILED,
+      "cleanup-failed",
+      cleanupOutcome?.error ?? "clean reset failed closed"
+    );
+  }
+
+  // --- Stage 6 (repair): GREEN -----------------------------------------
+  let greenOutcome;
+  try {
+    greenOutcome = await adapters.green({
+      baselineSha,
+      finding,
+      redResult,
+      limits: forwardableLimits
+    });
+  } catch (error) {
+    return failClosed(WORKFLOW_STATUS.GREEN_FAILED, "green-failed", errorMessage(error));
+  }
+  if (!greenOutcome || greenOutcome.valid !== true) {
+    return failClosed(
+      WORKFLOW_STATUS.GREEN_FAILED,
+      "green-failed",
+      greenOutcome?.error ?? "GREEN stage failed closed"
+    );
+  }
+  const greenCheck = validateGreenResult(greenOutcome.result, baselineSha);
+  if (!greenCheck.valid) {
+    const isBaseline = /baseline/i.test(String(greenCheck.error));
+    return failClosed(
+      isBaseline ? WORKFLOW_STATUS.BASELINE_BLOCKED : WORKFLOW_STATUS.GREEN_FAILED,
+      isBaseline ? "baseline-blocked" : "green-failed",
+      greenCheck.error
+    );
+  }
+  const green = greenCheck.result;
+
+  // publicationAllowed=true only when the repair is validated, the clean reset
+  // succeeded, and the baseline is still consistent.  This is a publication
+  // candidate — it is never published from this module.
+  return scrubResult(
+    {
+      schemaVersion: 1,
+      mode,
+      status: WORKFLOW_STATUS.REPAIR_VERIFIED,
+      reasonCode: "repair-verified",
+      reason: "repair verified; publication candidate (not published)",
+      publicationAllowed: true,
+      baselineSha,
+      checks: baselineCheck.checks,
+      findingTitle: finding.title,
+      findingCategory: finding.category,
+      red: {
+        testFile: redResult.testFile,
+        testName: redResult.testName,
+        failureKind: redResult.failureKind,
+        patchSha256: redResult.patchSha256,
+        replayConfirmed: redResult.replayConfirmed
+      },
+      green: {
+        findingTitle: green.findingTitle,
+        productionFiles: green.productionFiles,
+        rootCause: green.rootCause,
+        fixSummary: green.fixSummary,
+        checks: green.checks,
+        changedFiles: green.changedFiles,
+        changedLines: green.changedLines,
+        finalDiffSha256: green.finalDiffSha256
+      },
+      changedFiles: green.changedFiles,
+      changedLines: green.changedLines,
+      finalDiffSha256: green.finalDiffSha256,
+      completedAt: now()
+    },
+    sensitiveValues
+  );
+}

--- a/scripts/gemini-correctness/workflow-orchestrator.test.ts
+++ b/scripts/gemini-correctness/workflow-orchestrator.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it, vi } from "vitest";
+// @ts-expect-error -- plain .mjs module, no types
+import { runWorkflowOrchestration } from "./workflow-orchestrator.mjs";
+
+const SECRET = "fixture-orchestrator-secret-98765";
+const ENV_DUMP = "PATH=/usr/local/bin:/usr/bin";
+const ABSOLUTE_PATH = "/tmp/some/absolute/path";
+const MODEL_COMMAND = "pnpm exec gemini-correctness --repair";
+const FAKE_TOKEN = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";
+
+function finding() {
+  return {
+    schemaVersion: 1,
+    status: "finding",
+    title: "empty queue fallback",
+    confidence: 0.95,
+    category: "boundary-condition",
+    evidence: [
+      {
+        file: "src/domain/example.ts",
+        startLine: 1,
+        endLine: 3,
+        reason: "the empty branch returns a stale value"
+      }
+    ],
+    expectedBehavior: "an empty queue returns the safe fallback",
+    actualBehavior: "an empty queue returns the stale value",
+    reproduction: { testFile: "src/domain/example.regression.test.ts", testName: "returns the safe fallback for an empty queue" },
+    productionFiles: ["src/domain/example.ts"],
+    risk: "low"
+  };
+}
+
+function validatedFinding() {
+  return { valid: true, result: finding() };
+}
+
+function redResult() {
+  return {
+    schemaVersion: 1,
+    status: "red-confirmed",
+    baselineSha: "a".repeat(40),
+    testFile: "src/domain/example.regression.test.ts",
+    testName: "returns the safe fallback for an empty queue",
+    failureKind: "assertion",
+    sanitizedSummary: "returns the safe fallback for an empty queue: Expected behavior: an empty queue returns the safe fallback | Actual behavior: an empty queue returns the stale value",
+    patchSha256: "b".repeat(64),
+    replayConfirmed: true
+  };
+}
+
+function greenResult() {
+  return {
+    schemaVersion: 1,
+    status: "repair-verified",
+    baselineSha: "a".repeat(40),
+    findingTitle: "empty queue fallback",
+    testFile: "src/domain/example.regression.test.ts",
+    testName: "returns the safe fallback for an empty queue",
+    productionFiles: ["src/domain/example.ts"],
+    rootCause: "the empty branch returns a stale value instead of the fallback",
+    fixSummary: "return the safe fallback when the queue is empty",
+    checks: [
+      { name: "targeted-test", status: "passed" },
+      { name: "lint", status: "passed" },
+      { name: "typecheck", status: "passed" },
+      { name: "test", status: "passed" },
+      { name: "build", status: "passed" }
+    ],
+    changedFiles: 1,
+    changedLines: 2,
+    testPatchSha256: "b".repeat(64),
+    finalDiffSha256: "c".repeat(64)
+  };
+}
+
+function allFns() {
+  const base = {
+    openAiPrGate: vi.fn().mockResolvedValue({ valid: true, openPrs: [] }),
+    baseline: vi.fn().mockResolvedValue({
+      valid: true,
+      checks: [
+        { name: "lint", status: "passed" },
+        { name: "typecheck", status: "passed" },
+        { name: "test", status: "passed" },
+        { name: "build", status: "passed" },
+        { name: "diff-check", status: "passed" }
+      ]
+    }),
+    discovery: vi.fn().mockResolvedValue(validatedFinding()),
+    red: vi.fn().mockResolvedValue({ valid: true, result: redResult() }),
+    green: vi.fn().mockResolvedValue({ valid: true, result: greenResult() }),
+    cleanup: vi.fn().mockResolvedValue({ valid: true }),
+    clock: vi.fn().mockReturnValue(1_700_000_000_000)
+  };
+  return base;
+}
+
+function opts(adapterSet: ReturnType<typeof allFns>, extra = {}) {
+  return {
+    mode: "off",
+    baselineSha: "a".repeat(40),
+    adapters: adapterSet,
+    limits: { baselineTimeoutMs: 1000, findingBytes: 4096 },
+    ...extra
+  };
+}
+
+describe("off mode", () => {
+  it("returns a safe skip with zero adapter calls", async () => {
+    const a = allFns();
+    const result = await runWorkflowOrchestration(opts(a, { mode: "off" }));
+
+    expect(result.status).toBe("off-skip");
+    expect(result.publicationAllowed).toBe(false);
+    expect(result.reason).toBe("safe skip");
+    for (const fn of Object.values(a)) {
+      expect(fn).not.toHaveBeenCalled();
+    }
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+    expect(JSON.stringify(result)).not.toContain(ABSOLUTE_PATH);
+  });
+});
+
+describe("observe mode", () => {
+  it("runs open-PR gate, baseline, discovery; never RED/GREEN/cleanup", async () => {
+    const a = allFns();
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("observed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.openAiPrGate).toHaveBeenCalledTimes(1);
+    expect(a.baseline).toHaveBeenCalledTimes(1);
+    expect(a.discovery).toHaveBeenCalledTimes(1);
+    expect(a.red).not.toHaveBeenCalled();
+    expect(a.green).not.toHaveBeenCalled();
+    expect(a.cleanup).not.toHaveBeenCalled();
+    expect(result.findingTitle).toBe("empty queue fallback");
+    expect(result.checks).toHaveLength(5);
+  });
+
+  it("maps a rejected finding to finding-rejected", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({ valid: false, error: "low confidence" });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("finding-rejected");
+    expect(result.publicationAllowed).toBe(false);
+  });
+
+  it("maps quota/API errors to quota-api-error", async () => {
+    const a = allFns();
+    a.discovery.mockRejectedValueOnce(new Error("quota exhausted"));
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("quota-api-error");
+    expect(result.publicationAllowed).toBe(false);
+  });
+
+  it("redacts secrets, env values, and absolute paths from the result", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({
+      valid: false,
+      error: `Gemini failed with ${SECRET} at ${ABSOLUTE_PATH}; ${ENV_DUMP}`
+    });
+    const result = await runWorkflowOrchestration({
+      ...opts(a, { mode: "observe" }),
+      limits: {
+        baselineTimeoutMs: 1000,
+        findingBytes: 4096,
+        environment: {
+          FIXTURE_SECRET: SECRET,
+          PATH: "/usr/local/bin:/usr/bin",
+          HOME: ABSOLUTE_PATH
+        }
+      }
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain(ABSOLUTE_PATH);
+    expect(serialized).toContain("REDACTED_KEY");
+    expect(result.findingTitle).toBeUndefined();
+  });
+});
+
+describe("open-PR gate", () => {
+  it("skips before baseline and Gemini when an open gemini/auto-fix- PR exists", async () => {
+    const a = allFns();
+    a.openAiPrGate.mockResolvedValueOnce({
+      valid: true,
+      openPrs: [{ ref: "gemini/auto-fix-empty-queue", title: "fix empty queue", url: "https://example.invalid/pr/1" }]
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("open-pr-blocked");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.baseline).not.toHaveBeenCalled();
+    expect(a.discovery).not.toHaveBeenCalled();
+    expect(a.red).not.toHaveBeenCalled();
+    expect(a.green).not.toHaveBeenCalled();
+    expect(a.cleanup).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the open-PR gate itself throws", async () => {
+    const a = allFns();
+    a.openAiPrGate.mockRejectedValueOnce(new Error("gh rate limited"));
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("open-pr-blocked");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.baseline).not.toHaveBeenCalled();
+    expect(a.discovery).not.toHaveBeenCalled();
+  });
+});
+
+describe("baseline checks fail closed", () => {
+  it.each(["lint", "typecheck", "test", "build", "diff-check"])(
+    "returns baseline-blocked when %s fails",
+    async (failedCheck) => {
+      const a = allFns();
+      const baseline = {
+        valid: true,
+        checks: [
+          { name: "lint", status: "passed" },
+          { name: "typecheck", status: "passed" },
+          { name: "test", status: "passed" },
+          { name: "build", status: "passed" },
+          { name: "diff-check", status: "passed" }
+        ]
+      };
+      baseline.checks = baseline.checks.map(c =>
+        c.name === failedCheck ? { ...c, status: "failed" } : c
+      );
+      a.baseline.mockResolvedValueOnce(baseline);
+
+      const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+      expect(result.status).toBe("baseline-blocked");
+      expect(result.publicationAllowed).toBe(false);
+      expect(a.discovery).not.toHaveBeenCalled();
+    }
+  );
+
+  it("fails closed when baseline throws", async () => {
+    const a = allFns();
+    a.baseline.mockRejectedValueOnce(new Error("lint crashed"));
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("baseline-blocked");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.discovery).not.toHaveBeenCalled();
+  });
+});
+
+describe("no-finding", () => {
+  it("maps a valid no-finding to no-finding", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({
+      valid: true,
+      result: { schemaVersion: 1, status: "no-finding", reason: "no issues found" }
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "observe" }));
+
+    expect(result.status).toBe("no-finding");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.red).not.toHaveBeenCalled();
+  });
+});
+
+describe("repair mode", () => {
+  it("executes the fixed stage order with exactly one clean reset", async () => {
+    const a = allFns();
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("repair-verified");
+    expect(result.publicationAllowed).toBe(true);
+    expect(a.openAiPrGate).toHaveBeenCalledTimes(1);
+    expect(a.baseline).toHaveBeenCalledTimes(1);
+    expect(a.discovery).toHaveBeenCalledTimes(1);
+    expect(a.red).toHaveBeenCalledTimes(1);
+    expect(a.green).toHaveBeenCalledTimes(1);
+    expect(a.cleanup).toHaveBeenCalledTimes(1);
+
+    // Red/green receive the validated finding, never the raw adapter envelope.
+    const redArg = a.red.mock.calls[0][0];
+    expect(redArg.finding).toEqual(finding());
+    expect(redArg.finding.status).toBe("finding");
+    expect(redArg.baselineSha).toBe("a".repeat(40));
+    const greenArg = a.green.mock.calls[0][0];
+    expect(greenArg.finding).toEqual(finding());
+    expect(greenArg.redResult).toEqual(redResult());
+    expect(greenArg.baselineSha).toBe("a".repeat(40));
+
+    // Cleanup receives the trusted baseline.
+    expect(a.cleanup.mock.calls[0][0]).toMatchObject({ baselineSha: "a".repeat(40) });
+
+    // The orchestrator never spawns a model command or reads a secret.
+    expect(JSON.stringify(a.red.mock.calls)).not.toContain(MODEL_COMMAND);
+    expect(JSON.stringify(a.green.mock.calls)).not.toContain(SECRET);
+    expect(JSON.stringify(a.green.mock.calls)).not.toContain(FAKE_TOKEN);
+  });
+
+  it("maps no-finding in repair to no-finding", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({
+      valid: true,
+      result: { schemaVersion: 1, status: "no-finding", reason: "nothing to repair" }
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("no-finding");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.red).not.toHaveBeenCalled();
+  });
+
+  it("maps invalid finding to finding-rejected", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({ valid: false, error: "schema failed" });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("finding-rejected");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.red).not.toHaveBeenCalled();
+  });
+
+  it("maps a red-stage failure to red-failed", async () => {
+    const a = allFns();
+    a.red.mockResolvedValueOnce({ valid: false, status: "red-confirmed-fail", error: "test did not reproduce" });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("red-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.green).not.toHaveBeenCalled();
+  });
+
+  it("maps a green-stage failure to green-failed", async () => {
+    const a = allFns();
+    a.green.mockResolvedValueOnce({ valid: false, status: "targeted-test-failed", error: "test still red" });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("green-failed");
+    expect(result.publicationAllowed).toBe(false);
+  });
+
+  it("fails closed when the clean reset (cleanup) fails", async () => {
+    const a = allFns();
+    a.cleanup.mockResolvedValueOnce({ valid: false, error: "reset could not be verified" });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("cleanup-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.green).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when cleanup throws", async () => {
+    const a = allFns();
+    a.cleanup.mockRejectedValueOnce(new Error("reset failed"));
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("cleanup-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.green).not.toHaveBeenCalled();
+  });
+
+  it("requires the green result to claim repair-verified; otherwise publicationAllowed=false", async () => {
+    const a = allFns();
+    a.green.mockResolvedValueOnce({
+      valid: true,
+      result: { schemaVersion: 1, status: "repair-pending", baselineSha: "a".repeat(40) }
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("green-failed");
+    expect(result.publicationAllowed).toBe(false);
+  });
+
+  it("requires the green result baseline to match the trusted baseline", async () => {
+    const a = allFns();
+    a.green.mockResolvedValueOnce({ valid: true, result: { ...greenResult(), baselineSha: "d".repeat(40) } });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("baseline-blocked");
+    expect(result.publicationAllowed).toBe(false);
+  });
+
+  it("rejects a tampered baseline from the discovery result", async () => {
+    const a = allFns();
+    a.discovery.mockResolvedValueOnce({
+      valid: true,
+      result: {
+        ...finding(),
+        baselineSha: "zzz-not-a-sha"
+      }
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("finding-rejected");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.red).not.toHaveBeenCalled();
+  });
+
+  it("rejects a red result whose baselineSha does not match the trusted baseline", async () => {
+    const a = allFns();
+    a.red.mockResolvedValueOnce({ valid: true, result: { ...redResult(), baselineSha: "d".repeat(40) } });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("red-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.green).not.toHaveBeenCalled();
+  });
+
+  it("rejects a red result with an invalid schema/hash", async () => {
+    const a = allFns();
+    a.red.mockResolvedValueOnce({ valid: true, result: { ...redResult(), patchSha256: "not-hex" } });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("red-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.green).not.toHaveBeenCalled();
+  });
+
+  it("maps timeout/signal/throw to a bounded machine-readable status", async () => {
+    const a = allFns();
+    a.red.mockResolvedValueOnce({
+      valid: false,
+      error: "targeted Vitest process timed out",
+      signal: "SIGKILL",
+      exitCode: null
+    });
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.status).toBe("red-failed");
+    expect(result.reason).toContain("SIGKILL");
+  });
+
+  it("sanitizes the final result so fake secrets and env dumps never appear", async () => {
+    const a = allFns();
+    a.green.mockResolvedValueOnce({
+      valid: false,
+      status: "full-check-failed",
+      error: `build failed with ${SECRET} at ${ABSOLUTE_PATH}; ${ENV_DUMP}`
+    });
+    const result = await runWorkflowOrchestration({
+      ...opts(a, { mode: "repair" }),
+      limits: {
+        baselineTimeoutMs: 1000,
+        findingBytes: 4096,
+        environment: {
+          FIXTURE_SECRET: SECRET,
+          PATH: "/usr/local/bin:/usr/bin",
+          HOME: ABSOLUTE_PATH
+        }
+      }
+    });
+
+    const serialized = JSON.stringify(result);
+    expect(result.status).toBe("green-failed");
+    expect(result.publicationAllowed).toBe(false);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain(ABSOLUTE_PATH);
+    expect(serialized).toContain("REDACTED_KEY");
+  });
+
+  it("returns a publication candidate with sanitized fields only", async () => {
+    const a = allFns();
+    const result = await runWorkflowOrchestration(opts(a, { mode: "repair" }));
+
+    expect(result.publicationAllowed).toBe(true);
+    expect(result.status).toBe("repair-verified");
+    expect(result.baselineSha).toBe("a".repeat(40));
+    expect(result.changedFiles).toBe(1);
+    expect(result.changedLines).toBe(2);
+    expect(result.finalDiffSha256).toBe("c".repeat(64));
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain(ENV_DUMP);
+    expect(serialized).not.toContain(ABSOLUTE_PATH);
+    expect(serialized).not.toContain("ghp_");
+  });
+});
+
+describe("strict repeat run", () => {
+  it("does not carry mutable state between runs", async () => {
+    const a1 = allFns();
+    const r1 = await runWorkflowOrchestration(opts(a1, { mode: "repair" }));
+    expect(r1.status).toBe("repair-verified");
+
+    // A second invocation with fresh adapters must run the same stage sequence.
+    const a2 = allFns();
+    const r2 = await runWorkflowOrchestration(opts(a2, { mode: "observe" }));
+    expect(r2.status).toBe("observed");
+    expect(a2.red).not.toHaveBeenCalled();
+
+    // A third run in repair mode again runs every stage exactly once.
+    const a3 = allFns();
+    const r3 = await runWorkflowOrchestration(opts(a3, { mode: "repair" }));
+    expect(r3.status).toBe("repair-verified");
+    expect(a3.red).toHaveBeenCalledTimes(1);
+    expect(a3.green).toHaveBeenCalledTimes(1);
+    expect(a3.cleanup).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #688

## Summary

- Add `scripts/gemini-correctness/workflow-orchestrator.mjs`: a GitHub-independent deterministic orchestration state machine serializing the merged discovery / RED / GREEN stages into `off` / `observe` / `repair` outcomes.
- `runWorkflowOrchestration({ mode, baselineSha, adapters, limits })` — all adapters injected (fakes in tests); never spawns a model command, reads a secret store, or calls a GitHub write API.
- `off` skips with zero adapter calls; `observe` stops at discovery; `repair` runs gate → baseline → discovery → RED → clean reset → GREEN.
- Every stage hand-off is a validated contract (finding re-validated, red/green results schema+hash+baseline checked, tampered rejected). `publicationAllowed=true` only for a repair-verified clean worktree with a consistent baseline; result is a publication candidate, never published.
- Results are sanitized (shared `redactForOutput` + scrub for tokens/env-dump/absolute paths); injected environment is used only for redaction and never forwarded to adapters.

## Scope

Only the two new files: `scripts/gemini-correctness/workflow-orchestrator.mjs` and `workflow-orchestrator.test.ts`. No workflow YAML, no GitHub write code, no changes to #635–#637 policy/prompt/runner/validator behavior.

## Verification

- `node --check` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run scripts/gemini-correctness/workflow-orchestrator.test.ts` — 30/30 pass
- `pnpm build` — pass
- `git diff --cached --check` — pass

## Reviewer verdict

```
Blocking findings:
- (none)

Non-blocking findings:
- (none)

Verdict:
No blocking findings.
```