### PR TITLE
refactor(grammar): reset level filters by keyed mount

### DIFF
--- a/src/components/GrammarIndexPage.test.tsx
+++ b/src/components/GrammarIndexPage.test.tsx
@@ -1,0 +1,217 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StrictMode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { GrammarIndexPage } from "./GrammarIndexPage";
+import { copy } from "../i18n";
+import type { JlptLevel } from "../domain/types";
+
+const t = copy["zh-Hant"];
+
+type PageProps = {
+  language: "zh-Hant";
+  level: JlptLevel | null;
+  onOpenPattern: (surface: string) => void;
+  onBack: () => void;
+  onBackToOverview: () => void;
+  onSelectLevel: (level: JlptLevel) => void;
+};
+
+function makeProps(level: JlptLevel | null): PageProps {
+  return {
+    language: "zh-Hant",
+    level,
+    onOpenPattern: vi.fn(),
+    onBack: vi.fn(),
+    onBackToOverview: vi.fn(),
+    onSelectLevel: vi.fn(),
+  };
+}
+
+function setup(level: JlptLevel | null) {
+  const props = makeProps(level);
+  const view = render(<GrammarIndexPage {...props} />);
+  return { ...view, props };
+}
+
+// N5 文型總數：16（14 must_know + 2 high_frequency）。
+// N4 文型總數：19（3 must_know + 16 high_frequency）。
+// 只有 N2 有 4 條含影視例句的文型（ni-shitemo/kaneru/warini/nimo-kakawarazu）。
+
+describe("GrammarIndexPage level-local filters (issue #682)", () => {
+  it("resets media + importance filters after an overview round-trip back into N5", async () => {
+    const user = userEvent.setup();
+    const { rerender } = setup("N5");
+
+    // 16 N5 patterns by default, filters off.
+    expect(screen.getAllByRole("listitem")).toHaveLength(16);
+    const mediaButton = screen.getByRole("button", { name: t.grammarFilterMediaOnly });
+    const importanceSelect = screen.getByLabelText(t.grammarFilterImportance);
+    expect(mediaButton).not.toHaveClass("active");
+    expect(importanceSelect).toHaveValue("");
+
+    // Enable both level-local filters.
+    await user.click(mediaButton);
+    await user.selectOptions(importanceSelect, "must_know");
+    expect(mediaButton).toHaveClass("active");
+    expect(importanceSelect).toHaveValue("must_know");
+
+    // Back to overview: the level-local filter UI unmounts.
+    rerender(<GrammarIndexPage {...makeProps(null)} />);
+    expect(
+      screen.queryByRole("button", { name: t.grammarFilterMediaOnly })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(t.grammarFilterImportance)).not.toBeInTheDocument();
+
+    // Re-entering N5 remounts the level subtree with default filters.
+    rerender(<GrammarIndexPage {...makeProps("N5")} />);
+    expect(screen.getByRole("button", { name: t.grammarFilterMediaOnly })).not.toHaveClass(
+      "active"
+    );
+    expect(screen.getByLabelText(t.grammarFilterImportance)).toHaveValue("");
+    expect(screen.getAllByRole("listitem")).toHaveLength(16);
+  });
+
+  it("starts N4 with default filters on a direct N5 -> N4 switch", async () => {
+    const user = userEvent.setup();
+    const { rerender } = setup("N5");
+
+    // Apply an importance filter inside N5.
+    await user.selectOptions(screen.getByLabelText(t.grammarFilterImportance), "must_know");
+    // N5 must_know = 14.
+    expect(screen.getAllByRole("listitem")).toHaveLength(14);
+    expect(screen.getByLabelText(t.grammarFilterImportance)).toHaveValue("must_know");
+
+    // Switch straight to N4 without visiting the overview.
+    rerender(<GrammarIndexPage {...makeProps("N4")} />);
+    // The keyed N4 subtree mounts fresh: default filter, all 19 N4 patterns.
+    expect(screen.getByLabelText(t.grammarFilterImportance)).toHaveValue("");
+    expect(screen.getAllByRole("listitem")).toHaveLength(19);
+  });
+
+  it("keeps the search query across overview round-trips and level switches", async () => {
+    const user = userEvent.setup();
+    const { rerender } = setup("N2");
+
+    const input = screen.getByRole("searchbox");
+    await user.type(input, "としても");
+    // In a level, the query filters that level's list down to the match.
+    expect(input).toHaveValue("としても");
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+
+    // Overview still owns the same searchQuery -> global search shows the match.
+    rerender(<GrammarIndexPage {...makeProps(null)} />);
+    expect(screen.getByRole("searchbox")).toHaveValue("としても");
+    expect(
+      screen.getByRole("heading", { name: `${t.grammarSearchResults}（1）` })
+    ).toBeInTheDocument();
+
+    // Re-entering the level keeps the query and re-applies it to the level list.
+    rerender(<GrammarIndexPage {...makeProps("N2")} />);
+    expect(screen.getByRole("searchbox")).toHaveValue("としても");
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+  });
+
+  it("does not remount the search input when the level branch changes mid-composition", () => {
+    const { rerender } = setup("N5");
+
+    const input = screen.getByRole("searchbox");
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "ても" } });
+
+    rerender(<GrammarIndexPage {...makeProps(null)} />);
+    expect(screen.getByRole("searchbox")).toBe(input);
+
+    rerender(<GrammarIndexPage {...makeProps("N5")} />);
+    expect(screen.getByRole("searchbox")).toBe(input);
+    expect(input).toHaveValue("ても");
+
+    fireEvent.compositionEnd(input);
+  });
+
+  it("does not leak unmounted level filters into overview global search", async () => {
+    const user = userEvent.setup();
+    const { rerender } = setup("N2");
+
+    // N2 has 5 "understand" patterns; toshitemo is high_frequency (not filtered in).
+    await user.selectOptions(screen.getByLabelText(t.grammarFilterImportance), "understand");
+    expect(screen.getAllByRole("listitem")).toHaveLength(5);
+
+    // Back to overview and run a global search matching a non-understand pattern.
+    rerender(<GrammarIndexPage {...makeProps(null)} />);
+    await user.type(screen.getByRole("searchbox"), "としても");
+
+    // Global search is driven solely by the query — no level-filter leakage.
+    expect(
+      screen.getByRole("heading", { name: `${t.grammarSearchResults}（1）` })
+    ).toBeInTheDocument();
+    expect(screen.getByText("〜としても")).toBeInTheDocument();
+  });
+
+  it("keeps level results, empty state, matched count and pattern-open behavior intact", async () => {
+    const user = userEvent.setup();
+
+    // Level results: full N5 list.
+    const levelView = setup("N5");
+    expect(screen.getAllByRole("listitem")).toHaveLength(16);
+
+    // Empty state inside a level when the query matches nothing there.
+    await user.type(screen.getByRole("searchbox"), "としても");
+    expect(screen.getByText(t.grammarNoPatterns)).toBeInTheDocument();
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+
+    // Matched count on the overview global search.
+    levelView.unmount();
+    const overview = setup(null);
+    await user.type(screen.getByRole("searchbox"), "としても");
+    expect(
+      screen.getByRole("heading", { name: `${t.grammarSearchResults}（1）` })
+    ).toBeInTheDocument();
+    overview.unmount();
+
+    // Opening a pattern still strips the 〜 prefix and calls onOpenPattern.
+    const openProps = makeProps("N5");
+    const openView = render(<GrammarIndexPage {...openProps} />);
+    await user.click(screen.getByText("〜てもいい"));
+    expect(openProps.onOpenPattern).toHaveBeenCalledWith("てもいい");
+    openView.unmount();
+
+    expect(levelView.props.onOpenPattern).not.toHaveBeenCalled();
+  });
+
+  it("resets filters exactly once under StrictMode without state-update warnings", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    const props = makeProps("N5");
+    const { rerender } = render(
+      <StrictMode>
+        <GrammarIndexPage {...props} />
+      </StrictMode>
+    );
+    await user.selectOptions(screen.getByLabelText(t.grammarFilterImportance), "must_know");
+    await user.click(screen.getByRole("button", { name: t.grammarFilterMediaOnly }));
+
+    rerender(
+      <StrictMode>
+        <GrammarIndexPage {...makeProps(null)} />
+      </StrictMode>
+    );
+    rerender(
+      <StrictMode>
+        <GrammarIndexPage {...makeProps("N5")} />
+      </StrictMode>
+    );
+
+    // Fresh mount defaults, not a double-applied filter.
+    expect(screen.getByLabelText(t.grammarFilterImportance)).toHaveValue("");
+    expect(screen.getByRole("button", { name: t.grammarFilterMediaOnly })).not.toHaveClass(
+      "active"
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(16);
+
+    // No React warning was emitted during the branch switches.
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/GrammarIndexPage.tsx
+++ b/src/components/GrammarIndexPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { ArrowLeft, BookOpen, Search, Clapperboard } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import {
@@ -26,8 +26,6 @@ export function GrammarIndexPage({
 }) {
   const t = copy[language];
   const [searchQuery, setSearchQuery] = useState("");
-  const [showMediaOnly, setShowMediaOnly] = useState(false);
-  const [showImportanceFilter, setShowImportanceFilter] = useState<string | null>(null);
   const [expandedLevel, setExpandedLevel] = useState<JlptLevel | null>(level);
 
   const grouped = useMemo(() => getPatternsGroupedByLevel(), []);
@@ -61,23 +59,6 @@ export function GrammarIndexPage({
     [t]
   );
 
-  /** 篩選單一等級的列表 */
-  const filterPatterns = (patterns: GrammarPattern[]): GrammarPattern[] => {
-    let result = patterns;
-    if (searchQuery.trim()) {
-      result = searchPatterns(searchQuery).filter((p) =>
-        patterns.some((sp) => sp.id === p.id)
-      );
-    }
-    if (showMediaOnly) {
-      result = result.filter((p) => p.mediaExamples.length > 0);
-    }
-    if (showImportanceFilter) {
-      result = result.filter((p) => p.importance === showImportanceFilter);
-    }
-    return result;
-  };
-
   /** 跨等級搜尋結果 */
   const globalSearchResults = useMemo(() => {
     if (!searchQuery.trim()) return null;
@@ -93,14 +74,6 @@ export function GrammarIndexPage({
       return { pattern: p, matchedField: matchedFieldLabels[field] };
     });
   }, [searchQuery, matchedFieldLabels]);
-
-  /** 在 overview 隱藏等級篩選器時同步重設，避免 filter 隱形滲漏 */
-  useEffect(() => {
-    if (level === null) {
-      setShowMediaOnly(false);
-      setShowImportanceFilter(null);
-    }
-  }, [level]);
 
   /** 共用搜尋列 — 在三個分支外層統一只渲染一份，避免查詢時 IME 因 remount 被中斷 */
   const renderSearchBar = (
@@ -120,7 +93,6 @@ export function GrammarIndexPage({
   const showGlobalSearch = !level && globalSearchResults !== null;
   const showLevel = level !== null;
   const showOverview = !showGlobalSearch && !showLevel;
-  const levelPatterns = level ? filterPatterns(grouped[level]) : [];
 
   return (
     <section className="grammar-index" aria-label={t.grammarIndexTitle}>
@@ -142,32 +114,6 @@ export function GrammarIndexPage({
       )}
 
       {renderSearchBar}
-
-      {showLevel && (
-        <div className="gi-filters">
-          <button
-            type="button"
-            className={`gi-filter-btn${showMediaOnly ? " active" : ""}`}
-            onClick={() => setShowMediaOnly(!showMediaOnly)}
-          >
-            <Clapperboard aria-hidden="true" size={16} />
-            {t.grammarFilterMediaOnly}
-          </button>
-          <select
-            className="gi-filter-select"
-            value={showImportanceFilter ?? ""}
-            onChange={(e) => setShowImportanceFilter(e.target.value || null)}
-            aria-label={t.grammarFilterImportance}
-          >
-            <option value="">{t.grammarFilterAllImportance}</option>
-            {Object.entries(importanceLabels).map(([key, label]) => (
-              <option key={key} value={key}>
-                {label}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
 
       {showGlobalSearch ? (
         <div className="gi-section">
@@ -192,26 +138,25 @@ export function GrammarIndexPage({
             </ul>
           )}
         </div>
-      ) : showLevel && levelPatterns.length === 0 ? (
-        <p className="gi-empty">{t.grammarNoPatterns}</p>
       ) : showLevel ? (
-        <ul className="gi-pattern-list">
-          {levelPatterns.map((p) => (
-            <PatternCard
-              key={p.id}
-              pattern={p}
-              importanceLabels={importanceLabels}
-              matchedField={null}
-              onOpen={onOpenPattern}
-              grammarHasMedia={t.grammarHasMedia}
-              grammarMatchFieldLabel={t.grammarMatchFieldLabel}
-            />
-          ))}
-          </ul>
-        ) : (
+        // Level-local filters live in GrammarLevelResults, mounted with
+        // key={level} so a level switch (or overview round-trip) unmounts them
+        // and the next level starts from the default filters again — no
+        // effect-driven reset needed (#682).
+        <GrammarLevelResults
+          key={level}
+          language={language}
+          searchQuery={searchQuery}
+          patterns={grouped[level]}
+          importanceLabels={importanceLabels}
+          onOpenPattern={onOpenPattern}
+          onBack={onBack}
+          onBackToOverview={onBackToOverview}
+        />
+      ) : (
         (["N5", "N4", "N3", "N2", "N1"] as JlptLevel[]).map((lvl) => {
           const stats = summary[lvl];
-          const overviewPatterns = filterPatterns(grouped[lvl]);
+          const overviewPatterns = filterBySearch(grouped[lvl], searchQuery);
           const isExpanded = expandedLevel === lvl;
           return (
             <details
@@ -278,16 +223,118 @@ export function GrammarIndexPage({
           );
         })
       )}
-
-      {showLevel && (
-        <div className="gi-cta">
-          <button type="button" className="ghost-button" onClick={onBackToOverview ?? onBack}>
-            <ArrowLeft aria-hidden="true" />
-            {t.grammarBackToIndex}
-          </button>
-        </div>
-      )}
     </section>
+  );
+}
+
+/** 只依搜尋字串縮減列表（overview 用）— 不套用任何 level-local filter。 */
+function filterBySearch(
+  patterns: GrammarPattern[],
+  searchQuery: string
+): GrammarPattern[] {
+  if (!searchQuery.trim()) return patterns;
+  return searchPatterns(searchQuery).filter((p) =>
+    patterns.some((sp) => sp.id === p.id)
+  );
+}
+
+/**
+ * 單一等級的文型列表，持有 level-local 的 showMediaOnly / showImportanceFilter
+ * state。以 key={level} 掛載於 GrammarIndexPage，因此離開等級 route（回 overview
+ * 或直接切等級）即 unmount，下次進入任何等級都從預設 filter 重新開始 —
+ * 不需要在父層用 effect 同步重設（#682）。
+ */
+function GrammarLevelResults({
+  language,
+  searchQuery,
+  patterns,
+  importanceLabels,
+  onOpenPattern,
+  onBack,
+  onBackToOverview,
+}: {
+  language: Language;
+  searchQuery: string;
+  patterns: GrammarPattern[];
+  importanceLabels: Record<string, string>;
+  onOpenPattern: (surface: string) => void;
+  onBack: () => void;
+  onBackToOverview?: () => void;
+}) {
+  const t = copy[language];
+  const [showMediaOnly, setShowMediaOnly] = useState(false);
+  const [showImportanceFilter, setShowImportanceFilter] = useState<string | null>(null);
+
+  /** 篩選單一等級的列表：search + level-local filters */
+  const filterPatterns = (patterns: GrammarPattern[]): GrammarPattern[] => {
+    let result = patterns;
+    if (searchQuery.trim()) {
+      result = searchPatterns(searchQuery).filter((p) =>
+        patterns.some((sp) => sp.id === p.id)
+      );
+    }
+    if (showMediaOnly) {
+      result = result.filter((p) => p.mediaExamples.length > 0);
+    }
+    if (showImportanceFilter) {
+      result = result.filter((p) => p.importance === showImportanceFilter);
+    }
+    return result;
+  };
+
+  const levelPatterns = filterPatterns(patterns);
+
+  return (
+    <>
+      <div className="gi-filters">
+        <button
+          type="button"
+          className={`gi-filter-btn${showMediaOnly ? " active" : ""}`}
+          onClick={() => setShowMediaOnly(!showMediaOnly)}
+        >
+          <Clapperboard aria-hidden="true" size={16} />
+          {t.grammarFilterMediaOnly}
+        </button>
+        <select
+          className="gi-filter-select"
+          value={showImportanceFilter ?? ""}
+          onChange={(e) => setShowImportanceFilter(e.target.value || null)}
+          aria-label={t.grammarFilterImportance}
+        >
+          <option value="">{t.grammarFilterAllImportance}</option>
+          {Object.entries(importanceLabels).map(([key, label]) => (
+            <option key={key} value={key}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {levelPatterns.length === 0 ? (
+        <p className="gi-empty">{t.grammarNoPatterns}</p>
+      ) : (
+        <ul className="gi-pattern-list">
+          {levelPatterns.map((p) => (
+            <PatternCard
+              key={p.id}
+              pattern={p}
+              importanceLabels={importanceLabels}
+              matchedField={null}
+              onOpen={onOpenPattern}
+              grammarHasMedia={t.grammarHasMedia}
+              grammarMatchFieldLabel={t.grammarMatchFieldLabel}
+            />
+          ))}
+        </ul>
+      )}
+
+      <div className="gi-cta">
+        <button type="button" className="ghost-button" onClick={onBackToOverview ?? onBack}>
+          <ArrowLeft aria-hidden="true" />
+          {t.grammarBackToIndex}
+        </button>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #682

## Summary

- Extract `GrammarLevelResults`, the sole owner of the level-local `showMediaOnly` / `showImportanceFilter` state, mounted with `key={level}` only when `level !== null`.
- Leaving the level route unmounts it; the next level starts from default filters — no effect-driven reset.
- The search input stays parent-owned and is rendered once, so level-subtree remounts never rebuild it or interrupt IME.
- Overview search now applies only the query (`filterBySearch`), never level-local filters.

## Scope

Only `src/components/GrammarIndexPage.tsx` and a new `src/components/GrammarIndexPage.test.tsx`. `src/App.test.tsx` is untouched (it belongs to #686).

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/components/GrammarIndexPage.test.tsx` — 7/7 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test` — pass (1716 tests)

## Reviewer verdict

```
Blocking findings:
- (none)

Non-blocking findings:
- filterBySearch 與 GrammarLevelResults.filterPatterns 有部分重複的 search 步驟（純修飾性）。
- StrictMode 測試的 errorSpy 斷言範圍較廣（任何 console.error 都會失敗），但屬合法 guard。

Verdict:
No blocking findings.
```