### PR TITLE
refactor(route): normalize unavailable blog routes at ingress

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1173,6 +1173,140 @@ describe("App", () => {
     window.history.replaceState({}, "", "/");
   });
 
+  it("normalizes a ja direct /blog/<slug> load to home — no intermediate blog commit (#686)", async () => {
+    // Same 0-frame gate as the #483 test above, but for the initializer path:
+    // a ja direct hit must commit the home view on FIRST render (no redirect
+    // effect), so the (warmed, mocked) blog chunk is never committed and the
+    // URL is rewritten by the URL-sync effect's first run.
+    localStorage.setItem("jabiko.lang", "ja");
+    blogRenders.index = 0;
+    blogRenders.article = 0;
+
+    window.history.replaceState({}, "", "/blog/oshikatsu-slang-nyumon");
+    render(<App />);
+    // Route normalization happens in the initializer, before the first paint,
+    // so no waitFor should be needed to observe the home shell (ja: ホーム).
+    expect(screen.getByRole("button", { name: "ホーム" })).toBeInTheDocument();
+    expect(blogRenders.article).toBe(0);
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("normalizes a ja direct /blog load to home — blog module never mounts (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "ja");
+    blogRenders.index = 0;
+    blogRenders.article = 0;
+
+    window.history.replaceState({}, "", "/blog");
+    render(<App />);
+    expect(screen.getByRole("button", { name: "ホーム" })).toBeInTheDocument();
+    expect(blogRenders.index).toBe(0);
+    expect(screen.queryByRole("button", { name: "記事" })).not.toBeInTheDocument();
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("renders the zh-Hant blog index and article routes (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "zh-Hant");
+    blogRenders.index = 0;
+
+    window.history.replaceState({}, "", "/blog");
+    const { unmount: unmountIndex } = render(<App />);
+    await waitFor(() => expect(blogRenders.index).toBeGreaterThan(0));
+    expect(window.location.pathname).toBe("/blog");
+    unmountIndex();
+
+    blogRenders.article = 0;
+    window.history.replaceState({}, "", "/blog/oshikatsu-slang-nyumon");
+    const { unmount: unmountArticle } = render(<App />);
+    await waitFor(() => expect(blogRenders.article).toBeGreaterThan(0));
+    expect(window.location.pathname).toBe("/blog/oshikatsu-slang-nyumon");
+    unmountArticle();
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("switching to ja while ON the zh-Hant blog lands home in one event (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "zh-Hant");
+    window.history.replaceState({}, "", "/blog");
+    render(<App />);
+    await waitFor(() => expect(blogRenders.index).toBeGreaterThan(0));
+    expect(window.location.pathname).toBe("/blog");
+    // Open the header language picker (still zh-Hant UI).
+    await userEvent.click(screen.getByRole("button", { name: "切換語言" }));
+    // Zero the counter now (opening the picker just re-rendered the zh-Hant
+    // blog) so we can prove the language SWITCH itself never re-commits it.
+    blogRenders.index = 0;
+    await userEvent.click(screen.getByRole("button", { name: "日本語" }));
+
+    // Synchronous: a single user event takes the home route, clears the slug,
+    // saves the preference, and rewrites the URL — no intermediate blog commit.
+    expect(window.location.pathname).toBe("/");
+    expect(localStorage.getItem("jabiko.lang")).toBe("ja");
+    expect(screen.getByRole("button", { name: "ホーム" })).toHaveAttribute("aria-current", "page");
+    expect(blogRenders.index).toBe(0);
+    expect(screen.queryByRole("button", { name: "記事" })).not.toBeInTheDocument();
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("switching to zh-Hant from a non-blog view keeps the route (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "en");
+    window.history.replaceState({}, "", "/about");
+    render(<App />);
+
+    // English UI: the switch button and the About nav carry English labels.
+    await userEvent.click(screen.getByRole("button", { name: "Change language" }));
+    await userEvent.click(screen.getByRole("button", { name: "繁體中文" }));
+
+    expect(window.location.pathname).toBe("/about");
+    expect(localStorage.getItem("jabiko.lang")).toBe("zh-Hant");
+    expect(screen.getByRole("button", { name: "關於" })).toHaveAttribute("aria-current", "page");
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("back/forward to a blog route in ja normalizes to home (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "zh-Hant");
+    window.history.replaceState({}, "", "/blog/oshikatsu-slang-nyumon");
+    const zhRender = render(<App />);
+    await waitFor(() => expect(blogRenders.article).toBeGreaterThan(0));
+    expect(window.location.pathname).toBe("/blog/oshikatsu-slang-nyumon");
+    zhRender.unmount();
+
+    // Now in ja, back/forward to that blog URL must normalize to home without
+    // ever committing the blog article (the old popstate handler would have
+    // committed a blog frame before the effect redirected).
+    localStorage.setItem("jabiko.lang", "ja");
+    blogRenders.article = 0;
+    window.history.replaceState({}, "", "/blog/oshikatsu-slang-nyumon");
+    render(<App />);
+    expect(screen.getByRole("button", { name: "ホーム" })).toBeInTheDocument();
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    expect(screen.getByRole("button", { name: "ホーム" })).toBeInTheDocument();
+    expect(blogRenders.article).toBe(0);
+    await waitFor(() => expect(window.location.pathname).toBe("/"));
+
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("back/forward to a blog route in zh-Hant works normally (#686)", async () => {
+    localStorage.setItem("jabiko.lang", "zh-Hant");
+    window.history.replaceState({}, "", "/blog");
+    render(<App />);
+    await waitFor(() => expect(blogRenders.index).toBeGreaterThan(0));
+
+    // zh-Hant: a popstate to the article route keeps the blog view.
+    window.history.replaceState({}, "", "/blog/oshikatsu-slang-nyumon");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await waitFor(() => expect(blogRenders.article).toBeGreaterThan(0));
+    expect(window.location.pathname).toBe("/blog/oshikatsu-slang-nyumon");
+
+    window.history.replaceState({}, "", "/");
+  });
+
   it("navigates to secondary views through the nav's 更多 menu (#608)", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
 import { kanjiDefaultLevel, type LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
-import { parseRoute, serializeRoute, type AppView } from "./domain/routes";
+import { parseRoute, serializeRoute, type AppRoute, type AppView } from "./domain/routes";
 import packageJson from "../package.json";
 import "./styles.css";
 
@@ -112,21 +112,45 @@ const LANGUAGE_OPTIONS: readonly Language[] = LAUNCHED_LANGUAGES;
 // the nine call sites identical.
 const navIconStyle = { verticalAlign: "middle", marginRight: "0.2rem" } as const;
 
-export default function App() {
-  const [appView, setAppView] = useState<AppView>(() => parseRoute(window.location.pathname).view);
-  // The grammar-point surface for the active /grammar/<surface> route (#281).
-  const [grammarSurface, setGrammarSurface] = useState<string | null>(
-    () => parseRoute(window.location.pathname).grammarSurface
-  );
-  // The article slug for the active /blog/<slug> route (#483); null = index.
-  const [blogSlug, setBlogSlug] = useState<string | null>(
-    () => parseRoute(window.location.pathname).blogSlug
-  );
+// #686: the 文章 blog is zh-Hant-only original content, so any route that
+// resolves to the blog view is normalized to home when the active language
+// can't serve it. Every route ingress (initial load / refresh, popstate, and
+// language switches) funnels through here so the blog view is never committed
+// for a non-zh-Hant language -- the old effect-based redirect (which would
+// briefly render the blog before kicking the user home) is gone. The blog
+// slug is cleared alongside so a later switch back to zh-Hant opens the blog
+// index, not a stale article.
+function normalizeRouteForLanguage(route: AppRoute, language: Language): AppRoute {
+  if (route.view === "blog" && language !== "zh-Hant") {
+    return { view: "home", grammarSurface: null, blogSlug: null };
+  }
+  return route;
+}
 
-  // UI language is pulled up here so the analytics effects (page_view /
-  // study_page_viewed) below can read `language` without a TDZ violation.
+export default function App() {
+  // The active language is resolved before the route state initializers below
+  // so a direct /blog hit in a non-zh-Hant language is normalized to home on
+  // the very first render -- no redirect effect, no intermediate blog commit.
   const { language, setLanguage } = useLanguage();
   const t = copy[language];
+
+  // #686: the initial route is normalized once for the initial language. All
+  // three route-state initializers share this single normalized route so they
+  // can never disagree (e.g. appView=home but blogSlug still set).
+  const initialRoute = useMemo(
+    () => normalizeRouteForLanguage(parseRoute(window.location.pathname), language),
+    // Computed once on mount; `language` is the initial language because the
+    // initializer reads it before any user interaction.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  const [appView, setAppView] = useState<AppView>(() => initialRoute.view);
+  // The grammar-point surface for the active /grammar/<surface> route (#281).
+  const [grammarSurface, setGrammarSurface] = useState<string | null>(
+    () => initialRoute.grammarSurface
+  );
+  // The article slug for the active /blog/<slug> route (#483); null = index.
+  const [blogSlug, setBlogSlug] = useState<string | null>(() => initialRoute.blogSlug);
 
   // Open a grammar point's study page (#282): from the post-answer feedback's
   // "深入學習這個文法 →" link, and deep-linkable directly via the URL.
@@ -152,10 +176,16 @@ export default function App() {
     }
   }, [appView, grammarSurface, blogSlug]);
 
-  // Back/forward: read the view (and grammar surface) back off the URL.
+  // Back/forward: read the view (and grammar surface) back off the URL. The
+  // parsed route is normalized for the CURRENT language first, so a non-zh-Hant
+  // user navigating back/forward into a /blog URL lands on home without ever
+  // committing the blog view (#686).
   useEffect(() => {
     const onPopState = () => {
-      const route = parseRoute(window.location.pathname);
+      const route = normalizeRouteForLanguage(
+        parseRoute(window.location.pathname),
+        language
+      );
       setAppView(route.view);
       setGrammarSurface(route.grammarSurface);
       setBlogSlug(route.blogSlug);
@@ -166,7 +196,7 @@ export default function App() {
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
-  }, []);
+  }, [language]);
 
   // Per-view <title>/description/canonical/og so each route surfaces its own
   // metadata to crawlers (SPA otherwise shares one static shell). See seo.ts.
@@ -221,14 +251,24 @@ export default function App() {
   // #483: the 文章 blog is zh-Hant-only original content (流行語 / 推し活 /
   // 歌詞解說…), so both the nav entry and the view are gated to zh-Hant like
   // the grammar index. A non-zh visitor who deep-links /blog or /blog/<slug>
-  // gets sent home rather than an empty shell.
+  // is sent home rather than an empty shell. The gating itself is enforced at
+  // every route ingress (initial load / popstate / language switch) via
+  // normalizeRouteForLanguage, so the blog view is never committed for a
+  // non-zh-Hant language (#686) -- no redirect effect is needed here.
   const blogAvailable = language === "zh-Hant";
-  useEffect(() => {
-    if (appView === "blog" && !blogAvailable) {
+
+  // #686: the single language-change entry point. All language picker options
+  // route through here so that leaving the zh-Hant-only blog for a language
+  // that can't serve it clears the blog slug and returns home IN THE SAME
+  // event (no intermediate blog render, no redirect effect) before the new
+  // language's preference is saved.
+  const changeLanguage = (nextLanguage: Language) => {
+    if (appView === "blog" && nextLanguage !== "zh-Hant") {
       setBlogSlug(null);
       setAppView("home");
     }
-  }, [appView, blogAvailable]);
+    setLanguage(nextLanguage);
+  };
 
   // Language picker, opened from the header Globe button (#326).
   const [langPickerOpen, setLangPickerOpen] = useState(false);
@@ -266,7 +306,7 @@ export default function App() {
   // (#264), so a shared or bookmarked drill restores; a bare /challenge or any
   // other route stays undefined (default landing).
   const [launch, setLaunch] = useState<SessionInit | undefined>(() =>
-    parseRoute(window.location.pathname).view === "challenge"
+    initialRoute.view === "challenge"
       ? challengeInitFromQuery(window.location.search)
       : undefined
   );
@@ -432,7 +472,7 @@ export default function App() {
           options={LANGUAGE_OPTIONS}
           onChoose={(code) => {
             trackEvent("locale_changed", { from: language, to: code });
-            setLanguage(code);
+            changeLanguage(code);
             setLangPickerOpen(false);
           }}
           onClose={() => setLangPickerOpen(false)}


### PR DESCRIPTION
Closes #686

## Summary

- Replace the effect that redirected away from a non-zh-Hant blog (`set-state-in-effect`) with ingress normalization: `normalizeRouteForLanguage` funnels every route entry — initial load, popstate, and a single `changeLanguage` handler — so the blog view is never committed for a non-zh-Hant language.
- The three route-state initializers share one normalized `initialRoute`; the popstate callback normalizes before writing state.
- `blogAvailable` stays derived from `language === "zh-Hant"`; lazy blog components and nav gating unchanged.

## Scope

Only `src/App.tsx` and `src/App.test.tsx`.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/App.test.tsx` — 66/66 pass
- `pnpm build` — pass
- `git diff --check` — pass
- Full `pnpm test` — pass (1732 tests)

## Reviewer verdict

```
Blocking findings:
- 無

Non-blocking findings:
- initialRoute 的 useMemo 空 deps + eslint-disable（脆弱 suppression，註解合理）。
- changeLanguage 讀 closure appView（僅 user event 觸發，無實際風險）。
- popstate 理論上語言切換時間窗內可能以舊 language 執行（結構性 fall-through，非本實作引入）。

Verdict:
No blocking findings.
```