### PR TITLE
chore(i18n): add exam overlay audit adapter

### DIFF
--- a/scripts/i18n-overlay-audit.mjs
+++ b/scripts/i18n-overlay-audit.mjs
@@ -421,3 +421,263 @@ function getLine(sourceFile, node) {
   const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
   return line + 1;
 }
+
+// ---------------------------------------------------------------------------
+// Exam overlay adapter (#696)
+// ---------------------------------------------------------------------------
+//
+// Audits the six source/overlay field pairs of every `examQuestion({ ... })`
+// literal call in the five fixed exam item files, per item and per target
+// locale. It deliberately knows ONLY the exam shape: any other function or
+// object form is ignored, and any shape that cannot be statically resolved
+// (computed key, spread, dynamic value, duplicate id / field / locale key)
+// throws a deterministic AuditParseError instead of guessing.
+//
+// Canonical key format: `<item-id>.<overlay-field>` (e.g. `n3-foo.hintI18n`).
+
+/** The only source -> overlay field pairs the exam adapter audits. */
+const EXAM_OVERLAY_PAIRS = [
+  ["meaningZh", "meaningI18n"],
+  ["instructionZh", "instructionI18n"],
+  ["promptContextZh", "promptContextI18n"],
+  ["hintZh", "hintI18n"],
+  ["exampleMeaningZh", "exampleMeaningI18n"],
+  ["explanation", "explanationI18n"]
+];
+
+/** Fixed scan set for the exam adapter (issue #696). */
+const EXAM_ITEM_FILES = ["n1.ts", "n2.ts", "n3.ts", "n4.ts", "n5.ts"];
+
+/**
+ * Collect the direct members of an object literal into a name -> member map,
+ * failing closed on spreads, computed names and duplicate member names.
+ * Getter/setter/method members keep their static names so the caller can
+ * reject them when a value is required to be plain text.
+ */
+function collectItemMembers(node, sourceFile) {
+  const sf = sourceFile ?? node.getSourceFile?.();
+  if (!ts.isObjectLiteralExpression(node)) {
+    throw new AuditParseError(
+      `expected an object literal for examQuestion arguments, got ${ts.SyntaxKind[node.kind]}`,
+      { file: sf?.fileName, line: getLine(sf, node), context: node.getText() }
+    );
+  }
+  const members = new Map();
+  for (const member of node.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file: sf?.fileName, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    const name = readStaticPropertyName(member.name, sf);
+    if (members.has(name)) {
+      throw new AuditParseError(
+        `duplicate field "${name}" in examQuestion item`,
+        { file: sf?.fileName, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    members.set(name, member);
+  }
+  return members;
+}
+
+/** True when a value node is a plain static string (incl. no-substitution
+ *  template literals). Numeric literals are accepted for overlay content. */
+function isStaticString(node) {
+  return (
+    ts.isStringLiteral(node) ||
+    ts.isNoSubstitutionTemplateLiteral(node) ||
+    ts.isNumericLiteral(node)
+  );
+}
+
+/**
+ * Audit the exam item files under `repoRoot/src/domain/exam/items/` and return
+ * the overlay audit records (system "exam") for every `examQuestion({ ... })`
+ * literal call, per item and per target locale.
+ *
+ *   - A non-empty source field requires the overlay to carry every target
+ *     locale -> missing record otherwise.
+ *   - An absent or authored-empty source field requires nothing; any overlay
+ *     locale key that still exists is reported as dangling.
+ *   - Non-target locale keys are shape-checked but never reported.
+ *   - item ids must be non-empty static string literals; duplicates fail closed.
+ *   - Spreads, computed keys, dynamic values, duplicate fields and duplicate
+ *     locale keys fail closed with a deterministic AuditParseError.
+ *
+ * Returns records sorted by the canonical `sortAuditRecords` order. Performs
+ * zero filesystem writes, console output, network access and never calls
+ * process.exit.
+ */
+export function auditExamOverlays({ repoRoot, targetLocales }) {
+  if (typeof repoRoot !== "string" || repoRoot.length === 0) {
+    throw new Error("auditExamOverlays requires a non-empty repoRoot directory");
+  }
+  if (
+    !Array.isArray(targetLocales) ||
+    !targetLocales.every((l) => typeof l === "string" && l.length > 0)
+  ) {
+    throw new Error("auditExamOverlays requires targetLocales to be an array of locale strings");
+  }
+  const locales = [...new Set(targetLocales)];
+
+  const records = [];
+  const seenItemIds = new Set();
+
+  for (const fileName of EXAM_ITEM_FILES) {
+    const filePath = `${repoRoot}/src/domain/exam/items/${fileName}`;
+    const sourceFile = parseTypeScriptFile(filePath);
+
+    const visit = (node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "examQuestion"
+      ) {
+        const itemObject = node.arguments[0];
+        if (!ts.isObjectLiteralExpression(itemObject)) {
+          throw new AuditParseError(
+            "examQuestion must be called with an object literal",
+            { file: filePath, line: getLine(sourceFile, node), context: node.getText() }
+          );
+        }
+        const members = collectItemMembers(itemObject, sourceFile);
+
+        // --- item id: non-empty static string literal ---------------------
+        const idMember = members.get("id");
+        if (!idMember || !ts.isPropertyAssignment(idMember)) {
+          throw new AuditParseError(
+            "exam item is missing a static string id",
+            { file: filePath, line: getLine(sourceFile, idMember ?? node) }
+          );
+        }
+        const idInit = idMember.initializer;
+        if (!ts.isStringLiteral(idInit) && !ts.isNoSubstitutionTemplateLiteral(idInit)) {
+          throw new AuditParseError(
+            `exam item id must be a static string literal: ${idInit.getText(sourceFile)}`,
+            { file: filePath, line: getLine(sourceFile, idMember), context: idInit.getText(sourceFile) }
+          );
+        }
+        const itemId = idInit.text;
+        if (itemId.trim().length === 0) {
+          throw new AuditParseError(
+            "exam item id must be a non-empty string literal",
+            { file: filePath, line: getLine(sourceFile, idMember) }
+          );
+        }
+        if (seenItemIds.has(itemId)) {
+          throw new AuditParseError(
+            `duplicate exam item id "${itemId}"`,
+            { file: filePath, line: getLine(sourceFile, idMember), context: itemId }
+          );
+        }
+        seenItemIds.add(itemId);
+
+        // --- six source/overlay pairs -------------------------------------
+        for (const [sourceField, overlayField] of EXAM_OVERLAY_PAIRS) {
+          const sourceMember = members.get(sourceField);
+          const overlayMember = members.get(overlayField);
+
+          // Source value: static string; absent stays null, "" means authored-empty.
+          let sourceText = null;
+          if (sourceMember) {
+            if (!ts.isPropertyAssignment(sourceMember)) {
+              throw new AuditParseError(
+                `${sourceField} must be a static string literal`,
+                { file: filePath, line: getLine(sourceFile, sourceMember) }
+              );
+            }
+            const sourceInit = sourceMember.initializer;
+            if (
+              !ts.isStringLiteral(sourceInit) &&
+              !ts.isNoSubstitutionTemplateLiteral(sourceInit)
+            ) {
+              throw new AuditParseError(
+                `${sourceField} must be a static string literal: ${sourceInit.getText(sourceFile)}`,
+                { file: filePath, line: getLine(sourceFile, sourceMember), context: sourceInit.getText(sourceFile) }
+              );
+            }
+            sourceText = sourceInit.text;
+          }
+
+          // Overlay value: an object literal of static locale -> static content.
+          let overlayLocales = null; // null = overlay field absent
+          if (overlayMember) {
+            if (!ts.isPropertyAssignment(overlayMember)) {
+              throw new AuditParseError(
+                `${overlayField} must be an object literal mapping locales to text`,
+                { file: filePath, line: getLine(sourceFile, overlayMember) }
+              );
+            }
+            const overlayInit = overlayMember.initializer;
+            if (!ts.isObjectLiteralExpression(overlayInit)) {
+              throw new AuditParseError(
+                `${overlayField} must be an object literal mapping locales to text`,
+                { file: filePath, line: getLine(sourceFile, overlayMember), context: overlayInit.getText(sourceFile) }
+              );
+            }
+            overlayLocales = new Map();
+            for (const localeMember of overlayInit.properties) {
+              if (ts.isSpreadAssignment(localeMember)) {
+                throw new AuditParseError(
+                  `object spread cannot be resolved statically in overlay: ${localeMember.getText(sourceFile)}`,
+                  { file: filePath, line: getLine(sourceFile, localeMember), context: localeMember.getText(sourceFile) }
+                );
+              }
+              if (!ts.isPropertyAssignment(localeMember)) {
+                throw new AuditParseError(
+                  `overlay locale entries must be static property assignments: ${localeMember.getText(sourceFile)}`,
+                  { file: filePath, line: getLine(sourceFile, localeMember), context: localeMember.getText(sourceFile) }
+                );
+              }
+              const locale = readStaticPropertyName(localeMember.name, sourceFile);
+              if (overlayLocales.has(locale)) {
+                throw new AuditParseError(
+                  `duplicate overlay locale key "${locale}" for ${itemId}.${overlayField}`,
+                  { file: filePath, line: getLine(sourceFile, localeMember), context: locale }
+                );
+              }
+              if (!isStaticString(localeMember.initializer)) {
+                throw new AuditParseError(
+                  `${overlayField}["${locale}"] must be a static string/content value`,
+                  { file: filePath, line: getLine(sourceFile, localeMember), context: localeMember.initializer.getText(sourceFile) }
+                );
+              }
+              overlayLocales.set(locale, localeMember);
+            }
+          }
+
+          const active = sourceText !== null && sourceText !== "";
+          if (active) {
+            for (const locale of locales) {
+              if (!overlayLocales || !overlayLocales.has(locale)) {
+                records.push({
+                  system: "exam",
+                  locale,
+                  sourceKey: `${itemId}.${overlayField}`,
+                  overlayKey: "",
+                  status: "missing"
+                });
+              }
+            }
+          } else if (overlayLocales) {
+            for (const locale of overlayLocales.keys()) {
+              records.push({
+                system: "exam",
+                locale,
+                sourceKey: "",
+                overlayKey: `${itemId}.${overlayField}`,
+                status: "dangling"
+              });
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  return sortAuditRecords(records);
+}

--- a/scripts/i18n-overlay-audit.test.ts
+++ b/scripts/i18n-overlay-audit.test.ts
@@ -9,6 +9,7 @@ import ts from "typescript";
 // @ts-expect-error -- plain .mjs tooling module, no types
 import {
   AuditParseError,
+  auditExamOverlays,
   auditKeySets,
   collectStaticObjectKeys,
   parseLaunchedLocales,
@@ -404,6 +405,346 @@ describe("core side-effect discipline", () => {
       };
       runOverlayAdapters([adapter], {});
       parseLaunchedLocales(parseTypeScriptFile(localesFixture));
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe("auditExamOverlays (#696)", () => {
+  // Built inside beforeAll: the outer suite assigns tmpDir there, and the
+  // describe body is evaluated before that hook runs.
+  let OPTIONS: { repoRoot: string; targetLocales: string[] };
+
+  /** Write every exam item file. Files not present in `files` are reset to an
+   *  empty stub so leftover fixtures never leak across tests. */
+  function writeExamFixture(files: Record<string, string>): void {
+    const stubs: Record<string, string> = {
+      n1: "export const n1Items: unknown[] = [];",
+      n2: "export const n2Items: unknown[] = [];",
+      n3: "export const n3Items: unknown[] = [];",
+      n4: "export const n4Items: unknown[] = [];",
+      n5: "export const n5Items: unknown[] = [];"
+    };
+    for (const name of ["n1", "n2", "n3", "n4", "n5"]) {
+      fs.writeFileSync(
+        path.join(tmpDir, "src", "domain", "exam", "items", `${name}.ts`),
+        files[name] ?? stubs[name]
+      );
+    }
+  }
+
+  beforeAll(() => {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain", "exam", "items"), {
+      recursive: true
+    });
+    OPTIONS = { repoRoot: tmpDir, targetLocales: ["ja", "en"] };
+    writeExamFixture({});
+  });
+
+  it("reports missing and dangling overlays for all six field pairs, per item and per locale", () => {
+    writeExamFixture({
+      n1: [
+        'import { examQuestion } from "../helpers";',
+        'export const n1Items = [',
+        "  examQuestion({",
+        '    id: "n1-foo",',
+        // meaning: en overlay missing
+        '    meaningZh: "吃",',
+        '    meaningI18n: { "ja": "食べる" },',
+        // instruction: overlay missing entirely (ja + en)
+        '    instructionZh: "選對的。",',
+        // promptContext: complete for ja + en; a non-target locale key (fr) is
+        // parsed for shape but never reported
+        '    promptContextZh: "每天吃。",',
+        '    promptContextI18n: { "ja": "毎日食べる。", "en": "Eat daily.", "fr": "Mange quotidien." },',
+        // hint: empty source but overlay present -> dangling (ja + en)
+        '    hintZh: "",',
+        '    hintI18n: { "ja": "ヒント", "en": "Hint." },',
+        // exampleMeaning: no source, overlay present -> dangling (ja + en)
+        '    exampleMeaningI18n: { "ja": "例文の意味", "en": "Example meaning." },',
+        // explanation: complete -> no records
+        '    explanation: "解說",',
+        '    explanationI18n: { "ja": "解説", "en": "Explanation." }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(auditExamOverlays(OPTIONS)).toEqual([
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "n1-foo.exampleMeaningI18n", status: "dangling" },
+      { system: "exam", locale: "en", sourceKey: "", overlayKey: "n1-foo.hintI18n", status: "dangling" },
+      { system: "exam", locale: "en", sourceKey: "n1-foo.instructionI18n", overlayKey: "", status: "missing" },
+      { system: "exam", locale: "en", sourceKey: "n1-foo.meaningI18n", overlayKey: "", status: "missing" },
+      { system: "exam", locale: "ja", sourceKey: "", overlayKey: "n1-foo.exampleMeaningI18n", status: "dangling" },
+      { system: "exam", locale: "ja", sourceKey: "", overlayKey: "n1-foo.hintI18n", status: "dangling" },
+      { system: "exam", locale: "ja", sourceKey: "n1-foo.instructionI18n", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("keeps the canonical key format <item-id>.<overlay-field>", () => {
+    writeExamFixture({
+      n2: [
+        'import { examQuestion } from "../helpers";',
+        'export const n2Items = [',
+        "  examQuestion({",
+        '    id: "n2-item-x",',
+        '    meaningZh: "非空",',
+        '    hintZh: "提示",',
+        '    hintI18n: { "ja": "ヒント", "en": "Hint." }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    const records = auditExamOverlays(OPTIONS);
+    const meaningMissing = records.filter(
+      (r) => r.sourceKey.startsWith("n2-item-x.meaningI18n") && r.status === "missing"
+    );
+    expect(meaningMissing).toHaveLength(2); // ja + en
+    for (const r of meaningMissing) expect(r.sourceKey).toBe("n2-item-x.meaningI18n");
+  });
+
+  it("skips empty-string source fields but flags an existing overlay as dangling", () => {
+    writeExamFixture({
+      n3: [
+        'import { examQuestion } from "../helpers";',
+        'export const n3Items = [',
+        "  examQuestion({",
+        '    id: "n3-empty",',
+        '    meaningZh: "",',
+        '    meaningI18n: { "ja": "落ち穂", "en": "gleanings" },',
+        '    hintZh: ""',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    const records = auditExamOverlays(OPTIONS);
+    const dangling = records.filter((r) => r.status === "dangling");
+    expect(dangling).toHaveLength(2); // ja + en for n3-empty.meaningI18n
+    expect(dangling.every((r) => r.overlayKey === "n3-empty.meaningI18n")).toBe(true);
+    // hintZh is empty with no overlay at all: no record
+    expect(records.some((r) => r.overlayKey === "n3-empty.hintI18n")).toBe(false);
+  });
+
+  it("requires a non-empty static string item id and fails closed otherwise", () => {
+    writeExamFixture({
+      n5: [
+        'import { examQuestion } from "../helpers";',
+        'export const n5Items = [',
+        "  examQuestion({",
+        '    id: "",',
+        '    meaningZh: "x",',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(AuditParseError);
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/id/);
+
+    writeExamFixture({
+      n5: [
+        'import { examQuestion } from "../helpers";',
+        'export const n5Items = [',
+        "  examQuestion({",
+        "    id: DYNAMIC_ID,",
+        '    meaningZh: "x",',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/id/);
+  });
+
+  it("fails closed on overlay spreads, computed locale keys and dynamic values", () => {
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-spread",',
+        '    meaningZh: "x",',
+        '    meaningI18n: { "ja": "ヒント", ...extra }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/spread/);
+
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-computed",',
+        '    meaningZh: "x",',
+        "    meaningI18n: { [key]: \"v\" }",
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/computed/);
+
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-dynamic",',
+        '    meaningZh: "x",',
+        '    meaningI18n: { "ja": translate("こんにちは") }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/static string|literal/i);
+  });
+
+  it("fails closed on duplicate item ids and duplicate locale keys", () => {
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-dup",',
+        '    meaningZh: "a",',
+        "  }),",
+        "  examQuestion({",
+        '    id: "n4-dup",',
+        '    meaningZh: "b",',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/duplicate|id/);
+
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-duplocale",',
+        '    meaningZh: "a",',
+        '    meaningI18n: { "ja": "x", "ja": "y", "en": "z" }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/duplicate/);
+  });
+
+  it("fails closed on duplicate overlay field keys within one item", () => {
+    writeExamFixture({
+      n4: [
+        'import { examQuestion } from "../helpers";',
+        'export const n4Items = [',
+        "  examQuestion({",
+        '    id: "n4-dupfield",',
+        '    meaningZh: "a",',
+        '    meaningZh: "b",',
+        '    meaningI18n: { "ja": "x", "en": "y" }',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    expect(() => auditExamOverlays(OPTIONS)).toThrow(/duplicate/);
+  });
+
+  it("does not misclassify other functions or object forms as exam items", () => {
+    writeExamFixture({
+      n1: [
+        'import { examQuestion } from "../helpers";',
+        'function examQuestionShim(x: unknown) { return x; }',
+        'const helper = examQuestionShim({',
+        '  id: "not-an-item",',
+        '  meaningZh: "untranslated",',
+        '});',
+        'export const n1Items = [',
+        "  examQuestion({",
+        '    id: "n1-real",',
+        '    meaningZh: "real",',
+        '    meaningI18n: { "ja": "本物", "en": "real" },',
+        '    instructionZh: "選對的。",',
+        '    promptContextZh: "每天吃。",',
+        '    hintZh: "提示",',
+        '    exampleMeaningZh: "例句",',
+        '    explanation: "解說"',
+        "  }),",
+        "];"
+      ].join("\n")
+    });
+    const records = auditExamOverlays(OPTIONS);
+    expect(records.some((r) => String(r.sourceKey).includes("not-an-item"))).toBe(false);
+    const realSourceKeys = records
+      .filter((r) => String(r.sourceKey).includes("n1-real"))
+      .map((r) => String(r.sourceKey));
+    // meaningI18n is complete; the other five zh fields are not overlaid -> 5 x 2 locales
+    expect(realSourceKeys).toHaveLength(10);
+    for (const field of [
+      "instructionI18n",
+      "promptContextI18n",
+      "hintI18n",
+      "exampleMeaningI18n",
+      "explanationI18n"
+    ]) {
+      expect(realSourceKeys).toContain(`n1-real.${field}`);
+    }
+  });
+
+  it("reports byte-equivalent sorted records regardless of locale order", () => {
+    writeExamFixture({
+      n1: [
+        'import { examQuestion } from "../helpers";',
+        'export const n1Items = [',
+        "  examQuestion({ id: \"n1-b\", meaningZh: \"b\", meaningI18n: { \"ja\": \"B\" } }),",
+        "  examQuestion({ id: \"n1-a\", meaningZh: \"a\", meaningI18n: { \"en\": \"A\" } }),",
+        "];"
+      ].join("\n"),
+      n2: [
+        'import { examQuestion } from "../helpers";',
+        'export const n2Items = [',
+        "  examQuestion({ id: \"n2-a\", hintZh: \"h\", hintI18n: { \"ja\": \"H\" } }),",
+        "];"
+      ].join("\n")
+    });
+    const a = JSON.stringify(auditExamOverlays(OPTIONS));
+    const b = JSON.stringify(auditExamOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] }));
+    expect(a).toBe(b);
+    const parsed = JSON.parse(a) as Array<{ sourceKey: string }>;
+    expect(parsed).toHaveLength(3);
+    expect(parsed.map((r) => r.sourceKey).sort()).toEqual([
+      "n1-a.meaningI18n",
+      "n1-b.meaningI18n",
+      "n2-a.hintI18n"
+    ]);
+  });
+
+  it("performs zero filesystem writes, console output, network and process.exit", () => {
+    writeExamFixture({
+      n5: [
+        'import { examQuestion } from "../helpers";',
+        'export const n5Items = [',
+        "  examQuestion({ id: \"n5-ok\", meaningZh: \"ok\", meaningI18n: { \"ja\": \"OK\", \"en\": \"OK\" } }),",
+        "];"
+      ].join("\n")
+    });
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const logSpy = vi.spyOn(console, "log");
+    const errorSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      auditExamOverlays(OPTIONS);
       expect(writeSpy).not.toHaveBeenCalled();
       expect(mkdirSpy).not.toHaveBeenCalled();
       expect(logSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #696

## Summary

- Extend the #695 AST overlay audit core with `auditExamOverlays({ repoRoot, targetLocales })`, scanning `src/domain/exam/items/n1.ts`–`n5.ts` and auditing every `examQuestion({...})` literal call.
- Six field pairs (meaningZh↔meaningI18n, instructionZh↔instructionI18n, promptContextZh↔promptContextI18n, hintZh↔hintI18n, exampleMeaningZh↔exampleMeaningI18n, explanation↔explanationI18n), per item and per target locale.
- Records keyed `<item-id>.<overlay-field>`; non-empty source without overlay → missing, empty/absent source with overlay → dangling.
- Spread/computed/dynamic/duplicate shapes fail closed with `AuditParseError` (file/line/context). No `check:i18n` wiring.

## Scope

Only `scripts/i18n-overlay-audit.mjs` and `scripts/i18n-overlay-audit.test.ts`.

## Verification

- `node --check` — pass
- `pnpm exec vitest run scripts/i18n-overlay-audit.test.ts` — 36/36 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm test` (1770) / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- (none)

Non-blocking findings:
- isStaticString() 接受 NumericLiteral（比純 string 寬鬆，屬 tolerance note）。
- collectItemMembers/isStaticString module-private（非 issue 要求 export）。
- EXAM_ITEM_FILES hardcoded basename（issue 明定 n1-n5，可接受）。

Verdict:
No blocking findings.
```