### PR TITLE
feat(privacy): add user-scoped history deletion protocol

### DIFF
--- a/src/domain/attemptRemote.test.ts
+++ b/src/domain/attemptRemote.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { fetchRemoteAttempts, planLoginSync, pushAttempts } from "./attemptRemote";
+import {
+  deleteRemoteAttempts,
+  fetchRemoteAttempts,
+  planLoginSync,
+  pushAttempts
+} from "./attemptRemote";
 import { attemptKey } from "./attemptSync";
 import type { Attempt } from "./types";
 
@@ -42,6 +47,12 @@ interface UpsertCall {
   options: { onConflict?: string; ignoreDuplicates?: boolean } | undefined;
 }
 
+interface DeleteCall {
+  table: string;
+  eqColumn: string;
+  eqValue: string;
+}
+
 interface QueryResult {
   data: Array<{ payload: Attempt }> | null;
   error: Error | null;
@@ -51,9 +62,11 @@ function makeFakeClient(opts: {
   rows?: Array<{ payload: Attempt }>;
   selectError?: Error;
   upsertError?: Error;
+  deleteError?: Error;
 }) {
   const selectCalls: SelectCall[] = [];
   const upsertCalls: UpsertCall[] = [];
+  const deleteCalls: DeleteCall[] = [];
 
   const client = {
     from(table: string) {
@@ -85,6 +98,16 @@ function makeFakeClient(opts: {
         ): Promise<{ error: Error | null }> {
           upsertCalls.push({ table, rows, options });
           return Promise.resolve({ error: opts.upsertError ?? null });
+        },
+        delete(): {
+          eq(eqColumn: string, eqValue: string): Promise<{ error: Error | null }>;
+        } {
+          return {
+            eq(eqColumn: string, eqValue: string): Promise<{ error: Error | null }> {
+              deleteCalls.push({ table, eqColumn, eqValue });
+              return Promise.resolve({ error: opts.deleteError ?? null });
+            }
+          };
         }
       };
     }
@@ -93,7 +116,8 @@ function makeFakeClient(opts: {
   return {
     client: client as unknown as SupabaseClient,
     selectCalls,
-    upsertCalls
+    upsertCalls,
+    deleteCalls
   };
 }
 
@@ -168,6 +192,32 @@ describe("pushAttempts", () => {
   it("throws when the upsert returns an error", async () => {
     const { client } = makeFakeClient({ upsertError: new Error("nope") });
     await expect(pushAttempts(client, "user-1", [makeAttempt()])).rejects.toThrow("nope");
+  });
+});
+
+// --- deleteRemoteAttempts ---------------------------------------------------
+
+describe("deleteRemoteAttempts", () => {
+  it("deletes attempts filtered by exactly the captured user id (no other filter)", async () => {
+    const { client, deleteCalls } = makeFakeClient({});
+    const result = await deleteRemoteAttempts(client, "user-42");
+    expect(result).toEqual({ ok: true });
+    expect(deleteCalls).toEqual([{ table: "attempts", eqColumn: "user_id", eqValue: "user-42" }]);
+  });
+
+  it("sanitizes a Supabase error: no raw message, SQL, env or token leakage", async () => {
+    const raw = "permission denied for table attempts (sql: DELETE FROM attempts WHERE user_id='$2'). env: SUPABASE_ANON_KEY=supersecret token=eyJhbGciOiJIUzI1NiJ9";
+    const { client } = makeFakeClient({ deleteError: new Error(raw) });
+    const result = await deleteRemoteAttempts(client, "user-1");
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.message).not.toContain("supersecret");
+    expect(result.message).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+    expect(result.message).not.toContain("DELETE FROM");
+    expect(result.message).not.toContain("SUPABASE_ANON_KEY");
+    expect(result.message).not.toContain("$2");
   });
 });
 

--- a/src/domain/attemptRemote.ts
+++ b/src/domain/attemptRemote.ts
@@ -86,6 +86,30 @@ export async function pushAttempts(
   }
 }
 
+// Delete this user's attempts from the Supabase `attempts` table (#692).
+// Remote-first delete protocol: the caller writes a pending marker BEFORE
+// invoking this, and only clears it after local cleanup also lands. The query
+// is pinned to the captured `userId` (the current authenticated user) and
+// relies on the existing RLS -- no service-role, RPC, migration or admin API.
+// A Supabase error is turned into a fixed, sanitized message that never
+// includes the raw response, SQL or any token/environment value, so it is
+// safe to surface in UI state.
+export async function deleteRemoteAttempts(
+  client: SupabaseClient,
+  userId: string
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const { error } = await client
+    .from("attempts")
+    .delete()
+    .eq("user_id", userId);
+
+  if (error) {
+    return { ok: false, message: "Failed to delete remote practice history." };
+  }
+
+  return { ok: true };
+}
+
 // Pure login-sync planner. Given the local attempt history and what the
 // remote already holds, produce:
 //   - `merged`:   the union to write into the local store (mergeAttempts:

--- a/src/domain/practiceHistoryDeletion.test.ts
+++ b/src/domain/practiceHistoryDeletion.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deletionMarkerKey,
+  readDeletionMarker,
+  removeDeletionMarker,
+  writeDeletionMarker
+} from "./practiceHistoryDeletion";
+
+// #692: per-user pending marker for synced-history deletion. These tests pin
+// the fixed key, per-user isolation, crash-safe read/write/remove, and the
+// guarantee that the marker is only ever a boolean flag.
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("practiceHistoryDeletion marker", () => {
+  it("reads false for an untouched user", () => {
+    expect(readDeletionMarker("user-1")).toBe(false);
+  });
+
+  it("write then read is true for that user only (per-user isolation)", () => {
+    expect(writeDeletionMarker("user-A")).toBe(true);
+    expect(readDeletionMarker("user-A")).toBe(true);
+    // A different user is never affected.
+    expect(readDeletionMarker("user-B")).toBe(false);
+  });
+
+  it("uses the fixed key jabiko.attempt-history-delete-pending:<userId>", () => {
+    expect(deletionMarkerKey("user-42")).toBe(
+      "jabiko.attempt-history-delete-pending:user-42"
+    );
+    writeDeletionMarker("user-42");
+    expect(window.localStorage.getItem("jabiko.attempt-history-delete-pending:user-42")).toBe("1");
+  });
+
+  it("remove clears the marker", () => {
+    expect(writeDeletionMarker("user-A")).toBe(true);
+    expect(removeDeletionMarker("user-A")).toBe(true);
+    expect(readDeletionMarker("user-A")).toBe(false);
+  });
+
+  it("write fails (blocked storage) -> returns false and marker stays unset", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    try {
+      expect(writeDeletionMarker("user-A")).toBe(false);
+      expect(readDeletionMarker("user-A")).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("remove fails (blocked storage) -> returns false and marker persists", () => {
+    writeDeletionMarker("user-A");
+    const spy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    try {
+      expect(removeDeletionMarker("user-A")).toBe(false);
+      // The flag is still readable, so the next login can resume cleanup.
+      expect(window.localStorage.getItem(deletionMarkerKey("user-A"))).toBe("1");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("never stores attempt payload / email / token -- only a boolean flag", () => {
+    writeDeletionMarker("user-A");
+    expect(window.localStorage.getItem(deletionMarkerKey("user-A"))).toBe("1");
+  });
+});

--- a/src/domain/practiceHistoryDeletion.ts
+++ b/src/domain/practiceHistoryDeletion.ts
@@ -1,0 +1,52 @@
+import { readStored, writeStored } from "./safeStorage";
+
+// Pending deletion marker for a user's synced practice history (#692).
+//
+// When the learner deletes their synced history we follow a remote-first
+// protocol: delete the Supabase rows, then clear the local persistent store,
+// then (only if both landed) remove this marker. The marker is written up
+// front so that a crash, tab close or offline failure mid-protocol leaves a
+// durable record that the cleanup was *requested* but not yet *confirmed*.
+// On the next login (or a later attempt to delete), the hook must resume the
+// remote delete + local clear BEFORE any normal fetch/merge, and must not
+// re-push local attempts to remote while the marker is present.
+//
+// Deliberately minimal: the marker is a boolean flag keyed per user. It never
+// holds attempt payload, email or token. Written through the crash-safe
+// safeStorage abstraction (blocked storage reads back as "no marker" and a
+// failed write reports failure to the caller instead of throwing).
+
+export const DELETION_MARKER_PREFIX = "jabiko.attempt-history-delete-pending";
+
+/** Fixed per-user storage key for the pending-deletion marker. */
+export function deletionMarkerKey(userId: string): string {
+  return `${DELETION_MARKER_PREFIX}:${userId}`;
+}
+
+/** True when this user's delete is still pending completion. */
+export function readDeletionMarker(userId: string): boolean {
+  return readStored(deletionMarkerKey(userId)) !== null;
+}
+
+/** Record that a delete for this user is pending. Returns success. */
+export function writeDeletionMarker(userId: string): boolean {
+  try {
+    writeStored(deletionMarkerKey(userId), "1");
+  } catch {
+    return false;
+  }
+  return readDeletionMarker(userId);
+}
+
+/** Clear the pending marker once cleanup is confirmed. Returns success. */
+export function removeDeletionMarker(userId: string): boolean {
+  try {
+    if (typeof window === "undefined") {
+      return true;
+    }
+    window.localStorage.removeItem(deletionMarkerKey(userId));
+  } catch {
+    return false;
+  }
+  return !readDeletionMarker(userId);
+}

--- a/src/hooks/useProgressAttempts.test.tsx
+++ b/src/hooks/useProgressAttempts.test.tsx
@@ -13,6 +13,12 @@ const getSupabase = vi.fn<() => Promise<SupabaseClient | null>>();
 const fetchRemoteAttempts = vi.fn<(client: SupabaseClient | null, userId: string) => Promise<Attempt[]>>();
 const pushAttempts =
   vi.fn<(client: SupabaseClient | null, userId: string, attempts: Attempt[]) => Promise<void>>();
+const deleteRemoteAttempts = vi.fn<
+  (client: SupabaseClient, userId: string) => Promise<{ ok: true } | { ok: false; message: string }>
+>();
+const readDeletionMarker = vi.fn<(userId: string) => boolean>();
+const writeDeletionMarker = vi.fn<(userId: string) => boolean>();
+const removeDeletionMarker = vi.fn<(userId: string) => boolean>();
 
 vi.mock("../lib/supabase", () => ({
   getSupabase: () => getSupabase(),
@@ -29,9 +35,17 @@ vi.mock("../domain/attemptRemote", async () => {
     fetchRemoteAttempts: (client: SupabaseClient | null, userId: string) =>
       fetchRemoteAttempts(client, userId),
     pushAttempts: (client: SupabaseClient | null, userId: string, attempts: Attempt[]) =>
-      pushAttempts(client, userId, attempts)
+      pushAttempts(client, userId, attempts),
+    deleteRemoteAttempts: (client: SupabaseClient, userId: string) =>
+      deleteRemoteAttempts(client, userId)
   };
 });
+
+vi.mock("../domain/practiceHistoryDeletion", () => ({
+  readDeletionMarker: (userId: string) => readDeletionMarker(userId),
+  writeDeletionMarker: (userId: string) => writeDeletionMarker(userId),
+  removeDeletionMarker: (userId: string) => removeDeletionMarker(userId)
+}));
 
 // Imported AFTER the mocks are registered. The hook owns a module-singleton
 // attemptStore backed by window.localStorage (jsdom), so each test clears it.
@@ -83,6 +97,11 @@ beforeEach(() => {
   getSupabase.mockResolvedValue(fakeClient);
   fetchRemoteAttempts.mockResolvedValue([]);
   pushAttempts.mockResolvedValue(undefined);
+  deleteRemoteAttempts.mockResolvedValue({ ok: true });
+  // Default: no pending-deletion marker.
+  readDeletionMarker.mockReturnValue(false);
+  writeDeletionMarker.mockReturnValue(true);
+  removeDeletionMarker.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -552,5 +571,396 @@ describe("useProgressAttempts -- login sync commit safety (codex review)", () =>
     expect(user1Pushes[0][2]).toEqual([localOnly]);
     expect(fetchRemoteAttempts.mock.calls.filter(([, id]) => id === "user-1")).toHaveLength(1);
     expect(readStore()).toEqual([localOnly]);
+  });
+});
+
+// --- deleteSyncedPracticeHistory (#692) ------------------------------------
+
+type DeleteResult = { ok: true } | { ok: false; message: string };
+
+describe("useProgressAttempts -- deleteSyncedPracticeHistory", () => {
+  it("not logged in -> false, zero supabase/marker mutation", async () => {
+    const { result } = renderHook(() => useProgressAttempts(null));
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.deleteSyncedPracticeHistory();
+    });
+    expect(ok).toBe(false);
+    expect(result.current.historyDeletionStatus).toBe("idle");
+    expect(getSupabase).not.toHaveBeenCalled();
+    expect(deleteRemoteAttempts).not.toHaveBeenCalled();
+    expect(writeDeletionMarker).not.toHaveBeenCalled();
+    expect(removeDeletionMarker).not.toHaveBeenCalled();
+  });
+
+  it("marker write fails -> false, no remote delete, no local mutation", async () => {
+    const localOnly = makeAttempt({ timestamp: 1, submittedAnswer: "local" });
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    writeDeletionMarker.mockReturnValue(false);
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.deleteSyncedPracticeHistory();
+    });
+    expect(ok).toBe(false);
+    expect(deleteRemoteAttempts).not.toHaveBeenCalled();
+    expect(removeDeletionMarker).not.toHaveBeenCalled();
+    // Local store and React state are completely untouched.
+    expect(readStore()).toEqual([localOnly]);
+    expect(result.current.progressAttempts).toEqual([localOnly]);
+    expect(result.current.historyDeletionStatus).toBe("idle");
+  });
+
+  it("remote fail -> local untouched, marker removed, status error", async () => {
+    const localOnly = makeAttempt({ timestamp: 1, submittedAnswer: "local" });
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    deleteRemoteAttempts.mockResolvedValue({
+      ok: false,
+      message: "Failed to delete remote practice history."
+    });
+
+    let ok = true;
+    await act(async () => {
+      ok = await result.current.deleteSyncedPracticeHistory();
+    });
+    expect(ok).toBe(false);
+    expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1");
+    expect(writeDeletionMarker).toHaveBeenCalledWith("user-1");
+    // Marker was dropped (nothing was deleted, so nothing to resume).
+    expect(removeDeletionMarker).toHaveBeenCalledWith("user-1");
+    // Local store/state untouched.
+    expect(readStore()).toEqual([localOnly]);
+    expect(result.current.progressAttempts).toEqual([localOnly]);
+    expect(result.current.historyDeletionStatus).toBe("error");
+  });
+
+  it("remote success -> store + React cleared, marker removed, status deleted", async () => {
+    const localOnly = makeAttempt({ timestamp: 1, submittedAnswer: "local" });
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    let ok = false;
+    await act(async () => {
+      ok = await result.current.deleteSyncedPracticeHistory();
+    });
+    expect(ok).toBe(true);
+    expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1");
+    expect(removeDeletionMarker).toHaveBeenCalledWith("user-1");
+    // Persistent store cleared and React attempts cleared.
+    expect(readStore()).toBeNull();
+    expect(result.current.progressAttempts).toEqual([]);
+    expect(result.current.historyDeletionStatus).toBe("deleted");
+  });
+
+  it("historyDeletionStatus is deleting while a delete is in flight, then deleted", async () => {
+    const deleteGate = deferred<DeleteResult>();
+    deleteRemoteAttempts.mockReturnValue(deleteGate.promise);
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    let pending!: Promise<boolean>;
+    act(() => {
+      pending = result.current.deleteSyncedPracticeHistory();
+    });
+    await waitFor(() => expect(result.current.historyDeletionStatus).toBe("deleting"));
+
+    await act(async () => {
+      deleteGate.resolve({ ok: true });
+      await pending;
+    });
+    expect(result.current.historyDeletionStatus).toBe("deleted");
+  });
+
+  it("double call -> one remote delete, same operation result shared", async () => {
+    const deleteGate = deferred<DeleteResult>();
+    deleteRemoteAttempts.mockReturnValue(deleteGate.promise);
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    let p1!: Promise<boolean>;
+    let p2!: Promise<boolean>;
+    act(() => {
+      p1 = result.current.deleteSyncedPracticeHistory();
+      p2 = result.current.deleteSyncedPracticeHistory();
+    });
+    await waitFor(() => expect(deleteRemoteAttempts).toHaveBeenCalledTimes(1));
+    // Single-flight: no parallel deletes, and both callers share the op.
+    expect(p2).toBe(p1);
+
+    await act(async () => {
+      deleteGate.resolve({ ok: true });
+      await p1;
+    });
+    expect(result.current.historyDeletionStatus).toBe("deleted");
+  });
+
+  it("login with a pending marker -> resumes delete (remote + local) BEFORE fetch/merge", async () => {
+    const staleLocal = makeAttempt({ timestamp: 1, submittedAnswer: "stale-local" });
+    // Seed the persistent store with pre-delete history and the marker on.
+    window.localStorage.setItem(ATTEMPTS_KEY, JSON.stringify([staleLocal]));
+    readDeletionMarker.mockReturnValue(true);
+    // Removing the marker flips the read back to false (mirrors the real
+    // module removing the localStorage flag), so the resumed sync proceeds.
+    removeDeletionMarker.mockImplementation(() => {
+      readDeletionMarker.mockReturnValue(false);
+      return true;
+    });
+
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+
+    // The resume runs the remote delete first.
+    await waitFor(() => expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1"));
+    await waitFor(() => expect(result.current.historyDeletionStatus).toBe("deleted"));
+
+    // The stale local history was cleared and never merged/pushed back.
+    expect(result.current.progressAttempts).toEqual([]);
+    expect(readStore()).toEqual([]);
+    expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", []);
+    // Normal fetch/merge resumed after the marker was cleared.
+    expect(fetchRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1");
+  });
+
+  it("login with pending marker, remote fails -> keeps marker, no fetch/push of stale local", async () => {
+    const staleLocal = makeAttempt({ timestamp: 1, submittedAnswer: "stale-local" });
+    window.localStorage.setItem(ATTEMPTS_KEY, JSON.stringify([staleLocal]));
+    readDeletionMarker.mockReturnValue(true);
+    removeDeletionMarker.mockReturnValue(false); // marker stuck
+    deleteRemoteAttempts.mockResolvedValue({
+      ok: false,
+      message: "Failed to delete remote practice history."
+    });
+
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+
+    await waitFor(() => expect(result.current.historyDeletionStatus).toBe("error"));
+    // The stale local must not be pushed back while the marker is on.
+    expect(pushAttempts).not.toHaveBeenCalled();
+    expect(fetchRemoteAttempts).not.toHaveBeenCalled();
+  });
+
+  it("recordAttempt while marker present -> no remote push; marker cleared -> push resumes", async () => {
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")));
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    pushAttempts.mockClear(); // drop the login-sync's empty push
+
+    // Marker present: a new attempt stays local-only.
+    readDeletionMarker.mockReturnValue(true);
+    const duringMarker = makeAttempt({ timestamp: 5, submittedAnswer: "during-marker" });
+    act(() => {
+      result.current.recordAttempt(duringMarker);
+    });
+    expect(result.current.progressAttempts).toContainEqual(duringMarker);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(pushAttempts).not.toHaveBeenCalled();
+
+    // Marker cleared: live push resumes.
+    pushAttempts.mockClear();
+    readDeletionMarker.mockReturnValue(false);
+    const afterClear = makeAttempt({ timestamp: 6, submittedAnswer: "after-clear" });
+    act(() => {
+      result.current.recordAttempt(afterClear);
+    });
+    await waitFor(() =>
+      expect(pushAttempts).toHaveBeenCalledWith(fakeClient, "user-1", [afterClear])
+    );
+  });
+
+  it("A delete in flight, switch to B -> A's late success does NOT clear B or change B status", async () => {
+    const bAttempt = makeAttempt({ timestamp: 60, submittedAnswer: "B-data" });
+    const aDeleteGate = deferred<DeleteResult>();
+    deleteRemoteAttempts.mockReturnValue(aDeleteGate.promise);
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    rerender({ user: makeUser("user-A") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    // A starts a delete; it parks on the remote delete gate.
+    let aDelete!: Promise<boolean>;
+    act(() => {
+      aDelete = result.current.deleteSyncedPracticeHistory();
+    });
+    await waitFor(() => expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    // Switch to B while A's delete is still in flight.
+    rerender({ user: makeUser("user-B") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+    act(() => {
+      result.current.recordAttempt(bAttempt);
+    });
+    expect(result.current.progressAttempts).toContainEqual(bAttempt);
+
+    // A's late delete completes (successfully) -- it must be inert on B.
+    await act(async () => {
+      aDeleteGate.resolve({ ok: true });
+      await aDelete;
+    });
+
+    expect(result.current.progressAttempts).toContainEqual(bAttempt);
+    expect(result.current.historyDeletionStatus).toBe("idle");
+    expect(result.current.syncStatus).toBe("synced");
+  });
+
+  it("A delete in flight, logout -> A's late success does NOT clear the anon store", async () => {
+    const anonAttempt = makeAttempt({ timestamp: 65, submittedAnswer: "anon-data" });
+    const aDeleteGate = deferred<DeleteResult>();
+    deleteRemoteAttempts.mockReturnValue(aDeleteGate.promise);
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(anonAttempt);
+    });
+    rerender({ user: makeUser("user-A") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    let aDelete!: Promise<boolean>;
+    act(() => {
+      aDelete = result.current.deleteSyncedPracticeHistory();
+    });
+    await waitFor(() => expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-A"));
+
+    // Logout while A's delete is parked.
+    rerender({ user: null });
+    expect(result.current.syncStatus).toBe("idle");
+
+    await act(async () => {
+      aDeleteGate.resolve({ ok: true });
+      await aDelete;
+    });
+
+    // The anon store keeps its pre-delete data; A's delete is inert.
+    expect(result.current.progressAttempts).toContainEqual(anonAttempt);
+    expect(result.current.historyDeletionStatus).toBe("idle");
+    expect(result.current.syncStatus).toBe("idle");
+  });
+
+  it("delete during login-sync await -> stale sync does NOT commit old remote (no resurrection)", async () => {
+    const oldRemote = makeAttempt({ timestamp: 70, submittedAnswer: "old-remote" });
+    const fetchGate = deferred<Attempt[]>();
+    fetchRemoteAttempts.mockReturnValue(fetchGate.promise);
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(fetchRemoteAttempts).toHaveBeenCalled());
+
+    // The delete completes while the sync is parked on the fetch await.
+    await act(async () => {
+      await result.current.deleteSyncedPracticeHistory();
+    });
+    expect(result.current.progressAttempts).toEqual([]);
+
+    // The stale sync's fetch now resolves with pre-delete remote data.
+    await act(async () => {
+      fetchGate.resolve([oldRemote]);
+      await fetchGate.promise;
+    });
+
+    // The old remote must NOT be merged back in.
+    expect(result.current.progressAttempts).not.toContainEqual(oldRemote);
+    expect(readStore() ?? []).not.toContainEqual(oldRemote);
+  });
+
+  it("StrictMode replay -> no duplicate delete or local replace", async () => {
+    const staleLocal = makeAttempt({ timestamp: 1, submittedAnswer: "stale-local" });
+    window.localStorage.setItem(ATTEMPTS_KEY, JSON.stringify([staleLocal]));
+    readDeletionMarker.mockReturnValue(true);
+    removeDeletionMarker.mockImplementation(() => {
+      readDeletionMarker.mockReturnValue(false);
+      return true;
+    });
+
+    const { result } = renderHook(() => useProgressAttempts(makeUser("user-1")), {
+      wrapper: StrictMode
+    });
+    await waitFor(() => expect(result.current.historyDeletionStatus).toBe("deleted"));
+
+    // Only the replay generation ran the delete (no duplicate remote delete).
+    expect(deleteRemoteAttempts).toHaveBeenCalledTimes(1);
+    expect(deleteRemoteAttempts).toHaveBeenCalledWith(fakeClient, "user-1");
+    // Cleared once and the empty merge committed once.
+    expect(result.current.progressAttempts).toEqual([]);
+    expect(readStore()).toEqual([]);
+  });
+
+  // LAST in this describe: the Storage.prototype.removeItem spy below flips
+  // the module-singleton attemptStore into memory mode (clear()'s fallback),
+  // which would corrupt the storage-backed assertions of any later test.
+  it("remote ok but persistent clear fails -> React cleared, marker kept, status error, old data not pushed", async () => {
+    const localOnly = makeAttempt({ timestamp: 1, submittedAnswer: "local" });
+    const { result, rerender } = renderHook(
+      ({ user }: { user: User | null }) => useProgressAttempts(user),
+      { initialProps: { user: null as User | null } }
+    );
+    act(() => {
+      result.current.recordAttempt(localOnly);
+    });
+    rerender({ user: makeUser("user-1") });
+    await waitFor(() => expect(result.current.syncStatus).toBe("synced"));
+
+    // From here the marker is stuck present and unremovable.
+    readDeletionMarker.mockReturnValue(true);
+    removeDeletionMarker.mockReturnValue(false);
+
+    // Blocked persistent store: the attempts key survives while memory clears.
+    const removeSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    try {
+      let ok = true;
+      await act(async () => {
+        ok = await result.current.deleteSyncedPracticeHistory();
+      });
+      expect(ok).toBe(false);
+      // React state was still cleared.
+      expect(result.current.progressAttempts).toEqual([]);
+      expect(result.current.historyDeletionStatus).toBe("error");
+      // The persistent copy survived (clear failed) -- marker was kept.
+      expect(readStore()).toEqual([localOnly]);
+
+      // While the marker is present, a fresh live attempt is NOT pushed remote.
+      pushAttempts.mockClear();
+      const postDelete = makeAttempt({ timestamp: 9, submittedAnswer: "post-delete" });
+      act(() => {
+        result.current.recordAttempt(postDelete);
+      });
+      expect(result.current.progressAttempts).toContainEqual(postDelete);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(pushAttempts).not.toHaveBeenCalled();
+    } finally {
+      removeSpy.mockRestore();
+    }
   });
 });

--- a/src/hooks/useProgressAttempts.ts
+++ b/src/hooks/useProgressAttempts.ts
@@ -1,8 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { User } from "@supabase/supabase-js";
+import type { SupabaseClient, User } from "@supabase/supabase-js";
 import { createAttemptStore } from "../domain/storage";
-import { fetchRemoteAttempts, planLoginSync, pushAttempts } from "../domain/attemptRemote";
+import {
+  deleteRemoteAttempts,
+  fetchRemoteAttempts,
+  planLoginSync,
+  pushAttempts
+} from "../domain/attemptRemote";
 import { mergeAttempts } from "../domain/attemptSync";
+import {
+  readDeletionMarker,
+  removeDeletionMarker,
+  writeDeletionMarker
+} from "../domain/practiceHistoryDeletion";
 import { getSupabase } from "../lib/supabase";
 import type { Attempt } from "../domain/types";
 
@@ -26,6 +36,33 @@ type SyncResult = {
   status: "synced" | "error";
 };
 
+// Status of the synced-history deletion protocol (#692). Like SyncStatus it is
+// DERIVED (never set synchronously by an effect): `deletionInFlight` drives
+// "deleting" and `lastDeletionResult` (keyed to its user) drives the terminal
+// states, so a previous user's outcome can never leak into the current user's
+// status (the #681 user-scoped terminal-result pattern).
+//   idle     -- no user, nothing in flight, or no outcome for the current user
+//   deleting -- the current user's delete (or pending-marker resume) is running
+//   deleted  -- the last delete for the current user completed fully
+//   error    -- the last delete for the current user failed
+export type HistoryDeletionStatus = "idle" | "deleting" | "deleted" | "error";
+
+type DeletionResult = {
+  userId: string;
+  status: "deleted" | "error";
+};
+
+// A single in-flight delete operation. Only one runs at a time per user;
+// repeated calls share the same promise (no parallel deletes). `active` goes
+// false when the captured user logs out / switches away, so a stale operation
+// bails before it can touch the current user's state or store.
+type DeletionOp = {
+  userId: string;
+  promise: Promise<boolean>;
+  settled: boolean;
+  active: boolean;
+};
+
 // Owns the lifetime attempt history (loaded from storage on mount,
 // appended on every answer). Lifted OUT of usePracticeSession so it can
 // live in the always-mounted App shell: the home/learn dashboards read
@@ -38,6 +75,14 @@ type SyncResult = {
 // logged-in user we merge the remote history into the local store and push
 // the local-only delta back up. The anon (no-user) path is unchanged --
 // local only, never cleared, and the Supabase SDK stays in its lazy chunk.
+//
+// #692 adds a remote-first delete of the CURRENT user's synced history:
+//   - deleteSyncedPracticeHistory() writes a per-user pending marker, deletes
+//     the remote rows, clears the local store + React state, then removes the
+//     marker. While a marker exists, no local attempts are pushed back remote.
+//   - on login with a leftover marker, the delete is resumed (remote + local)
+//     BEFORE the normal fetch/merge, and sync only resumes once the marker is
+//     gone -- so a half-finished delete can never be re-synced back up.
 export function useProgressAttempts(user: User | null) {
   const [progressAttempts, setProgressAttempts] = useState<Attempt[]>(() => attemptStore.list());
   // Only the last COMPLETED sync result is held in state; "in flight" and
@@ -45,6 +90,13 @@ export function useProgressAttempts(user: User | null) {
   // synchronously (it just starts the async flow, which writes the terminal
   // result once a generation finishes).
   const [lastSyncResult, setLastSyncResult] = useState<SyncResult | null>(null);
+  // Terminal outcome of the deletion protocol, keyed to its user (see above).
+  const [lastDeletionResult, setLastDeletionResult] = useState<DeletionResult | null>(null);
+  // The deletion operation currently in flight (a logged-in user may never
+  // request a delete, so "deleting" cannot be derived as "no result yet").
+  const [deletionInFlight, setDeletionInFlight] = useState<{ userId: string; gen: number } | null>(
+    null
+  );
 
   const userId = user?.id ?? null;
 
@@ -60,6 +112,16 @@ export function useProgressAttempts(user: User | null) {
         ? "syncing"
         : lastSyncResult.status;
 
+  // Derived deletion status -- only the current user's own op/result counts.
+  const historyDeletionStatus: HistoryDeletionStatus =
+    userId === null
+      ? "idle"
+      : deletionInFlight !== null && deletionInFlight.userId === userId
+        ? "deleting"
+        : lastDeletionResult !== null && lastDeletionResult.userId === userId
+          ? lastDeletionResult.status
+          : "idle";
+
   // Keep the latest userId for recordAttempt's best-effort push without
   // making the callback's identity depend on it (identity must stay stable
   // so the lazy challenge view doesn't re-render on every answer).
@@ -67,6 +129,136 @@ export function useProgressAttempts(user: User | null) {
   useEffect(() => {
     userIdRef.current = userId;
   }, [userId]);
+
+  // Deletion protocol bookkeeping:
+  //   deletionOpRef    -- the in-flight user-initiated delete (dedup target)
+  //   deletionGenRef   -- monotonic gen so a stale op's finally can't clear a
+  //                       newer op's "deleting" status for the same user
+  //   dataGenRef       -- bumped whenever a delete clears the store; a login
+  //                       sync anchored to an older gen must not commit its
+  //                       stale pre-delete merge (prevents resurrection)
+  const deletionOpRef = useRef<DeletionOp | null>(null);
+  const deletionGenRef = useRef(0);
+  const dataGenRef = useRef(0);
+
+  // Shared tail of the delete protocol: remote delete, then (only on success)
+  // clear the persistent store + React state, then remove the marker. Returns
+  // true only when the marker was actually removed (full cleanup confirmed).
+  // `dropMarkerOnRemoteFail`: the user-initiated flow drops the marker when
+  // the remote delete fails (nothing was deleted, so there is nothing to
+  // resume); the login-resume flow keeps it so the next login retries.
+  const runDeleteCleanup = useCallback(
+    async (
+      client: SupabaseClient,
+      userId: string,
+      isActive: () => boolean,
+      dropMarkerOnRemoteFail: boolean
+    ): Promise<boolean> => {
+      const remote = await deleteRemoteAttempts(client, userId);
+      // Stale (logout / user switch while parked on the remote delete): bail
+      // WITHOUT touching store/state -- A's late completion must never clear
+      // B's data or change B's status.
+      if (!isActive()) {
+        return false;
+      }
+      if (!remote.ok) {
+        if (dropMarkerOnRemoteFail) {
+          removeDeletionMarker(userId);
+        }
+        setLastDeletionResult({ userId, status: "error" });
+        return false;
+      }
+      // Remote succeeded: wipe local (persistent store first, then React),
+      // then commit the marker removal. The marker removal is the durable
+      // "cleanup confirmed" signal: when persistent storage is blocked it
+      // fails together with the attempts-key removal above, so a kept marker
+      // is the honest record that the local persistent copy may have survived
+      // and must not be re-pushed.
+      dataGenRef.current += 1;
+      attemptStore.clear();
+      setProgressAttempts([]);
+      const removed = removeDeletionMarker(userId);
+      setLastDeletionResult({ userId, status: removed ? "deleted" : "error" });
+      return removed;
+    },
+    []
+  );
+
+  // Deletes the CURRENT user's synced practice history, remote-first. Returns
+  // true only when the whole protocol completed (remote rows gone AND local
+  // store + React cleared AND the marker removed). Never throws: failures are
+  // reported via the boolean and the terminal status.
+  const deleteSyncedPracticeHistory = useCallback((): Promise<boolean> => {
+    const capturedUserId = userIdRef.current;
+    if (!capturedUserId) {
+      // Not logged in: nothing to do, and no marker / supabase mutation.
+      return Promise.resolve(false);
+    }
+
+    // Single-flight: an in-flight delete for this same user is shared, never
+    // duplicated. A settled or stale (inactive) op is replaced by a fresh one.
+    const existing = deletionOpRef.current;
+    if (
+      existing &&
+      existing.userId === capturedUserId &&
+      !existing.settled &&
+      existing.active
+    ) {
+      return existing.promise;
+    }
+    if (existing) {
+      existing.active = false;
+    }
+
+    // The marker is the durable intent record; if we can't write it we must
+    // not touch remote at all.
+    if (!writeDeletionMarker(capturedUserId)) {
+      return Promise.resolve(false);
+    }
+
+    const gen = ++deletionGenRef.current;
+    setDeletionInFlight({ userId: capturedUserId, gen });
+
+    const op: DeletionOp = {
+      userId: capturedUserId,
+      settled: false,
+      active: true,
+      promise: Promise.resolve(false)
+    };
+    op.promise = (async (): Promise<boolean> => {
+      try {
+        const client = await getSupabase();
+        if (!op.active) {
+          // Logout / user switch invalidated this operation before it ran.
+          return false;
+        }
+        if (!client) {
+          // Supabase unconfigured: nothing remote to delete; complete the
+          // intent locally.
+          dataGenRef.current += 1;
+          attemptStore.clear();
+          setProgressAttempts([]);
+          removeDeletionMarker(capturedUserId);
+          setLastDeletionResult({ userId: capturedUserId, status: "deleted" });
+          return true;
+        }
+        return await runDeleteCleanup(client, capturedUserId, () => op.active, true);
+      } catch {
+        if (op.active) {
+          // Unexpected failure: leave local untouched, drop the marker (no
+          // confirmed cleanup), surface the error.
+          removeDeletionMarker(capturedUserId);
+          setLastDeletionResult({ userId: capturedUserId, status: "error" });
+        }
+        return false;
+      } finally {
+        op.settled = true;
+        setDeletionInFlight((prev) => (prev && prev.gen === gen ? null : prev));
+      }
+    })();
+    deletionOpRef.current = op;
+    return op.promise;
+  }, [runDeleteCleanup]);
 
   // Login sync: runs when the user id transitions to a non-null value.
   // NOTE: no synchronous setState in the effect body (react-hooks v7
@@ -95,11 +287,70 @@ export function useProgressAttempts(user: User | null) {
       if (!active) {
         return;
       }
+
+      // Generation anchor: a delete that clears the store bumps dataGenRef;
+      // a sync that parked on an await while that happened must not commit
+      // its pre-delete history (resurrection guard).
+      let gen = dataGenRef.current;
+
+      // Pending-deletion resume (#692): a previous delete for this user was
+      // requested but never confirmed. Complete it (remote delete + local
+      // clear) BEFORE any normal fetch/merge, and only continue to sync once
+      // the marker is gone.
+      if (readDeletionMarker(userId)) {
+        // Reuse an in-flight user-initiated delete for this user if one exists
+        // (never run two deletes in parallel).
+        const inFlight = deletionOpRef.current;
+        if (inFlight && inFlight.userId === userId && !inFlight.settled) {
+          await inFlight.promise;
+          if (!active) {
+            return;
+          }
+        }
+        if (readDeletionMarker(userId)) {
+          const resumeGen = ++deletionGenRef.current;
+          setDeletionInFlight({ userId, gen: resumeGen });
+          try {
+            let done = false;
+            if (client) {
+              done = await runDeleteCleanup(client, userId, () => active, false);
+            } else {
+              dataGenRef.current += 1;
+              attemptStore.clear();
+              setProgressAttempts([]);
+              removeDeletionMarker(userId);
+              setLastDeletionResult({ userId, status: "deleted" });
+              done = true;
+            }
+            if (!active) {
+              return;
+            }
+            if (!done) {
+              // Marker stays: the local persistent copy may have survived, so
+              // do NOT fetch/merge/push stale local data back to remote.
+              return;
+            }
+          } finally {
+            setDeletionInFlight((prev) =>
+              prev && prev.gen === resumeGen ? null : prev
+            );
+          }
+          // Re-anchor after OUR OWN resume clear so the sync below is not
+          // (wrongly) treated as stale.
+          gen = dataGenRef.current;
+        }
+      }
+
       // fetch + push run BEFORE any local mutation, so a throw from either
       // (offline, RLS, push conflict, ...) lands in the catch with the local
       // store completely untouched.
       const remote = await fetchRemoteAttempts(client, userId);
       if (!active) {
+        return;
+      }
+      // A delete happened while we were fetching: never merge/push the stale
+      // pre-delete history on top of the cleared store.
+      if (dataGenRef.current !== gen || readDeletionMarker(userId)) {
         return;
       }
       const { toUpload } = planLoginSync(attemptStore.list(), remote);
@@ -109,6 +360,9 @@ export function useProgressAttempts(user: User | null) {
       // can never write a previous user's remote history into the now-anon
       // or new-user store.
       if (!active) {
+        return;
+      }
+      if (dataGenRef.current !== gen || readDeletionMarker(userId)) {
         return;
       }
       // Re-read the live local set at commit time (rather than reusing the
@@ -130,8 +384,17 @@ export function useProgressAttempts(user: User | null) {
 
     return () => {
       active = false;
+      // A user-initiated delete for this user is abandoned on logout/switch:
+      // it must not clear the next user's store or change their status.
+      const op = deletionOpRef.current;
+      if (op && op.userId === userId && !op.settled) {
+        op.active = false;
+      }
+      // Drop the "deleting" status entry for this user so a later re-login
+      // of the same user doesn't read a stale in-flight flag as "deleting".
+      setDeletionInFlight((prev) => (prev && prev.userId === userId ? null : prev));
     };
-  }, [userId]);
+  }, [userId, runDeleteCleanup]);
 
   // Stable identity (setProgressAttempts is stable; attemptStore is a
   // module singleton; user id read via ref) so passing it down to the
@@ -144,7 +407,9 @@ export function useProgressAttempts(user: User | null) {
     // the local store, so a failed push is swallowed -- it will sync on the
     // next login. Fire-and-forget: never blocks recording.
     const id = userIdRef.current;
-    if (id) {
+    // While a pending-delete marker exists for this user, never push live
+    // attempts back to remote (#692): the cleanup must leave history empty.
+    if (id && !readDeletionMarker(id)) {
       void getSupabase()
         .then((client) => pushAttempts(client, id, [attempt]))
         .catch(() => {
@@ -153,5 +418,11 @@ export function useProgressAttempts(user: User | null) {
     }
   }, []);
 
-  return { progressAttempts, recordAttempt, syncStatus };
+  return {
+    progressAttempts,
+    recordAttempt,
+    syncStatus,
+    historyDeletionStatus,
+    deleteSyncedPracticeHistory
+  };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,7 +90,8 @@ export default defineConfig({
             "src/domain/bookmarks.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
-            "src/domain/diagnostics.test.ts"
+            "src/domain/diagnostics.test.ts",
+            "src/domain/practiceHistoryDeletion.test.ts"
           ]
         }
       },
@@ -109,7 +110,8 @@ export default defineConfig({
             "src/domain/bookmarks.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
-            "src/domain/diagnostics.test.ts"
+            "src/domain/diagnostics.test.ts",
+            "src/domain/practiceHistoryDeletion.test.ts"
           ]
         }
       }


### PR DESCRIPTION
Closes #692

## Summary

- `deleteRemoteAttempts(client, userId)` in `attemptRemote.ts`: remote-first delete scoped to the captured user id via existing RLS (`delete().eq("user_id", userId)`), sanitized error message.
- Pending-deletion marker in new `practiceHistoryDeletion.ts`: `readDeletionMarker` / `writeDeletionMarker` / `removeDeletionMarker`, key `jabiko.attempt-history-delete-pending:<userId>`, safe-storage backed, boolean only.
- `deleteSyncedPracticeHistory()` on `useProgressAttempts` with `HistoryDeletionStatus`: marker-first, remote delete, clear store → clear React state → remove marker; marker-gated push suppression (live recordAttempt and login sync), login-resume cleanup, single-flight, and A→B/logout isolation via the #681 generation pattern.
- `vite.config.ts`: register the new localStorage-based test in the jsdom project (same pattern as bookmarks/levelPreference/etc.) — necessary test infra, no production behavior change.

## Scope

`attemptRemote.ts`(+test), `practiceHistoryDeletion.ts`(+test), `useProgressAttempts.ts`(+test), `vite.config.ts` (test-project registration only). No UI, copy, schema/RLS, or auth changes.

## Verification

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/domain/attemptRemote.test.ts src/domain/practiceHistoryDeletion.test.ts src/hooks/useProgressAttempts.test.tsx` — 52/52 pass
- `pnpm test` (130 files / 1783 tests) / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- 無。

Non-blocking findings:
- vite.config.ts 為測試基建必要（與既有 4 個 domain test 模式一致），非 blocking。
- login-resume 路徑未登錄 deletionOpRef（resume 中使用者主動 delete 可能並行兩次等冪 remote delete；無 UI 不可觸發、無資料風險）。
- historyDeletionStatus==="deleted" 具黏性（terminal-outcome 語意，UI 消費時不應當一次性事件）。
- writeDeletionMarker 的 try/catch 是 dead code（writeStored 內部已吞例外），無害。

Verdict:
No blocking findings.
```