### PR TITLE
chore(i18n): audit learning block overlay keys

### DIFF
--- a/scripts/i18n-overlay-audit.mjs
+++ b/scripts/i18n-overlay-audit.mjs
@@ -681,3 +681,303 @@ export function auditExamOverlays({ repoRoot, targetLocales }) {
 
   return sortAuditRecords(records);
 }
+
+// ---------------------------------------------------------------------------
+// Learning-block overlay adapter (#697)
+// ---------------------------------------------------------------------------
+//
+// Audits the "source stable block id <-> overlay first-level key" mapping for
+// the learning-blocks system.
+//
+//   source:  src/domain/learningBlocks.ts    (the `learningBlocks` array)
+//   overlay: src/domain/learningBlocks.i18n.ts (the `learningBlockI18n` record)
+//   key:     the stable id of a real learner-facing block
+//
+// The source side only admits actual learner-facing block elements of the
+// `learningBlocks` array literal; section/container/helper objects and stray
+// `id` fields elsewhere in the file are never counted. The overlay side only
+// admits first-level keys of the `learningBlockI18n` object literal; nested
+// field keys (category / title / explanation / notes / pitfalls / drillNote)
+// are never flattened.
+//
+// For each target locale (resolved by #695's launched-locale registry, never
+// hardcoded) the overlay is expected to carry a first-level key for EVERY
+// source block id. source-without-overlay = missing; overlay-without-source =
+// dangling. A block whose overlay entry omits one locale produces a missing
+// record for that locale only.
+//
+// Fails closed on duplicate source ids / duplicate overlay keys, spreads,
+// computed keys and any dynamic form whose runtime key mapping cannot be
+// confirmed. Performs zero filesystem writes, console output, network access
+// and never calls process.exit.
+
+/**
+ * Resolve the `learningBlocks` array literal from a SourceFile. Returns the
+ * array node when present (identifier `learningBlocks`), otherwise undefined.
+ */
+function findLearningBlocksArray(sourceFile) {
+  let found = undefined;
+  const visit = (node) => {
+    if (
+      found === undefined &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "learningBlocks") continue;
+        if (ts.isArrayLiteralExpression(d.initializer)) found = d.initializer;
+        break;
+      }
+    }
+    if (found === undefined) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Resolve the `learningBlockI18n` object literal from a SourceFile. Returns the
+ * object node when present (identifier `learningBlockI18n`), otherwise
+ * undefined.
+ */
+function findLearningBlockOverlay(sourceFile) {
+  let found = undefined;
+  const visit = (node) => {
+    if (
+      found === undefined &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "learningBlockI18n") continue;
+        if (ts.isObjectLiteralExpression(d.initializer)) found = d.initializer;
+        break;
+      }
+    }
+    if (found === undefined) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Read the static `id` from a learner-facing block object literal. The id must
+ * be a non-empty static string literal; anything else (computed / dynamic
+ * value) fails closed because the runtime key mapping cannot be confirmed.
+ */
+function readBlockId(blockNode, sourceFile, filePath) {
+  const sf = sourceFile ?? blockNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(blockNode)) {
+    throw new AuditParseError(
+      `learning block element must be an object literal, got ${ts.SyntaxKind[blockNode.kind]}`,
+      { file, line: getLine(sf, blockNode), context: blockNode.getText() }
+    );
+  }
+  let idMember = undefined;
+  for (const member of blockNode.properties) {
+    if (ts.isPropertyAssignment(member) && ts.isIdentifier(member.name) && member.name.text === "id") {
+      idMember = member;
+      break;
+    }
+  }
+  if (!idMember) {
+    throw new AuditParseError("learning block is missing a static string id", {
+      file,
+      line: getLine(sf, blockNode)
+    });
+  }
+  const init = idMember.initializer;
+  if (!ts.isStringLiteral(init) && !ts.isNoSubstitutionTemplateLiteral(init)) {
+    throw new AuditParseError(
+      `learning block id must be a static string literal: ${init.getText(sf)}`,
+      { file, line: getLine(sf, idMember), context: init.getText(sf) }
+    );
+  }
+  const id = init.text;
+  if (id.trim().length === 0) {
+    throw new AuditParseError("learning block id must be a non-empty string literal", {
+      file,
+      line: getLine(sf, idMember)
+    });
+  }
+  return id;
+}
+
+/**
+ * Collect the first-level overlay blocks of the `learningBlockI18n` object into
+ * a Map<blockId, localeKeys>, in declaration order. Each block entry must be an
+ * object literal mapping locales to text; its locale keys are read statically.
+ * Computed keys, spreads, non-property members and non-object entry values fail
+ * closed (their runtime key mapping cannot be confirmed).
+ */
+function collectOverlayBlockEntries(overlayNode, sourceFile, filePath) {
+  const sf = sourceFile ?? overlayNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(overlayNode)) {
+    throw new AuditParseError(
+      `learningBlockI18n must be an object literal, got ${ts.SyntaxKind[overlayNode.kind]}`,
+      { file, line: getLine(sf, overlayNode) }
+    );
+  }
+  const entries = new Map();
+  for (const member of overlayNode.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      throw new AuditParseError(
+        `overlay block entries must be static property assignments: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    const blockId = readStaticPropertyName(member.name, sf);
+    if (entries.has(blockId)) {
+      throw new AuditParseError(`duplicate overlay block key "${blockId}"`, {
+        file,
+        line: getLine(sf, member),
+        context: blockId
+      });
+    }
+    const localeObject = member.initializer;
+    if (!ts.isObjectLiteralExpression(localeObject)) {
+      throw new AuditParseError(
+        `overlay entry "${blockId}" must be an object literal mapping locales to text`,
+        { file, line: getLine(sf, member), context: blockId }
+      );
+    }
+    const localeKeys = [];
+    const seenLocales = new Set();
+    for (const localeMember of localeObject.properties) {
+      if (ts.isSpreadAssignment(localeMember)) {
+        throw new AuditParseError(
+          `object spread cannot be resolved statically in overlay entry "${blockId}"`,
+          { file, line: getLine(sf, localeMember), context: localeMember.getText() }
+        );
+      }
+      if (!ts.isPropertyAssignment(localeMember)) {
+        throw new AuditParseError(
+          `overlay locale entries must be static property assignments: ${localeMember.getText()}`,
+          { file, line: getLine(sf, localeMember), context: localeMember.getText() }
+        );
+      }
+      const locale = readStaticPropertyName(localeMember.name, sf);
+      if (seenLocales.has(locale)) {
+        throw new AuditParseError(
+          `duplicate overlay locale key "${locale}" for block "${blockId}"`,
+          { file, line: getLine(sf, localeMember), context: locale }
+        );
+      }
+      seenLocales.add(locale);
+      localeKeys.push(locale);
+    }
+    entries.set(blockId, localeKeys);
+  }
+  return entries;
+}
+
+/**
+ * Audit the source/overlay first-level key mapping for the learning-blocks
+ * system and return the overlay audit records (system "learningBlocks") for
+ * every learner-facing block id and every target locale.
+ *
+ *   - The source set is the static `id` of every element of the `learningBlocks`
+ *     array literal. Non-object elements, missing / empty / dynamic ids fail
+ *     closed; duplicate ids fail closed.
+ *   - The overlay set is the first-level keys of the `learningBlockI18n` object
+ *     literal; nested field keys are never flattened. Spreads, computed keys
+ *     and non-object entry values fail closed.
+ *   - For each target locale, a source id with no overlay entry for that locale
+ *     is `missing`; an overlay key with no source id is `dangling` (per locale
+ *     the overlay entry carries). The common record shape, sorting and counts
+ *     come from #695; the system is fixed to "learningBlocks". Target locales
+ *     must come from the launched registry; this adapter never hardcodes one.
+ *
+ * Returns records sorted by the canonical `sortAuditRecords` order. Performs
+ * zero filesystem writes, console output, network access and never calls
+ * process.exit.
+ */
+export function auditLearningBlockOverlays({ repoRoot, targetLocales }) {
+  if (typeof repoRoot !== "string" || repoRoot.length === 0) {
+    throw new Error("auditLearningBlockOverlays requires a non-empty repoRoot directory");
+  }
+  if (
+    !Array.isArray(targetLocales) ||
+    !targetLocales.every((l) => typeof l === "string" && l.length > 0)
+  ) {
+    throw new Error(
+      "auditLearningBlockOverlays requires targetLocales to be an array of locale strings"
+    );
+  }
+  const locales = [...new Set(targetLocales)];
+
+  const sourcePath = `${repoRoot}/src/domain/learningBlocks.ts`;
+  const overlayPath = `${repoRoot}/src/domain/learningBlocks.i18n.ts`;
+
+  const sourceFile = parseTypeScriptFile(sourcePath);
+  const overlayFile = parseTypeScriptFile(overlayPath);
+
+  const blocksArray = findLearningBlocksArray(sourceFile);
+  const overlayObject = findLearningBlockOverlay(overlayFile);
+
+  if (!blocksArray) {
+    throw new AuditParseError("learningBlocks array literal not found", { file: sourcePath });
+  }
+  if (!overlayObject) {
+    throw new AuditParseError("learningBlockI18n object literal not found", { file: overlayPath });
+  }
+
+  // --- source: static block ids -------------------------------------------
+  const sourceKeys = [];
+  const seenIds = new Set();
+  for (const element of blocksArray.elements) {
+    const id = readBlockId(element, sourceFile, sourcePath);
+    if (seenIds.has(id)) {
+      throw new AuditParseError(`duplicate learning block id "${id}"`, {
+        file: sourcePath,
+        context: id
+      });
+    }
+    seenIds.add(id);
+    sourceKeys.push(id);
+  }
+
+  // --- overlay: first-level block keys + per-entry locales ------------------
+  const overlayEntries = collectOverlayBlockEntries(overlayObject, overlayFile, overlayPath);
+
+  // --- per-target-locale comparison ----------------------------------------
+  const records = [];
+  for (const locale of locales) {
+    // source-without-overlay-for-this-locale => missing
+    for (const sourceKey of sourceKeys) {
+      const entry = overlayEntries.get(sourceKey);
+      if (!entry || !entry.includes(locale)) {
+        records.push({
+          system: "learningBlocks",
+          locale,
+          sourceKey,
+          overlayKey: "",
+          status: "missing"
+        });
+      }
+    }
+  }
+  // overlay-without-source => dangling (per locale the overlay entry carries)
+  for (const [blockId, localeKeys] of overlayEntries) {
+    if (seenIds.has(blockId)) continue;
+    for (const locale of localeKeys) {
+      records.push({
+        system: "learningBlocks",
+        locale,
+        sourceKey: "",
+        overlayKey: blockId,
+        status: "dangling"
+      });
+    }
+  }
+
+  return sortAuditRecords(records);
+}

--- a/scripts/i18n-overlay-audit.test.ts
+++ b/scripts/i18n-overlay-audit.test.ts
@@ -5,12 +5,14 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import ts from "typescript";
 // @ts-expect-error -- plain .mjs tooling module, no types
 import {
   AuditParseError,
   auditExamOverlays,
   auditKeySets,
+  auditLearningBlockOverlays,
   collectStaticObjectKeys,
   parseLaunchedLocales,
   parseTypeScriptFile,
@@ -758,6 +760,221 @@ describe("auditExamOverlays (#696)", () => {
       errorSpy.mockRestore();
       exitSpy.mockRestore();
       fetchSpy.mockRestore();
+    }
+  });
+});
+
+describe("auditLearningBlockOverlays (#697)", () => {
+  /** Repo-style fixture tree rooted at tmpDir/src/domain. */
+  function writeBlockFixtures(sourceText: string, overlayText: string): void {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "learningBlocks.ts"), sourceText);
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "learningBlocks.i18n.ts"), overlayText);
+  }
+
+  const SOURCE = (blocks: string): string => `export const learningBlocks = [${blocks}];`;
+  const OVERLAY = (blocks: string): string => `export const learningBlockI18n = {${blocks}};`;
+  const BLOCK = (id: string, extra = ""): string => `{ id: "${id}"${extra ? `, ${extra}` : ""} }`;
+  const LOCALE = (body: string): string => `{ "en": { ${body} }, "ja": { ${body} } }`;
+
+  beforeAll(() => {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+  });
+
+  it("yields zero records when every source block id has an overlay entry", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana"), BLOCK("adverbial", `title: "修飾"`), BLOCK("n3-jouken")]),
+      OVERLAY([`"kana-hiragana": ${LOCALE(`title: "Hiragana"`)}`, `"adverbial": ${LOCALE(`title: "Adverbial"`)}`, `"n3-jouken": ${LOCALE(`title: "Conditions"`)}`])
+    );
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([]);
+  });
+
+  it("reports a missing overlay for a single block and locale, and dangling for a deleted source block", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana"), BLOCK("adverbial")]),
+      OVERLAY([
+        `"kana-hiragana": { "en": { title: "Hiragana" } }`,
+        `"adverbial": ${LOCALE(`title: "Adverbial"`)}`,
+        `"deleted-block": ${LOCALE(`title: "Orphan"`)}`
+      ])
+    );
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([
+      { system: "learningBlocks", locale: "en", sourceKey: "", overlayKey: "deleted-block", status: "dangling" },
+      { system: "learningBlocks", locale: "ja", sourceKey: "", overlayKey: "deleted-block", status: "dangling" },
+      { system: "learningBlocks", locale: "ja", sourceKey: "kana-hiragana", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("emits a missing record per target locale for a block with no overlay entry", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("starter-vocab"), BLOCK("starter-desu")]),
+      OVERLAY([`"starter-desu": ${LOCALE(`title: "Desu"`)}`])
+    );
+    const records = auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] });
+    expect(records).toEqual([
+      { system: "learningBlocks", locale: "en", sourceKey: "starter-vocab", overlayKey: "", status: "missing" },
+      { system: "learningBlocks", locale: "ja", sourceKey: "starter-vocab", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("only audits first-level overlay keys, never flattening nested field keys", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana")]),
+      OVERLAY([
+        `"kana-hiragana": ${LOCALE(`title: "H", notes: ["a", "b"], pitfalls: ["p"]`)}`,
+        `"nested": ${LOCALE(`title: "Nested"`)}`
+      ])
+    );
+    // kana-hiragana is fully overlaid (en + ja) -> no record. "nested" exists
+    // only in the overlay -> a single dangling record per locale, and the
+    // overlay's own field keys (title/notes/pitfalls) must NOT be counted.
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([
+      { system: "learningBlocks", locale: "en", sourceKey: "", overlayKey: "nested", status: "dangling" },
+      { system: "learningBlocks", locale: "ja", sourceKey: "", overlayKey: "nested", status: "dangling" }
+    ]);
+  });
+
+  it("does not misclassify section/container/helper objects or unrelated ids", () => {
+    writeBlockFixtures(
+      SOURCE([
+        BLOCK("teTa", `drills: [{ labelKey: "drillGodanTeTa" }]`),
+        BLOCK("n5-sonzai", `patternDrills: [{ labelKey: "x", patternIds: ["n5-sonzai"] }]`),
+        BLOCK("verb-types", `completionMode: "reference"`)
+      ]),
+      OVERLAY([
+        `"teTa": ${LOCALE(`title: "Te-ta"`)}`,
+        `"n5-sonzai": ${LOCALE(`title: "Existence"`)}`,
+        `"verb-types": ${LOCALE(`title: "Groups"`)}`
+      ])
+    );
+    // "teTa" is a genuine block id (helper functions like
+    // isLearningBlockComplete or the IMPLICIT_HISTORY_THRESHOLD constant live in
+    // the same file but are not array elements, so no ids leak). All three
+    // blocks are fully overlaid for en + ja -> zero records.
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([]);
+  });
+
+  it("parses quoted and unquoted keys, multiline values and trailing commas", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("negative", `title: "否定"`), BLOCK("plain")]),
+      OVERLAY([
+        `"negative": {\n  "en": {\n    "title": "Negative",\n  },\n  'ja': {\n    title: "否定",\n  },\n},`,
+        `plain: {\n  "en": { "title": "Plain" },\n  "ja": { "title": "普通形" },\n},`
+      ])
+    );
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([]);
+  });
+
+  it("does not confuse an overlay value containing another block id with a real key", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("starter-desu", `title: "基本句"`)]),
+      OVERLAY([`"starter-desu": { "en": { "title": "AはBです, see n5-sonzai" }, "ja": { "title": "基本句" } }`])
+    );
+    // "n5-sonzai" appears inside the value text but is not an overlay key.
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([]);
+  });
+
+  it("fails closed on duplicate source block ids", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("dup-block"), BLOCK("dup-block")]),
+      OVERLAY([`"dup-block": ${LOCALE(`title: "Dup"`)}`])
+    );
+    expect(() => auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on duplicate overlay first-level keys", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana")]),
+      OVERLAY([`"kana-hiragana": ${LOCALE(`title: "A"`)}`, `"kana-hiragana": ${LOCALE(`title: "B"`)}`])
+    );
+    expect(() => auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on overlay spreads", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana")]),
+      OVERLAY([`"kana-hiragana": ${LOCALE(`title: "A"`)}, ...extra`])
+    );
+    expect(() => auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/spread/i);
+  });
+
+  it("fails closed on computed first-level overlay keys", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana")]),
+      OVERLAY([`[getKey()]: ${LOCALE(`title: "A"`)}`])
+    );
+    expect(() => auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+  });
+
+  it("fails closed on dynamic computed source ids", () => {
+    writeBlockFixtures(
+      SOURCE([`{ id: DYNAMIC_ID, title: "x" }`]),
+      OVERLAY([`"whatever": ${LOCALE(`title: "A"`)}`])
+    );
+    expect(() => auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/static|literal|id/i);
+  });
+
+  it("returns byte-equivalent records regardless of source or locale traversal order", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("n5-sonzai"), BLOCK("adverbial"), BLOCK("starter-vocab")]),
+      OVERLAY([
+        `"adverbial": ${LOCALE(`title: "A"`)}`,
+        `"starter-vocab": ${LOCALE(`title: "S"`)}`,
+        `"n5-sonzai": ${LOCALE(`title: "N"`)}`
+      ])
+    );
+    const a = JSON.stringify(
+      auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    );
+    const b = JSON.stringify(
+      auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["ja", "en"] })
+    );
+    expect(a).toBe(b);
+    expect(auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })).toEqual([]);
+  });
+
+  it("performs zero filesystem writes, console output, network and process.exit, and has no hardcoded locales", () => {
+    writeBlockFixtures(
+      SOURCE([BLOCK("kana-hiragana", `title: "平假名"`)]),
+      OVERLAY([`"kana-hiragana": ${LOCALE(`title: "Hiragana"`)}`])
+    );
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const logSpy = vi.spyOn(console, "log");
+    const errorSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const records = auditLearningBlockOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("audits the real repo without producing records and without writing anything", () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    try {
+      const records = auditLearningBlockOverlays({ repoRoot, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
Closes #697

## Summary

- Add `auditLearningBlockOverlays({ repoRoot, targetLocales })` to the #695 AST overlay audit core (system `learningBlocks`).
- Source: static `id`s of actual learner-facing blocks in `src/domain/learningBlocks.ts`; overlay: first-level block keys in `src/domain/learningBlocks.i18n.ts` (nested field keys never flattened).
- missing/dangling per target locale; duplicate/spread/computed/dynamic shapes fail closed with `AuditParseError`.
- No hardcoded locales, no runtime imports, no content/CLI changes.

## Scope

Only `scripts/i18n-overlay-audit.mjs` and `scripts/i18n-overlay-audit.test.ts`.

## Verification

- `node --check` — pass
- `pnpm exec vitest run scripts/i18n-overlay-audit.test.ts` — 51/51 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- 無。

Non-blocking findings:
- Issue 描述「新增 14 個測試」實際新增 15 個 it（總數 51 正確），屬描述出入。
- findLearningBlocksArray 取檔內第一個同名宣告，未來 shadow 重宣告不會 fail closed（目前無風險）。

Verdict:
No blocking findings.
```