### PR TITLE
feat(ci): publish verified repairs as isolated draft PRs

### DIFF
--- a/scripts/gemini-correctness/publication-adapter.mjs
+++ b/scripts/gemini-correctness/publication-adapter.mjs
@@ -1,0 +1,723 @@
+// =============================================================================
+// publication-adapter.mjs — GitHub publication adapter for verified repairs
+// (Issue #689)
+// =============================================================================
+//
+// Publishes a #688-validated, publicationAllowed=true repair candidate as an
+// isolated branch + one commit + one Draft PR on GitHub.  This module never
+// runs Gemini stages and never creates a workflow.
+//
+// Public contract:
+//   publishVerifiedRepair({ candidate, runId, repository, adapters, limits })
+//     => Promise<PublicationResult>
+//
+// Security posture (fail closed):
+//   - candidate is re-validated locally (schema/hash/file list/line stats)
+//     before ANY write; the adapter never re-interprets the finding or widens
+//     scope.
+//   - remote main is re-read immediately before publication; a mismatch with
+//     candidate.baselineSha returns baseline-stale with zero writes.
+//   - the branch is created only from candidate.baselineSha.
+//   - commit contains exactly the verified regression test + allowlisted
+//     production diff; .tmp/** and other generated/raw/secret content is never
+//     included.
+//   - the PR body is built from validated candidate fields only; raw model
+//     Markdown is never spliced in.
+//   - read/create/commit/push/PR/delete each use a fixed bounded retry of 3;
+//     there is no infinite loop and no background process.
+//   - push-success-but-PR-failure triggers remote branch cleanup for this run
+//     only; successful cleanup => publication-cleaned-up, failure => hard
+//     failure naming the orphan branch.
+//   - the adapter never force-pushes, never merges/rebases, never auto-approves
+//     or auto-merges, and never uses --admin.
+//
+// adapters is the fixed injection boundary — tests always use fakes:
+//   readRemoteHead({ ref })                       -> { valid, sha? } | throws
+//   createBranch({ name, baseSha })               -> { valid } | throws
+//   commit({ branch, message, regressionTest, productionDiff }) -> { valid, sha? } | throws
+//   push({ branch })                              -> { valid } | throws
+//   createPullRequest({ title, body, base, head, draft }) -> { valid, number?, url? } | throws
+//   deleteBranch({ name })                        -> { valid } | throws
+//   clock()                                       -> number (completion timestamp)
+// =============================================================================
+
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { redactForOutput } from "./discover.mjs";
+import {
+  getDefaultAllowlist,
+  getDefaultProtectedPaths,
+  isAllowlisted,
+  isPathSafe,
+  isProtected,
+  parseUnifiedDiff
+} from "./policy.mjs";
+
+const MAX_ADAPTER_ATTEMPTS = 3;
+const MAX_TITLE_LENGTH = 140;
+const GEMINI_AI_PR_PREFIX = "gemini/auto-fix-";
+const HEX64_RE = /^[0-9a-f]{64}$/i;
+const SHA_RE = /^[0-9a-f]{40,64}$/i;
+const SECRET_VALUE_RE = /(?:AIza[0-9A-Za-z_-]{35}|ghp_[A-Za-z0-9]{20,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16})/;
+const REQUIRED_ADAPTERS = [
+  "readRemoteHead",
+  "createBranch",
+  "commit",
+  "push",
+  "createPullRequest",
+  "deleteBranch",
+  "clock"
+];
+
+export const PUBLICATION_STATUS = Object.freeze({
+  PUBLISHED: "published",
+  INVALID_CANDIDATE: "invalid-candidate",
+  BASELINE_STALE: "baseline-stale",
+  BRANCH_EXISTS: "branch-exists",
+  CLEANED_UP: "publication-cleaned-up",
+  CLEANUP_FAILED: "cleanup-failed",
+  CONFIG_ERROR: "config-error",
+  PUBLICATION_FAILED: "publication-failed"
+});
+
+const PR_BODY_FIXED_KEYS = [
+  "schemaVersion",
+  "status",
+  "publicationAllowed",
+  "baselineSha",
+  "findingTitle",
+  "findingCategory",
+  "model",
+  "runUrl",
+  "finalDiffSha256",
+  "changedFiles",
+  "changedLines",
+  "productionDiff",
+  "regressionTest",
+  "red",
+  "green"
+];
+
+function invalid(error) {
+  return { valid: false, error };
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function errorMessage(error) {
+  return error?.message ?? "unknown error";
+}
+
+function normalizePath(filePath) {
+  return String(filePath).replace(/\\/g, "/");
+}
+
+// Strips C0/C1 control characters (including newline/tab) from a single-line
+// narrative string.  Avoids a control-character regex entirely (no-control-regex).
+function stripControlCharacters(value) {
+  let out = "";
+  for (const char of String(value ?? "")) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code === 0x7f || (code < 0x20) || (code >= 0x80 && code <= 0x9f)) continue;
+    out += char;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive-value collection from an injected environment (same policy as the
+// orchestrator: used only for output redaction, never forwarded to adapters).
+// ---------------------------------------------------------------------------
+function collectSensitiveValues(environment) {
+  const values = new Set();
+  if (
+    environment === null ||
+    environment === undefined ||
+    typeof environment !== "object" ||
+    Array.isArray(environment)
+  ) {
+    return [];
+  }
+  for (const [key, value] of Object.entries(environment)) {
+    if (typeof value !== "string" || value.length === 0) continue;
+    if (
+      /(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH|COOKIE)/i.test(key) ||
+      value.length >= 8
+    ) {
+      values.add(value);
+    }
+  }
+  if (typeof environment.PATH === "string") {
+    for (const entry of environment.PATH.split(path.delimiter)) {
+      if (entry.length >= 4) values.add(entry);
+    }
+  }
+  return [...values].filter((value) => typeof value === "string" && value.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Unified result redaction.  Shares the redactForOutput base, then scrubs
+// common token/env-dump/absolute-path leak shapes.  The POSIX absolute-path
+// scrub anchors on a system root and never spans "://", so GitHub PR URLs
+// (https://github.com/...) survive intact.
+// ---------------------------------------------------------------------------
+function scrubResult(value, sensitiveValues) {
+  const base = redactForOutput(value, sensitiveValues);
+  let json = JSON.stringify(base);
+  json = json
+    .replace(/ghp_[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/sk-[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/AKIA[0-9A-Z]{16}/g, "REDACTED_KEY")
+    .replace(/\b[A-Z][A-Z0-9_]{2,}=[^\s,;"']{4,}/g, "REDACTED_KEY")
+    .replace(
+      /(?:\/|~\/)(?:tmp|var|home|Users|etc|usr|opt|root|private|Applications|Library)(?:\/[A-Za-z0-9._~/-]+)*/g,
+      "REDACTED_PATH"
+    );
+  try {
+    return JSON.parse(json);
+  } catch {
+    return value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Narrative-field scrubber for the PR body.  Model-authored strings (finding
+// title, root cause, fix summary, test name) are the only place a secret,
+// token, or host absolute path could appear; structural body content (repo
+// paths, URLs, branch, hashes) is adapter-generated and must survive intact.
+// System-root absolute paths (/tmp, /var, /home, /Users, ...) are scrubbed;
+// URLs and repo-relative paths are not.  Control characters (including
+// newline/tab) are collapsed to spaces so a narrative field cannot inject
+// Markdown structure into the PR body.
+// ---------------------------------------------------------------------------
+function scrubNarrative(value, sensitiveValues = []) {
+  const base = redactForOutput(String(value ?? ""), sensitiveValues);
+  const scrubbed = String(base)
+    .replace(/ghp_[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/sk-[A-Za-z0-9]{20,}/g, "REDACTED_KEY")
+    .replace(/AKIA[0-9A-Z]{16}/g, "REDACTED_KEY")
+    .replace(
+      /(?:\/|~\/)(?:tmp|var|home|Users|etc|usr|opt|root|private|Applications|Library)\/[A-Za-z0-9._~/-]+/g,
+      "REDACTED_PATH"
+    );
+  return stripControlCharacters(scrubbed.replace(/\s+/g, " ")).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Candidate validation — the ONLY interpretation of the publication input.
+// The candidate must already be a #688-verified result with
+// publicationAllowed === true; this validator never re-interprets a finding or
+// widens scope.  Any mismatch (schema/hash/file list/line stats) fails closed
+// before a single write.
+// ---------------------------------------------------------------------------
+export function validatePublicationCandidate(candidate, options = {}) {
+  if (candidate === null || candidate === undefined || typeof candidate !== "object" || Array.isArray(candidate)) {
+    return invalid("candidate must be a plain object");
+  }
+  const keys = Object.keys(candidate);
+  const unknown = keys.filter((key) => !PR_BODY_FIXED_KEYS.includes(key));
+  if (unknown.length > 0) {
+    return invalid(`candidate has unknown fields: ${unknown.join(", ")}`);
+  }
+
+  if (candidate.schemaVersion !== 1) return invalid("candidate schemaVersion must be 1");
+  if (candidate.status !== "repair-verified") {
+    return invalid('candidate status must be "repair-verified"');
+  }
+  if (candidate.publicationAllowed !== true) {
+    return invalid("candidate publicationAllowed must be exactly true");
+  }
+  if (!SHA_RE.test(String(candidate.baselineSha ?? ""))) {
+    return invalid("candidate baselineSha is invalid");
+  }
+  if (!HEX64_RE.test(String(candidate.finalDiffSha256 ?? ""))) {
+    return invalid("candidate finalDiffSha256 is invalid");
+  }
+  if (typeof candidate.findingTitle !== "string" || candidate.findingTitle.trim() === "") {
+    return invalid("candidate findingTitle must be a non-empty string");
+  }
+  if (typeof candidate.model !== "string" || candidate.model.trim() === "") {
+    return invalid("candidate model must be a non-empty string");
+  }
+  if (typeof candidate.runUrl !== "string" || candidate.runUrl.trim() === "") {
+    return invalid("candidate runUrl must be a non-empty string");
+  }
+  if (!Number.isFinite(candidate.changedFiles) || candidate.changedFiles < 0) {
+    return invalid("candidate changedFiles is invalid");
+  }
+  if (!Number.isFinite(candidate.changedLines) || candidate.changedLines < 0) {
+    return invalid("candidate changedLines is invalid");
+  }
+  if (typeof candidate.productionDiff !== "string" || candidate.productionDiff.trim() === "") {
+    return invalid("candidate productionDiff must be a non-empty unified diff");
+  }
+
+  const allowlist = options.allowlist ?? getDefaultAllowlist();
+  const protectedPaths = options.protectedPaths ?? getDefaultProtectedPaths();
+
+  const regression = candidate.regressionTest;
+  if (typeof regression !== "object" || regression === null || Array.isArray(regression)) {
+    return invalid("candidate regressionTest must be an object");
+  }
+  const regressionKeys = Object.keys(regression);
+  const unknownRegression = regressionKeys.filter((key) => !["path", "source"].includes(key));
+  if (unknownRegression.length > 0) {
+    return invalid(`candidate regressionTest has unknown fields: ${unknownRegression.join(", ")}`);
+  }
+  if (typeof regression.path !== "string" || regression.path.trim() === "") {
+    return invalid("candidate regressionTest.path must be a non-empty string");
+  }
+  if (!isPathSafe(regression.path)) {
+    return invalid(`candidate regressionTest.path "${regression.path}" is not a safe relative path`);
+  }
+  if (!/\.regression\.test\.tsx?$/.test(normalizePath(regression.path))) {
+    return invalid(`candidate regressionTest.path "${regression.path}" must end with .regression.test.ts or .regression.test.tsx`);
+  }
+  const regressionNormalized = normalizePath(regression.path);
+  if (isProtected(regressionNormalized, protectedPaths)) {
+    return invalid(`candidate regressionTest.path "${regression.path}" is a protected path`);
+  }
+  if (!isAllowlisted(regressionNormalized, allowlist)) {
+    return invalid(`candidate regressionTest.path "${regression.path}" is outside the allowlist`);
+  }
+  if (typeof regression.source !== "string" || regression.source.trim() === "") {
+    return invalid("candidate regressionTest.source must be a non-empty string");
+  }
+
+  const red = candidate.red;
+  if (typeof red !== "object" || red === null || Array.isArray(red)) {
+    return invalid("candidate red must be an object");
+  }
+  if (red.testFile !== regression.path) {
+    return invalid("candidate red.testFile does not match regressionTest.path");
+  }
+  if (typeof red.testName !== "string" || red.testName.trim() === "") {
+    return invalid("candidate red.testName must be a non-empty string");
+  }
+  if (red.failureKind !== "assertion") {
+    return invalid('candidate red.failureKind must be "assertion"');
+  }
+  if (red.replayConfirmed !== true) {
+    return invalid("candidate red.replayConfirmed must be true");
+  }
+  if (!HEX64_RE.test(String(red.patchSha256 ?? ""))) {
+    return invalid("candidate red.patchSha256 is invalid");
+  }
+
+  const green = candidate.green;
+  if (typeof green !== "object" || green === null || Array.isArray(green)) {
+    return invalid("candidate green must be an object");
+  }
+  if (!Array.isArray(green.productionFiles) || green.productionFiles.length === 0) {
+    return invalid("candidate green.productionFiles must be a non-empty array");
+  }
+  for (const filePath of green.productionFiles) {
+    if (typeof filePath !== "string" || filePath.trim() === "") {
+      return invalid("candidate green.productionFiles entries must be non-empty strings");
+    }
+    if (!isPathSafe(filePath)) {
+      return invalid(`candidate green.productionFiles "${filePath}" is not a safe relative path`);
+    }
+    const normalized = normalizePath(filePath);
+    if (isProtected(normalized, protectedPaths)) {
+      return invalid(`candidate green.productionFiles "${filePath}" is a protected path`);
+    }
+    if (!isAllowlisted(normalized, allowlist)) {
+      return invalid(`candidate green.productionFiles "${filePath}" is outside the allowlist`);
+    }
+  }
+  if (!Array.isArray(green.checks) || green.checks.length === 0) {
+    return invalid("candidate green.checks must be a non-empty array");
+  }
+  for (const check of green.checks) {
+    if (typeof check !== "object" || check === null || check.status !== "passed") {
+      return invalid("candidate green.checks entries must all be passed");
+    }
+  }
+  if (green.finalDiffSha256 !== candidate.finalDiffSha256) {
+    return invalid("candidate green.finalDiffSha256 does not match the top-level finalDiffSha256");
+  }
+  if (green.changedFiles !== candidate.changedFiles) {
+    return invalid("candidate green.changedFiles does not match the top-level changedFiles");
+  }
+  if (green.changedLines !== candidate.changedLines) {
+    return invalid("candidate green.changedLines does not match the top-level changedLines");
+  }
+  if (typeof green.rootCause !== "string" || green.rootCause.trim() === "") {
+    return invalid("candidate green.rootCause must be a non-empty string");
+  }
+  if (typeof green.fixSummary !== "string" || green.fixSummary.trim() === "") {
+    return invalid("candidate green.fixSummary must be a non-empty string");
+  }
+
+  // --- Content hash guard: productionDiff must match finalDiffSha256. -------
+  if (sha256(candidate.productionDiff) !== candidate.finalDiffSha256) {
+    return invalid("candidate productionDiff sha256 does not match finalDiffSha256");
+  }
+
+  // --- Diff interpretation (reuse the shared unified-diff parser). ----------
+  const parsed = parseUnifiedDiff(candidate.productionDiff);
+  if (!parsed.valid) return parsed;
+  if (parsed.changedFiles !== candidate.changedFiles) {
+    return invalid(`production diff touches ${parsed.changedFiles} files but candidate claims ${candidate.changedFiles}`);
+  }
+  const parsedLines = parsed.totalAdditions + parsed.totalDeletions;
+  if (parsedLines !== candidate.changedLines) {
+    return invalid(`production diff changes ${parsedLines} lines but candidate claims ${candidate.changedLines}`);
+  }
+
+  // --- Scope containment: diff may only touch finding production files. -----
+  const productionFileSet = new Set(green.productionFiles.map(normalizePath));
+  for (const file of parsed.files) {
+    const normalized = normalizePath(file.path);
+    if (!productionFileSet.has(normalized)) {
+      return invalid(`production diff file "${file.path}" is not in candidate green.productionFiles`);
+    }
+    if (!isPathSafe(file.path)) {
+      return invalid(`production diff file "${file.path}" is not a safe relative path`);
+    }
+    if (isProtected(normalized, protectedPaths)) {
+      return invalid(`production diff file "${file.path}" is a protected path`);
+    }
+    if (!isAllowlisted(normalized, allowlist)) {
+      return invalid(`production diff file "${file.path}" is outside the allowlist`);
+    }
+  }
+
+  // --- Secret scan on commit payload (diff + regression test source + the
+  // path fields that render into the commit and PR body). ---------------------
+  const sensitiveValues = (options.sensitiveValues ?? []).filter(
+    (value) => typeof value === "string" && value.length >= 4
+  );
+  const payloadText = [
+    candidate.productionDiff,
+    regression.source,
+    regression.path,
+    ...green.productionFiles,
+    red.testFile
+  ].join("\n");
+  if (SECRET_VALUE_RE.test(payloadText)) {
+    return invalid("commit payload contains secret-like content");
+  }
+  if (redactForOutput(payloadText, sensitiveValues) !== payloadText) {
+    return invalid("commit payload contains sensitive content");
+  }
+
+  return {
+    valid: true,
+    result: {
+      schemaVersion: 1,
+      status: "repair-verified",
+      publicationAllowed: true,
+      baselineSha: candidate.baselineSha,
+      findingTitle: candidate.findingTitle,
+      findingCategory: candidate.findingCategory,
+      model: candidate.model,
+      runUrl: candidate.runUrl,
+      finalDiffSha256: candidate.finalDiffSha256,
+      changedFiles: candidate.changedFiles,
+      changedLines: candidate.changedLines,
+      productionDiff: candidate.productionDiff,
+      regressionTest: { path: regression.path, source: regression.source },
+      red: { ...red },
+      green: { ...green }
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Title / branch sanitization — fixed prefixes, control-character scrubbing,
+// and a hard length bound.
+// ---------------------------------------------------------------------------
+function sanitizeTitle(rawTitle, sensitiveValues = []) {
+  const scrubbed = scrubNarrative(rawTitle, sensitiveValues);
+  const collapsed = stripControlCharacters(
+    String(scrubbed ?? "").replace(/\s+/g, " ")
+  )
+    .trim()
+    .replace(/^fix:\s*/i, "")
+    .slice(0, MAX_TITLE_LENGTH)
+    .replace(/\.{3,}$/, "")
+    .trim();
+  return `fix: ${collapsed || "verified repair"}`;
+}
+
+function sanitizeBranch(runId) {
+  const base = stripControlCharacters(runId);
+  const slug = base.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/-{2,}/g, "-").replace(/^[._-]+|[._-]+$/g, "").slice(0, 80);
+  const suffix = slug || "run";
+  return `${GEMINI_AI_PR_PREFIX}${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
+// PR body — deterministic, built only from validated candidate fields.
+// ---------------------------------------------------------------------------
+export function buildPullRequestBody(candidate, { runId, repository, sensitiveValues = [] }) {
+  const checks = (candidate.green?.checks ?? []).map(
+    (check) => `- [x] ${scrubNarrative(check.name ?? "", sensitiveValues)}: ${check.status}`
+  );
+  const productionFiles = (candidate.green?.productionFiles ?? []).map(
+    (filePath) => `- \`${scrubNarrative(filePath ?? "", sensitiveValues)}\``
+  );
+  const scrub = (value) => scrubNarrative(value, sensitiveValues);
+  return [
+    `fix: ${scrub(candidate.findingTitle ?? "verified repair")}`,
+    "",
+    "> **Automated Gemini repair — human review required before merge.**",
+    "> This Draft PR was created by an automated pipeline. Do not auto-merge.",
+    "",
+    "## Finding",
+    `- **Title**: ${scrub(candidate.findingTitle ?? "unknown")}`,
+    `- **Category**: ${scrub(candidate.findingCategory ?? "unknown")}`,
+    `- **Baseline**: \`${candidate.baselineSha ?? "unknown"}\``,
+    `- **Final diff sha256**: \`${candidate.finalDiffSha256 ?? "unknown"}\``,
+    "",
+    "## RED evidence",
+    `- Test file: \`${scrub(candidate.red?.testFile ?? "unknown")}\``,
+    `- Test name: ${scrub(candidate.red?.testName ?? "unknown")}`,
+    `- Failure kind: ${scrub(candidate.red?.failureKind ?? "unknown")}`,
+    `- Replay confirmed: ${candidate.red?.replayConfirmed === true ? "yes" : "no"}`,
+    "",
+    "## GREEN evidence",
+    `- Production files:`,
+    ...productionFiles,
+    `- Root cause: ${scrub(candidate.green?.rootCause ?? "unknown")}`,
+    `- Fix summary: ${scrub(candidate.green?.fixSummary ?? "unknown")}`,
+    "",
+    "## Checks",
+    ...checks,
+    "",
+    "## Stats",
+    `- Changed files: ${candidate.changedFiles ?? "unknown"}`,
+    `- Changed lines: ${candidate.changedLines ?? "unknown"}`,
+    "",
+    `## Run`,
+    `- Branch: \`gemini/auto-fix-${runId ?? "unknown"}\``,
+    `- Repository: ${repository?.owner ?? "unknown"}/${repository?.repo ?? "unknown"}`,
+    `- Run URL: ${scrub(candidate.runUrl ?? "unknown")}`,
+    `- Model: ${scrub(candidate.model ?? "unknown")}`,
+    "",
+    `_Generated by the Gemini correctness publication adapter. PR number: _`
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Bounded retry helper — exactly MAX_ADAPTER_ATTEMPTS attempts, no infinite
+// loop, no background process.
+// ---------------------------------------------------------------------------
+async function withBoundedRetry(fn, label) {
+  let lastError = "";
+  for (let attempt = 1; attempt <= MAX_ADAPTER_ATTEMPTS; attempt += 1) {
+    try {
+      const outcome = await fn();
+      if (outcome && outcome.valid === true) return { ok: true, value: outcome };
+      lastError = outcome?.error ?? `${label} failed closed (attempt ${attempt})`;
+      if (outcome?.code === "branch-exists") {
+        return { ok: false, code: "branch-exists", error: lastError };
+      }
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+  }
+  return { ok: false, error: lastError };
+}
+
+// ---------------------------------------------------------------------------
+// publishVerifiedRepair
+// ---------------------------------------------------------------------------
+export async function publishVerifiedRepair({
+  candidate,
+  runId,
+  repository,
+  adapters = {},
+  limits = {}
+} = {}) {
+  const sensitiveValues = collectSensitiveValues(limits?.environment);
+  const now = () => {
+    const value = typeof adapters.clock === "function" ? adapters.clock() : undefined;
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  };
+
+  const failClosed = (status, reasonCode, message, extra = {}) =>
+    scrubResult(
+      {
+        schemaVersion: 1,
+        status,
+        reasonCode,
+        reason: String(message ?? ""),
+        publicationAllowed: false,
+        baselineSha: typeof candidate?.baselineSha === "string" ? candidate.baselineSha : undefined,
+        completedAt: now(),
+        ...extra
+      },
+      sensitiveValues
+    );
+
+  const branch = sanitizeBranch(runId);
+
+  for (const adapterName of REQUIRED_ADAPTERS) {
+    if (typeof adapters[adapterName] !== "function") {
+      return failClosed(
+        PUBLICATION_STATUS.CONFIG_ERROR,
+        "missing-adapter",
+        `adapter ${adapterName} is required`
+      );
+    }
+  }
+  if (!repository || typeof repository !== "object" || typeof repository.owner !== "string" || typeof repository.repo !== "string") {
+    return failClosed(PUBLICATION_STATUS.CONFIG_ERROR, "invalid-repository", "repository must include owner and repo");
+  }
+  if (typeof runId !== "string" || runId.trim() === "") {
+    return failClosed(PUBLICATION_STATUS.CONFIG_ERROR, "invalid-run-id", "runId must be a non-empty string");
+  }
+
+  // --- 1. Re-validate the candidate locally before ANY write. ---------------
+  const candidateCheck = validatePublicationCandidate(candidate, { sensitiveValues });
+  if (!candidateCheck.valid) {
+    return failClosed(
+      PUBLICATION_STATUS.INVALID_CANDIDATE,
+      "invalid-candidate",
+      candidateCheck.error ?? "publication candidate validation failed"
+    );
+  }
+  const trusted = candidateCheck.result;
+  const defaultBranch = repository.defaultBranch ?? "main";
+
+  // --- 2. Re-read remote main; equal to baseline or fail closed. ------------
+  let headOutcome;
+  try {
+    headOutcome = await adapters.readRemoteHead({ ref: defaultBranch });
+  } catch (error) {
+    return failClosed(
+      PUBLICATION_STATUS.PUBLICATION_FAILED,
+      "read-head-failed",
+      errorMessage(error)
+    );
+  }
+  if (!headOutcome || headOutcome.valid !== true) {
+    return failClosed(
+      PUBLICATION_STATUS.PUBLICATION_FAILED,
+      "read-head-failed",
+      headOutcome?.error ?? "could not read remote head"
+    );
+  }
+  if (headOutcome.sha !== trusted.baselineSha) {
+    return failClosed(
+      PUBLICATION_STATUS.BASELINE_STALE,
+      "baseline-stale",
+      "remote main no longer equals the verified baseline; no rebase, merge, or model rerun is attempted"
+    );
+  }
+
+  // --- 3. Create the isolated branch (bounded retry). -----------------------
+  const branchOutcome = await withBoundedRetry(
+    () => adapters.createBranch({ name: branch, baseSha: trusted.baselineSha }),
+    "createBranch"
+  );
+  if (!branchOutcome.ok) {
+    if (branchOutcome.code === "branch-exists") {
+      return failClosed(
+        PUBLICATION_STATUS.BRANCH_EXISTS,
+        "branch-exists",
+        `branch ${branch} already exists; failing closed without overwriting`,
+        { branch }
+      );
+    }
+    return failClosed(
+      PUBLICATION_STATUS.PUBLICATION_FAILED,
+      "create-branch-failed",
+      branchOutcome.error,
+      { branch }
+    );
+  }
+
+  // --- 4. Create exactly one commit with the verified payload only. ---------
+  const commitOutcome = await withBoundedRetry(
+    () =>
+      adapters.commit({
+        branch,
+        message: sanitizeTitle(trusted.findingTitle, sensitiveValues),
+        regressionTest: {
+          path: trusted.regressionTest.path,
+          source: trusted.regressionTest.source
+        },
+        productionDiff: trusted.productionDiff
+      }),
+    "commit"
+  );
+  if (!commitOutcome.ok) {
+    return failClosed(
+      PUBLICATION_STATUS.PUBLICATION_FAILED,
+      "commit-failed",
+      commitOutcome.error,
+      { branch }
+    );
+  }
+
+  // --- 5. Push the branch (bounded retry). ----------------------------------
+  const pushOutcome = await withBoundedRetry(() => adapters.push({ branch }), "push");
+  if (!pushOutcome.ok) {
+    // The branch may or may not exist remotely; attempt best-effort cleanup of
+    // this run's branch so no orphan is left behind.
+    const cleanup = await withBoundedRetry(() => adapters.deleteBranch({ name: branch }), "deleteBranch");
+    const reason = `${pushOutcome.error ?? "push failed closed"}; branch ${branch} was not pushed`;
+    return failClosed(PUBLICATION_STATUS.PUBLICATION_FAILED, "push-failed", reason, {
+      branch,
+      cleanupSucceeded: cleanup.ok === true
+    });
+  }
+
+  // --- 6. Create the Draft PR (bounded retry). ------------------------------
+  const prOutcome = await withBoundedRetry(
+    () =>
+      adapters.createPullRequest({
+        title: sanitizeTitle(trusted.findingTitle, sensitiveValues),
+        body: buildPullRequestBody(trusted, { runId, repository, sensitiveValues }),
+        base: defaultBranch,
+        head: branch,
+        draft: true
+      }),
+    "createPullRequest"
+  );
+  if (prOutcome.ok) {
+    return scrubResult(
+      {
+        schemaVersion: 1,
+        status: PUBLICATION_STATUS.PUBLISHED,
+        reasonCode: "published",
+        reason: `draft PR created on ${defaultBranch}`,
+        publicationAllowed: true,
+        baselineSha: trusted.baselineSha,
+        branch,
+        pullRequest: {
+          number: prOutcome.value?.number ?? undefined,
+          url: prOutcome.value?.url ?? undefined,
+          draft: true,
+          base: defaultBranch
+        },
+        completedAt: now()
+      },
+      sensitiveValues
+    );
+  }
+
+  // --- 7. Push succeeded but PR creation failed: clean up this run's branch.
+  // Delete only the branch this run created; never touch other AI branches.
+  const cleanup = await withBoundedRetry(() => adapters.deleteBranch({ name: branch }), "deleteBranch");
+  if (cleanup.ok) {
+    return failClosed(
+      PUBLICATION_STATUS.CLEANED_UP,
+      "publication-cleaned-up",
+      `draft PR creation failed; deleted remote branch ${branch}`,
+      { branch }
+    );
+  }
+  return failClosed(
+    PUBLICATION_STATUS.CLEANUP_FAILED,
+    "cleanup-failed",
+    `draft PR creation failed and remote branch ${branch} could not be deleted (orphan branch remains)`,
+    { branch }
+  );
+}

--- a/scripts/gemini-correctness/publication-adapter.test.ts
+++ b/scripts/gemini-correctness/publication-adapter.test.ts
@@ -1,0 +1,716 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+// @ts-expect-error -- plain .mjs module, no types
+import {
+  publishVerifiedRepair,
+  validatePublicationCandidate,
+  buildPullRequestBody,
+  PUBLICATION_STATUS
+} from "./publication-adapter.mjs";
+
+const SECRET = "fixture-publication-secret-12345678";
+const ABSOLUTE_PATH = "/tmp/some/absolute/path";
+const ENV_DUMP = "PATH=/usr/local/bin:/usr/bin";
+const FAKE_TOKEN = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";
+const AIZA_KEY = `AIza${"A".repeat(35)}`;
+
+const PRODUCTION_DIFF = [
+  "diff --git a/src/domain/example.ts b/src/domain/example.ts",
+  "--- a/src/domain/example.ts",
+  "+++ b/src/domain/example.ts",
+  "@@ -1,3 +1,3 @@",
+  " export function emptyQueue(queue) {",
+  "-  return queue[0] ?? null;",
+  "+  return queue[0] ?? \"fallback\";",
+  " }",
+  ""
+].join("\n");
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const DIFF_SHA256 = sha256Hex(PRODUCTION_DIFF);
+
+const BASELINE_SHA = "a".repeat(40);
+const TEST_FILE = "src/domain/example.regression.test.ts";
+const PROD_FILE = "src/domain/example.ts";
+
+function regressionTestSource() {
+  return [
+    "import { describe, expect, it } from \"vitest\";",
+    "import { emptyQueue } from \"./example\";",
+    "",
+    "describe(\"example\", () => {",
+    "  it(\"returns the safe fallback for an empty queue\", () => {",
+    "    expect(emptyQueue([])).toBe(\"fallback\");",
+    "  });",
+    "});",
+    ""
+  ].join("\n");
+}
+
+function candidate(overrides: Record<string, unknown> = {}) {
+  const base = {
+    schemaVersion: 1,
+    status: "repair-verified",
+    publicationAllowed: true,
+    baselineSha: BASELINE_SHA,
+    findingTitle: "empty queue returns a stale value",
+    findingCategory: "boundary-condition",
+    model: "gemini-2.5-flash",
+    runUrl: "https://github.com/nurockplayer/Jabiko/actions/runs/424242",
+    finalDiffSha256: DIFF_SHA256,
+    changedFiles: 1,
+    changedLines: 2,
+    productionDiff: PRODUCTION_DIFF,
+    regressionTest: {
+      path: TEST_FILE,
+      source: regressionTestSource()
+    },
+    red: {
+      testFile: TEST_FILE,
+      testName: "returns the safe fallback for an empty queue",
+      failureKind: "assertion",
+      patchSha256: "b".repeat(64),
+      replayConfirmed: true
+    },
+    green: {
+      findingTitle: "empty queue returns a stale value",
+      productionFiles: [PROD_FILE],
+      rootCause: "the empty branch returns a stale value instead of the fallback",
+      fixSummary: "return the safe fallback when the queue is empty",
+      checks: [
+        { name: "targeted-test", status: "passed" },
+        { name: "lint", status: "passed" },
+        { name: "typecheck", status: "passed" },
+        { name: "test", status: "passed" },
+        { name: "build", status: "passed" }
+      ],
+      changedFiles: 1,
+      changedLines: 2,
+      finalDiffSha256: DIFF_SHA256
+    }
+  };
+  return { ...base, ...overrides };
+}
+
+function adapters(overrides: Record<string, unknown> = {}) {
+  return {
+    readRemoteHead: vi.fn().mockResolvedValue({ valid: true, sha: BASELINE_SHA }),
+    createBranch: vi.fn().mockResolvedValue({ valid: true }),
+    commit: vi.fn().mockResolvedValue({ valid: true, sha: "c".repeat(40) }),
+    push: vi.fn().mockResolvedValue({ valid: true }),
+    createPullRequest: vi.fn().mockResolvedValue({ valid: true, number: 12, url: "https://github.com/nurockplayer/Jabiko/pull/12" }),
+    deleteBranch: vi.fn().mockResolvedValue({ valid: true }),
+    clock: vi.fn().mockReturnValue(1_700_000_000_000),
+    ...overrides
+  };
+}
+
+const REPOSITORY = { owner: "nurockplayer", repo: "Jabiko", defaultBranch: "main" };
+const RUN_ID = "run-2026-08-06-1234";
+
+function opts(adapterSet: ReturnType<typeof adapters>, extra: Record<string, unknown> = {}) {
+  return {
+    candidate: candidate(),
+    runId: RUN_ID,
+    repository: REPOSITORY,
+    adapters: adapterSet,
+    ...extra
+  };
+}
+
+function expectZeroWrites(adapterSet: ReturnType<typeof adapters>, except: (keyof ReturnType<typeof adapters>)[] = []) {
+  for (const key of Object.keys(adapterSet)) {
+    if (key === "clock" || (except as string[]).includes(key)) continue;
+    expect(adapterSet[key as keyof typeof adapterSet]).not.toHaveBeenCalled();
+  }
+}
+
+describe("validatePublicationCandidate", () => {
+  it("accepts a fully validated publication candidate", () => {
+    const check = validatePublicationCandidate(candidate());
+    expect(check.valid).toBe(true);
+  });
+
+  it("rejects when publicationAllowed is not exactly true", () => {
+    for (const value of [false, "true", 1, null, undefined]) {
+      const check = validatePublicationCandidate(candidate({ publicationAllowed: value }));
+      expect(check.valid).toBe(false);
+    }
+  });
+
+  it("rejects non repair-verified status or wrong schemaVersion", () => {
+    expect(validatePublicationCandidate(candidate({ status: "observed" })).valid).toBe(false);
+    expect(validatePublicationCandidate(candidate({ schemaVersion: 2 })).valid).toBe(false);
+  });
+
+  it("rejects invalid baselineSha or finalDiffSha256", () => {
+    expect(validatePublicationCandidate(candidate({ baselineSha: "not-a-sha" })).valid).toBe(false);
+    expect(validatePublicationCandidate(candidate({ finalDiffSha256: "not-hex" })).valid).toBe(false);
+  });
+
+  it("rejects when productionDiff sha256 does not match finalDiffSha256", () => {
+    const tampered = candidate({ finalDiffSha256: "d".repeat(64) });
+    expect(validatePublicationCandidate(tampered).valid).toBe(false);
+  });
+
+  it("rejects unknown fields (extra tracked/untracked file claims)", () => {
+    const check = validatePublicationCandidate(
+      candidate({ extraFiles: [{ path: "src/domain/other.ts", content: "x" }] })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a diff file outside finding.productionFiles", () => {
+    const diff = PRODUCTION_DIFF.replace(/example\.ts/g, "other.ts");
+    const hash = sha256Hex(diff);
+    const check = validatePublicationCandidate(
+      candidate({
+        productionDiff: diff,
+        finalDiffSha256: hash,
+        green: { ...candidate().green, finalDiffSha256: hash }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects changedFiles/changedLines stats that do not match the diff", () => {
+    const wrongFiles = candidate({ changedFiles: 3 });
+    expect(validatePublicationCandidate(wrongFiles).valid).toBe(false);
+    const wrongLines = candidate({ changedLines: 99 });
+    expect(validatePublicationCandidate(wrongLines).valid).toBe(false);
+  });
+
+  it("rejects a productionFiles entry declaring a .tmp temp artifact path", () => {
+    const diff = PRODUCTION_DIFF.replace(/src\/domain\/example\.ts/g, ".tmp/leak.ts");
+    const hash = sha256Hex(diff);
+    const check = validatePublicationCandidate(
+      candidate({
+        productionDiff: diff,
+        finalDiffSha256: hash,
+        green: { ...candidate().green, finalDiffSha256: hash, productionFiles: [".tmp/leak.ts"] }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a productionFiles entry outside the allowlist (e.g. src/components)", () => {
+    const diff = PRODUCTION_DIFF.replace(/src\/domain\/example\.ts/g, "src/components/Example.tsx");
+    const hash = sha256Hex(diff);
+    const check = validatePublicationCandidate(
+      candidate({
+        productionDiff: diff,
+        finalDiffSha256: hash,
+        green: { ...candidate().green, finalDiffSha256: hash, productionFiles: ["src/components/Example.tsx"] }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a regression test path that is not a .regression.test file", () => {
+    const check = validatePublicationCandidate(
+      candidate({
+        regressionTest: { path: "src/domain/example.ts", source: regressionTestSource() },
+        red: { ...candidate().red, testFile: "src/domain/example.ts" }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a regression test path outside the allowlist (.tmp temp artifact)", () => {
+    const check = validatePublicationCandidate(
+      candidate({
+        regressionTest: { path: ".tmp/x.regression.test.ts", source: regressionTestSource() },
+        red: { ...candidate().red, testFile: ".tmp/x.regression.test.ts" }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a regression test path outside the allowlist (src/components)", () => {
+    const check = validatePublicationCandidate(
+      candidate({
+        regressionTest: { path: "src/components/Example.regression.test.tsx", source: regressionTestSource() },
+        red: { ...candidate().red, testFile: "src/components/Example.regression.test.tsx" }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects when regressionTest.path does not match red.testFile", () => {
+    const check = validatePublicationCandidate(
+      candidate({
+        regressionTest: { path: "src/domain/other.regression.test.ts", source: regressionTestSource() }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects secret-like content in the diff", () => {
+    const leaked = `${PRODUCTION_DIFF}\ndiff --git a/src/domain/example.ts b/src/domain/example.ts\n--- a/src/domain/example.ts\n+++ b/src/domain/example.ts\n@@ -10 +10 @@\n+  const token = "${FAKE_TOKEN}";\n`;
+    const hash = sha256Hex(leaked);
+    const check = validatePublicationCandidate(
+      candidate({
+        productionDiff: leaked,
+        finalDiffSha256: hash,
+        changedFiles: 1,
+        changedLines: 3,
+        green: { ...candidate().green, finalDiffSha256: hash, changedFiles: 1, changedLines: 3 }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects secret-like content in the regression test source", () => {
+    const leakedSource = `${regressionTestSource()}\n// key=${AIZA_KEY}\n`;
+    const check = validatePublicationCandidate(
+      candidate({ regressionTest: { path: TEST_FILE, source: leakedSource } })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a secret-shaped string embedded in a productionFiles path", () => {
+    const leakedPath = `src/domain/${FAKE_TOKEN}.ts`;
+    const diff = PRODUCTION_DIFF.replace(/src\/domain\/example\.ts/g, leakedPath);
+    const hash = sha256Hex(diff);
+    const check = validatePublicationCandidate(
+      candidate({
+        productionDiff: diff,
+        finalDiffSha256: hash,
+        green: { ...candidate().green, finalDiffSha256: hash, productionFiles: [leakedPath] }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+
+  it("rejects a secret-shaped string embedded in the regression test path", () => {
+    const leakedPath = `src/domain/${FAKE_TOKEN}.regression.test.ts`;
+    const check = validatePublicationCandidate(
+      candidate({
+        regressionTest: { path: leakedPath, source: regressionTestSource() },
+        red: { ...candidate().red, testFile: leakedPath }
+      })
+    );
+    expect(check.valid).toBe(false);
+  });
+});
+
+describe("non-verified / zero-write guard", () => {
+  it("rejects a candidate with publicationAllowed=false with zero Git/GitHub writes", async () => {
+    const a = adapters();
+    const result = await publishVerifiedRepair(
+      opts(a, { candidate: candidate({ publicationAllowed: false }) })
+    );
+    expect(result.status).toBe("invalid-candidate");
+    expect(result.publicationAllowed).toBe(false);
+    expectZeroWrites(a);
+  });
+
+  it("rejects a tampered candidate with zero writes (hash mismatch)", async () => {
+    const a = adapters();
+    const tampered = candidate({ finalDiffSha256: "d".repeat(64) });
+    const result = await publishVerifiedRepair(opts(a, { candidate: tampered }));
+    expect(result.status).toBe("invalid-candidate");
+    expectZeroWrites(a);
+  });
+
+  it("fails closed when a required adapter is missing", async () => {
+    const a = adapters();
+    const withoutCommit = { ...a };
+    // @ts-expect-error -- intentionally removing an adapter
+    delete withoutCommit.commit;
+    const result = await publishVerifiedRepair(opts(withoutCommit));
+    expect(result.status).toBe(PUBLICATION_STATUS.CONFIG_ERROR);
+    expectZeroWrites(a);
+  });
+});
+
+describe("stale baseline", () => {
+  it("returns baseline-stale with zero branch/commit/push/PR when remote main moved", async () => {
+    const a = adapters({
+      readRemoteHead: vi.fn().mockResolvedValue({ valid: true, sha: "d".repeat(40) })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe("baseline-stale");
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.readRemoteHead).toHaveBeenCalledTimes(1);
+    expectZeroWrites(a, ["readRemoteHead"]);
+  });
+
+  it("fails closed when reading remote head throws", async () => {
+    const a = adapters({
+      readRemoteHead: vi.fn().mockRejectedValue(new Error("network down"))
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLICATION_FAILED);
+    expectZeroWrites(a, ["readRemoteHead"]);
+  });
+});
+
+describe("successful publication", () => {
+  it("creates exactly one branch, commit, push, and Draft PR with the fixed contract", async () => {
+    const a = adapters();
+    const result = await publishVerifiedRepair(opts(a));
+
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+    expect(result.publicationAllowed).toBe(true);
+    expect(result.branch).toBe(`gemini/auto-fix-${RUN_ID}`);
+
+    expect(a.readRemoteHead).toHaveBeenCalledTimes(1);
+    expect(a.readRemoteHead.mock.calls[0][0]).toMatchObject({ ref: "main" });
+    expect(a.createBranch).toHaveBeenCalledTimes(1);
+    expect(a.createBranch.mock.calls[0][0]).toMatchObject({
+      name: `gemini/auto-fix-${RUN_ID}`,
+      baseSha: BASELINE_SHA
+    });
+    expect(a.commit).toHaveBeenCalledTimes(1);
+    const commitArg = a.commit.mock.calls[0][0];
+    expect(commitArg.message).toBe("fix: empty queue returns a stale value");
+    expect(commitArg.regressionTest).toMatchObject({ path: TEST_FILE });
+    expect(a.push).toHaveBeenCalledTimes(1);
+    expect(a.createPullRequest).toHaveBeenCalledTimes(1);
+    const prArg = a.createPullRequest.mock.calls[0][0];
+    expect(prArg).toMatchObject({
+      title: "fix: empty queue returns a stale value",
+      base: "main",
+      draft: true
+    });
+    expect(a.deleteBranch).not.toHaveBeenCalled();
+    expect(result.pullRequest).toMatchObject({ number: 12, draft: true, base: "main" });
+    // The PR URL must survive result redaction intact (never REDACTED_PATH).
+    expect(result.pullRequest.url).toBe("https://github.com/nurockplayer/Jabiko/pull/12");
+  });
+
+  it("builds a PR body from validated candidate fields only", async () => {
+    const a = adapters();
+    const result = await publishVerifiedRepair(opts(a));
+    const body = a.createPullRequest.mock.calls[0][0].body as string;
+
+    expect(body).toContain("human review");
+    expect(body).toContain("empty queue returns a stale value");
+    expect(body).toContain("boundary-condition");
+    expect(body).toContain(TEST_FILE);
+    expect(body).toContain("returns the safe fallback for an empty queue");
+    expect(body).toContain("assertion");
+    expect(body).toContain(BASELINE_SHA);
+    expect(body).toContain(DIFF_SHA256);
+    expect(body).toContain("424242");
+    expect(body).toContain("gemini-2.5-flash");
+    expect(body).toContain("Changed files: 1");
+    expect(body).toContain("Changed lines: 2");
+
+    // Raw model Markdown / the raw diff must never be spliced into the body.
+    expect(body).not.toContain(PRODUCTION_DIFF);
+    expect(body).not.toContain("diff --git");
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+  });
+});
+
+describe("sanitization", () => {
+  it("sanitizes a hostile finding title in branch/commit/PR title", async () => {
+    const hostileTitle = "fix: empty\nqueue\treturns stale value --force --admin";
+    const a = adapters();
+    await publishVerifiedRepair(opts(a, { candidate: candidate({ findingTitle: hostileTitle }) }));
+
+    expect(a.createBranch.mock.calls[0][0].name).toBe(`gemini/auto-fix-${RUN_ID}`);
+    expect(a.commit.mock.calls[0][0].message).toBe("fix: empty queue returns stale value --force --admin");
+    expect(a.createPullRequest.mock.calls[0][0].title).toBe("fix: empty queue returns stale value --force --admin");
+    expect(a.createPullRequest.mock.calls[0][0].title).not.toContain("\n");
+    expect(a.createPullRequest.mock.calls[0][0].title).not.toContain("\t");
+  });
+
+  it("truncates an overlong title to a fixed bound", async () => {
+    const longTitle = "x".repeat(500);
+    const a = adapters();
+    await publishVerifiedRepair(opts(a, { candidate: candidate({ findingTitle: longTitle }) }));
+
+    const title = a.createPullRequest.mock.calls[0][0].title as string;
+    expect(title).toMatch(/^fix: /);
+    expect(title.length).toBeLessThan(150);
+    expect(a.commit.mock.calls[0][0].message).toBe(title);
+  });
+
+  it("sanitizes runId into the branch name with the fixed prefix", async () => {
+    const hostileRunId = "run/..\\evil name --force";
+    const a = adapters();
+    await publishVerifiedRepair(opts(a, { runId: hostileRunId }));
+
+    const branch = a.createBranch.mock.calls[0][0].name as string;
+    expect(branch).toMatch(/^gemini\/auto-fix-[A-Za-z0-9._-]+$/);
+    expect(branch).not.toContain("/../");
+    expect(branch).not.toContain("\\");
+    expect(branch).not.toContain("--force");
+  });
+});
+
+describe("bounded retry", () => {
+  it("retries createBranch up to 3 times and succeeds on the last attempt", async () => {
+    const a = adapters({
+      createBranch: vi
+        .fn()
+        .mockResolvedValueOnce({ valid: false, error: "rate limited" })
+        .mockResolvedValueOnce({ valid: false, error: "network" })
+        .mockResolvedValueOnce({ valid: true })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+    expect(a.createBranch).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed after 3 createBranch failures with zero later writes", async () => {
+    const a = adapters({
+      createBranch: vi.fn().mockResolvedValue({ valid: false, error: "boom" })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLICATION_FAILED);
+    expect(a.createBranch).toHaveBeenCalledTimes(3);
+    expect(a.commit).not.toHaveBeenCalled();
+    expect(a.push).not.toHaveBeenCalled();
+    expect(a.createPullRequest).not.toHaveBeenCalled();
+  });
+
+  it("retries commit up to 3 times and succeeds on the last attempt", async () => {
+    const a = adapters({
+      commit: vi
+        .fn()
+        .mockResolvedValueOnce({ valid: false, error: "lock" })
+        .mockResolvedValueOnce({ valid: false, error: "lock" })
+        .mockResolvedValueOnce({ valid: true, sha: "c".repeat(40) })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+    expect(a.commit).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed after 3 commit failures", async () => {
+    const a = adapters({ commit: vi.fn().mockResolvedValue({ valid: false, error: "boom" }) });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLICATION_FAILED);
+    expect(a.commit).toHaveBeenCalledTimes(3);
+    expect(a.push).not.toHaveBeenCalled();
+  });
+
+  it("retries push up to 3 times and succeeds on the last attempt", async () => {
+    const a = adapters({
+      push: vi
+        .fn()
+        .mockResolvedValueOnce({ valid: false, error: "rejected" })
+        .mockResolvedValueOnce({ valid: false, error: "rejected" })
+        .mockResolvedValueOnce({ valid: true })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+    expect(a.push).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails closed after 3 push failures and cleans up the branch", async () => {
+    const a = adapters({ push: vi.fn().mockResolvedValue({ valid: false, error: "boom" }) });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLICATION_FAILED);
+    expect(a.push).toHaveBeenCalledTimes(3);
+    expect(a.deleteBranch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries createPullRequest up to 3 times and succeeds on the last attempt", async () => {
+    const a = adapters({
+      createPullRequest: vi
+        .fn()
+        .mockResolvedValueOnce({ valid: false, error: "rate limited" })
+        .mockResolvedValueOnce({ valid: false, error: "rate limited" })
+        .mockResolvedValueOnce({ valid: true, number: 12, url: "https://github.com/nurockplayer/Jabiko/pull/12" })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.PUBLISHED);
+    expect(a.createPullRequest).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("push-success then PR-failure cleanup", () => {
+  it("returns publication-cleaned-up when the remote branch is deleted after PR failure", async () => {
+    const a = adapters({ createPullRequest: vi.fn().mockResolvedValue({ valid: false, error: "boom" }) });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.CLEANED_UP);
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.createPullRequest).toHaveBeenCalledTimes(3);
+    expect(a.deleteBranch).toHaveBeenCalledTimes(1);
+    expect(a.deleteBranch.mock.calls[0][0].name).toBe(`gemini/auto-fix-${RUN_ID}`);
+    expect(result.reason).toContain(`gemini/auto-fix-${RUN_ID}`);
+  });
+
+  it("reports a hard failure listing the orphan branch when cleanup fails", async () => {
+    const a = adapters({
+      createPullRequest: vi.fn().mockResolvedValue({ valid: false, error: "boom" }),
+      deleteBranch: vi.fn().mockResolvedValue({ valid: false, error: "forbidden" })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.CLEANUP_FAILED);
+    expect(result.publicationAllowed).toBe(false);
+    expect(result.branch).toBe(`gemini/auto-fix-${RUN_ID}`);
+    expect(result.reason).toContain(`gemini/auto-fix-${RUN_ID}`);
+    expect(result.reason).toContain("orphan");
+  });
+
+  it("only ever deletes the current run's branch, never other AI branches", async () => {
+    const a = adapters({ createPullRequest: vi.fn().mockResolvedValue({ valid: false, error: "boom" }) });
+    await publishVerifiedRepair(opts(a, { runId: "run-42" }));
+    for (const call of a.deleteBranch.mock.calls) {
+      expect(call[0].name).toBe("gemini/auto-fix-run-42");
+      expect(call[0].name).not.toContain("other");
+    }
+  });
+});
+
+describe("duplicate runId / branch already exists", () => {
+  it("fails closed without committing or pushing when the branch already exists", async () => {
+    const a = adapters({
+      createBranch: vi.fn().mockResolvedValue({ valid: false, code: "branch-exists", error: "already exists" })
+    });
+    const result = await publishVerifiedRepair(opts(a));
+    expect(result.status).toBe(PUBLICATION_STATUS.BRANCH_EXISTS);
+    expect(result.publicationAllowed).toBe(false);
+    expect(a.createBranch).toHaveBeenCalledTimes(1);
+    expect(a.commit).not.toHaveBeenCalled();
+    expect(a.push).not.toHaveBeenCalled();
+    expect(a.createPullRequest).not.toHaveBeenCalled();
+    expect(a.deleteBranch).not.toHaveBeenCalled();
+  });
+});
+
+describe("redaction", () => {
+  it("never leaks secrets, env dumps, or absolute paths into the result", async () => {
+    const a = adapters();
+    a.readRemoteHead.mockRejectedValueOnce(new Error(`failed with ${SECRET} at ${ABSOLUTE_PATH}; ${ENV_DUMP}`));
+    const result = await publishVerifiedRepair({
+      ...opts(a),
+      limits: { environment: { FIXTURE_SECRET: SECRET, PATH: "/usr/local/bin:/usr/bin", HOME: ABSOLUTE_PATH } }
+    });
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain(SECRET);
+    expect(serialized).not.toContain(ABSOLUTE_PATH);
+    expect(serialized).not.toContain("ghp_");
+    expect(serialized).toContain("REDACTED_KEY");
+  });
+
+  it("never leaks secrets into the PR body", async () => {
+    const leakedCandidate = candidate({
+      findingTitle: `stale value ${SECRET}`,
+      green: { ...candidate().green, fixSummary: `leaked ${FAKE_TOKEN}` }
+    });
+    const a = adapters();
+    await publishVerifiedRepair({
+      ...opts(a, { candidate: leakedCandidate }),
+      limits: { environment: { FIXTURE_SECRET: SECRET, PATH: "/usr/local/bin:/usr/bin", HOME: ABSOLUTE_PATH } }
+    });
+    const body = a.createPullRequest.mock.calls[0][0].body as string;
+    expect(body).not.toContain(SECRET);
+    expect(body).not.toContain(FAKE_TOKEN);
+    expect(body).not.toContain(ABSOLUTE_PATH);
+  });
+
+  it("never leaks secrets embedded in runUrl into the PR body", async () => {
+    const leakedCandidate = candidate({
+      runUrl: `https://github.com/nurockplayer/Jabiko/actions/runs/424242?token=${SECRET}`
+    });
+    const a = adapters();
+    await publishVerifiedRepair({
+      ...opts(a, { candidate: leakedCandidate }),
+      limits: { environment: { FIXTURE_SECRET: SECRET, PATH: "/usr/local/bin:/usr/bin", HOME: ABSOLUTE_PATH } }
+    });
+    const body = a.createPullRequest.mock.calls[0][0].body as string;
+    expect(body).not.toContain(SECRET);
+    expect(body).toContain("424242");
+  });
+
+  it("never leaks secrets embedded in green.checks[].name into the PR body", async () => {
+    const leakedCandidate = candidate({
+      green: {
+        ...candidate().green,
+        checks: [
+          ...candidate().green.checks,
+          { name: `secret-check ${FAKE_TOKEN}`, status: "passed" }
+        ]
+      }
+    });
+    const a = adapters();
+    await publishVerifiedRepair({
+      ...opts(a, { candidate: leakedCandidate }),
+      limits: { environment: { FIXTURE_SECRET: SECRET, PATH: "/usr/local/bin:/usr/bin", HOME: ABSOLUTE_PATH } }
+    });
+    const body = a.createPullRequest.mock.calls[0][0].body as string;
+    expect(body).not.toContain(FAKE_TOKEN);
+  });
+
+  it("never leaks a secret-shaped string embedded in a path field into the PR body", async () => {
+    // Defense in depth: even a candidate that somehow reaches body rendering
+    // with a secret-shaped path must not leak it into the PR body.
+    const leakedPath = `src/domain/${FAKE_TOKEN}.ts`;
+    const body = buildPullRequestBody(
+      {
+        ...candidate(),
+        green: { ...candidate().green, productionFiles: [leakedPath] },
+        red: { ...candidate().red, testFile: leakedPath }
+      },
+      { runId: RUN_ID, repository: REPOSITORY }
+    );
+    expect(body).not.toContain(FAKE_TOKEN);
+  });
+
+  it("scrubs control characters out of narrative fields so Markdown cannot be injected", async () => {
+    const leakedCandidate = candidate({
+      findingTitle: "stale value\n\n## Fake Heading\n**bold**",
+      green: {
+        ...candidate().green,
+        rootCause: "root\n\t## Injected\n",
+        fixSummary: "fix\r\nline"
+      }
+    });
+    const a = adapters();
+    await publishVerifiedRepair(opts(a, { candidate: leakedCandidate }));
+    const body = a.createPullRequest.mock.calls[0][0].body as string;
+    // Control characters are collapsed to spaces, so an injected "##" can never
+    // form a standalone Markdown heading line (no newline before it).
+    const lines = body.split("\n");
+    expect(lines.some((line) => line.trim().startsWith("## Fake Heading"))).toBe(false);
+    expect(lines.some((line) => line.trim().startsWith("## Injected"))).toBe(false);
+    expect(body).toContain("stale value");
+  });
+});
+
+describe("never force-push / merge / rebase / auto-merge", () => {
+  it("never passes force/merge/rebase/admin flags to the injected adapters", async () => {
+    const a = adapters();
+    await publishVerifiedRepair(opts(a));
+
+    // The PR body necessarily contains the human-review / "do not auto-merge"
+    // warning text, so only adapter options are scanned here (never the body).
+    const pushCall = JSON.stringify(a.push.mock.calls);
+    expect(pushCall).not.toContain("--force");
+    expect(pushCall).not.toContain("--force-with-lease");
+    expect(pushCall).not.toContain("rebase");
+    expect(pushCall).not.toContain("admin");
+
+    const commitCall = JSON.stringify(a.commit.mock.calls);
+    expect(commitCall).not.toContain("--force");
+    expect(commitCall).not.toContain("rebase");
+
+    const prCall = JSON.stringify(a.createPullRequest.mock.calls);
+    expect(prCall).not.toContain("--force");
+    expect(prCall).not.toContain("autoMerge");
+    expect(prCall).not.toContain("admin");
+
+    const branchCall = JSON.stringify(a.createBranch.mock.calls);
+    expect(branchCall).not.toContain("--force");
+
+    const deleteCall = JSON.stringify(a.deleteBranch.mock.calls);
+    expect(deleteCall).not.toContain("--force");
+  });
+
+  it("buildPullRequestBody emits a deterministic sanitized body", () => {
+    const body = buildPullRequestBody(candidate(), { runId: RUN_ID, repository: REPOSITORY });
+    expect(body).toContain("human review");
+    expect(body).toContain("fix:");
+    expect(body).not.toContain(SECRET);
+  });
+});


### PR DESCRIPTION
Closes #689

## Summary

- Add `publishVerifiedRepair({ candidate, runId, repository, adapters })`: re-validates the #688 candidate (schema/hash/file/line stats/secret scan), re-reads origin/main (fails closed as `baseline-stale` if it moved), then creates an isolated `gemini/auto-fix-<runId>` branch, a single commit limited to the verified regression test + allowlisted production diff, a push, and a Draft PR with a sanitized body.
- Push/create-PR/delete use bounded 3-attempt retries; push-success/PR-fail cleans up the run branch (`publication-cleaned-up` or hard failure with branch name).
- Candidate paths (regression test, productionFiles, diff) are allowlisted + protected before commit; runUrl/checks/paths are scrubbed before entering the PR body; payload secret scan covers diff, source, and paths. No force push/merge/rebase/auto-merge/`--admin`.

## Scope

Only the two new files `scripts/gemini-correctness/publication-adapter.mjs` and `publication-adapter.test.ts`. No workflow, no Gemini stage changes, no GitHub-write integration test.

## Verification

- `node --check` — pass
- `pnpm exec vitest run scripts/gemini-correctness/publication-adapter.test.ts` — 47/47 pass
- `pnpm exec vitest run scripts/gemini-correctness` — 27 files / 607 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict (3 rounds)

```
Blocking findings:
- 無。（4 個 security blocking 已於 round-1/2 修正並於 round-3 確認）

Non-blocking findings:
- PR body ## Run 區塊的 runId/owner/repo 未 scrub（控制字元注入殘留缺口；不洩漏 secret、不影響合約）。
- 路徑 code span 可能被反引號跳出（純 Markdown 樣式破壞）。
- scrubNarrative 絕對路徑 regex 對 repo-relative 路徑有 over-scrub 風險（僅影響顯示）。

Verdict:
No blocking findings.
```