### PR TITLE
docs(privacy): document practice history deletion

### DIFF
--- a/src/components/LegalPanel.test.tsx
+++ b/src/components/LegalPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { LAUNCHED_LANGUAGES } from "../i18n";
 import { LegalPanel } from "./LegalPanel";
 
 describe("LegalPanel", () => {
@@ -26,5 +27,47 @@ describe("LegalPanel", () => {
     view.rerender(<LegalPanel language="ja" page="privacy" />);
     expect(screen.getByRole("heading", { name: "プライバシーポリシー" })).toBeInTheDocument();
     expect(screen.getByText(/Google OAuth と Supabase Auth/)).toBeInTheDocument();
+  });
+
+  it("renders the self-service history-deletion section in every launched privacy locale", () => {
+    const expected: Record<
+      "zh-Hant" | "ja" | "en",
+      { heading: string; marker: RegExp }
+    > = {
+      "zh-Hant": {
+        heading: "7. 刪除已同步的練習紀錄",
+        marker: /由帳號區自助刪除該帳號已同步的練習作答紀錄/
+      },
+      ja: {
+        heading: "7. 同期した練習履歴の削除",
+        marker: /アカウント領域からこのアカウントに同期した練習の回答記録を自分で削除/
+      },
+      en: {
+        heading: "7. Deleting your synced practice history",
+        marker: /delete the practice answers synced to this account on their own from the account area/
+      }
+    };
+
+    const view = render(<LegalPanel language="zh-Hant" page="privacy" />);
+
+    // The covered locales must match the launched set exactly.
+    expect(Object.keys(expected)).toEqual([...LAUNCHED_LANGUAGES]);
+
+    for (const language of Object.keys(expected) as (keyof typeof expected)[]) {
+      const { heading, marker } = expected[language];
+      view.rerender(<LegalPanel language={language} page="privacy" />);
+      expect(screen.getByRole("heading", { name: heading }), language).toBeInTheDocument();
+      expect(screen.getByText(marker), language).toBeInTheDocument();
+      // No raw key or zh fallback leaking through.
+      expect(screen.queryByText(/^\{/), language).not.toBeInTheDocument();
+      expect(screen.queryByText(/^sections\./), language).not.toBeInTheDocument();
+      // The section order holds: self-service deletion sits before the
+      // policy-change section in every locale.
+      const headings = screen.getAllByRole("heading", { level: 3 }).map((h) => h.textContent);
+      const deletionIndex = headings.indexOf(heading);
+      const changeIndex = headings.findIndex((h) => h?.startsWith("8. "));
+      expect(deletionIndex, language).toBeGreaterThanOrEqual(0);
+      expect(changeIndex, language).toBeGreaterThan(deletionIndex);
+    }
   });
 });

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -55,6 +55,49 @@ describe("legal content", () => {
     expect(en).toContain("if you request a reply, the contact detail you enter is stored as well");
   });
 
+  it("discloses self-service practice history deletion in every launched privacy locale", () => {
+    const disclosureText = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+        .join("\n");
+
+    // zh-Hant
+    const zh = disclosureText("zh-Hant");
+    expect(zh).toContain("自助刪除");
+    expect(zh).toContain("已同步的練習作答紀錄");
+    expect(zh).toContain("目前裝置的練習紀錄、弱點與複習進度");
+    expect(zh).toContain("帳號、收藏、語言與外觀設定");
+    expect(zh).toContain("不可復原");
+    expect(zh).toContain("請重試");
+    // Explicitly scoped: account is NOT deleted; no "all data" over-claim.
+    expect(zh).toContain("不會刪除登入帳號");
+    expect(zh).not.toContain("所有資料");
+
+    // ja
+    const ja = disclosureText("ja");
+    expect(ja).toContain("自分で削除");
+    expect(ja).toContain("同期した練習の回答記録");
+    expect(ja).toContain("この端末の練習記録・弱点・復習の進捗");
+    expect(ja).toContain("アカウント・お気に入り・言語・表示設定");
+    expect(ja).toContain("元に戻せません");
+    expect(ja).toContain("もう一度お試しください");
+    // Explicitly scoped: account is NOT deleted; no "all data" over-claim.
+    expect(ja).toContain("アカウント・お気に入り・言語・表示設定は削除されません");
+    expect(ja).not.toContain("すべての情報");
+
+    // en
+    const en = disclosureText("en");
+    expect(en).toContain("self-service");
+    expect(en).toContain("practice answers synced to this account");
+    expect(en).toContain("this device's practice records, weak points, and review progress");
+    expect(en).toContain("account, bookmarks, language, or appearance settings");
+    expect(en).toContain("cannot be undone");
+    expect(en).toContain("try again");
+    // Explicitly scoped: account is NOT deleted; no "all data" over-claim.
+    expect(en).toContain("does not delete your account");
+    expect(en).not.toContain("all data");
+  });
+
   it("does not claim that public source code is open source", () => {
     const terms = legalDocumentFor("zh-Hant", "terms");
     const text = terms.sections

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -76,11 +76,18 @@ const LEGAL_COPY = {
           title: "6. 保存、刪除與聯絡",
           paragraphs: [
             "本機資料會保留到你清除瀏覽器網站資料為止。遠端練習紀錄與回報會保留到完成其同步、維護、回覆或問題追蹤用途，或由你提出刪除要求為止。",
-            "目前尚未提供完整的自助匯出與刪除介面。若要詢問或刪除帳號相關資料，請先登入相同帳號，再使用網站的「回饋」功能並勾選希望回覆；請勿在公開 GitHub issue 張貼個人資料。Jabiko 不會出售個人資料。"
+            "目前尚未提供自助匯出介面。若要匯出或刪除其他與帳號相關的資料，請先登入相同帳號，再使用網站的「回饋」功能並勾選希望回覆；請勿在公開 GitHub issue 張貼個人資料。Jabiko 不會出售個人資料。"
           ]
         },
         {
-          title: "7. 政策變更",
+          title: "7. 刪除已同步的練習紀錄",
+          paragraphs: [
+            "已登入的使用者可以由帳號區自助刪除該帳號已同步的練習作答紀錄。刪除成功時，也會清除目前裝置的練習紀錄、弱點與複習進度。",
+            "此操作不會刪除登入帳號、收藏、語言與外觀設定。刪除不可復原；若刪除失敗，請重試，且不得宣稱資料已刪除。"
+          ]
+        },
+        {
+          title: "8. 政策變更",
           paragraphs: [
             "功能或資料處理方式有實質改變時，這份政策會同步更新日期與內容。若變更會明顯影響使用者權益，會以網站上的適當方式提醒。"
           ]
@@ -187,11 +194,18 @@ const LEGAL_COPY = {
           title: "6. 保存、削除、問い合わせ",
           paragraphs: [
             "ローカル情報はブラウザのサイトデータを削除するまで残ります。同期履歴とフィードバックは、同期・保守・返信・問題追跡に必要な期間、または削除依頼を受けるまで保持します。",
-            "現時点では完全な自己操作によるエクスポート・削除画面はありません。アカウント情報の確認や削除を希望する場合は、同じアカウントでログインし、サイトの「フィードバック」で返信希望を選んでください。公開 GitHub issue に個人情報を書かないでください。個人情報を販売することはありません。"
+            "現時点では自己操作によるエクスポート画面はありません。エクスポートを希望する場合や、その他のアカウント関連情報の削除を希望する場合は、同じアカウントでログインし、サイトの「フィードバック」で返信希望を選んでください。公開 GitHub issue に個人情報を書かないでください。個人情報を販売することはありません。"
           ]
         },
         {
-          title: "7. ポリシーの変更",
+          title: "7. 同期した練習履歴の削除",
+          paragraphs: [
+            "ログイン中の利用者は、アカウント領域からこのアカウントに同期した練習の回答記録を自分で削除できます。削除に成功すると、この端末の練習記録・弱点・復習の進捗も消去されます。",
+            "この操作では、アカウント・お気に入り・言語・表示設定は削除されません。削除は元に戻せません。削除に失敗した場合は、もう一度お試しください。データが削除されたと判断しないでください。"
+          ]
+        },
+        {
+          title: "8. ポリシーの変更",
           paragraphs: [
             "機能や情報の取扱いに実質的な変更がある場合、本ポリシーの内容と更新日を変更します。利用者への影響が大きい場合は、サイト上で適切にお知らせします。"
           ]
@@ -298,11 +312,18 @@ const LEGAL_COPY = {
           title: "6. Retention, deletion, and contact",
           paragraphs: [
             "Local data remains until you clear the browser's site data. Remote practice records and feedback are kept while needed for sync, maintenance, replies, or issue tracking, or until you request deletion.",
-            "A complete self-service export and deletion screen is not yet available. To ask about or request deletion of account-linked data, sign in with the same account and use the site's Feedback form with the reply option selected. Do not post personal data in a public GitHub issue. Jabiko does not sell personal data."
+            "A self-service export screen is not yet available. To request an export, or to ask about or request deletion of other account-linked data, sign in with the same account and use the site's Feedback form with the reply option selected. Do not post personal data in a public GitHub issue. Jabiko does not sell personal data."
           ]
         },
         {
-          title: "7. Changes to this policy",
+          title: "7. Deleting your synced practice history",
+          paragraphs: [
+            "Signed-in users can delete the practice answers synced to this account on their own from the account area. When the deletion succeeds, it also clears this device's practice records, weak points, and review progress.",
+            "This does not delete your account, bookmarks, language, or appearance settings. Deletion cannot be undone; if it fails, please try again and do not treat the data as deleted."
+          ]
+        },
+        {
+          title: "8. Changes to this policy",
           paragraphs: [
             "When features or data handling change materially, this policy and its update date will be revised. Changes with a significant effect on users will be highlighted through an appropriate notice on the site."
           ]


### PR DESCRIPTION
Closes #694

## Summary

- Add a section 7 to the privacy policy in all launched locales (zh-Hant/ja/en) describing self-service deletion of synced practice history from the account area.
- It also clears this device's practice records / weak points / review progress; does not delete the account, bookmarks, language, or appearance settings; is irreversible; failures should be retried without claiming deletion.
- Narrow the outdated "no deletion screen" statement in section 6 to export-only (the #693 deletion UI now ships). Terms untouched.

## Scope

Only `src/domain/legalContent.ts`, `src/domain/legalContent.test.ts`, `src/components/LegalPanel.test.tsx`.

## Verification

- `pnpm lint` / `pnpm typecheck` — pass
- `pnpm exec vitest run src/components/LegalPanel.test.tsx src/domain/legalContent.test.ts` — 8/8 pass
- `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- None.

Non-blocking findings:
- PRIVACY_UPDATED_AT 日期未 bump（新增重大段落，依第 8 節承諾可考慮 bump；低優先、可能已在 #693 時落地）。
- 測試未直接鎖「不得宣稱資料已刪除」半句（negative over-claim 斷言已涵蓋精神）。

Verdict:
No blocking findings.
```