### PR TITLE
chore(i18n): audit sentence pattern overlay keys

### DIFF
--- a/scripts/i18n-overlay-audit.mjs
+++ b/scripts/i18n-overlay-audit.mjs
@@ -981,3 +981,366 @@ export function auditLearningBlockOverlays({ repoRoot, targetLocales }) {
 
   return sortAuditRecords(records);
 }
+
+// ---------------------------------------------------------------------------
+// Sentence-pattern overlay adapter (#698)
+// ---------------------------------------------------------------------------
+//
+// Audits the "source item id <-> overlay first-level item key" mapping for the
+// sentence-patterns system.
+//
+//   source:  the object elements of every `SentencePatternItem[]`-typed array
+//            literal in src/domain/sentencePatterns.ts
+//   overlay: the first-level keys of the `sentencePatternI18n` record in
+//            src/domain/sentencePatterns.i18n.ts
+//   key:     the SentencePatternItem.id
+//
+// A source element is only counted when it is statically resolvable AND
+// learner-facing: a non-empty static `id` plus at least one non-empty static
+// `hintZh` / `promptContextZh` / `explanation`. Pattern metadata, type-union
+// members, helper objects and comments are never scanned (the audit keys on the
+// `SentencePatternItem[]` type annotation, never on a bare `id:` property
+// search). Pure-aggregation arrays -- a typed array whose elements are all
+// spreads of already-collected typed arrays (e.g. `sentencePatternItems = [...A,
+// ...B]`) -- add no ids of their own and are skipped, because their ids are
+// audited in the leaf arrays they spread.
+//
+// The overlay set is ONLY the first-level keys of the `sentencePatternI18n`
+// object literal; nested `hintI18n` / `promptContextI18n` / `explanationI18n`
+// field keys are never flattened into item keys. The `patternInstructionI18n`
+// global instruction overlay is deliberately ignored. Only item-level key
+// coverage is checked (this ticket does not check nested per-locale field
+// completeness).
+//
+// Duplicate source ids / duplicate overlay keys, spreads, computed keys,
+// dynamic ids and any shape that cannot be statically confirmed fail closed
+// with a deterministic AuditParseError. Performs zero filesystem writes,
+// console output, network access and never calls process.exit.
+
+/** The fields that make a sentence pattern object a learner-facing item. */
+const SENTENCE_PATTERN_LEARNER_FIELDS = ["hintZh", "promptContextZh", "explanation"];
+
+/** True when a type annotation node is `SentencePatternItem[]`. */
+function isSentencePatternItemArrayType(typeNode) {
+  return (
+    typeNode !== undefined &&
+    ts.isArrayTypeNode(typeNode) &&
+    ts.isTypeReferenceNode(typeNode.elementType) &&
+    ts.isIdentifier(typeNode.elementType.typeName) &&
+    typeNode.elementType.typeName.text === "SentencePatternItem"
+  );
+}
+
+/**
+ * Collect every `SentencePatternItem[]`-typed variable whose initializer is an
+ * array literal, with its declaration name. Any other initializer shape fails
+ * closed because the runtime item set cannot be resolved statically.
+ */
+function findSentencePatternItemArrays(sourceFile) {
+  const arrays = [];
+  const visit = (node) => {
+    if (
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!isSentencePatternItemArrayType(d.type)) continue;
+        if (!d.initializer || !ts.isArrayLiteralExpression(d.initializer)) {
+          throw new AuditParseError(
+            `SentencePatternItem[] declaration "${d.name.getText(sourceFile)}" must have an array-literal initializer so the audit can resolve item ids statically`,
+            { file: sourceFile.fileName, line: getLine(sourceFile, d) }
+          );
+        }
+        arrays.push({
+          name: ts.isIdentifier(d.name) ? d.name.text : null,
+          array: d.initializer
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return arrays;
+}
+
+/**
+ * Read the static `id` of a sentence pattern item object literal and whether it
+ * is learner-facing (carries at least one non-empty static hintZh /
+ * promptContextZh / explanation). Fails closed on spreads, computed / dynamic
+ * members, duplicate `id` members and shapes that cannot be statically
+ * confirmed.
+ */
+function readSentencePatternItem(elementNode, sourceFile, filePath) {
+  const sf = sourceFile ?? elementNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(elementNode)) {
+    throw new AuditParseError(
+      `sentence pattern item element must be an object literal, got ${ts.SyntaxKind[elementNode.kind]}`,
+      { file, line: getLine(sf, elementNode), context: elementNode.getText() }
+    );
+  }
+  let id = null;
+  let idMember = null;
+  let learnerFacing = false;
+  for (const member of elementNode.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically in a sentence pattern item: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      throw new AuditParseError(
+        `sentence pattern item members must be static property assignments: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    // Route through readStaticPropertyName so computed names (and any other
+    // non-static property-name shape) fail closed instead of being silently
+    // dropped -- the same contract the overlay-side adapter enforces.
+    const name = readStaticPropertyName(member.name, sf);
+    if (name === "id") {
+      if (idMember) {
+        throw new AuditParseError(
+          "duplicate \"id\" member in sentence pattern item",
+          { file, line: getLine(sf, member), context: member.getText() }
+        );
+      }
+      idMember = member;
+      const init = member.initializer;
+      if (!ts.isStringLiteral(init) && !ts.isNoSubstitutionTemplateLiteral(init)) {
+        throw new AuditParseError(
+          `sentence pattern item id must be a static string literal: ${init.getText(sf)}`,
+          { file, line: getLine(sf, member), context: init.getText(sf) }
+        );
+      }
+      id = init.text;
+      if (id.trim().length === 0) {
+        throw new AuditParseError(
+          "sentence pattern item id must be a non-empty string literal",
+          { file, line: getLine(sf, member) }
+        );
+      }
+      continue;
+    }
+    if (SENTENCE_PATTERN_LEARNER_FIELDS.includes(name)) {
+      const init = member.initializer;
+      if (!ts.isStringLiteral(init) && !ts.isNoSubstitutionTemplateLiteral(init)) {
+        throw new AuditParseError(
+          `${name} must be a static string literal: ${init.getText(sf)}`,
+          { file, line: getLine(sf, member), context: init.getText(sf) }
+        );
+      }
+      if (init.text.length > 0) learnerFacing = true;
+    }
+  }
+  if (id === null) {
+    throw new AuditParseError("sentence pattern item is missing a static string id", {
+      file,
+      line: getLine(sf, elementNode)
+    });
+  }
+  return { id, learnerFacing };
+}
+
+/**
+ * Resolve the `sentencePatternI18n` object literal from a SourceFile. Returns
+ * the object node when present (identifier `sentencePatternI18n`), otherwise
+ * undefined.
+ */
+function findSentencePatternOverlay(sourceFile) {
+  let found = undefined;
+  const visit = (node) => {
+    if (
+      found === undefined &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "sentencePatternI18n") continue;
+        if (ts.isObjectLiteralExpression(d.initializer)) found = d.initializer;
+        break;
+      }
+    }
+    if (found === undefined) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Collect the first-level item keys of the `sentencePatternI18n` object literal,
+ * in declaration order. Each entry value must be an object literal; the nested
+ * `hintI18n` / `promptContextI18n` / `explanationI18n` field keys are never
+ * read, so they can never be mistaken for item keys. Spreads, computed keys,
+ * non-property members and duplicate keys fail closed.
+ */
+function collectSentencePatternOverlayKeys(overlayNode, sourceFile, filePath) {
+  const sf = sourceFile ?? overlayNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(overlayNode)) {
+    throw new AuditParseError(
+      `sentencePatternI18n must be an object literal, got ${ts.SyntaxKind[overlayNode.kind]}`,
+      { file, line: getLine(sf, overlayNode) }
+    );
+  }
+  const keys = [];
+  const seen = new Set();
+  for (const member of overlayNode.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      throw new AuditParseError(
+        `sentencePatternI18n entries must be static property assignments: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    const key = readStaticPropertyName(member.name, sf);
+    if (seen.has(key)) {
+      throw new AuditParseError(`duplicate overlay item key "${key}"`, {
+        file,
+        line: getLine(sf, member),
+        context: key
+      });
+    }
+    seen.add(key);
+    const value = member.initializer;
+    if (!ts.isObjectLiteralExpression(value)) {
+      throw new AuditParseError(
+        `overlay entry "${key}" must be an object literal mapping overlay fields to locales`,
+        { file, line: getLine(sf, member), context: key }
+      );
+    }
+    keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * Audit the source/overlay first-level item key mapping for the
+ * sentence-patterns system and return the overlay audit records (system
+ * "sentencePatterns") for every learner-facing item id and every target locale.
+ *
+ *   - The source set is the static `id` of every learner-facing element of every
+ *     `SentencePatternItem[]` array literal. Non-object elements, missing /
+ *     empty / dynamic ids, item-level spreads and duplicate ids fail closed.
+ *     Pure-aggregation arrays are skipped.
+ *   - The overlay set is the first-level keys of the `sentencePatternI18n`
+ *     object literal; nested field keys are never flattened. Spreads, computed
+ *     keys, duplicate keys and non-object entry values fail closed.
+ *   - For each target locale, a source id with no overlay key is `missing`; an
+ *     overlay key with no source id is `dangling`. The common record shape,
+ *     sorting and counts come from #695; the system is fixed to
+ *     "sentencePatterns". Target locales must come from the launched registry;
+ *     this adapter never hardcodes one.
+ *
+ * Returns records sorted by the canonical `sortAuditRecords` order. Performs
+ * zero filesystem writes, console output, network access and never calls
+ * process.exit.
+ */
+export function auditSentencePatternOverlays({ repoRoot, targetLocales }) {
+  if (typeof repoRoot !== "string" || repoRoot.length === 0) {
+    throw new Error("auditSentencePatternOverlays requires a non-empty repoRoot directory");
+  }
+  if (
+    !Array.isArray(targetLocales) ||
+    !targetLocales.every((l) => typeof l === "string" && l.length > 0)
+  ) {
+    throw new Error(
+      "auditSentencePatternOverlays requires targetLocales to be an array of locale strings"
+    );
+  }
+  const locales = [...new Set(targetLocales)];
+
+  const sourcePath = `${repoRoot}/src/domain/sentencePatterns.ts`;
+  const overlayPath = `${repoRoot}/src/domain/sentencePatterns.i18n.ts`;
+
+  const sourceFile = parseTypeScriptFile(sourcePath);
+  const overlayFile = parseTypeScriptFile(overlayPath);
+
+  const arrays = findSentencePatternItemArrays(sourceFile);
+  if (arrays.length === 0) {
+    throw new AuditParseError(
+      "no SentencePatternItem[] array literal found; cannot resolve sentence pattern item ids",
+      { file: sourcePath }
+    );
+  }
+  const arrayNames = new Set(arrays.map((a) => a.name).filter((n) => n !== null));
+
+  // --- source: learner-facing static item ids -------------------------------
+  const sourceKeys = [];
+  const seenIds = new Set();
+  for (const { array } of arrays) {
+    // Pure-aggregation arrays add no ids of their own; the leaf arrays they
+    // spread are audited separately.
+    if (
+      array.elements.length > 0 &&
+      array.elements.every(
+        (el) => ts.isSpreadElement(el) && ts.isIdentifier(el.expression) && arrayNames.has(el.expression.text)
+      )
+    ) {
+      continue;
+    }
+    for (const element of array.elements) {
+      if (ts.isSpreadElement(element)) {
+        throw new AuditParseError(
+          `spread element cannot be resolved statically in a sentence pattern item array: ${element.getText()}`,
+          { file: sourcePath, line: getLine(sourceFile, element), context: element.getText() }
+        );
+      }
+      const { id, learnerFacing } = readSentencePatternItem(element, sourceFile, sourcePath);
+      if (!learnerFacing) continue;
+      if (seenIds.has(id)) {
+        throw new AuditParseError(`duplicate sentence pattern item id "${id}"`, {
+          file: sourcePath,
+          context: id
+        });
+      }
+      seenIds.add(id);
+      sourceKeys.push(id);
+    }
+  }
+
+  // --- overlay: first-level item keys ---------------------------------------
+  const overlayObject = findSentencePatternOverlay(overlayFile);
+  if (!overlayObject) {
+    throw new AuditParseError("sentencePatternI18n object literal not found", {
+      file: overlayPath
+    });
+  }
+  const overlayKeys = collectSentencePatternOverlayKeys(overlayObject, overlayFile, overlayPath);
+  const overlaySet = new Set(overlayKeys);
+
+  // --- per-target-locale comparison -----------------------------------------
+  const records = [];
+  for (const locale of locales) {
+    for (const sourceKey of sourceKeys) {
+      if (!overlaySet.has(sourceKey)) {
+        records.push({
+          system: "sentencePatterns",
+          locale,
+          sourceKey,
+          overlayKey: "",
+          status: "missing"
+        });
+      }
+    }
+    for (const overlayKey of overlayKeys) {
+      if (!seenIds.has(overlayKey)) {
+        records.push({
+          system: "sentencePatterns",
+          locale,
+          sourceKey: "",
+          overlayKey,
+          status: "dangling"
+        });
+      }
+    }
+  }
+
+  return sortAuditRecords(records);
+}

--- a/scripts/i18n-overlay-audit.test.ts
+++ b/scripts/i18n-overlay-audit.test.ts
@@ -13,6 +13,7 @@ import {
   auditExamOverlays,
   auditKeySets,
   auditLearningBlockOverlays,
+  auditSentencePatternOverlays,
   collectStaticObjectKeys,
   parseLaunchedLocales,
   parseTypeScriptFile,
@@ -969,6 +970,285 @@ describe("auditLearningBlockOverlays (#697)", () => {
     const mkdirSpy = vi.spyOn(fs, "mkdirSync");
     try {
       const records = auditLearningBlockOverlays({ repoRoot, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+    }
+  });
+});
+
+describe("auditSentencePatternOverlays (#698)", () => {
+  /** Repo-style fixture tree rooted at tmpDir/src/domain. */
+  function writeSentencePatternFixtures(sourceText: string, overlayText: string): void {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "sentencePatterns.ts"), sourceText);
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "sentencePatterns.i18n.ts"), overlayText);
+  }
+
+  /** An `Item: SentencePatternItem[]` typed array declaration. */
+  const ARRAY = (name: string, items: string): string =>
+    `const ${name}: SentencePatternItem[] = [${items}];`;
+  /** A learner-facing SentencePatternItem object literal with a non-empty id. */
+  const ITEM = (id: string): string =>
+    `{ id: "${id}", patternId: "starter-desu", promptText: "あ、___。", hintZh: "提示", promptContextZh: "情境", expectedAnswer: "です", options: ["です"], explanation: "解說" }`;
+  const OVERLAY = (entries: string): string =>
+    `export const sentencePatternI18n: Record<string, SentencePatternOverlay> = {${entries}};`;
+  const ENTRY = (id: string, locales: string): string =>
+    `"${id}": { "hintI18n": { ${locales} }, "promptContextI18n": { ${locales} }, "explanationI18n": { ${locales} } }`;
+  const PAIRS = `"en": "E", "ja": "J"`;
+  const SRC_WITH_TYPE = (name: string, items: string): string =>
+    `type SentencePatternItem = { id: string; hintZh: string; promptContextZh: string; explanation: string; };\n${ARRAY(name, items)}`;
+
+  beforeAll(() => {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+  });
+
+  it("yields zero records when every source item id has a first-level overlay key", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE(
+        "STARTER_ITEMS",
+        ITEM("pattern-a-001") + ITEM("pattern-b-001") + ITEM("pattern-c-001")
+      ),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS) + ENTRY("pattern-b-001", PAIRS) + ENTRY("pattern-c-001", PAIRS))
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("reports a missing record per target locale for a source item with no overlay entry", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001") + ITEM("pattern-b-001")),
+      OVERLAY(ENTRY("pattern-b-001", PAIRS))
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "sentencePatterns", locale: "en", sourceKey: "pattern-a-001", overlayKey: "", status: "missing" },
+      { system: "sentencePatterns", locale: "ja", sourceKey: "pattern-a-001", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("reports a dangling record for an overlay key with no source item id", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS) + ENTRY("pattern-deleted-001", PAIRS))
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "sentencePatterns", locale: "en", sourceKey: "", overlayKey: "pattern-deleted-001", status: "dangling" },
+      { system: "sentencePatterns", locale: "ja", sourceKey: "", overlayKey: "pattern-deleted-001", status: "dangling" }
+    ]);
+  });
+
+  it("ignores the patternInstructionI18n global instruction overlay", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      [
+        'export const patternInstructionI18n = { en: "Choose.", ja: "選んで。" };',
+        OVERLAY(ENTRY("pattern-a-001", PAIRS))
+      ].join("\n")
+    );
+    // The global instruction overlay's own locale keys (en / ja) must never be
+    // read as item keys, and it must not fabricate phantom source keys.
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("never flattens nested hintI18n / promptContextI18n / explanationI18n keys into item keys", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      // The nested field names must not be treated as item keys even though the
+      // "hintI18n" field name equals an item's own identifier.
+      OVERLAY(`"hintI18n": { "en": "N", "ja": "N" }, "pattern-a-001": { "hintI18n": { ${PAIRS} } }`)
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "sentencePatterns", locale: "en", sourceKey: "", overlayKey: "hintI18n", status: "dangling" },
+      { system: "sentencePatterns", locale: "ja", sourceKey: "", overlayKey: "hintI18n", status: "dangling" }
+    ]);
+  });
+
+  it("does not misclassify pattern metadata, type-union members, helper objects or comments", () => {
+    writeSentencePatternFixtures(
+      [
+        "type SentencePatternItem = { id: string; hintZh: string; patternId: string; };",
+        'const STARTER_ITEMS: SentencePatternItem[] = [',
+        '  { id: "pattern-a-001", patternId: "starter-desu", hintZh: "提示" },',
+        "];",
+        'const PATTERN_LABEL_ZH = { "starter-desu": "基本句", "not-an-item": "元" };',
+        "// The id below is a type-union member, not an item id.",
+        'type SentencePatternId = "starter-desu" | "pattern-not-an-item";',
+        "const helper: SentencePatternItem = {",
+        '  id: "pattern-helper-001",',
+        '  patternId: "starter-desu",',
+        '  hintZh: "helper hint",',
+        "};",
+        "const meta = { id: \"pattern-meta-001\" };"
+      ].join("\n"),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS))
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("only audits first-level overlay keys, ignoring locale keys nested two levels deep", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(`"pattern-a-001": { "hintI18n": { "en": "E", "ja": "J" }, "promptContextI18n": { "ja": "J" } }`)
+    );
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("skips non-learner-facing objects inside item arrays instead of counting them as source keys", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE(
+        "STARTER_ITEMS",
+        ITEM("pattern-a-001") + `{ id: "pattern-config-001", patternId: "starter-desu" }`
+      ),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS))
+    );
+    // "pattern-config-001" carries an id but no hintZh / promptContextZh /
+    // explanation, so it is not a learner-facing item and must not produce a
+    // missing record (nor become a phantom source key).
+    expect(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("fails closed on duplicate source item ids", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-dup-001") + ITEM("pattern-dup-001")),
+      OVERLAY(ENTRY("pattern-dup-001", PAIRS))
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on duplicate overlay first-level keys", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS) + ENTRY("pattern-a-001", PAIRS))
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on overlay spreads at the first level", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(`"pattern-a-001": { "hintI18n": { ${PAIRS} } }, ...extra`)
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/spread/i);
+  });
+
+  it("fails closed on computed first-level overlay keys", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(`[getKey()]: { "hintI18n": { ${PAIRS} } }`)
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+  });
+
+  it("fails closed on dynamic / missing source item ids", () => {
+    writeSentencePatternFixtures(
+      "type SentencePatternItem = { id: string; hintZh: string; };\n" +
+        "const STARTER_ITEMS: SentencePatternItem[] = [{ id: DYNAMIC_ID, hintZh: \"x\" }];",
+      OVERLAY(ENTRY("whatever", PAIRS))
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/id|static|literal/i);
+
+    writeSentencePatternFixtures(
+      "type SentencePatternItem = { id: string; hintZh: string; };\n" +
+        "const STARTER_ITEMS: SentencePatternItem[] = [{ hintZh: \"x\" }];",
+      OVERLAY(ENTRY("whatever", PAIRS))
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/id/);
+  });
+
+  it("fails closed on a spread inside an item array element", () => {
+    writeSentencePatternFixtures(
+      "type SentencePatternItem = { id: string; hintZh: string; };\n" +
+        "const EXTRA = { hintZh: \"x\" };\n" +
+        "const STARTER_ITEMS: SentencePatternItem[] = [{ id: \"pattern-a-001\", ...EXTRA }];",
+      OVERLAY(ENTRY("pattern-a-001", PAIRS))
+    );
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/spread/i);
+  });
+
+  it("fails closed on computed member names in an item instead of silently dropping them", () => {
+    writeSentencePatternFixtures(
+      "type SentencePatternItem = { id: string; hintZh: string; };\n" +
+        "const STARTER_ITEMS: SentencePatternItem[] = [{ id: \"pattern-a-001\", [\"hintZh\"]: \"hint\" }];",
+      OVERLAY(ENTRY("pattern-a-001", PAIRS))
+    );
+    // A computed non-id member must not be silently treated as absent: that
+    // would misclassify the item and fabricate a phantom missing/dangling pair.
+    expect(() => auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+  });
+
+  it("returns byte-equivalent records regardless of source or locale traversal order", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001") + ITEM("pattern-b-001") + ITEM("pattern-c-001")),
+      OVERLAY(
+        ENTRY("pattern-c-001", PAIRS) +
+          ENTRY("pattern-a-001", PAIRS) +
+          ENTRY("pattern-b-001", PAIRS) +
+          ENTRY("pattern-orphan-001", PAIRS)
+      )
+    );
+    const a = JSON.stringify(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    );
+    const b = JSON.stringify(
+      auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["ja", "en"] })
+    );
+    expect(a).toBe(b);
+  });
+
+  it("has no hardcoded locales, no filesystem writes, no console output and no process.exit", () => {
+    writeSentencePatternFixtures(
+      SRC_WITH_TYPE("STARTER_ITEMS", ITEM("pattern-a-001")),
+      OVERLAY(ENTRY("pattern-a-001", PAIRS))
+    );
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const logSpy = vi.spyOn(console, "log");
+    const errorSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const records = auditSentencePatternOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("audits the real repo with zero records and without writing anything", () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    try {
+      const records = auditSentencePatternOverlays({ repoRoot, targetLocales: ["en", "ja"] });
       expect(records).toEqual([]);
       expect(writeSpy).not.toHaveBeenCalled();
       expect(mkdirSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #698

## Summary

- Add `auditSentencePatternOverlays({ repoRoot, targetLocales })` to the #695 AST core (system `sentencePatterns`).
- Source ids locked via `SentencePatternItem[]` AST type annotation (not bare `id:` search); only learner-facing items (non-empty static id + at least one of hintZh/promptContextZh/explanation) counted.
- Overlay reads only `sentencePatternI18n` first-level keys; nested fields never flatten; `patternInstructionI18n` ignored.
- missing/dangling per locale; duplicate/spread/computed/dynamic shapes fail closed via `AuditParseError` (member names routed through `readStaticPropertyName`).
- No hardcoded locales, no runtime imports, no content/CLI changes.

## Scope

Only `scripts/i18n-overlay-audit.mjs` and `scripts/i18n-overlay-audit.test.ts`.

## Verification

- `node --check` — pass
- `pnpm exec vitest run scripts/i18n-overlay-audit.test.ts` — 69/69 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict (2 rounds)

```
Blocking findings:
- None.（第一輪 computed-key fail-open 已修正並於複審確認）

Non-blocking findings:
- 無 id 也無 learner-facing field 的 typed-array 元素會 throw（fail closed，與 sibling 一致）。
- [`tpl`] computed template member name 視為 computed 而 throw（與 fail-closed 要求一致，非缺陷）。

Verdict:
No blocking findings.
```