### PR TITLE
chore(i18n): audit grammar note overlay keys

### DIFF
--- a/scripts/i18n-overlay-audit.mjs
+++ b/scripts/i18n-overlay-audit.mjs
@@ -1344,3 +1344,312 @@ export function auditSentencePatternOverlays({ repoRoot, targetLocales }) {
 
   return sortAuditRecords(records);
 }
+
+// ---------------------------------------------------------------------------
+// Grammar-note overlay adapter (#700)
+// ---------------------------------------------------------------------------
+//
+// Audits the "source stable note key <-> overlay first-level note key" mapping
+// for the grammar-notes system.
+//
+//   source:  src/domain/grammarNotes.ts       (the `grammarNotes` record)
+//   overlay: src/domain/grammarNotes.i18n.ts  (the `grammarNoteI18n` record)
+//   key:     the stable surface key of a real learner-facing grammar note
+//
+// The source side only admits actual learner-facing note keys of the
+// `grammarNotes` record literal; helper / template / container objects and
+// stray `surface:` members elsewhere in the file are never counted. Each
+// source entry must be an object literal (a GrammarNote) whose member names
+// are routed through `readStaticPropertyName`, so a computed member name fails
+// closed instead of being silently dropped (same contract as #698). The
+// overlay side only admits first-level keys of the `grammarNoteI18n` object
+// literal; nested per-locale field keys (meaningZh / formation / usageZh /
+// examplesZh / confusions) are never flattened.
+//
+// For each target locale (resolved by #695's launched-locale registry, never
+// hardcoded) the overlay is expected to carry a first-level key for EVERY
+// source note key. source-without-overlay = missing; overlay-without-source =
+// dangling. A note whose overlay entry omits one locale produces a missing
+// record for that locale only.
+//
+// Fails closed on duplicate source keys / duplicate overlay keys, spreads,
+// computed keys and any dynamic form whose runtime key mapping cannot be
+// confirmed. Performs zero filesystem writes, console output, network access
+// and never calls process.exit.
+
+/**
+ * Resolve the `grammarNotes` object literal from a SourceFile. Returns the
+ * object node when present (identifier `grammarNotes`), otherwise undefined.
+ */
+function findGrammarNotesRecord(sourceFile) {
+  let found = undefined;
+  const visit = (node) => {
+    if (
+      found === undefined &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "grammarNotes") continue;
+        if (ts.isObjectLiteralExpression(d.initializer)) found = d.initializer;
+        break;
+      }
+    }
+    if (found === undefined) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Resolve the `grammarNoteI18n` object literal from a SourceFile. Returns the
+ * object node when present (identifier `grammarNoteI18n`), otherwise
+ * undefined.
+ */
+function findGrammarNoteOverlay(sourceFile) {
+  let found = undefined;
+  const visit = (node) => {
+    if (
+      found === undefined &&
+      ts.isVariableStatement(node) &&
+      ts.isVariableDeclarationList(node.declarationList)
+    ) {
+      for (const d of node.declarationList.declarations) {
+        if (!ts.isIdentifier(d.name) || d.name.text !== "grammarNoteI18n") continue;
+        if (ts.isObjectLiteralExpression(d.initializer)) found = d.initializer;
+        break;
+      }
+    }
+    if (found === undefined) ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+/**
+ * Collect the static first-level note keys of the `grammarNotes` record literal
+ * into an array, in declaration order. Every entry must be an object literal (a
+ * learner-facing GrammarNote); its member names are routed through
+ * `readStaticPropertyName` so a computed member name fails closed instead of
+ * being silently dropped (#698 contract). Spreads, computed keys, non-property
+ * members, non-object entry values and duplicate keys fail closed.
+ */
+function collectGrammarNoteSourceKeys(recordNode, sourceFile, filePath) {
+  const sf = sourceFile ?? recordNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(recordNode)) {
+    throw new AuditParseError(
+      `grammarNotes must be an object literal, got ${ts.SyntaxKind[recordNode.kind]}`,
+      { file, line: getLine(sf, recordNode), context: recordNode.getText() }
+    );
+  }
+  const keys = [];
+  const seen = new Set();
+  for (const member of recordNode.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      throw new AuditParseError(
+        `grammarNotes entries must be static property assignments: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    // Route through readStaticPropertyName so computed names fail closed
+    // instead of being silently dropped -- the same contract the overlay side
+    // and #698's item members enforce.
+    const key = readStaticPropertyName(member.name, sf);
+    if (seen.has(key)) {
+      throw new AuditParseError(`duplicate grammar note key "${key}"`, {
+        file,
+        line: getLine(sf, member),
+        context: key
+      });
+    }
+    seen.add(key);
+    const value = member.initializer;
+    if (!ts.isObjectLiteralExpression(value)) {
+      throw new AuditParseError(
+        `grammar note "${key}" must be an object literal (a GrammarNote)`,
+        { file, line: getLine(sf, member), context: key }
+      );
+    }
+    // Fail closed on computed / spread / unsupported members inside the note
+    // entry; the returned field keys are deliberately discarded (only the
+    // first-level note keys are collected, nested fields are never flattened).
+    collectStaticObjectKeys(value, undefined);
+    keys.push(key);
+  }
+  return keys;
+}
+
+/**
+ * Collect the first-level overlay note keys of the `grammarNoteI18n` object into
+ * a Map<noteKey, localeKeys>, in declaration order. Each entry must be an object
+ * literal mapping locales to text; its locale keys are read statically.
+ * Computed keys, spreads, non-property members and non-object entry values fail
+ * closed (their runtime key mapping cannot be confirmed).
+ */
+function collectOverlayNoteEntries(overlayNode, sourceFile, filePath) {
+  const sf = sourceFile ?? overlayNode.getSourceFile?.();
+  const file = filePath ?? sf?.fileName;
+  if (!ts.isObjectLiteralExpression(overlayNode)) {
+    throw new AuditParseError(
+      `grammarNoteI18n must be an object literal, got ${ts.SyntaxKind[overlayNode.kind]}`,
+      { file, line: getLine(sf, overlayNode) }
+    );
+  }
+  const entries = new Map();
+  for (const member of overlayNode.properties) {
+    if (ts.isSpreadAssignment(member)) {
+      throw new AuditParseError(
+        `object spread cannot be resolved statically: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    if (!ts.isPropertyAssignment(member)) {
+      throw new AuditParseError(
+        `overlay note entries must be static property assignments: ${member.getText()}`,
+        { file, line: getLine(sf, member), context: member.getText() }
+      );
+    }
+    const noteKey = readStaticPropertyName(member.name, sf);
+    if (entries.has(noteKey)) {
+      throw new AuditParseError(`duplicate overlay note key "${noteKey}"`, {
+        file,
+        line: getLine(sf, member),
+        context: noteKey
+      });
+    }
+    const localeObject = member.initializer;
+    if (!ts.isObjectLiteralExpression(localeObject)) {
+      throw new AuditParseError(
+        `overlay entry "${noteKey}" must be an object literal mapping locales to text`,
+        { file, line: getLine(sf, member), context: noteKey }
+      );
+    }
+    const localeKeys = [];
+    const seenLocales = new Set();
+    for (const localeMember of localeObject.properties) {
+      if (ts.isSpreadAssignment(localeMember)) {
+        throw new AuditParseError(
+          `object spread cannot be resolved statically in overlay entry "${noteKey}"`,
+          { file, line: getLine(sf, localeMember), context: localeMember.getText() }
+        );
+      }
+      if (!ts.isPropertyAssignment(localeMember)) {
+        throw new AuditParseError(
+          `overlay locale entries must be static property assignments: ${localeMember.getText()}`,
+          { file, line: getLine(sf, localeMember), context: localeMember.getText() }
+        );
+      }
+      const locale = readStaticPropertyName(localeMember.name, sf);
+      if (seenLocales.has(locale)) {
+        throw new AuditParseError(
+          `duplicate overlay locale key "${locale}" for note "${noteKey}"`,
+          { file, line: getLine(sf, localeMember), context: locale }
+        );
+      }
+      seenLocales.add(locale);
+      localeKeys.push(locale);
+    }
+    entries.set(noteKey, localeKeys);
+  }
+  return entries;
+}
+
+/**
+ * Audit the source/overlay first-level note key mapping for the grammar-notes
+ * system and return the overlay audit records (system "grammarNotes") for every
+ * learner-facing note key and every target locale.
+ *
+ *   - The source set is the static first-level key of every entry of the
+ *     `grammarNotes` record literal. Non-object entries, spreads, computed keys
+ *     and duplicate keys fail closed.
+ *   - The overlay set is the first-level keys of the `grammarNoteI18n` object
+ *     literal; nested per-locale field keys are never flattened. Spreads,
+ *     computed keys and non-object entry values fail closed.
+ *   - For each target locale, a source key with no overlay entry for that
+ *     locale is `missing`; an overlay key with no source key is `dangling` (per
+ *     locale the overlay entry carries). The common record shape, sorting and
+ *     counts come from #695; the system is fixed to "grammarNotes". Target
+ *     locales must come from the launched registry; this adapter never
+ *     hardcodes one.
+ *
+ * Returns records sorted by the canonical `sortAuditRecords` order. Performs
+ * zero filesystem writes, console output, network access and never calls
+ * process.exit.
+ */
+export function auditGrammarNoteOverlays({ repoRoot, targetLocales }) {
+  if (typeof repoRoot !== "string" || repoRoot.length === 0) {
+    throw new Error("auditGrammarNoteOverlays requires a non-empty repoRoot directory");
+  }
+  if (
+    !Array.isArray(targetLocales) ||
+    !targetLocales.every((l) => typeof l === "string" && l.length > 0)
+  ) {
+    throw new Error(
+      "auditGrammarNoteOverlays requires targetLocales to be an array of locale strings"
+    );
+  }
+  const locales = [...new Set(targetLocales)];
+
+  const sourcePath = `${repoRoot}/src/domain/grammarNotes.ts`;
+  const overlayPath = `${repoRoot}/src/domain/grammarNotes.i18n.ts`;
+
+  const sourceFile = parseTypeScriptFile(sourcePath);
+  const overlayFile = parseTypeScriptFile(overlayPath);
+
+  const recordObject = findGrammarNotesRecord(sourceFile);
+  const overlayObject = findGrammarNoteOverlay(overlayFile);
+
+  if (!recordObject) {
+    throw new AuditParseError("grammarNotes object literal not found", { file: sourcePath });
+  }
+  if (!overlayObject) {
+    throw new AuditParseError("grammarNoteI18n object literal not found", { file: overlayPath });
+  }
+
+  // --- source: static learner-facing note keys ------------------------------
+  const sourceKeys = collectGrammarNoteSourceKeys(recordObject, sourceFile, sourcePath);
+  const sourceSet = new Set(sourceKeys);
+
+  // --- overlay: first-level note keys + per-entry locales --------------------
+  const overlayEntries = collectOverlayNoteEntries(overlayObject, overlayFile, overlayPath);
+
+  // --- per-target-locale comparison -----------------------------------------
+  const records = [];
+  for (const locale of locales) {
+    // source-without-overlay-for-this-locale => missing
+    for (const sourceKey of sourceKeys) {
+      const entry = overlayEntries.get(sourceKey);
+      if (!entry || !entry.includes(locale)) {
+        records.push({
+          system: "grammarNotes",
+          locale,
+          sourceKey,
+          overlayKey: "",
+          status: "missing"
+        });
+      }
+    }
+  }
+  // overlay-without-source => dangling (per locale the overlay entry carries)
+  for (const [noteKey, localeKeys] of overlayEntries) {
+    if (sourceSet.has(noteKey)) continue;
+    for (const locale of localeKeys) {
+      records.push({
+        system: "grammarNotes",
+        locale,
+        sourceKey: "",
+        overlayKey: noteKey,
+        status: "dangling"
+      });
+    }
+  }
+
+  return sortAuditRecords(records);
+}

--- a/scripts/i18n-overlay-audit.test.ts
+++ b/scripts/i18n-overlay-audit.test.ts
@@ -11,6 +11,7 @@ import ts from "typescript";
 import {
   AuditParseError,
   auditExamOverlays,
+  auditGrammarNoteOverlays,
   auditKeySets,
   auditLearningBlockOverlays,
   auditSentencePatternOverlays,
@@ -1249,6 +1250,260 @@ describe("auditSentencePatternOverlays (#698)", () => {
     const mkdirSpy = vi.spyOn(fs, "mkdirSync");
     try {
       const records = auditSentencePatternOverlays({ repoRoot, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+    }
+  });
+});
+
+describe("auditGrammarNoteOverlays (#700)", () => {
+  /** Repo-style fixture tree rooted at tmpDir/src/domain. */
+  function writeGrammarNoteFixtures(sourceText: string, overlayText: string): void {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "grammarNotes.ts"), sourceText);
+    fs.writeFileSync(path.join(tmpDir, "src", "domain", "grammarNotes.i18n.ts"), overlayText);
+  }
+
+  /** A learner-facing note entry with a non-empty static surface key. */
+  const NOTE = (surface: string): string =>
+    `  ${surface}: { surface: "${surface}", jlptLevel: "N2", meaningZh: "意思", formation: "接續", usageZh: "用法", examples: [], confusions: [] }`;
+  const OVERLAY = (entries: string): string =>
+    `export const grammarNoteI18n: GrammarNoteOverlays = {${entries}};`;
+  const ENTRY = (surface: string, locales: string): string =>
+    `  "${surface}": { ${locales} }`;
+  const PAIRS = `"en": { "meaningZh": "E", "usageZh": "U" }, "ja": { "meaningZh": "J", "usageZh": "U" }`;
+  const SRC = (notes: string): string =>
+    `type GrammarNote = { surface: string; jlptLevel: string | null; meaningZh: string; formation: string; usageZh: string; examples: unknown[]; confusions: string[]; };\n` +
+    `export const grammarNotes: Record<string, GrammarNote> = {\n${notes}\n};`;
+
+  beforeAll(() => {
+    fs.mkdirSync(path.join(tmpDir, "src", "domain"), { recursive: true });
+  });
+
+  it("yields zero records when every learner-facing source note has a first-level overlay key for every locale", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE('"だけあって"'), NOTE("なり")].join(",\n")),
+      OVERLAY([ENTRY("ばかりに", PAIRS), ENTRY("だけあって", PAIRS), ENTRY("なり", PAIRS)].join(",\n"))
+    );
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("reports a missing record per target locale for a single note with no overlay entry", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE('"あげく"')].join(",\n")),
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "grammarNotes", locale: "en", sourceKey: "あげく", overlayKey: "", status: "missing" },
+      { system: "grammarNotes", locale: "ja", sourceKey: "あげく", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("reports a dangling record per overlay locale for a source note that has been deleted", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY([ENTRY("ばかりに", PAIRS), ENTRY("せいで", PAIRS)].join(",\n"))
+    );
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "grammarNotes", locale: "en", sourceKey: "", overlayKey: "せいで", status: "dangling" },
+      { system: "grammarNotes", locale: "ja", sourceKey: "", overlayKey: "せいで", status: "dangling" }
+    ]);
+  });
+
+  it("does not confuse an overlay value containing another source note key with a real first-level key", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE('"だけあって"')].join(",\n")),
+      OVERLAY(
+        ENTRY("ばかりに", `"en": { "meaningZh": "E, see だけあって" }, "ja": { "meaningZh": "J, see だけあって" }`)
+      )
+    );
+    // "だけあって" appears inside the value text but is not an overlay first-level
+    // key; it must remain a missing record rather than being matched by text.
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([
+      { system: "grammarNotes", locale: "en", sourceKey: "だけあって", overlayKey: "", status: "missing" },
+      { system: "grammarNotes", locale: "ja", sourceKey: "だけあって", overlayKey: "", status: "missing" }
+    ]);
+  });
+
+  it("never flattens nested locale field keys into first-level overlay keys", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY(
+        ENTRY(
+          "ばかりに",
+          `"en": { "meaningZh": "E", "formation": "F", "usageZh": "U", "examplesZh": ["X"], "confusions": ["C"] }`
+        )
+      )
+    );
+    // The nested field names (meaningZh / formation / usageZh / examplesZh /
+    // confusions) must never be read as note keys, even though "confusions" could
+    // be confused with a surface. ばかりに is fully overlaid for en -> zero records.
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })
+    ).toEqual([]);
+  });
+
+  it("does not misclassify helper objects, template keys or unrelated surface fields", () => {
+    writeGrammarNoteFixtures(
+      [
+        SRC(NOTE('"ばかりに"')),
+        "export const GRAMMAR_HELPER = { surface: \"なり\" };",
+        'const TEMPLATE_NOTE: Record<string, GrammarNote> = { "せいで": { surface: "せいで", jlptLevel: null, meaningZh: "x", formation: "f", usageZh: "u", examples: [], confusions: [] } };',
+        '// The surface below lives inside a comment and must never count.',
+        "// あげく is not a real note here."
+      ].join("\n"),
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    // The helper/template/comment objects are not elements of the grammarNotes
+    // array-of-record literal, so なり / せいで / あげく must not become source
+    // keys. ばかりに is fully overlaid for en + ja -> zero records.
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("parses quoted and unquoted keys, multiline values and trailing commas", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE("なり")].join(",\n")),
+      OVERLAY([
+        `  "ばかりに": {\n    "en": { "meaningZh": "E" },\n    'ja': { meaningZh: "J" },\n  },`,
+        `  なり: {\n    "en": { "meaningZh": "E" },\n    "ja": { "meaningZh": "J" },\n  },`
+      ].join("\n"))
+    );
+    expect(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    ).toEqual([]);
+  });
+
+  it("fails closed on duplicate source note keys", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE('"ばかりに"')].join(",\n")),
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on duplicate overlay first-level keys", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY([ENTRY("ばかりに", PAIRS), ENTRY("ばかりに", PAIRS)].join(",\n"))
+    );
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/duplicate/i);
+  });
+
+  it("fails closed on overlay spreads at the first level", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY(`${ENTRY("ばかりに", PAIRS)}, ...extra`)
+    );
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/spread/i);
+  });
+
+  it("fails closed on computed first-level overlay keys", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY(`  [getKey()]: { ${PAIRS} }`)
+    );
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+  });
+
+  it("fails closed on dynamic / missing source note keys", () => {
+    writeGrammarNoteFixtures(
+      "type GrammarNote = { surface: string; jlptLevel: string | null; meaningZh: string; formation: string; usageZh: string; examples: unknown[]; confusions: string[]; };\n" +
+        "export const grammarNotes: Record<string, GrammarNote> = { [DYNAMIC_KEY]: { surface: \"x\", jlptLevel: null, meaningZh: \"m\", formation: \"f\", usageZh: \"u\", examples: [], confusions: [] } };",
+      OVERLAY(ENTRY("whatever", PAIRS))
+    );
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+
+    writeGrammarNoteFixtures(
+      "type GrammarNote = { surface: string; jlptLevel: string | null; meaningZh: string; formation: string; usageZh: string; examples: unknown[]; confusions: string[]; };\n" +
+        "export const grammarNotes: Record<string, GrammarNote> = { ばかりに: { surface: \"ばかりに\", jlptLevel: null, meaningZh: \"m\", formation: \"f\", usageZh: \"u\", examples: [], confusions: [] } };",
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    // The surface member inside a note entry is not the key of the record; the
+    // key of ばかりに is the static member name, which is present.
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).not.toThrow();
+  });
+
+  it("fails closed on computed member names in a note entry instead of silently dropping them", () => {
+    writeGrammarNoteFixtures(
+      SRC(`  "ばかりに": { surface: "ばかりに", ["meaningZh"]: "意思", jlptLevel: "N2", formation: "f", usageZh: "u", examples: [], confusions: [] }`),
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    // A computed non-key member must not be silently treated as absent: that
+    // would misclassify the note and fabricate a phantom missing/dangling pair.
+    expect(() => auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en"] })).toThrow(/computed/i);
+  });
+
+  it("returns byte-equivalent records regardless of source or locale traversal order", () => {
+    writeGrammarNoteFixtures(
+      SRC([NOTE('"ばかりに"'), NOTE('"だけあって"'), NOTE('"あげく"')].join(",\n")),
+      OVERLAY(
+        [
+          ENTRY("あげく", PAIRS),
+          ENTRY("ばかりに", PAIRS),
+          ENTRY("だけあって", PAIRS),
+          ENTRY("っぱなし", PAIRS)
+        ].join(",\n")
+      )
+    );
+    const a = JSON.stringify(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] })
+    );
+    const b = JSON.stringify(
+      auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["ja", "en"] })
+    );
+    expect(a).toBe(b);
+  });
+
+  it("has no hardcoded locales, no filesystem writes, no console output and no process.exit", () => {
+    writeGrammarNoteFixtures(
+      SRC(NOTE('"ばかりに"')),
+      OVERLAY(ENTRY("ばかりに", PAIRS))
+    );
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const logSpy = vi.spyOn(console, "log");
+    const errorSpy = vi.spyOn(console, "error");
+    const exitSpy = vi.spyOn(process, "exit");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const records = auditGrammarNoteOverlays({ repoRoot: tmpDir, targetLocales: ["en", "ja"] });
+      expect(records).toEqual([]);
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      exitSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("audits the real repo with zero records and without writing anything", () => {
+    const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+    const writeSpy = vi.spyOn(fs, "writeFileSync");
+    const mkdirSpy = vi.spyOn(fs, "mkdirSync");
+    try {
+      const records = auditGrammarNoteOverlays({ repoRoot, targetLocales: ["en", "ja"] });
       expect(records).toEqual([]);
       expect(writeSpy).not.toHaveBeenCalled();
       expect(mkdirSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #700

## Summary

- Add `auditGrammarNoteOverlays({ repoRoot, targetLocales })` to the #695 AST core (system `grammarNotes`).
- Source: first-level learner-facing keys of the `grammarNotes` record literal; overlay: first-level `grammarNoteI18n` keys; nested per-locale fields never flatten.
- missing/dangling per locale; duplicate/spread/computed shapes fail closed via `readStaticPropertyName`.
- No hardcoded locales, no runtime imports, no content/CLI changes.

## Scope

Only `scripts/i18n-overlay-audit.mjs` and `scripts/i18n-overlay-audit.test.ts`.

## Verification

- `node --check` — pass
- `pnpm exec vitest run scripts/i18n-overlay-audit.test.ts` — 85/85 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- 無

Non-blocking findings:
- 源端 key 未驗證與 note entry 的 surface field 一致（目前真實資料一致，邊緣防護缺口）。
- findGrammarNotesRecord 錯誤訊息較籠統（與 #697 既有 pattern 一致）。

Verdict:
No blocking findings.
```