### PR TITLE
feat(mock): wire N4 and N5 into the section picker

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -392,6 +392,22 @@ describe("HomePanel grid label", () => {
   });
 });
 
+describe("HomePanel mock card coverage (#703)", () => {
+  it("the 題型練習 card copy spans N1–N5 now that the N4/N5 picker is wired", () => {
+    renderHome();
+    const card = screen.getByRole("button", { name: /題型練習/ });
+    expect(card).toHaveTextContent("N1〜N5");
+    expect(card).not.toHaveTextContent("N1〜N3");
+  });
+
+  it("launched locales carry no stale N1–N3 mock coverage string", () => {
+    for (const locale of ["zh-Hant", "ja", "en"] as const) {
+      expect(copy[locale].homeCardMockSub).toContain("N1〜N5");
+      expect(copy[locale].homeCardMockSub).not.toContain("N1〜N3");
+    }
+  });
+});
+
 describe("HomePanel content total", () => {
   it("renders the grand total of exam + vocab + kanji-readings + patterns", () => {
     renderHome();

--- a/src/components/MockExamPanel.test.tsx
+++ b/src/components/MockExamPanel.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MockExamPanel } from "./MockExamPanel";
+import { N4_BLUEPRINT, N5_BLUEPRINT } from "../domain/mockExam";
+
+const noop = () => {};
+
+function renderPanel() {
+  render(<MockExamPanel language="zh-Hant" onStartSection={noop} />);
+}
+
+// 模擬考 mode 的 level picker 與 section list（#703：接入 #702 的 N4/N5
+// blueprints）。picker 順序固定 N1→N5；選 level 後只消費該級 blueprint 的
+// sections；沒有題目的 section 沿用「準備中」UI，不建立空 challenge。
+describe("MockExamPanel level picker (#703)", () => {
+  it("renders the level picker in fixed N1–N5 order", () => {
+    renderPanel();
+    const picker = screen.getByRole("group", { name: "等級" });
+    const buttons = within(picker).getAllByRole("button");
+    expect(buttons.map((button) => button.textContent)).toEqual([
+      "N1",
+      "N2",
+      "N3",
+      "N4",
+      "N5"
+    ]);
+  });
+
+  it("marks only the active level as selected when switching levels", () => {
+    renderPanel();
+    const levelButtons = () => screen.getAllByRole("button", { name: /^N[1-5]$/ });
+
+    fireEvent.click(levelButtons()[3]); // N4
+    expect(levelButtons()[3]).toHaveClass("selected");
+    expect(
+      levelButtons().filter((button) => button.classList.contains("selected"))
+    ).toHaveLength(1);
+
+    fireEvent.click(levelButtons()[0]); // N1
+    expect(levelButtons()[0]).toHaveClass("selected");
+    expect(levelButtons()[3]).not.toHaveClass("selected");
+  });
+
+  it("keeps the picker accessible (fieldset + legend, focusable buttons)", () => {
+    renderPanel();
+    const picker = screen.getByRole("group", { name: "等級" });
+    const buttons = within(picker).getAllByRole("button");
+    buttons[0].focus();
+    expect(buttons[0]).toHaveFocus();
+  });
+});
+
+describe("MockExamPanel N4 / N5 blueprints (#703)", () => {
+  it("selecting N4 shows exactly the N4 blueprint sections", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: "N4" }));
+    for (const section of N4_BLUEPRINT.sections) {
+      expect(screen.getByText(section.labelJa)).toBeInTheDocument();
+    }
+  });
+
+  it("selecting N5 shows exactly the N5 blueprint sections", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: "N5" }));
+    for (const section of N5_BLUEPRINT.sections) {
+      expect(screen.getByText(section.labelJa)).toBeInTheDocument();
+    }
+  });
+
+  it("an N5 section with authored items shows its live count, not 準備中", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: "N5" }));
+    // 漢字読み has authored N5 items (n5.ts), so it is a startable card.
+    const reading = screen.getByRole("button", { name: /漢字読み/ });
+    expect(reading).toHaveTextContent("題");
+    expect(reading).not.toHaveTextContent("準備中");
+  });
+
+  it("an N4 section with no authored items renders as 準備中, not a startable button", () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: "N4" }));
+    // 表記 has no authored N4 items yet, so the row is a plain info row.
+    const row = screen.getByText("表記").closest("li");
+    expect(row).not.toBeNull();
+    expect(row).toHaveTextContent("準備中");
+    expect(within(row as HTMLLIElement).queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("starting a section calls onStartSection with the level and matching promptLabel", () => {
+    const onStartSection = vi.fn();
+    render(<MockExamPanel language="zh-Hant" onStartSection={onStartSection} />);
+    fireEvent.click(screen.getByRole("button", { name: "N5" }));
+    fireEvent.click(screen.getByRole("button", { name: /漢字読み/ }));
+    expect(onStartSection).toHaveBeenCalledWith("N5", "漢字読み");
+  });
+});
+
+describe("MockExamPanel level switching (#703)", () => {
+  it("switching N5→N4→N1 leaves no stale sections from the previous level", () => {
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "N5" }));
+    // N5 drops 詞彙用法 (N4+ only), so it must be absent.
+    expect(screen.queryByText("詞彙用法")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "N4" }));
+    expect(screen.getByText("詞彙用法")).toBeInTheDocument();
+    // 内容理解（長文） is N3-only, never present at N4.
+    expect(screen.queryByText("内容理解（長文）")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "N1" }));
+    // N1 has no 表記 (N2+ only) and no 内容理解（長文）.
+    expect(screen.queryByText("表記")).not.toBeInTheDocument();
+    expect(screen.queryByText("内容理解（長文）")).not.toBeInTheDocument();
+  });
+
+  it("N1–N3 picker and sections behave as before", () => {
+    renderPanel();
+    // Default level is N2.
+    expect(screen.getByText("漢字読み")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "N1" }));
+    expect(screen.getByText("統合理解")).toBeInTheDocument();
+    expect(screen.queryByText("表記")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/MockExamPanel.tsx
+++ b/src/components/MockExamPanel.tsx
@@ -43,7 +43,7 @@ export function MockExamPanel({
       <fieldset className="mock-level-picker">
         <legend>{t.mockExamLevelLabel}</legend>
         <div className="segmented level-segmented">
-          {(["N3", "N2", "N1"] as MockExamLevel[]).map((option) => (
+          {(["N1", "N2", "N3", "N4", "N5"] as MockExamLevel[]).map((option) => (
             <button
               key={option}
               type="button"

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -240,6 +240,36 @@ describe("buildPracticeQuestions", () => {
     expect(questions.every((q) => q.promptLabel === promptLabel)).toBe(true);
   });
 
+  it("exam mode (N4 mock section): filters to the N4 level + promptLabel (#703)", () => {
+    const n4 = buildExamQuestionPool("N4");
+    const sample = n4.find((q) => q.promptLabel);
+    expect(sample).toBeDefined();
+    const promptLabel = sample!.promptLabel!;
+
+    const questions = buildPracticeQuestions(
+      poolParams({ mode: "exam", examSection: { level: "N4", promptLabel } })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.vocabulary.level === "N4")).toBe(true);
+    expect(questions.every((q) => q.promptLabel === promptLabel)).toBe(true);
+  });
+
+  it("exam mode (N5 mock section): filters to the N5 level + promptLabel (#703)", () => {
+    const n5 = buildExamQuestionPool("N5");
+    const sample = n5.find((q) => q.promptLabel);
+    expect(sample).toBeDefined();
+    const promptLabel = sample!.promptLabel!;
+
+    const questions = buildPracticeQuestions(
+      poolParams({ mode: "exam", examSection: { level: "N5", promptLabel } })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((q) => q.vocabulary.level === "N5")).toBe(true);
+    expect(questions.every((q) => q.promptLabel === promptLabel)).toBe(true);
+  });
+
   it("cloze mode: returns the cloze pool (same membership)", () => {
     const questions = buildPracticeQuestions(poolParams({ mode: "cloze" }));
     const expected = buildClozeQuestionPool(clozeSentences, vocabulary);

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -96,6 +96,29 @@ describe("usePracticeSession pool snapshot (#623)", () => {
     expect(snapshot.kanaScript).toBeUndefined();
   });
 
+  it("carries an N4/N5 mock-section filter through the snapshot (#703)", () => {
+    const snapshot = createPracticePoolSnapshot(
+      {
+        ...baseConfig,
+        mode: "exam",
+        filter: { examSection: { level: "N4", promptLabel: "文法形式選擇" } }
+      },
+      liveInputs
+    );
+    expect(snapshot.mode).toBe("exam");
+    expect(snapshot.examSection).toEqual({ level: "N4", promptLabel: "文法形式選擇" });
+
+    const n5Snapshot = createPracticePoolSnapshot(
+      {
+        ...baseConfig,
+        mode: "exam",
+        filter: { examSection: { level: "N5", promptLabel: "詞彙填空" } }
+      },
+      liveInputs
+    );
+    expect(n5Snapshot.examSection).toEqual({ level: "N5", promptLabel: "詞彙填空" });
+  });
+
   // #679 — snapshot copy: the live inputs are captured by reference at pass
   // start; a later mutation of the caller's arrays must not corrupt the
   // stored pass (the hook hands in freshly-computed inputs each pass).

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -133,7 +133,7 @@ export const en: Copy = {
   homeCardChallengeSub: "Three groups: the daily loop, N1–N4 exam-prep banks, and focused drills.",
   homeCardChallengeMeta: "Pick your JLPT level and question type",
   homeCardMockTitle: "JLPT Question Types",
-  homeCardMockSub: "JLPT N1〜N3 sections, working through each part by the official structure.",
+  homeCardMockSub: "JLPT N1〜N5 sections, working through each part by the official structure.",
   homeCardMockMeta: "Follows the official section structure",
   homeCardReviewTitle: "Weakness review",
   homeCardReviewSubActive: (count) => `${count} questions waiting for you to nail them.`,

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -133,7 +133,7 @@ export const id: Copy = {
   homeCardChallengeSub: "Tiga grup mode: rutinitas harian · bank soal persiapan N1–N4 · latihan terfokus.",
   homeCardChallengeMeta: "Bebas pilih level JLPT dan tipe soal",
   homeCardMockTitle: "Latihan jenis soal JLPT",
-  homeCardMockSub: "Jenis soal JLPT N1〜N3 dibagi per bagian, taklukkan sesuai struktur resmi bagian demi bagian.",
+  homeCardMockSub: "Jenis soal JLPT N1〜N5 dibagi per bagian, taklukkan sesuai struktur resmi bagian demi bagian.",
   homeCardMockMeta: "Sesuai struktur jenis soal resmi",
   homeCardReviewTitle: "Ulang kelemahan",
   homeCardReviewSubActive: (count) => `${count} soal menunggu kamu latih ulang sampai benar.`,

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -134,7 +134,7 @@ export const ja: Copy = {
   homeCardChallengeSub: "3つのグループ：毎日の練習・N1〜N4試験対策・分野別ドリル。",
   homeCardChallengeMeta: "JLPTレベルと問題形式を自由に選択",
   homeCardMockTitle: "JLPT 問題形式別",
-  homeCardMockSub: "JLPT N1〜N3 の問題タイプ別。公式の構成に沿ってセクションごとに攻略。",
+  homeCardMockSub: "JLPT N1〜N5 の問題タイプ別。公式の構成に沿ってセクションごとに攻略。",
   homeCardMockMeta: "公式の問題構成に準拠",
   homeCardReviewTitle: "弱点復習",
   homeCardReviewSubActive: (count) => `${count} 問、正解できるまで再挑戦しましょう。`,

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -133,7 +133,7 @@ export const ko: Copy = {
   homeCardChallengeSub: "세 그룹: 데일리 루프 · N1〜N4 시험 대비 · 집중 드릴.",
   homeCardChallengeMeta: "JLPT 레벨과 문제 유형 자유 선택",
   homeCardMockTitle: "JLPT 유형별 연습",
-  homeCardMockSub: "JLPT N1〜N3 섹션을 공식 구조에 따라 파트별로 풀어 나가요.",
+  homeCardMockSub: "JLPT N1〜N5 섹션을 공식 구조에 따라 파트별로 풀어 나가요.",
   homeCardMockMeta: "공식 섹션 구조를 따릅니다",
   homeCardReviewTitle: "약점 복습",
   homeCardReviewSubActive: (count) => `${count}문제가 당신이 맞히길 기다리고 있어요.`,

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -133,7 +133,7 @@ export const my: Copy = {
   homeCardChallengeSub: "မုဒ်သုံးစု— နေ့စဉ်လေ့ကျင့်ခန်း · N1〜N4 စာမေးပွဲပြင်ဆင်မှု · အထူးလေ့ကျင့်ခန်းများ။",
   homeCardChallengeMeta: "JLPT အဆင့်နှင့် မေးခွန်းအမျိုးအစား လွတ်လပ်စွာရွေးနိုင်",
   homeCardMockTitle: "JLPT ပုံစံအလိုက်လေ့ကျင့်",
-  homeCardMockSub: "JLPT N1〜N3 အပိုင်းများကို တရားဝင်ဖွဲ့စည်းပုံအတိုင်း တစ်ပိုင်းချင်း လေ့ကျင့်ပါ။",
+  homeCardMockSub: "JLPT N1〜N5 အပိုင်းများကို တရားဝင်ဖွဲ့စည်းပုံအတိုင်း တစ်ပိုင်းချင်း လေ့ကျင့်ပါ။",
   homeCardMockMeta: "တရားဝင် အပိုင်းဖွဲ့စည်းပုံကို လိုက်နာသည်",
   homeCardReviewTitle: "အားနည်းချက် ပြန်လေ့ကျင့်ခြင်း",
   homeCardReviewSubActive: (count) => `မေးခွန်း ${count} ခု သင် ကျွမ်းကျင်အောင် လုပ်ရန် စောင့်နေသည်။`,

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -134,7 +134,7 @@ export const th: Copy = {
   homeCardChallengeSub: "สามกลุ่มโหมด: ฝึกประจำวัน · คลังข้อสอบ N1〜N4 · ฝึกเฉพาะทาง",
   homeCardChallengeMeta: "เลือกระดับ JLPT และประเภทข้อสอบได้อิสระ",
   homeCardMockTitle: "ฝึกตามประเภทโจทย์ JLPT",
-  homeCardMockSub: "แบ่งโซนตามประเภทโจทย์ JLPT N1〜N3 ตะลุยทีละโซนตามโครงสร้างทางการ",
+  homeCardMockSub: "แบ่งโซนตามประเภทโจทย์ JLPT N1〜N5 ตะลุยทีละโซนตามโครงสร้างทางการ",
   homeCardMockMeta: "ตามโครงสร้างประเภทโจทย์ทางการ",
   homeCardReviewTitle: "ทบทวนจุดอ่อน",
   homeCardReviewSubActive: (count) => `${count} ข้อรอคุณฝึกซ้ำจนตอบถูก`,

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -133,7 +133,7 @@ export const vi: Copy = {
   homeCardChallengeSub: "Ba nhóm chế độ: vòng luyện hằng ngày · ngân hàng đề N1–N4 · luyện chuyên sâu.",
   homeCardChallengeMeta: "Tự chọn cấp độ JLPT và dạng câu hỏi",
   homeCardMockTitle: "Luyện theo dạng đề JLPT",
-  homeCardMockSub: "Các phần JLPT N1〜N3, đi qua từng phần theo cấu trúc chính thức.",
+  homeCardMockSub: "Các phần JLPT N1〜N5, đi qua từng phần theo cấu trúc chính thức.",
   homeCardMockMeta: "Theo cấu trúc phần thi chính thức",
   homeCardReviewTitle: "Ôn điểm yếu",
   homeCardReviewSubActive: (count) => `${count} câu đang chờ bạn làm cho đúng.`,

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -133,7 +133,7 @@ export const zhHant: Copy = {
   homeCardChallengeSub: "三組模式：每日循環 · 備考題庫 · 專項練習。",
   homeCardChallengeMeta: "自由選 JLPT 等級與題型",
   homeCardMockTitle: "JLPT 題型練習",
-  homeCardMockSub: "JLPT N1〜N3 題型分區，照官方結構逐區攻略。",
+  homeCardMockSub: "JLPT N1〜N5 題型分區，照官方結構逐區攻略。",
   homeCardMockMeta: "依官方題型結構",
   homeCardReviewTitle: "弱點複習",
   homeCardReviewSubActive: (count) => `${count} 題等你重練到對。`,


### PR DESCRIPTION
Closes #703

## Summary

- Extend `MockExamPanel`'s level picker to N1–N5 (fixed order), consuming only `getMockExamBlueprint(level)` — the #702 N4/N5 blueprints become selectable.
- Empty-pool sections keep the 準備中 non-button state; level switching leaves no stale section/selected state.
- Update the home-card mock coverage copy N1〜N3 → N1〜N5 in all 8 locales.
- No blueprint, exam-item, contentStats, timed-mode, route, or PracticeMode changes; lazy bundle boundary intact.

## Scope

`MockExamPanel.tsx`(+test), `HomePanel.test.tsx`, `sessionPools.test.ts`, `usePracticeSession.test.ts`, 8 locale copy files.

## Verification

- `pnpm lint` / `pnpm typecheck` / `pnpm check:i18n` — pass
- 4 affected test files — 140/140 pass
- `pnpm build` — pass (examBlocks still lazy)
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- 無

Non-blocking findings:
- MockExamPanel picker 測試未同測試內斷言非該級 section 不存在（level-switching 測試已組合覆蓋）。
- HomePanel locale drift guard 只抽查 3 語系（8 個實際已一致改、check:i18n 過）。
- N5 exam items 含 6 筆詞彙用法題目但 N5 blueprint 無該 section（#702 設計，可經綜合考題庫觸及）。

Verdict:
No blocking findings.
```