### PR TITLE
feat(ci): wire guarded Gemini correctness workflow

### DIFF
--- a/.github/workflows/gemini-correctness-autofix.yml
+++ b/.github/workflows/gemini-correctness-autofix.yml
@@ -1,0 +1,617 @@
+name: Gemini correctness autofix
+
+# Wire #688 (orchestration state machine) + #689 (publication adapter) into a
+# manual/scheduled observe/repair run (#690).
+#
+# - workflow_dispatch input `mode` is authoritative: observe (discovery only) or
+#   repair (discovery -> RED -> GREEN -> publication candidate).  The input can
+#   never adjust limits, model policy, or permissions.
+# - schedule reads the repository variable GEMINI_AUTOFIX_MODE
+#   (off|observe|repair).  A missing/empty/unknown value is treated as `off`
+#   and safe-skips immediately after checkout (no Gemini call, no repo write).
+# - Permission isolation: `evaluate` is read-only and runs the #688 state
+#   machine; GEMINI_API_KEY is injected into exactly one step inside it.
+#   `publish` runs only on a validated repair candidate and holds the minimal
+#   contents/pull-requests write scopes; it never sees a model secret and only
+#   calls the #689 adapter (no Gemini stages, no re-running the model).
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: observe (discover only) or repair (discover -> RED -> GREEN)
+        required: true
+        default: observe
+        type: choice
+        options: [observe, repair]
+  schedule:
+    - cron: "17 19 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gemini-correctness-autofix
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    name: Evaluate correctness (observe / repair)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Read-only: the state machine reads PRs/baseline/discovery and produces a
+    # sanitized candidate.  It never writes to the repository.
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      mode: ${{ steps.mode.outputs.mode }}
+      publicationAllowed: ${{ steps.orchestrate.outputs.publicationAllowed }}
+      status: ${{ steps.orchestrate.outputs.status }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Full baseline: the state machine resets to a recorded baseline SHA
+          # and the publish job branches from it.
+          fetch-depth: 0
+
+      # Resolve the effective mode.  workflow_dispatch input is authoritative;
+      # the schedule path reads GEMINI_AUTOFIX_MODE with an off fallback.
+      - name: Resolve run mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            MODE="${{ inputs.mode }}"
+          else
+            MODE="${{ vars.GEMINI_AUTOFIX_MODE }}"
+          fi
+          case "$MODE" in
+            off|observe|repair) ;;
+            *) MODE="off" ;;
+          esac
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+      - name: Safe skip when GEMINI_AUTOFIX_MODE is off
+        if: ${{ steps.mode.outputs.mode == 'off' }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Gemini correctness autofix — safe skip
+          GEMINI_AUTOFIX_MODE is off, missing, or invalid. No Gemini call and no repository writes were performed.
+          EOF
+
+      - name: Set up pnpm
+        if: ${{ steps.mode.outputs.mode != 'off' }}
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        if: ${{ steps.mode.outputs.mode != 'off' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ steps.mode.outputs.mode != 'off' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Gemini correctness orchestration (#688)
+        id: orchestrate
+        if: ${{ steps.mode.outputs.mode != 'off' }}
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_AUTOFIX_MODEL: ${{ vars.GEMINI_AUTOFIX_MODEL }}
+          GEMINI_AUTOFIX_MIN_CONFIDENCE: ${{ vars.GEMINI_AUTOFIX_MIN_CONFIDENCE }}
+          GEMINI_AUTOFIX_MAX_FILES: ${{ vars.GEMINI_AUTOFIX_MAX_FILES }}
+          GEMINI_AUTOFIX_MAX_LINES: ${{ vars.GEMINI_AUTOFIX_MAX_LINES }}
+          INPUT_MODE: ${{ steps.mode.outputs.mode }}
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { spawnSync } from "node:child_process";
+          // @ts-ignore -- plain .mjs module, no types
+          import { runWorkflowOrchestration } from "./scripts/gemini-correctness/workflow-orchestrator.mjs";
+
+          const repoRoot = process.env.GITHUB_WORKSPACE;
+          const repository = process.env.GITHUB_REPOSITORY ?? "nurockplayer/Jabiko";
+          const runId = process.env.GITHUB_RUN_ID ?? "local";
+          const runUrl = `https://github.com/${repository}/actions/runs/${runId}`;
+          const mode = process.env.INPUT_MODE ?? "off";
+          const artifactDir = path.join(repoRoot, ".tmp", "gemini-correctness");
+          const baselineSha = runShell("git rev-parse HEAD").stdout.trim();
+
+          const MODEL_ALLOWLIST = ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite"];
+          const DEFAULT_MIN_CONFIDENCE = 0.8;
+          const DEFAULT_MAX_FILES = 200;
+          const DEFAULT_MAX_LINES = 250;
+          // Program hard caps (tighten-only): a variable can never loosen them.
+          const HARD_MAX_FILES = 200;
+          const HARD_MAX_LINES = 250;
+
+          function runShell(cmd, opts = {}) {
+            const result = spawnSync(cmd, {
+              cwd: repoRoot,
+              encoding: "utf8",
+              shell: true,
+              stdio: ["pipe", "pipe", "pipe"],
+              maxBuffer: 64 * 1024 * 1024,
+              ...opts
+            });
+            return {
+              ok: result.status === 0,
+              status: result.status,
+              stdout: result.stdout ?? "",
+              stderr: result.stderr ?? ""
+            };
+          }
+
+          function resolveModel() {
+            const value = (process.env.GEMINI_AUTOFIX_MODEL ?? "").trim();
+            // A missing/empty/unknown model fails closed: the policy allowlist
+            // is the only source of truth and there is no implicit default.
+            if (!MODEL_ALLOWLIST.includes(value)) return null;
+            return value;
+          }
+
+          function resolveNumber(name, fallback, hardMax, minValue) {
+            const raw = (process.env[name] ?? "").trim();
+            if (!raw) return fallback;
+            const n = Number(raw);
+            if (!Number.isFinite(n) || n < minValue || n > hardMax) return null;
+            return n;
+          }
+
+          function writeOutputs(fields) {
+            for (const [key, value] of Object.entries(fields)) {
+              fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+            }
+          }
+
+          async function failClosedResult(reason, statusCode = "config-error") {
+            const result = {
+              schemaVersion: 1,
+              mode,
+              status: statusCode,
+              reasonCode: "invalid-limit",
+              reason: String(reason ?? "invalid configuration"),
+              publicationAllowed: false,
+              baselineSha,
+              completedAt: Date.now()
+            };
+            fs.mkdirSync(artifactDir, { recursive: true });
+            fs.writeFileSync(
+              path.join(artifactDir, "command-summary.json"),
+              JSON.stringify({ schemaVersion: 1, mode, status: result.status, publicationAllowed: false, baselineSha, workflowResult: result }, null, 2) + "\n"
+            );
+            writeOutputs({ mode, publicationAllowed: "false", status: result.status });
+            fs.writeFileSync(
+              process.env.GITHUB_STEP_SUMMARY,
+              [
+                `## Gemini correctness ${mode}`,
+                "",
+                `- **Status**: \`${result.status}\``,
+                `- **Reason**: ${result.reason}`,
+                `- **Publication**: not allowed`,
+                ""
+              ].join("\n") + "\n"
+            );
+            // A configuration failure is a hard fail-closed: the run must be
+            // visibly failed, and no downstream job may consume its outputs.
+            process.exit(1);
+          }
+
+          // Validate limits BEFORE any Gemini/baseline work (fail closed).
+          const model = resolveModel();
+          if (!model) await failClosedResult(`model ${process.env.GEMINI_AUTOFIX_MODEL ?? ""} is not on the policy allowlist`);
+          const minConfidence = resolveNumber("GEMINI_AUTOFIX_MIN_CONFIDENCE", DEFAULT_MIN_CONFIDENCE, 1, 0);
+          if (minConfidence === null) await failClosedResult("GEMINI_AUTOFIX_MIN_CONFIDENCE must be a finite number in [0,1]");
+          if (minConfidence < DEFAULT_MIN_CONFIDENCE) await failClosedResult("GEMINI_AUTOFIX_MIN_CONFIDENCE cannot be lower than the program default (tighten-only)");
+          const maxFiles = resolveNumber("GEMINI_AUTOFIX_MAX_FILES", DEFAULT_MAX_FILES, HARD_MAX_FILES, 1);
+          if (maxFiles === null) await failClosedResult("GEMINI_AUTOFIX_MAX_FILES cannot exceed the program hard maximum (tighten-only)");
+          const maxLines = resolveNumber("GEMINI_AUTOFIX_MAX_LINES", DEFAULT_MAX_LINES, HARD_MAX_LINES, 1);
+          if (maxLines === null) await failClosedResult("GEMINI_AUTOFIX_MAX_LINES cannot exceed the program hard maximum (tighten-only)");
+
+          // observe/repair require the Gemini secret; off mode never does.
+          if (!process.env.GEMINI_API_KEY) {
+            await failClosedResult("GEMINI_API_KEY is missing; observe/repair fail closed without calling Gemini");
+          }
+
+          const adapters = {
+            openAiPrGate: async () => {
+              const result = runShell(`gh pr list --repo "${repository}" --state open --limit 50 --json headRefName --jq '.[].headRefName'`);
+              if (!result.ok) return { valid: false, error: (result.stderr || result.stdout).trim() || "could not list open PRs" };
+              const refs = result.stdout.trim().split("\n").filter(Boolean);
+              return { valid: true, openPrs: refs.map((ref) => ({ ref })) };
+            },            baseline: async ({ baselineSha: expected }) => {
+              const checks = [];
+              for (const [name, cmd] of [
+                ["lint", "pnpm lint"],
+                ["typecheck", "pnpm typecheck"],
+                ["test", "pnpm test"],
+                ["build", "pnpm build"],
+                ["diff-check", "git diff --check"]
+              ]) {
+                const run = runShell(cmd, { timeoutMs: 10 * 60 * 1000 });
+                checks.push({ name, status: run.ok ? "passed" : "failed" });
+              }
+              if (checks.some((c) => c.status !== "passed")) {
+                return { valid: false, error: `baseline failed: ${checks.filter((c) => c.status !== "passed").map((c) => c.name).join(", ")}`, checks };
+              }
+              return { valid: true, baselineSha: expected, checks };
+            },
+            discovery: async ({ baselineSha: sha, limits }) => {
+              fs.mkdirSync(artifactDir, { recursive: true });
+              // discover.mjs resolves --output/--summary relative to .tmp/ and
+              // constrains them to that directory, so the CLI path is
+              // gemini-correctness/<file> (it lands at .tmp/gemini-correctness/).
+              const run = runShell(
+                `node scripts/gemini-correctness/discover.mjs --commit-sha ${sha} --model ${model} --output gemini-correctness/finding.json --summary gemini-correctness/discovery-summary.md`,
+                { timeoutMs: 8 * 60 * 1000 }
+              );
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "discovery failed" };
+              let raw;
+              try {
+                raw = JSON.parse(fs.readFileSync(path.join(artifactDir, "finding.json"), "utf8"));
+              } catch {
+                return { valid: false, error: "discovery output is not valid JSON" };
+              }
+              if (!raw.valid) return { valid: false, error: raw.error ?? "discovery failed validation" };
+              const finding = raw.result;
+              const threshold = limits?.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+              if (finding && finding.status === "finding" && typeof finding.confidence === "number" && finding.confidence < threshold) {
+                return { valid: true, result: { schemaVersion: 1, status: "no-finding", reason: `finding confidence ${finding.confidence} is below threshold ${threshold}` } };
+              }
+              return { valid: true, result: finding };
+            },
+            red: async () => {
+              const run = runShell(`node scripts/gemini-correctness/red-stage.mjs --model ${model}`, { timeoutMs: 8 * 60 * 1000 });
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "RED stage failed" };
+              try {
+                const redResult = JSON.parse(fs.readFileSync(path.join(artifactDir, "red-result.json"), "utf8"));
+                return { valid: true, result: redResult };
+              } catch {
+                return { valid: false, error: "RED result artifact is missing or invalid" };
+              }
+            },
+            green: async () => {
+              const run = runShell(`node scripts/gemini-correctness/green-stage.mjs --model ${model}`, { timeoutMs: 8 * 60 * 1000 });
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "GREEN stage failed" };
+              try {
+                const greenResult = JSON.parse(fs.readFileSync(path.join(artifactDir, "repair-result.json"), "utf8"));
+                return { valid: true, result: greenResult };
+              } catch {
+                return { valid: false, error: "GREEN result artifact is missing or invalid" };
+              }
+            },
+            cleanup: async ({ baselineSha: sha }) => {
+              const reset = runShell(`git reset --hard ${sha}`);
+              if (!reset.ok) return { valid: false, error: reset.stderr.trim() || "clean reset failed" };
+              const clean = runShell("git clean -fdq");
+              if (!clean.ok) return { valid: false, error: clean.stderr.trim() || "clean reset failed" };
+              return { valid: true };
+            },
+            clock: () => Date.now()
+          };
+
+          const result = await runWorkflowOrchestration({
+            mode,
+            baselineSha,
+            adapters,
+            limits: { minConfidence, maxFiles, maxLines, environment: process.env }
+          });
+
+          // Assemble a validated publication candidate ONLY when the state
+          // machine says publicationAllowed=true.  The candidate embeds the
+          // production diff and regression-test source produced by RED/GREEN.
+          let candidate;
+          if (result.publicationAllowed === true) {
+            const diffOut = runShell("git diff --binary --no-ext-diff --no-renames");
+            const productionDiff = diffOut.stdout;
+            const testFile = result.red?.testFile;
+            const regressionSource = testFile ? fs.readFileSync(path.join(repoRoot, testFile), "utf8") : "";
+            candidate = {
+              schemaVersion: 1,
+              status: "repair-verified",
+              publicationAllowed: true,
+              baselineSha: result.baselineSha,
+              findingTitle: result.findingTitle,
+              findingCategory: result.findingCategory,
+              model,
+              runUrl,
+              finalDiffSha256: result.finalDiffSha256,
+              changedFiles: result.changedFiles,
+              changedLines: result.changedLines,
+              productionDiff,
+              regressionTest: { path: testFile, source: regressionSource },
+              red: result.red,
+              green: result.green
+            };
+          }
+
+          fs.mkdirSync(artifactDir, { recursive: true });
+          fs.writeFileSync(
+            path.join(artifactDir, "command-summary.json"),
+            JSON.stringify({
+              schemaVersion: 1,
+              mode,
+              status: result.status,
+              publicationAllowed: result.publicationAllowed === true,
+              baselineSha: result.baselineSha,
+              workflowResult: result,
+              ...(candidate ? { candidate } : {})
+            }, null, 2) + "\n"
+          );
+
+          writeOutputs({
+            mode,
+            publicationAllowed: result.publicationAllowed === true ? "true" : "false",
+            status: result.status
+          });
+
+          const checksLine = Array.isArray(result.checks)
+            ? result.checks.map((c) => c.status).join("/")
+            : "n/a";
+          const summary = [
+            `## Gemini correctness ${mode}`,
+            "",
+            `- **Mode**: \`${mode}\``,
+            `- **Status**: \`${result.status}\``,
+            `- **Baseline**: \`${result.baselineSha ?? "n/a"}\``,
+            `- **Baseline checks**: ${checksLine}`,
+            `- **Discovery**: ${result.findingTitle ? `\`${result.findingTitle}\` (${result.findingCategory})` : (result.status === "no-finding" ? "no finding" : "n/a")}`,
+            result.red?.testFile
+              ? `- **RED**: \`${result.red.testFile}\` :: ${result.red.testName}`
+              : `- **RED**: n/a`,
+            Array.isArray(result.green?.productionFiles) && result.green.productionFiles.length > 0
+              ? `- **GREEN**: ${result.green.productionFiles.map((f) => `\`${f}\``).join(", ")}`
+              : `- **GREEN**: n/a`,
+            `- **Diff gate**: ${result.green?.checks?.some((c) => c.name === "targeted-test") ? "passed" : "n/a"}`,
+            `- **Publication**: ${result.publicationAllowed === true ? "allowed (candidate produced)" : "not allowed"}${result.reason ? ` — ${result.reason}` : ""}`,
+            ""
+          ];
+          fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, summary.join("\n") + "\n");
+
+          console.log(JSON.stringify(result, null, 2));
+          process.exit(0);
+          NODE
+
+      # Sanitized artifacts only — allowlisted files that exist.  Raw prompts,
+      # responses, env dumps, headers, debug logs, patches, and source archives
+      # are never uploaded.  Missing stage artifacts are simply not included.
+      # always(): a fail-closed orchestration still publishes its sanitized
+      # command-summary so the failure is observable and never silently lost.
+      - name: Upload sanitized artifacts
+        if: ${{ always() && steps.mode.outputs.mode != 'off' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-correctness-results
+          path: |
+            .tmp/gemini-correctness/finding.json
+            .tmp/gemini-correctness/red-result.json
+            .tmp/gemini-correctness/repair-result.json
+            .tmp/gemini-correctness/command-summary.json
+          retention-days: 7
+          if-no-files-found: warn
+
+  publish:
+    name: Publish verified repair (#689)
+    needs: evaluate
+    # Only ever publishes a validated repair candidate in repair mode.
+    if: ${{ needs.evaluate.outputs.publicationAllowed == 'true' && needs.evaluate.outputs.mode == 'repair' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Minimal write scopes for one branch + one Draft PR.  No model secret.
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Full baseline so the branch can be created from the verified
+          # baseline SHA without an extra fetch.
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Restore the artifact at the repo root so the preserved
+      # .tmp/gemini-correctness/... structure lands exactly where the glue
+      # expects it.
+      - name: Download sanitized artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: gemini-correctness-results
+          path: ${{ github.workspace }}
+
+      # Calls ONLY the #689 publication adapter with the validated candidate.
+      # It never reruns the model or the Gemini stages, and it never receives a
+      # model secret — only the automatic GITHUB_TOKEN for the git/gh writes.
+      - name: Publish verified repair as Draft PR
+        id: publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+          import { spawnSync } from "node:child_process";
+          // @ts-ignore -- plain .mjs modules, no types
+          import { publishVerifiedRepair, validatePublicationCandidate } from "./scripts/gemini-correctness/publication-adapter.mjs";
+          // @ts-ignore -- plain .mjs module, no types
+          import { parseUnifiedDiff } from "./scripts/gemini-correctness/policy.mjs";
+
+          const repoRoot = process.env.GITHUB_WORKSPACE;
+          const repository = process.env.GITHUB_REPOSITORY;
+          const [owner, repoName] = repository.split("/");
+          const runId = process.env.GITHUB_RUN_ID ?? "local";
+          const artifactDir = path.join(repoRoot, ".tmp", "gemini-correctness");
+
+          function runShell(cmd, opts = {}) {
+            const result = spawnSync(cmd, {
+              cwd: repoRoot,
+              encoding: "utf8",
+              shell: true,
+              stdio: ["pipe", "pipe", "pipe"],
+              maxBuffer: 64 * 1024 * 1024,
+              ...opts
+            });
+            return {
+              ok: result.status === 0,
+              status: result.status,
+              stdout: result.stdout ?? "",
+              stderr: result.stderr ?? ""
+            };
+          }
+
+          function writePublicationResult(result) {
+            fs.mkdirSync(artifactDir, { recursive: true });
+            fs.writeFileSync(
+              path.join(artifactDir, "publication-result.json"),
+              JSON.stringify(result, null, 2) + "\n"
+            );
+          }
+
+          const summaryPath = path.join(artifactDir, "command-summary.json");
+          if (!fs.existsSync(summaryPath)) {
+            const failed = { schemaVersion: 1, status: "invalid-candidate", reasonCode: "invalid-candidate", reason: "command-summary artifact is missing", publicationAllowed: false, completedAt: Date.now() };
+            writePublicationResult(failed);
+            console.error(JSON.stringify(failed));
+            process.exit(1);
+          }
+
+          const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+          const candidate = summary.candidate;
+          if (!candidate) {
+            const failed = { schemaVersion: 1, status: "invalid-candidate", reasonCode: "invalid-candidate", reason: "no validated publication candidate in the evaluate output", publicationAllowed: false, completedAt: Date.now() };
+            writePublicationResult(failed);
+            console.error(JSON.stringify(failed));
+            process.exit(1);
+          }
+
+          // Re-validate the candidate locally before ANY write.
+          const candidateCheck = validatePublicationCandidate(candidate, { sensitiveValues: [] });
+          if (!candidateCheck.valid) {
+            const failed = { schemaVersion: 1, status: "invalid-candidate", reasonCode: "invalid-candidate", reason: candidateCheck.error, publicationAllowed: false, completedAt: Date.now() };
+            writePublicationResult(failed);
+            console.error(JSON.stringify(failed));
+            process.exit(1);
+          }
+
+          runShell("git config user.name \"jabiko-gemini-autofix\"");
+          runShell("git config user.email \"actions@users.noreply.github.com\"");
+
+          const adapters = {
+            readRemoteHead: async ({ ref }) => {
+              const run = runShell(`gh api "repos/${repository}/git/ref/heads/${ref}" --jq '.object.sha'`);
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "could not read remote head" };
+              return { valid: true, sha: run.stdout.trim() };
+            },
+            createBranch: async ({ name, baseSha }) => {
+              const run = runShell(`git switch -c "${name}" "${baseSha}"`);
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "could not create branch" };
+              return { valid: true };
+            },
+            commit: async ({ message, regressionTest, productionDiff }) => {
+              const testAbsolute = path.join(repoRoot, regressionTest.path);
+              fs.mkdirSync(path.dirname(testAbsolute), { recursive: true });
+              fs.writeFileSync(testAbsolute, regressionTest.source);
+              const diffFile = path.join(repoRoot, ".tmp", "production-diff.patch");
+              fs.mkdirSync(path.dirname(diffFile), { recursive: true });
+              fs.writeFileSync(diffFile, productionDiff);
+              const applyRun = runShell(`git apply --binary --whitespace=nowarn "${diffFile}"`);
+              if (!applyRun.ok) return { valid: false, error: (applyRun.stderr || applyRun.stdout).trim() || "production diff could not be applied" };
+              // Stage exactly the files the validated diff touches, plus the
+              // regression test.  Derived from the shared unified-diff parser,
+              // never from the raw candidate.
+              const parsed = parseUnifiedDiff(productionDiff);
+              if (!parsed.valid) return { valid: false, error: parsed.error ?? "production diff could not be parsed" };
+              const staged = [regressionTest.path, ...parsed.files.map((file) => file.path)];
+              const addRun = runShell(`git add -- ${staged.map((f) => `"${f}"`).join(" ")}`);
+              if (!addRun.ok) return { valid: false, error: (addRun.stderr || addRun.stdout).trim() || "could not stage the verified payload" };
+              const messageFile = path.join(repoRoot, ".tmp", "commit-msg.txt");
+              fs.writeFileSync(messageFile, message);
+              const commitRun = runShell(`git commit --file "${messageFile}"`);
+              if (!commitRun.ok) return { valid: false, error: (commitRun.stderr || commitRun.stdout).trim() || "could not create the commit" };
+              const sha = runShell("git rev-parse HEAD").stdout.trim();
+              return { valid: true, sha };
+            },
+            push: async ({ branch }) => {
+              const run = runShell(`git push origin "HEAD:${branch}"`);
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "could not push branch" };
+              return { valid: true };
+            },
+            createPullRequest: async ({ title, body, base, head, draft }) => {
+              const bodyFile = path.join(repoRoot, ".tmp", "pr-body.md");
+              fs.writeFileSync(bodyFile, body);
+              const safeTitle = title.replace(/["$`]/g, "").replace(/\s+/g, " ");
+              const args = [
+                `gh pr create --repo "${repository}" --base "${base}" --head "${head}"`,
+                `--title "${safeTitle}"`,
+                `--body-file "${bodyFile}"`,
+                draft ? "--draft" : ""
+              ].filter(Boolean).join(" ");
+              const run = runShell(args);
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "could not create the pull request" };
+              const url = run.stdout.trim();
+              const match = url.match(/pull\/(\d+)/);
+              return { valid: true, number: match ? Number(match[1]) : undefined, url };
+            },
+            deleteBranch: async ({ name }) => {
+              const run = runShell(`git push origin --delete "${name}"`);
+              if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "could not delete branch" };
+              return { valid: true };
+            },
+            clock: () => Date.now()
+          };
+
+          const result = await publishVerifiedRepair({
+            candidate,
+            runId,
+            repository: { owner, repo: repoName, defaultBranch: process.env.GITHUB_BASE_REF || "main" },
+            adapters,
+            limits: { environment: process.env }
+          });
+
+          writePublicationResult(result);
+          const prLine = result.pullRequest?.url
+            ? `- **PR**: ${result.pullRequest.url}`
+            : `- **PR**: not created — ${result.reason ?? result.status}`;
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              `## Publication`,
+              "",
+              `- **Status**: \`${result.status}\``,
+              prLine,
+              ""
+            ].join("\n") + "\n"
+          );
+          console.log(JSON.stringify(result, null, 2));
+          process.exit(result.status === "published" ? 0 : 1);
+          NODE
+
+      # Only the sanitized publication result is kept, never raw request/response
+      # or debug logs.
+      - name: Upload publication result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-correctness-publication
+          path: .tmp/gemini-correctness/publication-result.json
+          retention-days: 7
+          if-no-files-found: warn

--- a/scripts/gemini-correctness/workflow-contract.test.ts
+++ b/scripts/gemini-correctness/workflow-contract.test.ts
@@ -1,0 +1,408 @@
+// =============================================================================
+// workflow-contract.test.ts — Structure contract for the #690 GitHub Actions
+// workflow that wires #688 (orchestration state machine) + #689 (publication
+// adapter) into a manual/scheduled observe/repair run.
+//
+// This test parses .github/workflows/gemini-correctness-autofix.yml as YAML and
+// asserts the security-sensitive wiring contract: fixed triggers/runner/tooling,
+// minimal permissions, secret isolation, concurrency, gating, artifact
+// allowlist/retention, and the absence of PAT / pull_request_target /
+// self-hosted / third-party write actions / auto-merge / force push.
+// =============================================================================
+
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+// @ts-expect-error -- js-yaml ships no type declarations (transitive via eslint)
+import yaml from "js-yaml";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, "..", "..");
+const WORKFLOW_PATH = path.join(
+  projectRoot,
+  ".github",
+  "workflows",
+  "gemini-correctness-autofix.yml"
+);
+
+const ALLOWED_ARTIFACTS = [
+  "finding.json",
+  "red-result.json",
+  "repair-result.json",
+  "command-summary.json",
+  "publication-result.json"
+];
+
+const FIXED_VARIABLES = [
+  "GEMINI_AUTOFIX_MODE",
+  "GEMINI_AUTOFIX_MODEL",
+  "GEMINI_AUTOFIX_MIN_CONFIDENCE",
+  "GEMINI_AUTOFIX_MAX_FILES",
+  "GEMINI_AUTOFIX_MAX_LINES"
+];
+
+const raw = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+type Json = Record<string, unknown>;
+
+function rec(value: unknown): Json {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Json)
+    : {};
+}
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+function arr(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+const doc = rec(yaml.load(raw));
+const jobMap = rec(doc.jobs);
+
+function jobOutputs(jobName: string): string[] {
+  return Object.keys(rec(rec(jobMap[jobName]).outputs));
+}
+
+function allSteps(): Array<{ job: string; step: Json }> {
+  const out: Array<{ job: string; step: Json }> = [];
+  for (const [jobName, jobValue] of Object.entries(jobMap)) {
+    for (const stepValue of arr(rec(jobValue).steps)) {
+      out.push({ job: jobName, step: rec(stepValue) });
+    }
+  }
+  return out;
+}
+
+function stepById(jobName: string, id: string): Json | undefined {
+  const job = rec(jobMap[jobName]);
+  return arr(job.steps)
+    .map((value) => rec(value))
+    .find((step) => step.id === id);
+}
+
+function glueRun(jobName: string, stepId: string): string {
+  return str(stepById(jobName, stepId)?.run);
+}
+
+describe("gemini-correctness-autofix.yml trigger contract (#690)", () => {
+  it("parses as a single YAML mapping", () => {
+    expect(doc).not.toBeNull();
+    expect(Object.keys(doc).length).toBeGreaterThan(0);
+  });
+
+  it("is triggered only by workflow_dispatch and schedule", () => {
+    const on = rec(doc.on);
+    expect(Object.keys(on).sort()).toEqual(["schedule", "workflow_dispatch"]);
+    expect(on).not.toHaveProperty("pull_request");
+    expect(on).not.toHaveProperty("pull_request_target");
+  });
+
+  it("fixes the workflow_dispatch mode input exactly", () => {
+    const on = rec(doc.on);
+    const input = rec(rec(on.workflow_dispatch).inputs).mode;
+    const mode = rec(input);
+    expect(mode.type).toBe("choice");
+    expect(mode.required).toBe(true);
+    expect(mode.default).toBe("observe");
+    expect(arr(mode.options)).toEqual(["observe", "repair"]);
+  });
+
+  it("fixes the schedule cron expression", () => {
+    const on = rec(doc.on);
+    const schedule = arr(on.schedule);
+    expect(schedule.length).toBeGreaterThan(0);
+    expect(str(rec(schedule[0]).cron)).toBe("17 19 * * *");
+  });
+});
+
+describe("gemini-correctness-autofix.yml runner/tooling contract (#690)", () => {
+  it("fixes ubuntu-latest runners and a 30-minute timeout on every job", () => {
+    expect(Object.keys(jobMap).sort()).toEqual(["evaluate", "publish"]);
+    for (const jobValue of Object.values(jobMap)) {
+      const job = rec(jobValue);
+      expect(job["runs-on"]).toBe("ubuntu-latest");
+      expect(job["timeout-minutes"]).toBe(30);
+    }
+  });
+
+  it("fixes the concurrency group and cancel behavior", () => {
+    const c = rec(doc.concurrency);
+    expect(c.group).toBe("gemini-correctness-autofix");
+    expect(c["cancel-in-progress"]).toBe(false);
+  });
+
+  it("pins Node 22 and pnpm 10.33.0", () => {
+    const setupNode = allSteps().find(({ step }) =>
+      str(step.uses).includes("actions/setup-node@")
+    );
+    expect(setupNode).toBeTruthy();
+    expect(rec(setupNode?.step.with)["node-version"]).toBe(22);
+
+    const pnpmSetup = allSteps().find(({ step }) =>
+      str(step.uses).includes("pnpm/action-setup@")
+    );
+    expect(pnpmSetup).toBeTruthy();
+    expect(str(rec(pnpmSetup?.step.with).version)).toBe("10.33.0");
+  });
+
+  it("installs dependencies with pnpm install --frozen-lockfile", () => {
+    const installs = allSteps().filter(({ step }) =>
+      str(step.run).includes("pnpm install --frozen-lockfile")
+    );
+    expect(installs.length).toBeGreaterThan(0);
+  });
+});
+
+describe("gemini-correctness-autofix.yml permission isolation (#690)", () => {
+  it("keeps the workflow default and evaluate permissions read-only", () => {
+    const perms = rec(doc.permissions);
+    expect(Object.values(perms)).not.toContain("write");
+
+    const evaluate = rec(jobMap.evaluate);
+    const evalPerms = rec(evaluate.permissions);
+    expect(evalPerms.contents).toBe("read");
+    expect(Object.values(evalPerms)).not.toContain("write");
+  });
+
+  it("grants publish exactly contents and pull-requests write", () => {
+    const publish = rec(jobMap.publish);
+    expect(rec(publish.permissions)).toEqual({
+      contents: "write",
+      "pull-requests": "write"
+    });
+  });
+});
+
+describe("gemini-correctness-autofix.yml secret isolation (#690)", () => {
+  it("injects GEMINI_API_KEY into exactly one step, inside evaluate", () => {
+    const secretSteps = allSteps().filter(({ step }) =>
+      str(rec(step.env).GEMINI_API_KEY).length > 0
+    );
+    expect(secretSteps).toHaveLength(1);
+    expect(secretSteps[0].job).toBe("evaluate");
+    expect(rec(secretSteps[0].step.env).GEMINI_API_KEY).toBe(
+      "${{ secrets.GEMINI_API_KEY }}"
+    );
+  });
+
+  it("never passes a model secret into the publish job", () => {
+    const publish = rec(jobMap.publish);
+    const publishText = JSON.stringify(publish);
+    expect(publishText).not.toContain("GEMINI_API_KEY");
+    expect(publishText).not.toMatch(/GEMINI_(KEY|TOKEN|SECRET|PASSWORD)/);
+  });
+
+  it("uses only GEMINI_API_KEY and the automatic GITHUB_TOKEN as secrets", () => {
+    const refs = [...new Set(
+      [...raw.matchAll(/secrets\.([A-Za-z0-9_-]+)/g)].map((m) => m[1])
+    )].sort();
+    expect(refs).toEqual(["GEMINI_API_KEY", "GITHUB_TOKEN"]);
+  });
+});
+
+describe("gemini-correctness-autofix.yml schedule mode gating (#690)", () => {
+  it("resolves schedule mode from GEMINI_AUTOFIX_MODE with an off fallback", () => {
+    const resolve = stepById("evaluate", "mode");
+    expect(resolve).toBeTruthy();
+    const resolveText = `${str(resolve?.run)}\n${JSON.stringify(rec(resolve?.env))}`;
+    expect(resolveText).toContain("GEMINI_AUTOFIX_MODE");
+    expect(resolveText).toContain("off");
+  });
+
+  it("gates the Gemini orchestration step behind a non-off mode", () => {
+    const orchestrate = stepById("evaluate", "orchestrate");
+    expect(orchestrate).toBeTruthy();
+    expect(str(orchestrate?.if)).toContain("mode");
+    expect(str(orchestrate?.if)).toContain("off");
+  });
+
+  it("has an explicit safe-skip step for off mode that runs before Gemini", () => {
+    const evaluate = rec(jobMap.evaluate);
+    const skip = arr(evaluate.steps)
+      .map((value) => rec(value))
+      .find((step) => str(step.name).toLowerCase().includes("skip"));
+    expect(skip).toBeTruthy();
+    expect(str(skip?.if)).toContain("off");
+    expect(str(skip?.run)).toContain("GITHUB_STEP_SUMMARY");
+  });
+});
+
+describe("gemini-correctness-autofix.yml job separation (#690)", () => {
+  it("evaluate runs the #688 orchestrator but never the publication adapter", () => {
+    const glue = glueRun("evaluate", "orchestrate");
+    expect(glue).toContain("runWorkflowOrchestration");
+    expect(glue).not.toContain("publishVerifiedRepair");
+  });
+
+  it("publish calls the #689 adapter but never reruns Gemini stages", () => {
+    const publishStep = arr(rec(jobMap.publish).steps)
+      .map((value) => rec(value))
+      .find((step) => str(step.name).toLowerCase().includes("publish"));
+    expect(publishStep).toBeTruthy();
+    const glue = str(publishStep?.run);
+    expect(glue).toContain("publishVerifiedRepair");
+    expect(glue).not.toContain("runWorkflowOrchestration");
+    expect(glue).not.toContain("GEMINI_API_KEY");
+    expect(glue).not.toMatch(/discover|red-stage|green-stage/);
+  });
+});
+
+describe("gemini-correctness-autofix.yml publication gating (#690)", () => {
+  it("runs publish only on a validated repair candidate from evaluate", () => {
+    const publish = rec(jobMap.publish);
+    expect(str(publish.if)).toContain("publicationAllowed");
+    expect(str(publish.if)).toContain("'true'");
+    expect(str(publish.if)).toContain("'repair'");
+    const needsValue = publish.needs;
+    const needsList = Array.isArray(needsValue) ? needsValue : [str(needsValue)];
+    expect(needsList.map((value) => str(value))).toEqual(["evaluate"]);
+  });
+
+  it("routes publicationAllowed through evaluate job outputs to the gate", () => {
+    expect(jobOutputs("evaluate")).toEqual(
+      expect.arrayContaining(["mode", "publicationAllowed", "status"])
+    );
+    expect(str(rec(rec(jobMap.evaluate).outputs).publicationAllowed)).toContain(
+      "publicationAllowed"
+    );
+  });
+
+  it("publish consumes the validated candidate artifact from evaluate", () => {
+    const publishStep = arr(rec(jobMap.publish).steps)
+      .map((value) => rec(value))
+      .find((step) => str(step.name).toLowerCase().includes("publish"));
+    const glue = str(publishStep?.run);
+    expect(glue).toContain("command-summary.json");
+    expect(glue).toContain("validatePublicationCandidate");
+  });
+});
+
+describe("gemini-correctness-autofix.yml artifact contract (#690)", () => {
+  it("fixes artifact retention at 7 days and uploads only allowlisted files", () => {
+    const uploads = allSteps().filter(({ step }) =>
+      str(step.uses).includes("upload-artifact")
+    );
+    expect(uploads.length).toBeGreaterThan(0);
+    for (const { step } of uploads) {
+      expect(rec(step.with)["retention-days"]).toBe(7);
+      const paths = str(rec(step.with).path)
+        .split("\n")
+        .map((p) => p.trim())
+        .filter(Boolean);
+      expect(paths.length).toBeGreaterThan(0);
+      for (const p of paths) {
+        expect(ALLOWED_ARTIFACTS).toContain(p.split("/").pop());
+      }
+    }
+  });
+
+  it("never uploads raw/log/patch/env/debug/source-archive content", () => {
+    const uploads = allSteps().filter(({ step }) =>
+      str(step.uses).includes("upload-artifact")
+    );
+    for (const { step } of uploads) {
+      const paths = str(rec(step.with).path);
+      expect(paths).not.toMatch(
+        /raw|red-test\.log|red-test\.patch|\.vitest|env|headers|debug|archive|\.tar|\.zip/i
+      );
+    }
+  });
+
+  it("does not fabricate empty RED/GREEN results for stages that did not run", () => {
+    const glue = glueRun("evaluate", "orchestrate");
+    // The glue may only copy stage-produced artifacts; it must never write
+    // red-result.json / repair-result.json itself.
+    expect(glue).not.toMatch(/writeFileSync\([^)]*red-result/);
+    expect(glue).not.toMatch(/writeFileSync\([^)]*repair-result/);
+  });
+});
+
+describe("gemini-correctness-autofix.yml baseline contract (#690)", () => {
+  it("fixes the baseline command set to lint/typecheck/test/build/diff-check", () => {
+    const glue = glueRun("evaluate", "orchestrate");
+    for (const cmd of ["lint", "typecheck", "test", "build", "diff-check"]) {
+      expect(glue).toContain(cmd);
+    }
+    expect(glue).toContain("pnpm lint");
+    expect(glue).toContain("pnpm typecheck");
+    expect(glue).toContain("pnpm test");
+    expect(glue).toContain("pnpm build");
+    expect(glue).toContain("diff --check");
+  });
+
+  it("reads all fixed repository variables", () => {
+    for (const variable of FIXED_VARIABLES) {
+      expect(raw).toContain(variable);
+    }
+  });
+});
+
+describe("gemini-correctness-autofix.yml forbidden constructs (#690)", () => {
+  it("forbids pull_request_target, self-hosted runners, and PATs", () => {
+    expect(raw).not.toContain("pull_request_target");
+    expect(raw).not.toContain("self-hosted");
+    expect(raw).not.toMatch(/ghp_[A-Za-z0-9]{20,}/);
+    expect(raw).not.toMatch(/ghs_|github_pat_/);
+  });
+
+  it("uses no third-party write actions", () => {
+    const uses = allSteps()
+      .map(({ step }) => str(step.uses))
+      .filter(Boolean);
+    expect(uses.length).toBeGreaterThan(0);
+    for (const use of uses) {
+      expect(use).toMatch(/^(actions\/|pnpm\/action-setup@)/);
+    }
+  });
+
+  it("never force-pushes or auto-merges", () => {
+    expect(raw).not.toMatch(/--force|force-with-lease|force-push/);
+    expect(raw).not.toMatch(/auto-merge|--merge|--squash|--rebase/);
+  });
+});
+
+describe("gemini-correctness-autofix.yml reference integrity (#690)", () => {
+  it("resolves every needs.<job>.outputs.<name> reference", () => {
+    for (const jobValue of Object.values(jobMap)) {
+      const job = rec(jobValue);
+      const jobText = JSON.stringify(job);
+      const needsValue = job.needs;
+      const needs = Array.isArray(needsValue)
+        ? needsValue.map((value) => str(value))
+        : [str(needsValue)].filter(Boolean);
+      const refs = [
+        ...jobText.matchAll(/needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
+      ];
+      for (const [, neededJob, outputName] of refs) {
+        expect(needs).toContain(neededJob);
+        expect(jobOutputs(neededJob)).toContain(outputName);
+      }
+    }
+  });
+
+  it("resolves every steps.<id>.outputs.<name> reference", () => {
+    for (const jobValue of Object.values(jobMap)) {
+      const job = rec(jobValue);
+      const jobText = JSON.stringify(job);
+      const stepIds = new Set(
+        arr(job.steps)
+          .map((value) => str(rec(value).id))
+          .filter(Boolean)
+      );
+      const refs = [
+        ...jobText.matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
+      ];
+      for (const [, stepId] of refs) {
+        expect(stepIds).toContain(stepId);
+      }
+    }
+  });
+
+  it("sets step outputs via GITHUB_OUTPUT, not deprecated ::set-output", () => {
+    const glue = glueRun("evaluate", "orchestrate");
+    expect(glue).toContain("GITHUB_OUTPUT");
+    expect(glue).not.toContain("::set-output");
+  });
+});

--- a/scripts/gemini-correctness/workflow-contract.test.ts
+++ b/scripts/gemini-correctness/workflow-contract.test.ts
@@ -3,9 +3,11 @@
 // workflow that wires #688 (orchestration state machine) + #689 (publication
 // adapter) into a manual/scheduled observe/repair run.
 //
-// This test parses .github/workflows/gemini-correctness-autofix.yml as YAML and
-// asserts the security-sensitive wiring contract: fixed triggers/runner/tooling,
-// minimal permissions, secret isolation, concurrency, gating, artifact
+// This test intentionally has NO YAML dependency: it validates the workflow as
+// fixed text/structure (indentation-aware section slicing + regex) so it runs
+// under a clean `--frozen-lockfile` CI install.  It asserts the
+// security-sensitive wiring contract: fixed triggers/runner/tooling, minimal
+// permissions, secret isolation, concurrency, gating, artifact
 // allowlist/retention, and the absence of PAT / pull_request_target /
 // self-hosted / third-party write actions / auto-merge / force push.
 // =============================================================================
@@ -14,8 +16,6 @@ import { describe, expect, it } from "vitest";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-// @ts-expect-error -- js-yaml ships no type declarations (transitive via eslint)
-import yaml from "js-yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..", "..");
@@ -44,236 +44,311 @@ const FIXED_VARIABLES = [
 
 const raw = fs.readFileSync(WORKFLOW_PATH, "utf8");
 
-type Json = Record<string, unknown>;
+// ---------------------------------------------------------------------------
+// Minimal indentation-aware slicing.  The workflow uses fixed 2-space
+// indentation, so these helpers are deterministic and need no YAML parser.
+// Sliced blocks preserve their original leading whitespace so anchored
+// regexes (`^ {n}...`) keep working.
+// ---------------------------------------------------------------------------
+type RawLine = { indent: number; text: string };
 
-function rec(value: unknown): Json {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Json)
-    : {};
-}
-function str(value: unknown): string {
-  return typeof value === "string" ? value : "";
-}
-function arr(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : [];
+function rawLines(source: string): RawLine[] {
+  return source.split("\n").map((line) => {
+    const m = /^(\s*)(.*)$/.exec(line);
+    return { indent: m ? m[1].length : 0, text: m ? m[2] : "" };
+  });
 }
 
-const doc = rec(yaml.load(raw));
-const jobMap = rec(doc.jobs);
+// Text of the block under the first line matching `header` at exactly `indent`,
+// stopping at the next non-blank line with indent <= `indent`.  Original
+// indentation is preserved in the returned text.
+function subBlock(source: string, indent: number, header: RegExp): string {
+  const srcLines = source.split("\n");
+  const ls = srcLines.map((line) => {
+    const m = /^(\s*)(.*)$/.exec(line);
+    return { indent: m ? m[1].length : 0, text: m ? m[2] : "" };
+  });
+  const start = ls.findIndex((l) => l.indent === indent && header.test(l.text));
+  if (start < 0) return "";
+  const out: string[] = [];
+  for (let i = start + 1; i < ls.length; i++) {
+    if (ls[i].text === "") {
+      out.push(srcLines[i]); // keep blank lines; they never terminate a block
+      continue;
+    }
+    if (ls[i].indent <= indent) break;
+    out.push(srcLines[i]);
+  }
+  return out.join("\n");
+}
+
+function normBlock(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function jobBlock(jobName: string): string {
+  const jobsText = subBlock(raw, 0, /^jobs:$/);
+  return subBlock(jobsText, 2, new RegExp(`^${jobName}:$`));
+}
 
 function jobOutputs(jobName: string): string[] {
-  return Object.keys(rec(rec(jobMap[jobName]).outputs));
+  const outputs = subBlock(jobBlock(jobName), 4, /^outputs:$/);
+  return [...outputs.matchAll(/^ {6}([A-Za-z0-9_-]+):/gm)].map((m) => m[1]);
 }
 
-function allSteps(): Array<{ job: string; step: Json }> {
-  const out: Array<{ job: string; step: Json }> = [];
-  for (const [jobName, jobValue] of Object.entries(jobMap)) {
-    for (const stepValue of arr(rec(jobValue).steps)) {
-      out.push({ job: jobName, step: rec(stepValue) });
+// Each `- name: ...` item (indent 6) starts a step; its keys (indent 8) and
+// deeper content belong to that step.
+function stepBlocks(jobName: string): string[] {
+  const block = jobBlock(jobName);
+  const ls = rawLines(block);
+  const srcLines = block.split("\n");
+  const out: string[] = [];
+  let current: string[] = [];
+  for (let i = 0; i < ls.length; i++) {
+    if (ls[i].indent === 6 && ls[i].text.startsWith("- ")) {
+      if (current.length) out.push(current.join("\n"));
+      current = [srcLines[i]];
+    } else if (ls[i].indent > 6 && current.length) {
+      current.push(srcLines[i]);
+    }
+  }
+  if (current.length) out.push(current.join("\n"));
+  return out;
+}
+
+function stepById(jobName: string, id: string): string {
+  return (
+    stepBlocks(jobName).find((b) => new RegExp(`^ {8}id: ${id}$`, "m").test(b)) ??
+    ""
+  );
+}
+
+function stepIds(jobName: string): Set<string> {
+  const ids = new Set<string>();
+  for (const b of stepBlocks(jobName)) {
+    const m = b.match(/^ {8}id: ([A-Za-z0-9_-]+)$/m);
+    if (m) ids.add(m[1]);
+  }
+  return ids;
+}
+
+function uploadSteps(): Array<{ job: string; text: string }> {
+  const out: Array<{ job: string; text: string }> = [];
+  for (const job of ["evaluate", "publish"]) {
+    for (const block of stepBlocks(job)) {
+      if (block.includes("actions/upload-artifact@v4")) {
+        out.push({ job, text: block });
+      }
     }
   }
   return out;
 }
 
-function stepById(jobName: string, id: string): Json | undefined {
-  const job = rec(jobMap[jobName]);
-  return arr(job.steps)
-    .map((value) => rec(value))
-    .find((step) => step.id === id);
-}
-
-function glueRun(jobName: string, stepId: string): string {
-  return str(stepById(jobName, stepId)?.run);
+// In an upload step, `with:` sits at indent 8, its keys (name/path/retention)
+// at indent 10, and the multi-line `path: |` value list at indent 12.
+function artifactPaths(stepText: string): string[] {
+  const ls = rawLines(stepText);
+  const pathIdx = ls.findIndex((l) => l.indent === 10 && /^path:/.test(l.text));
+  if (pathIdx < 0) return [];
+  if (/^path: \|/.test(ls[pathIdx].text)) {
+    const out: string[] = [];
+    for (let i = pathIdx + 1; i < ls.length && ls[i].indent === 12; i++) {
+      if (ls[i].text.trim() !== "") out.push(ls[i].text.trim());
+    }
+    return out;
+  }
+  return [ls[pathIdx].text.replace(/^path:\s*/, "").trim()];
 }
 
 describe("gemini-correctness-autofix.yml trigger contract (#690)", () => {
-  it("parses as a single YAML mapping", () => {
-    expect(doc).not.toBeNull();
-    expect(Object.keys(doc).length).toBeGreaterThan(0);
+  const onText = subBlock(raw, 0, /^on:$/);
+
+  it("loads the workflow with the fixed top-level sections in order", () => {
+    const topKeys = raw
+      .split("\n")
+      .map((line) => /^([A-Za-z0-9_]+):/.exec(line)?.[1])
+      .filter((k): k is string => Boolean(k));
+    expect(topKeys).toEqual([
+      "name",
+      "on",
+      "permissions",
+      "concurrency",
+      "jobs"
+    ]);
+    expect(raw).toMatch(/^name: Gemini correctness autofix$/m);
   });
 
   it("is triggered only by workflow_dispatch and schedule", () => {
-    const on = rec(doc.on);
-    expect(Object.keys(on).sort()).toEqual(["schedule", "workflow_dispatch"]);
-    expect(on).not.toHaveProperty("pull_request");
-    expect(on).not.toHaveProperty("pull_request_target");
+    expect(onText).toMatch(/^ {2}workflow_dispatch:$/m);
+    expect(onText).toMatch(/^ {2}schedule:$/m);
+    expect(onText).not.toContain("pull_request");
   });
 
   it("fixes the workflow_dispatch mode input exactly", () => {
-    const on = rec(doc.on);
-    const input = rec(rec(on.workflow_dispatch).inputs).mode;
-    const mode = rec(input);
-    expect(mode.type).toBe("choice");
-    expect(mode.required).toBe(true);
-    expect(mode.default).toBe("observe");
-    expect(arr(mode.options)).toEqual(["observe", "repair"]);
+    expect(onText).toContain("mode:");
+    expect(onText).toContain("required: true");
+    expect(onText).toContain("default: observe");
+    expect(onText).toContain("type: choice");
+    expect(onText).toContain("options: [observe, repair]");
   });
 
   it("fixes the schedule cron expression", () => {
-    const on = rec(doc.on);
-    const schedule = arr(on.schedule);
-    expect(schedule.length).toBeGreaterThan(0);
-    expect(str(rec(schedule[0]).cron)).toBe("17 19 * * *");
+    expect(onText).toContain('cron: "17 19 * * *"');
   });
 });
 
 describe("gemini-correctness-autofix.yml runner/tooling contract (#690)", () => {
   it("fixes ubuntu-latest runners and a 30-minute timeout on every job", () => {
-    expect(Object.keys(jobMap).sort()).toEqual(["evaluate", "publish"]);
-    for (const jobValue of Object.values(jobMap)) {
-      const job = rec(jobValue);
-      expect(job["runs-on"]).toBe("ubuntu-latest");
-      expect(job["timeout-minutes"]).toBe(30);
+    for (const job of ["evaluate", "publish"]) {
+      const block = jobBlock(job);
+      expect(block).toMatch(/^ {4}runs-on: ubuntu-latest$/m);
+      expect(block).toMatch(/^ {4}timeout-minutes: 30$/m);
     }
   });
 
   it("fixes the concurrency group and cancel behavior", () => {
-    const c = rec(doc.concurrency);
-    expect(c.group).toBe("gemini-correctness-autofix");
-    expect(c["cancel-in-progress"]).toBe(false);
+    const concurrency = subBlock(raw, 0, /^concurrency:$/);
+    expect(concurrency).toMatch(/^ {2}group: gemini-correctness-autofix$/m);
+    expect(concurrency).toMatch(/^ {2}cancel-in-progress: false$/m);
   });
 
   it("pins Node 22 and pnpm 10.33.0", () => {
-    const setupNode = allSteps().find(({ step }) =>
-      str(step.uses).includes("actions/setup-node@")
+    const nodeVersions = [...raw.matchAll(/^ {10}node-version: (.+)$/gm)].map(
+      (m) => m[1]
     );
-    expect(setupNode).toBeTruthy();
-    expect(rec(setupNode?.step.with)["node-version"]).toBe(22);
-
-    const pnpmSetup = allSteps().find(({ step }) =>
-      str(step.uses).includes("pnpm/action-setup@")
-    );
-    expect(pnpmSetup).toBeTruthy();
-    expect(str(rec(pnpmSetup?.step.with).version)).toBe("10.33.0");
+    expect(nodeVersions).toEqual(["22", "22"]);
+    const pnpmSetup = [...raw.matchAll(/^ {10}version: 10\.33\.0$/gm)];
+    expect(pnpmSetup.length).toBeGreaterThan(0);
   });
 
   it("installs dependencies with pnpm install --frozen-lockfile", () => {
-    const installs = allSteps().filter(({ step }) =>
-      str(step.run).includes("pnpm install --frozen-lockfile")
-    );
+    const installs = [...raw.matchAll(/pnpm install --frozen-lockfile/g)];
     expect(installs.length).toBeGreaterThan(0);
   });
 });
 
 describe("gemini-correctness-autofix.yml permission isolation (#690)", () => {
   it("keeps the workflow default and evaluate permissions read-only", () => {
-    const perms = rec(doc.permissions);
-    expect(Object.values(perms)).not.toContain("write");
+    const topPerms = subBlock(raw, 0, /^permissions:$/);
+    expect(normBlock(topPerms)).toEqual(["contents: read"]);
+    expect(topPerms).not.toContain("write");
 
-    const evaluate = rec(jobMap.evaluate);
-    const evalPerms = rec(evaluate.permissions);
-    expect(evalPerms.contents).toBe("read");
-    expect(Object.values(evalPerms)).not.toContain("write");
+    const evalPerms = subBlock(jobBlock("evaluate"), 4, /^permissions:$/);
+    expect(normBlock(evalPerms)).toEqual([
+      "contents: read",
+      "pull-requests: read"
+    ]);
+    expect(evalPerms).not.toContain("write");
   });
 
   it("grants publish exactly contents and pull-requests write", () => {
-    const publish = rec(jobMap.publish);
-    expect(rec(publish.permissions)).toEqual({
-      contents: "write",
-      "pull-requests": "write"
-    });
+    const publishPerms = subBlock(jobBlock("publish"), 4, /^permissions:$/);
+    expect(normBlock(publishPerms)).toEqual([
+      "contents: write",
+      "pull-requests: write"
+    ]);
   });
 });
 
 describe("gemini-correctness-autofix.yml secret isolation (#690)", () => {
   it("injects GEMINI_API_KEY into exactly one step, inside evaluate", () => {
-    const secretSteps = allSteps().filter(({ step }) =>
-      str(rec(step.env).GEMINI_API_KEY).length > 0
-    );
-    expect(secretSteps).toHaveLength(1);
-    expect(secretSteps[0].job).toBe("evaluate");
-    expect(rec(secretSteps[0].step.env).GEMINI_API_KEY).toBe(
-      "${{ secrets.GEMINI_API_KEY }}"
+    const apiKeyEnv = [
+      ...raw.matchAll(/^ {10}GEMINI_API_KEY: \${{ secrets\.GEMINI_API_KEY }}\s*$/gm)
+    ];
+    expect(apiKeyEnv).toHaveLength(1);
+    expect(jobBlock("evaluate")).toMatch(
+      /^ {10}GEMINI_API_KEY: \${{ secrets\.GEMINI_API_KEY }}$/m
     );
   });
 
   it("never passes a model secret into the publish job", () => {
-    const publish = rec(jobMap.publish);
-    const publishText = JSON.stringify(publish);
-    expect(publishText).not.toContain("GEMINI_API_KEY");
-    expect(publishText).not.toMatch(/GEMINI_(KEY|TOKEN|SECRET|PASSWORD)/);
+    const publishBlock = jobBlock("publish");
+    expect(publishBlock).not.toContain("GEMINI_API_KEY");
+    expect(publishBlock).not.toMatch(/GEMINI_(KEY|TOKEN|SECRET|PASSWORD)/);
   });
 
   it("uses only GEMINI_API_KEY and the automatic GITHUB_TOKEN as secrets", () => {
-    const refs = [...new Set(
-      [...raw.matchAll(/secrets\.([A-Za-z0-9_-]+)/g)].map((m) => m[1])
-    )].sort();
+    const refs = [
+      ...new Set(
+        [...raw.matchAll(/secrets\.([A-Za-z0-9_-]+)/g)].map((m) => m[1])
+      )
+    ].sort();
     expect(refs).toEqual(["GEMINI_API_KEY", "GITHUB_TOKEN"]);
+    expect(raw).toMatch(/^ {10}GH_TOKEN: \${{ secrets\.GITHUB_TOKEN }}$/m);
   });
 });
 
 describe("gemini-correctness-autofix.yml schedule mode gating (#690)", () => {
   it("resolves schedule mode from GEMINI_AUTOFIX_MODE with an off fallback", () => {
-    const resolve = stepById("evaluate", "mode");
-    expect(resolve).toBeTruthy();
-    const resolveText = `${str(resolve?.run)}\n${JSON.stringify(rec(resolve?.env))}`;
-    expect(resolveText).toContain("GEMINI_AUTOFIX_MODE");
-    expect(resolveText).toContain("off");
+    const resolveStep = stepById("evaluate", "mode");
+    expect(resolveStep).toContain("GEMINI_AUTOFIX_MODE");
+    expect(resolveStep).toContain("off");
   });
 
   it("gates the Gemini orchestration step behind a non-off mode", () => {
-    const orchestrate = stepById("evaluate", "orchestrate");
-    expect(orchestrate).toBeTruthy();
-    expect(str(orchestrate?.if)).toContain("mode");
-    expect(str(orchestrate?.if)).toContain("off");
+    const orchestrateStep = stepById("evaluate", "orchestrate");
+    expect(orchestrateStep).toMatch(
+      /^ {8}if: \${{ steps\.mode\.outputs\.mode != 'off' }}$/m
+    );
   });
 
-  it("has an explicit safe-skip step for off mode that runs before Gemini", () => {
-    const evaluate = rec(jobMap.evaluate);
-    const skip = arr(evaluate.steps)
-      .map((value) => rec(value))
-      .find((step) => str(step.name).toLowerCase().includes("skip"));
-    expect(skip).toBeTruthy();
-    expect(str(skip?.if)).toContain("off");
-    expect(str(skip?.run)).toContain("GITHUB_STEP_SUMMARY");
+  it("has an explicit safe-skip step that runs before the Gemini step", () => {
+    const evaluateText = jobBlock("evaluate");
+    const skipIdx = evaluateText.indexOf(
+      "Safe skip when GEMINI_AUTOFIX_MODE is off"
+    );
+    const orchestrateIdx = evaluateText.indexOf(
+      "Run Gemini correctness orchestration"
+    );
+    expect(skipIdx).toBeGreaterThan(-1);
+    expect(orchestrateIdx).toBeGreaterThan(skipIdx);
+    const skipStep = stepBlocks("evaluate").find((b) =>
+      b.includes("Safe skip when GEMINI_AUTOFIX_MODE is off")
+    );
+    expect(skipStep).toBeTruthy();
+    expect(skipStep).toContain("GITHUB_STEP_SUMMARY");
   });
 });
 
 describe("gemini-correctness-autofix.yml job separation (#690)", () => {
   it("evaluate runs the #688 orchestrator but never the publication adapter", () => {
-    const glue = glueRun("evaluate", "orchestrate");
+    const glue = stepById("evaluate", "orchestrate");
     expect(glue).toContain("runWorkflowOrchestration");
     expect(glue).not.toContain("publishVerifiedRepair");
   });
 
   it("publish calls the #689 adapter but never reruns Gemini stages", () => {
-    const publishStep = arr(rec(jobMap.publish).steps)
-      .map((value) => rec(value))
-      .find((step) => str(step.name).toLowerCase().includes("publish"));
-    expect(publishStep).toBeTruthy();
-    const glue = str(publishStep?.run);
+    const glue = stepById("publish", "publish");
     expect(glue).toContain("publishVerifiedRepair");
     expect(glue).not.toContain("runWorkflowOrchestration");
     expect(glue).not.toContain("GEMINI_API_KEY");
-    expect(glue).not.toMatch(/discover|red-stage|green-stage/);
+    expect(glue).not.toMatch(/discover\.mjs|red-stage\.mjs|green-stage\.mjs/);
   });
 });
 
 describe("gemini-correctness-autofix.yml publication gating (#690)", () => {
   it("runs publish only on a validated repair candidate from evaluate", () => {
-    const publish = rec(jobMap.publish);
-    expect(str(publish.if)).toContain("publicationAllowed");
-    expect(str(publish.if)).toContain("'true'");
-    expect(str(publish.if)).toContain("'repair'");
-    const needsValue = publish.needs;
-    const needsList = Array.isArray(needsValue) ? needsValue : [str(needsValue)];
-    expect(needsList.map((value) => str(value))).toEqual(["evaluate"]);
+    const publishBlock = jobBlock("publish");
+    expect(publishBlock).toMatch(/^ {4}needs: evaluate$/m);
+    expect(publishBlock).toContain("publicationAllowed");
+    expect(publishBlock).toContain("'true'");
+    expect(publishBlock).toContain("'repair'");
   });
 
   it("routes publicationAllowed through evaluate job outputs to the gate", () => {
     expect(jobOutputs("evaluate")).toEqual(
       expect.arrayContaining(["mode", "publicationAllowed", "status"])
     );
-    expect(str(rec(rec(jobMap.evaluate).outputs).publicationAllowed)).toContain(
-      "publicationAllowed"
+    expect(jobBlock("evaluate")).toMatch(
+      /^ {6}publicationAllowed: \${{ steps\.orchestrate\.outputs\.publicationAllowed }}$/m
     );
   });
 
   it("publish consumes the validated candidate artifact from evaluate", () => {
-    const publishStep = arr(rec(jobMap.publish).steps)
-      .map((value) => rec(value))
-      .find((step) => str(step.name).toLowerCase().includes("publish"));
-    const glue = str(publishStep?.run);
+    const glue = stepById("publish", "publish");
     expect(glue).toContain("command-summary.json");
     expect(glue).toContain("validatePublicationCandidate");
   });
@@ -281,16 +356,11 @@ describe("gemini-correctness-autofix.yml publication gating (#690)", () => {
 
 describe("gemini-correctness-autofix.yml artifact contract (#690)", () => {
   it("fixes artifact retention at 7 days and uploads only allowlisted files", () => {
-    const uploads = allSteps().filter(({ step }) =>
-      str(step.uses).includes("upload-artifact")
-    );
+    const uploads = uploadSteps();
     expect(uploads.length).toBeGreaterThan(0);
-    for (const { step } of uploads) {
-      expect(rec(step.with)["retention-days"]).toBe(7);
-      const paths = str(rec(step.with).path)
-        .split("\n")
-        .map((p) => p.trim())
-        .filter(Boolean);
+    for (const { text } of uploads) {
+      expect(text).toMatch(/^ {10}retention-days: 7$/m);
+      const paths = artifactPaths(text);
       expect(paths.length).toBeGreaterThan(0);
       for (const p of paths) {
         expect(ALLOWED_ARTIFACTS).toContain(p.split("/").pop());
@@ -299,11 +369,9 @@ describe("gemini-correctness-autofix.yml artifact contract (#690)", () => {
   });
 
   it("never uploads raw/log/patch/env/debug/source-archive content", () => {
-    const uploads = allSteps().filter(({ step }) =>
-      str(step.uses).includes("upload-artifact")
-    );
-    for (const { step } of uploads) {
-      const paths = str(rec(step.with).path);
+    const uploads = uploadSteps();
+    for (const { text } of uploads) {
+      const paths = artifactPaths(text).join("\n");
       expect(paths).not.toMatch(
         /raw|red-test\.log|red-test\.patch|\.vitest|env|headers|debug|archive|\.tar|\.zip/i
       );
@@ -311,9 +379,7 @@ describe("gemini-correctness-autofix.yml artifact contract (#690)", () => {
   });
 
   it("does not fabricate empty RED/GREEN results for stages that did not run", () => {
-    const glue = glueRun("evaluate", "orchestrate");
-    // The glue may only copy stage-produced artifacts; it must never write
-    // red-result.json / repair-result.json itself.
+    const glue = stepById("evaluate", "orchestrate");
     expect(glue).not.toMatch(/writeFileSync\([^)]*red-result/);
     expect(glue).not.toMatch(/writeFileSync\([^)]*repair-result/);
   });
@@ -321,7 +387,7 @@ describe("gemini-correctness-autofix.yml artifact contract (#690)", () => {
 
 describe("gemini-correctness-autofix.yml baseline contract (#690)", () => {
   it("fixes the baseline command set to lint/typecheck/test/build/diff-check", () => {
-    const glue = glueRun("evaluate", "orchestrate");
+    const glue = stepById("evaluate", "orchestrate");
     for (const cmd of ["lint", "typecheck", "test", "build", "diff-check"]) {
       expect(glue).toContain(cmd);
     }
@@ -348,9 +414,7 @@ describe("gemini-correctness-autofix.yml forbidden constructs (#690)", () => {
   });
 
   it("uses no third-party write actions", () => {
-    const uses = allSteps()
-      .map(({ step }) => str(step.uses))
-      .filter(Boolean);
+    const uses = [...raw.matchAll(/^ {8}uses: ([^\s]+)/gm)].map((m) => m[1]);
     expect(uses.length).toBeGreaterThan(0);
     for (const use of uses) {
       expect(use).toMatch(/^(actions\/|pnpm\/action-setup@)/);
@@ -365,43 +429,31 @@ describe("gemini-correctness-autofix.yml forbidden constructs (#690)", () => {
 
 describe("gemini-correctness-autofix.yml reference integrity (#690)", () => {
   it("resolves every needs.<job>.outputs.<name> reference", () => {
-    for (const jobValue of Object.values(jobMap)) {
-      const job = rec(jobValue);
-      const jobText = JSON.stringify(job);
-      const needsValue = job.needs;
-      const needs = Array.isArray(needsValue)
-        ? needsValue.map((value) => str(value))
-        : [str(needsValue)].filter(Boolean);
-      const refs = [
-        ...jobText.matchAll(/needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
-      ];
-      for (const [, neededJob, outputName] of refs) {
-        expect(needs).toContain(neededJob);
-        expect(jobOutputs(neededJob)).toContain(outputName);
-      }
+    const refs = [
+      ...raw.matchAll(/needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
+    ];
+    expect(refs.length).toBeGreaterThan(0);
+    for (const [, neededJob, outputName] of refs) {
+      expect(["evaluate", "publish"]).toContain(neededJob);
+      expect(jobOutputs(neededJob)).toContain(outputName);
     }
   });
 
-  it("resolves every steps.<id>.outputs.<name> reference", () => {
-    for (const jobValue of Object.values(jobMap)) {
-      const job = rec(jobValue);
-      const jobText = JSON.stringify(job);
-      const stepIds = new Set(
-        arr(job.steps)
-          .map((value) => str(rec(value).id))
-          .filter(Boolean)
-      );
+  it("resolves every steps.<id>.outputs.<name> reference within its job", () => {
+    for (const job of ["evaluate", "publish"]) {
+      const block = jobBlock(job);
+      const ids = stepIds(job);
       const refs = [
-        ...jobText.matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
+        ...block.matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)
       ];
       for (const [, stepId] of refs) {
-        expect(stepIds).toContain(stepId);
+        expect(ids).toContain(stepId);
       }
     }
   });
 
   it("sets step outputs via GITHUB_OUTPUT, not deprecated ::set-output", () => {
-    const glue = glueRun("evaluate", "orchestrate");
+    const glue = stepById("evaluate", "orchestrate");
     expect(glue).toContain("GITHUB_OUTPUT");
     expect(glue).not.toContain("::set-output");
   });


### PR DESCRIPTION
Closes #690

## Summary

- Add `.github/workflows/gemini-correctness-autofix.yml`: manual/scheduled observe/repair workflow wiring #688 orchestration and #689 publication.
- `evaluate` job: read-only (contents/pull-requests read); `GEMINI_API_KEY` injected into exactly the orchestrate step; off/invalid schedule mode safe-skips before any Gemini/baseline call; model policy allowlist + tighten-only numeric limits + secret-missing fail closed.
- `publish` job: contents+pull-requests write only; condition-gated on `publicationAllowed == 'true' && mode == 'repair'`; no model secret; calls only the #689 adapter.
- Fixed cron (`17 19 * * *`), ubuntu-latest, Node 22 / pnpm 10.33.0 / `--frozen-lockfile`, 30-min timeout, concurrency group, sanitized artifact allowlist (retention 7d), GITHUB_STEP_SUMMARY. No PAT, `pull_request_target`, self-hosted, third-party write actions, auto-merge, or force push.
- `workflow-contract.test.ts` locks the structure (32 tests).

## Scope

Only `.github/workflows/gemini-correctness-autofix.yml` and `scripts/gemini-correctness/workflow-contract.test.ts`.

## Verification

- `pnpm exec vitest run scripts/gemini-correctness/workflow-contract.test.ts` — 32/32 pass
- `pnpm exec vitest run scripts/gemini-correctness` — 28 files / 639 pass
- `pnpm lint` / `pnpm typecheck` / `pnpm test` (1978) / `pnpm build` — pass
- `git diff --check` — pass

## Reviewer verdict

```
Blocking findings:
- 無

Non-blocking findings:
- orchestrate step 以 writeFileSync 覆寫 summary（目前無衝突，建議註解鎖定）。
- publish git config 未檢查 runShell ok（runner 環境風險極低）。
- contract test 未鎖 vars 白名單（目前實作僅引用 5 個固定 vars）。
- workflow 層預驗證 candidate 後 publish 內再驗證一次（double-check 無害）。

Verdict:
No blocking findings.
```