### PR TITLE
feat(analytics): route Jabiko events to GA4 through Cloudflare Zaraz (#745)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -80,18 +80,23 @@ slug, or leaving and later re-entering an article route, is a new view.
 Issue #745: one reusable outbound promotion click event, emitted **before**
 the external-link navigation proceeds, from the promotion CTA activation.
 
-- `promoId` — a stable, non-PII placement identifier such as `stay-d`.
+- `promoId` — bounded to approved promotion identifiers
+  (`PROMO_IDENTIFIERS`; currently `stay-d`). A free-form string such as an
+  email is rejected at compile time.
 - `destinationType` — narrowed to `"airbnb"` (the single approved
   destination); free-form destination strings are rejected at compile time.
-- `placement` — the Jabiko surface where the card rendered (e.g. `home`),
-  not free-form copy.
+- `placement` — bounded to known Jabiko surfaces (`PROMO_PLACEMENTS`:
+  `home`, `about`, `blog`). #744 picks from these; adding a new surface
+  extends the union. URLs or free text are rejected at compile time.
 - `locale` — the active UI locale.
 
 The payload never carries the destination URL, Airbnb listing content,
-account or visitor data, or arbitrary strings. Firing is fire-and-forget: a
-missing or failing Zaraz must never block the CTA or the outbound link. One
-activation emits exactly one `promo_click` (the CTA handler calls `trackEvent`
-once; there is no router-level promotion tracking).
+account or visitor data, or arbitrary strings. `promoId` / `placement` are
+bounded unions in `src/lib/analytics.ts`, so arbitrary text cannot pass the
+analytics boundary even if a caller builds the payload as a variable. Firing
+is fire-and-forget: a missing or failing Zaraz must never block the CTA or the
+outbound link. One activation emits exactly one `promo_click` (the CTA handler
+calls `trackEvent` once; there is no router-level promotion tracking).
 
 ### `view` allowed values
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,9 +1,11 @@
 # Jabiko analytics (Cloudflare Zaraz)
 
-This document describes the anonymous learning analytics layer
+This document describes the privacy-safe learning analytics layer
 introduced in issue #404. It is intentionally small: a single typed helper,
 an environment gate, ten coarse events, and a hard privacy contract.
-GA4 is connected only as a downstream destination **through** the existing
+Payloads are sanitized, metadata-only event shapes — no question text, user
+answers, emails, raw user IDs, or arbitrary free-form strings. GA4 is
+connected only as a downstream destination **through** the existing
 Zaraz layer (issue #745) — application code never talks to Google directly.
 
 ## Why Zaraz

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,8 +1,10 @@
-# Jabiko analytics (Cloudflare Zaraz, Phase 1)
+# Jabiko analytics (Cloudflare Zaraz)
 
-This document describes the **Phase 1** anonymous learning analytics layer
+This document describes the anonymous learning analytics layer
 introduced in issue #404. It is intentionally small: a single typed helper,
-an environment gate, nine coarse events, and a hard privacy contract.
+an environment gate, ten coarse events, and a hard privacy contract.
+GA4 is connected only as a downstream destination **through** the existing
+Zaraz layer (issue #745) — application code never talks to Google directly.
 
 ## Why Zaraz
 
@@ -13,8 +15,8 @@ open published articles.
 Cloudflare Zaraz is used as an event router / tag manager — it does **not**
 replace Jabiko's own learning-progress data model or Supabase sync.
 
-Zaraz provides 1,000,000 free events/month per Cloudflare account. Phase 1
-event volume is kept intentionally small (nine coarse flow events, not
+Zaraz provides 1,000,000 free events/month per Cloudflare account. Event
+volume is kept intentionally small (ten coarse flow events, not
 per-interaction UI events).
 
 ## Helper
@@ -66,11 +68,30 @@ is correctly treated as disabled.
 | `locale_changed`     | the learner switches the UI language   | `from` (LocaleCode), `to` (LocaleCode)                          |
 | `weak_review_started`| the learner opens weak-point review    | `dueCount` (a count, not content), `locale`                     |
 | `article_viewed`     | a published article is successfully displayed | `slug` (canonical article slug only)                       |
+| `promo_click`        | a promotion CTA is activated (outbound) | `promoId`, `destinationType` (`"airbnb"`), `placement`, `locale` |
 
 `article_viewed` is emitted by `BlogArticlePage` after a published article has
 committed to the UI. The component keeps the last displayed slug in a ref, so
 StrictMode and re-renders do not duplicate an event; entering a different
 slug, or leaving and later re-entering an article route, is a new view.
+
+### `promo_click`
+
+Issue #745: one reusable outbound promotion click event, emitted **before**
+the external-link navigation proceeds, from the promotion CTA activation.
+
+- `promoId` — a stable, non-PII placement identifier such as `stay-d`.
+- `destinationType` — narrowed to `"airbnb"` (the single approved
+  destination); free-form destination strings are rejected at compile time.
+- `placement` — the Jabiko surface where the card rendered (e.g. `home`),
+  not free-form copy.
+- `locale` — the active UI locale.
+
+The payload never carries the destination URL, Airbnb listing content,
+account or visitor data, or arbitrary strings. Firing is fire-and-forget: a
+missing or failing Zaraz must never block the CTA or the outbound link. One
+activation emits exactly one `promo_click` (the CTA handler calls `trackEvent`
+once; there is no router-level promotion tracking).
 
 ### `view` allowed values
 
@@ -116,7 +137,8 @@ keys. The following are NOT present on any shape and cannot be passed through
 - article title, body, query string, referrer, or other navigation/free text
 
 `article_viewed` is deliberately limited to the canonical `slug`; it must not
-carry article prose or visitor/navigation data.
+carry article prose or visitor/navigation data. `promo_click` is limited to
+the four keys above; it must never carry the destination URL or free text.
 
 This is enforced by a per-event allowlist of typed keys. To add a new payload
 field, the shape in `AnalyticsPayloadMap` must be extended first; ad-hoc keys
@@ -125,13 +147,74 @@ are rejected by the compiler.
 > Forbidden payload keys rejected by the type system (verified by tests):
 > `userAnswer`, `userId`, and any key not on the event's allowlist.
 
-## Out of scope (Phase 2+)
+## GA4 through Zaraz (issue #745)
 
-- GA4 or PostHog integration through Zaraz
-- Cloudflare Zaraz Consent Management (consent banner)
+GA4 is a **downstream destination** of Cloudflare Zaraz, not an application
+dependency. Application code sends events only through `trackEvent` →
+`window.zaraz.track(...)` → Zaraz; the GA4 managed tool and its Events action
+forward those custom events. No component, helper, or script adds `gtag.js`,
+Google Tag Manager, direct `gtag(...)` calls, or a GA SDK — a single app-facing
+analytics API is preserved.
+
+- Reuse the existing explicit `page_view` event. **Do not** enable the GA4
+  managed tool's automatic Pageviews action alongside it, or a single SPA
+  navigation would produce two logical page views (one automatic, one manual).
+  Leave the automatic action disabled and rely on the existing
+  `trackEvent("page_view", ...)` path.
+- Do **not** rely on GA4 Enhanced Measurement's generic outbound `click` as the
+  promotion source of truth. The #744/#745 contract is the explicit
+  `promo_click` event, which carries the stable product-level `promoId`.
+- `promo_click` measures Jabiko → Airbnb **interest only**. It is not a
+  booking-conversion event and is not configured as one.
+
+### GA4 reporting contract
+
+GA4 must answer at minimum: how many `promo_click` events / users, and which
+`promoId`, `placement`, `destinationType`, and `locale`. Create
+event-scoped custom dimensions only for parameters GA4 does not already
+expose:
+
+```text
+promoId
+placement
+destinationType
+locale
+```
+
+Do **not** create high-cardinality dimensions from full URLs, arbitrary text,
+question contents, user identifiers, timestamps, or session-specific values.
+
+### Production operator steps (Cloudflare / GA4)
+
+These are configuration steps performed in the Cloudflare dashboard and the
+GA4 property by the owner — they cannot be completed by editing this repo:
+
+1. Use the intended Jabiko GA4 property/data stream (owner supplies the
+   Measurement ID).
+2. In Cloudflare Zaraz, add/configure the native **Google Analytics 4** managed
+   tool for the production domain.
+3. Configure the Events action so `zaraz.track(...)` custom events reach GA4.
+4. Ensure the page-view configuration does **not** double-count the explicit
+   SPA `page_view` flow (disable the automatic pageview action if needed).
+5. Create only the required event-scoped custom dimensions
+   (`promoId`, `placement`, `destinationType`, `locale`).
+6. Verify the production stream with Zaraz Debugger/Monitoring and GA4
+   Realtime/DebugView.
+
+Do not commit GA credentials, secrets, cookies, or account identifiers to the
+repository. If the GA4 Measurement ID/property has not yet been chosen,
+repository implementation may proceed, but production activation stays blocked
+until the owner supplies/configures the intended property in Cloudflare.
+
+## Out of scope
+
+- Cloudflare Zaraz Consent Management (consent banner) — if production
+  activation legally or operationally requires a materially different consent
+  architecture, stop activation and escalate rather than inventing one here.
 - server-side events through the Zaraz HTTP Events API
 - account/sync events (`sign_in_started`, `sync_enabled`, `sync_failed`, …)
 - deeper learning analytics stored in Jabiko's own DB
+- UTM / redirect / enhanced outbound tracking (#305 stays separate)
 
 ## Tests
 
@@ -139,6 +222,11 @@ are rejected by the compiler.
 `window.zaraz.track`, missing `window.zaraz`, `window.zaraz.track` throwing,
 `window.zaraz.track` not a function, unknown event name (compile error),
 wrong payload type (compile error), and sensitive-key rejection (compile
-error), including the slug-only `article_viewed` allowlist. `BlogArticlePage`
+error), including the slug-only `article_viewed` allowlist and the
+four-key `promo_click` allowlist (accept + smuggle-strip + compile-time
+rejection of destination URL / PII / non-airbnb destinationType). `BlogArticlePage`
 tests cover published-only triggering, StrictMode/rerender deduplication, slug
 changes, unknown/draft suppression, and re-entry after route departure.
+`src/domain/legalContent.test.ts` asserts that every launched privacy locale
+discloses GA4 routing through Zaraz without over-claiming booking-conversion
+tracking or full anonymity.

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -85,9 +85,21 @@ the external-link navigation proceeds, from the promotion CTA activation.
   email is rejected at compile time.
 - `destinationType` — narrowed to `"airbnb"` (the single approved
   destination); free-form destination strings are rejected at compile time.
-- `placement` — bounded to known Jabiko surfaces (`PROMO_PLACEMENTS`:
-  `home`, `about`, `blog`). #744 picks from these; adding a new surface
-  extends the union. URLs or free text are rejected at compile time.
+- `placement` — bounded to the stable Stay.D funnel interaction placements
+  frozen by #744 (`PROMO_PLACEMENTS`):
+
+  ```text
+  home-airbnb          Home direct Airbnb CTA
+  home-video           Home video trigger
+  home-video-airbnb    Airbnb CTA with/after the Home video
+  stay-d-hero-airbnb   /stay-d hero Airbnb CTA
+  stay-d-video         /stay-d video trigger
+  stay-d-video-airbnb  Airbnb CTA with the /stay-d video section
+  stay-d-final-airbnb  /stay-d final Airbnb CTA
+  ```
+
+  #744 wires exactly these values; a new funnel step extends the union. URLs,
+  surface slugs, or free text are rejected at compile time.
 - `locale` — the active UI locale.
 
 The payload never carries the destination URL, Airbnb listing content,

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -101,7 +101,7 @@ describe("legal content", () => {
   it("discloses GA4 routing through Zaraz in every launched privacy locale without over-claiming", () => {
     const disclosureText = (language: "zh-Hant" | "ja" | "en") =>
       legalDocumentFor(language, "privacy").sections
-        .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+        .flatMap((section) => [section.title, ...(section.paragraphs ?? []), ...(section.items ?? [])])
         .join("\n");
 
     // GA4 is disclosed as a downstream analytics recipient routed through Zaraz.
@@ -130,10 +130,30 @@ describe("legal content", () => {
     expect(en).toContain("does not measure or track");
 
     // No claim that analytics is fully anonymous while GA4/Zaraz keep their
-    // own client/session mechanisms.
+    // own client/session mechanisms. The section title itself must not claim
+    // anonymity either.
     expect(en).not.toContain("fully anonymous");
     expect(zh).not.toContain("完全匿名");
     expect(ja).not.toContain("完全に匿名");
+
+    // The analytics section title must not assert anonymity in any launched
+    // locale, now that events can be routed to Google Analytics. Titles carry
+    // the numbered prefix ("3. 使用分析"), so assert the wording, not an
+    // exact match. The section is located per-locale (English has no 分析
+    // character), so key each matcher to the locale's own wording.
+    const analyticsSectionTitle = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .find((section) =>
+          language === "en" ? section.title.includes("analytics") : section.title.includes("分析")
+        )
+        ?.title ?? "";
+
+    expect(analyticsSectionTitle("zh-Hant")).toContain("使用分析");
+    expect(analyticsSectionTitle("zh-Hant")).not.toContain("匿名");
+    expect(analyticsSectionTitle("ja")).toContain("利用状況分析");
+    expect(analyticsSectionTitle("ja")).not.toContain("匿名");
+    expect(analyticsSectionTitle("en")).toContain("Usage analytics");
+    expect(analyticsSectionTitle("en")).not.toContain("Anonymous");
   });
 
   it("does not claim that public source code is open source", () => {

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -98,6 +98,44 @@ describe("legal content", () => {
     expect(en).not.toContain("all data");
   });
 
+  it("discloses GA4 routing through Zaraz in every launched privacy locale without over-claiming", () => {
+    const disclosureText = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .flatMap((section) => [...(section.paragraphs ?? []), ...(section.items ?? [])])
+        .join("\n");
+
+    // GA4 is disclosed as a downstream analytics recipient routed through Zaraz.
+    const zh = disclosureText("zh-Hant");
+    expect(zh).toContain("Google Analytics");
+    expect(zh).toContain("轉交 Google Analytics");
+
+    const ja = disclosureText("ja");
+    expect(ja).toContain("Google Analytics");
+    expect(ja).toContain("Google Analytics に転送");
+
+    const en = disclosureText("en");
+    expect(en).toContain("Google Analytics");
+    expect(en).toContain("routed through Cloudflare Zaraz to Google Analytics");
+
+    // Google Analytics is listed as an analytics provider separately from the
+    // optional Google sign-in purpose.
+    expect(zh).toContain("Google Analytics：分析啟用時");
+    expect(ja).toContain("Google Analytics：分析が有効な場合");
+    expect(en).toContain("Google Analytics: recipient of aggregate usage analysis");
+
+    // The outbound promotion click is scoped to interest measurement, not to
+    // Airbnb booking conversion tracking.
+    expect(zh).toContain("不代表測量或追蹤");
+    expect(ja).toContain("測定・追跡するものではありません");
+    expect(en).toContain("does not measure or track");
+
+    // No claim that analytics is fully anonymous while GA4/Zaraz keep their
+    // own client/session mechanisms.
+    expect(en).not.toContain("fully anonymous");
+    expect(zh).not.toContain("完全匿名");
+    expect(ja).not.toContain("完全に匿名");
+  });
+
   it("does not claim that public source code is open source", () => {
     const terms = legalDocumentFor("zh-Hant", "terms");
     const text = terms.sections

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -50,7 +50,7 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. 匿名使用分析",
+          title: "3. 使用分析",
           paragraphs: [
             "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。當分析啟用時，選定的淨化後使用事件（例如促銷外連點擊）可能透過 Cloudflare Zaraz 轉交 Google Analytics，用於彙總使用分析。",
             "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。促銷外連點擊僅傳送促銷識別碼、目的地類型、版面位置與介面語言，不代表測量或追蹤 Airbnb 訂房轉換。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
@@ -169,7 +169,7 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. 匿名の利用状況分析",
+          title: "3. 利用状況分析",
           paragraphs: [
             "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。分析が有効な場合、選定した浄化済みの利用イベント（プロモーションの外部リンクのクリックなど）は Cloudflare Zaraz を経由して Google Analytics に転送され、集計的な利用分析に使われることがあります。",
             "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。プロモーションの外部リンクのクリックでは、プロモーション ID、宛先の種類、掲載位置、表示言語のみを送信し、Airbnb の予約転換を測定・追跡するものではありません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
@@ -288,7 +288,7 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. Anonymous usage analytics",
+          title: "3. Usage analytics",
           paragraphs: [
             "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used. When analytics is enabled, selected sanitized usage events (such as promotion outbound clicks) may be routed through Cloudflare Zaraz to Google Analytics for aggregate usage analysis.",
             "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. A promotion outbound click carries only the promotion identifier, destination type, placement, and interface language; it does not measure or track Airbnb booking conversion. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -22,7 +22,7 @@ export interface LegalPageCopy extends LegalPageLabels {
   terms: LegalDocument;
 }
 
-const PRIVACY_UPDATED_AT = "2026-07-18";
+const PRIVACY_UPDATED_AT = "2026-08-11";
 const TERMS_UPDATED_AT = "2026-07-18";
 
 const LEGAL_COPY = {
@@ -52,8 +52,8 @@ const LEGAL_COPY = {
         {
           title: "3. 匿名使用分析",
           paragraphs: [
-            "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。",
-            "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
+            "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。當分析啟用時，選定的淨化後使用事件（例如促銷外連點擊）可能透過 Cloudflare Zaraz 轉交 Google Analytics，用於彙總使用分析。",
+            "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。促銷外連點擊僅傳送促銷識別碼、目的地類型、版面位置與介面語言，不代表測量或追蹤 Airbnb 訂房轉換。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
           ]
         },
         {
@@ -67,6 +67,7 @@ const LEGAL_COPY = {
           title: "5. 外部服務",
           items: [
             "Cloudflare：網站傳遞、安全與選用的 Zaraz 分析。",
+            "Google Analytics：分析啟用時，作為彙總使用分析的接收方。",
             "Supabase：Google 登入、登入狀態、練習同步與回報資料庫。",
             "Google：你主動選擇 Google 登入時的身分驗證。",
             "ECPay 與其他外部連結：只有在你主動點擊後才會前往第三方網站；付款資料不會由 Jabiko 前端保存。"
@@ -170,8 +171,8 @@ const LEGAL_COPY = {
         {
           title: "3. 匿名の利用状況分析",
           paragraphs: [
-            "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。",
-            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
+            "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。分析が有効な場合、選定した浄化済みの利用イベント（プロモーションの外部リンクのクリックなど）は Cloudflare Zaraz を経由して Google Analytics に転送され、集計的な利用分析に使われることがあります。",
+            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。プロモーションの外部リンクのクリックでは、プロモーション ID、宛先の種類、掲載位置、表示言語のみを送信し、Airbnb の予約転換を測定・追跡するものではありません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
           ]
         },
         {
@@ -185,6 +186,7 @@ const LEGAL_COPY = {
           title: "5. 外部サービス",
           items: [
             "Cloudflare：サイト配信、安全対策、任意の Zaraz 分析。",
+            "Google Analytics：分析が有効な場合の集計的な利用分析の受信者。",
             "Supabase：Google ログイン、セッション、練習同期、フィードバック保存。",
             "Google：利用者が Google ログインを選んだ場合の認証。",
             "ECPay その他の外部リンク：利用者がリンクを開いた後は第三者のサービスとなり、Jabiko のフロントエンドは決済情報を保存しません。"
@@ -288,8 +290,8 @@ const LEGAL_COPY = {
         {
           title: "3. Anonymous usage analytics",
           paragraphs: [
-            "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used.",
-            "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."
+            "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used. When analytics is enabled, selected sanitized usage events (such as promotion outbound clicks) may be routed through Cloudflare Zaraz to Google Analytics for aggregate usage analysis.",
+            "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. A promotion outbound click carries only the promotion identifier, destination type, placement, and interface language; it does not measure or track Airbnb booking conversion. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."
           ]
         },
         {
@@ -303,6 +305,7 @@ const LEGAL_COPY = {
           title: "5. External services",
           items: [
             "Cloudflare: site delivery, security, and optional Zaraz analytics.",
+            "Google Analytics: recipient of aggregate usage analysis when analytics is enabled.",
             "Supabase: Google sign-in, sessions, practice sync, and feedback storage.",
             "Google: authentication when you choose Google sign-in.",
             "ECPay and other external links: third-party services apply after you choose to open them; payment details are not stored by the Jabiko frontend."

--- a/src/domain/prerender/staticPages.test.ts
+++ b/src/domain/prerender/staticPages.test.ts
@@ -126,7 +126,7 @@ describe("buildStaticPages", () => {
     const terms = byPath.get("/terms");
 
     expect(privacy?.bodyHtml).toContain("Google 登入與跨裝置同步");
-    expect(privacy?.bodyHtml).toContain("匿名使用分析");
+    expect(privacy?.bodyHtml).toContain("使用分析");
     expect(terms?.bodyHtml).toContain("程式碼、內容與品牌");
     expect(terms?.bodyHtml).toContain("不代表已授權");
   });

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -190,6 +190,77 @@ describe("analytics.trackEvent", () => {
     });
   });
 
+  it("accepts promo_click with its documented payload shape", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "home",
+      locale: "zh-Hant"
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "home",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("strips non-allowlisted keys from promo_click before forwarding to Zaraz", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    // The promotion CTA must not forward the destination URL, account data,
+    // raw user ids, or arbitrary strings. Only the four allowlisted keys pass.
+    const smuggled = {
+      promoId: "stay-d",
+      destinationType: "airbnb" as const,
+      placement: "home",
+      locale: "zh-Hant" as const,
+      destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668",
+      email: "a@b.com",
+      userId: "supabase-123",
+      nested: { title: "秘密の宿" }
+    };
+    trackEvent("promo_click", smuggled);
+    expect(track).toHaveBeenCalledTimes(1);
+    const forwarded = track.mock.calls[0][1] as Record<string, unknown>;
+    expect(forwarded).not.toHaveProperty("destinationUrl");
+    expect(forwarded).not.toHaveProperty("email");
+    expect(forwarded).not.toHaveProperty("userId");
+    expect(forwarded).not.toHaveProperty("nested");
+    expect(forwarded).toEqual({
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "home",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects a non-airbnb destinationType for promo_click at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      // @ts-expect-error -- destinationType is narrowed to "airbnb"; free-form
+      // destination strings (e.g. booking providers) are not allowed
+      destinationType: "hotel",
+      placement: "home",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects destination URL or PII keys for promo_click at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "home",
+      locale: "zh-Hant",
+      // @ts-expect-error -- destinationUrl is not an allowlisted key; the
+      // Airbnb URL must never travel inside the analytics payload
+      destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668"
+    });
+  });
+
   it("strips article content and navigation metadata from article_viewed", () => {
     __setAnalyticsEnabledForTest(true);
     const track = installZaraz();

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -214,9 +214,9 @@ describe("analytics.trackEvent", () => {
     // The promotion CTA must not forward the destination URL, account data,
     // raw user ids, or arbitrary strings. Only the four allowlisted keys pass.
     const smuggled = {
-      promoId: "stay-d",
+      promoId: "stay-d" as const,
       destinationType: "airbnb" as const,
-      placement: "home",
+      placement: "home" as const,
       locale: "zh-Hant" as const,
       destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668",
       email: "a@b.com",
@@ -258,6 +258,28 @@ describe("analytics.trackEvent", () => {
       // @ts-expect-error -- destinationUrl is not an allowlisted key; the
       // Airbnb URL must never travel inside the analytics payload
       destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668"
+    });
+  });
+
+  it("rejects an arbitrary promoId at compile time", () => {
+    trackEvent("promo_click", {
+      // @ts-expect-error -- promoId is bounded to approved promotion ids; a
+      // free-form string such as an email must not pass the boundary
+      promoId: "user@example.com",
+      destinationType: "airbnb",
+      placement: "home",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects an arbitrary placement at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      // @ts-expect-error -- placement is bounded to known Jabiko surfaces; a
+      // URL or free text must not pass the boundary
+      placement: "https://example.com/",
+      locale: "zh-Hant"
     });
   });
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -190,21 +190,39 @@ describe("analytics.trackEvent", () => {
     });
   });
 
-  it("accepts promo_click with its documented payload shape", () => {
+  it("accepts promo_click with a Home direct Airbnb placement", () => {
     __setAnalyticsEnabledForTest(true);
     const track = installZaraz();
     trackEvent("promo_click", {
       promoId: "stay-d",
       destinationType: "airbnb",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant"
     });
     expect(track).toHaveBeenCalledTimes(1);
     expect(track).toHaveBeenCalledWith("promo_click", {
       promoId: "stay-d",
       destinationType: "airbnb",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant"
+    });
+  });
+
+  it("accepts promo_click with a /stay-d hero Airbnb placement", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "stay-d-hero-airbnb",
+      locale: "ja"
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      destinationType: "airbnb",
+      placement: "stay-d-hero-airbnb",
+      locale: "ja"
     });
   });
 
@@ -216,7 +234,7 @@ describe("analytics.trackEvent", () => {
     const smuggled = {
       promoId: "stay-d" as const,
       destinationType: "airbnb" as const,
-      placement: "home" as const,
+      placement: "home-airbnb" as const,
       locale: "zh-Hant" as const,
       destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668",
       email: "a@b.com",
@@ -233,7 +251,7 @@ describe("analytics.trackEvent", () => {
     expect(forwarded).toEqual({
       promoId: "stay-d",
       destinationType: "airbnb",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant"
     });
   });
@@ -244,7 +262,7 @@ describe("analytics.trackEvent", () => {
       // @ts-expect-error -- destinationType is narrowed to "airbnb"; free-form
       // destination strings (e.g. booking providers) are not allowed
       destinationType: "hotel",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant"
     });
   });
@@ -253,7 +271,7 @@ describe("analytics.trackEvent", () => {
     trackEvent("promo_click", {
       promoId: "stay-d",
       destinationType: "airbnb",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant",
       // @ts-expect-error -- destinationUrl is not an allowlisted key; the
       // Airbnb URL must never travel inside the analytics payload
@@ -267,7 +285,7 @@ describe("analytics.trackEvent", () => {
       // free-form string such as an email must not pass the boundary
       promoId: "user@example.com",
       destinationType: "airbnb",
-      placement: "home",
+      placement: "home-airbnb",
       locale: "zh-Hant"
     });
   });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -61,13 +61,22 @@ export interface ArticleViewedPayload {
   slug: string;
 }
 // Outbound promotion click (#745). destinationType is narrowed to the single
-// currently-approved destination ("airbnb"); placement identifies the Jabiko
-// surface the card rendered on, not free-form copy. Nothing about the
-// destination page, account, or visitor travels in this payload.
+// currently-approved destination ("airbnb"); promoId and placement are bounded
+// to approved identifiers so arbitrary free-form text or PII (an email, a URL)
+// cannot pass the analytics boundary at compile time. Extend the unions below
+// when a new approved promotion or placement lands.
+export const PROMO_IDENTIFIERS = ["stay-d"] as const satisfies readonly string[];
+export type PromoIdentifier = (typeof PROMO_IDENTIFIERS)[number];
+
+// Jabiko surfaces where a promotion card may render. #744 will choose from
+// these; adding a new non-interruptive informational surface extends the union.
+export const PROMO_PLACEMENTS = ["home", "about", "blog"] as const satisfies readonly string[];
+export type PromoPlacement = (typeof PROMO_PLACEMENTS)[number];
+
 export interface PromoClickPayload {
-  promoId: string;
+  promoId: PromoIdentifier;
   destinationType: "airbnb";
-  placement: string;
+  placement: PromoPlacement;
   locale: LocaleCode;
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,7 +11,8 @@ export type AnalyticsEventName =
   | "level_changed"
   | "locale_changed"
   | "weak_review_started"
-  | "article_viewed";
+  | "article_viewed"
+  | "promo_click";
 
 export interface PageViewPayload {
   view: string;
@@ -59,6 +60,16 @@ export interface WeakReviewStartedPayload {
 export interface ArticleViewedPayload {
   slug: string;
 }
+// Outbound promotion click (#745). destinationType is narrowed to the single
+// currently-approved destination ("airbnb"); placement identifies the Jabiko
+// surface the card rendered on, not free-form copy. Nothing about the
+// destination page, account, or visitor travels in this payload.
+export interface PromoClickPayload {
+  promoId: string;
+  destinationType: "airbnb";
+  placement: string;
+  locale: LocaleCode;
+}
 
 export interface AnalyticsPayloadMap {
   page_view: PageViewPayload;
@@ -70,6 +81,7 @@ export interface AnalyticsPayloadMap {
   locale_changed: LocaleChangedPayload;
   weak_review_started: WeakReviewStartedPayload;
   article_viewed: ArticleViewedPayload;
+  promo_click: PromoClickPayload;
 }
 
 const ZARAZ_ENABLED_FLAG = import.meta.env.VITE_ZARAZ_ENABLED;
@@ -89,7 +101,8 @@ const ALLOWED_PAYLOAD_KEYS: Record<AnalyticsEventName, readonly string[]> = {
   level_changed: ["scope", "levelRange", "locale"],
   locale_changed: ["from", "to"],
   weak_review_started: ["dueCount", "locale"],
-  article_viewed: ["slug"]
+  article_viewed: ["slug"],
+  promo_click: ["promoId", "destinationType", "placement", "locale"]
 };
 
 function sanitizePayload<K extends AnalyticsEventName>(

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -68,9 +68,19 @@ export interface ArticleViewedPayload {
 export const PROMO_IDENTIFIERS = ["stay-d"] as const satisfies readonly string[];
 export type PromoIdentifier = (typeof PROMO_IDENTIFIERS)[number];
 
-// Jabiko surfaces where a promotion card may render. #744 will choose from
-// these; adding a new non-interruptive informational surface extends the union.
-export const PROMO_PLACEMENTS = ["home", "about", "blog"] as const satisfies readonly string[];
+// Stable Stay.D funnel interaction placements frozen by #744 (#745 analytics
+// boundary). Each value identifies a distinct user-facing funnel interaction,
+// not a raw URL, surface slug, or free-form copy. #744 wires exactly these
+// values when the Stay.D UI lands; adding a new funnel step extends the union.
+export const PROMO_PLACEMENTS = [
+  "home-airbnb",
+  "home-video",
+  "home-video-airbnb",
+  "stay-d-hero-airbnb",
+  "stay-d-video",
+  "stay-d-video-airbnb",
+  "stay-d-final-airbnb"
+] as const satisfies readonly string[];
 export type PromoPlacement = (typeof PROMO_PLACEMENTS)[number];
 
 export interface PromoClickPayload {


### PR DESCRIPTION
Closes nothing — implements the repository half of **#745**. Relates to **#744** (Airbnb promotion; not merged yet).

## Repository-complete

- **`src/lib/analytics.ts`** — add one reusable, typed `promo_click` event with a narrowed `destinationType: "airbnb"` payload and a four-key per-event allowlist (`promoId`, `destinationType`, `placement`, `locale`). `trackEvent` / `sanitizePayload` / the `VITE_ZARAZ_ENABLED` gate are unchanged — GA4 stays a Cloudflare Zaraz destination, never a new app dependency. No `gtag.js`, no Google Tag Manager, no GA SDK, no second analytics client.
- **`src/lib/analytics.test.ts`** — accept, smuggle-strip (destinationUrl / email / userId / nested removed), and compile-time rejection (non-airbnb `destinationType`, `destinationUrl`) coverage for `promo_click`. The compile-time guards are load-bearing: removing the directives makes `tsc --noEmit` fail with TS2322 / TS2353 (verified against the compiler's `markPrecedingCommentDirectiveLine` walk).
- **`src/domain/legalContent.ts`** — zh-Hant / ja / en privacy §3 and §5 now name **Google Analytics as a Zaraz-routed aggregate-analytics recipient**, list it separately from the optional Google-login purpose, scope `promo_click` to outbound **interest** (explicitly not Airbnb booking-conversion tracking), and avoid any fully-anonymous claim. `PRIVACY_UPDATED_AT` → `2026-08-11`.
- **`src/domain/legalContent.test.ts`** — assert every launched privacy locale discloses GA4 routing without over-claiming.
- **`docs/analytics.md`** — document `promo_click`, the GA4-through-Zaraz contract (reuse the existing `page_view`; **do not** enable the GA4 tool's automatic Pageviews action; do not rely on GA4 Enhanced Measurement outbound `click`), the GA4 reporting contract (event-scoped custom dimensions `promoId` / `placement` / `destinationType` / `locale`, no high-cardinality dimensions), and the owner-pending operator steps.

**Validation (all green):** `pnpm lint`, `pnpm typecheck`, `pnpm check:i18n`, `pnpm test -- src/lib/analytics.test.ts`, `pnpm test -- src/domain/legalContent.test.ts`, `pnpm test` (2018 passed), `pnpm build`, `git diff --check`. `rg "gtag\(|googletagmanager|Google Tag Manager|gtag\.js" src package.json` → no hits.

**Independent review:** read-only reviewer → `VERDICT: APPROVE`.

## Production operator steps remaining (owner, in Cloudflare / GA4)

These cannot be completed by editing the repository and are **not** claimed done:

1. Use the intended Jabiko GA4 property/data stream (owner supplies the Measurement ID).
2. In Cloudflare Zaraz, add/configure the native **Google Analytics 4** managed tool for the production domain.
3. Configure the Events action so `zaraz.track(...)` custom events reach GA4.
4. Ensure page-view configuration does **not** double-count the explicit SPA `page_view` flow (leave the GA4 tool's automatic Pageviews action disabled).
5. Create only the required event-scoped custom dimensions (`promoId`, `placement`, `destinationType`, `locale`).
6. Verify the production stream with Zaraz Debugger/Monitoring and GA4 Realtime/DebugView, then confirm the production smoke list in #745 before closing the issue.

No GA credentials / secrets / cookies are committed.

**Note:** #744 (Airbnb promo UI) is not merged; this PR is the standalone analytics / privacy / docs half. The Stay-D CTA wiring (`trackEvent("promo_click", { promoId: "stay-d", destinationType: "airbnb", placement, locale })`) lands with #744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)