### PR TITLE
refactor(stay-d): replace Home promotion card with lightweight editorial footer (#750)

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -466,7 +466,7 @@ describe("HomePanel Stay.D placement (#748 editorial)", () => {
     const placement = document.querySelector('[data-placement="home-bottom"]');
     expect(placement).not.toBeNull();
     expect(placement?.querySelector("img")).toBeNull();
-    expect(placement?.querySelector(".stay-d-promo-image")).toBeNull();
+    expect(placement?.querySelector(".stay-d-home-image")).toBeNull();
   });
 
   it("keeps the direct Airbnb CTA visible on the Home block", () => {
@@ -482,5 +482,28 @@ describe("HomePanel Stay.D placement (#748 editorial)", () => {
     );
     expect(primary).toHaveAttribute("target", "_blank");
     expect(primary).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});
+
+describe("HomePanel Stay.D placement (#750 editorial footer)", () => {
+  it("renders the frozen #750 Home teaser copy, not the /stay-d editorial copy", () => {
+    renderHome({ language: "zh-Hant" });
+
+    expect(
+      screen.getByRole("heading", { name: "在東京，來一趟真正用上學過日文的旅行。" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("JABIKO 推薦 · 東京住宿")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /查看 Stay\.D/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "想和家人朋友一起感受觀光景點之外的東京日常嗎？JABIKO 推薦 Stay.D，作為另一種更貼近生活的東京停留方式。"
+      )
+    ).toBeInTheDocument();
+    // #750: the Home teaser is intentionally shorter than the /stay-d copy.
+    expect(
+      screen.queryByText("下一次來東京，不只是觀光。用學過的日文，和家人朋友一起更深入地享受東京的日常。")
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/StayDPromoCard.test.tsx
+++ b/src/components/StayDPromoCard.test.tsx
@@ -3,22 +3,23 @@ import { describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
   STAY_D_AIRBNB_URL,
+  STAY_D_HOME_TEASER,
   STAY_D_REQUIRED_LOCALES,
   STAY_D_VIDEO_ID
 } from "../domain/stayD";
 import { StayDPromoCard } from "./StayDPromoCard";
 
-describe("StayDPromoCard (#748 editorial)", () => {
+describe("StayDPromoCard (#750 editorial footer)", () => {
   it("makes Airbnb the direct primary action at home-bottom", () => {
     render(<StayDPromoCard language="zh-Hant" />);
 
     const promo = screen.getByRole("region", {
-      name: "下一次來東京，不只是觀光。用學過的日文，和家人朋友一起更深入地享受東京的日常。"
+      name: "在東京，來一趟真正用上學過日文的旅行。"
     });
     expect(promo).toHaveAttribute("data-placement", "home-bottom");
 
     const primary = screen.getByRole("link", {
-      name: "在 Airbnb 查看 Stay.D"
+      name: /查看 Stay\.D/
     });
     expect(primary).toHaveAttribute("href", STAY_D_AIRBNB_URL);
     expect(primary).toHaveAttribute("target", "_blank");
@@ -30,14 +31,14 @@ describe("StayDPromoCard (#748 editorial)", () => {
   it("renders no Stay.D property photo in the Home block", () => {
     const { container } = render(<StayDPromoCard language="zh-Hant" />);
     expect(container.querySelector("img")).toBeNull();
-    expect(container.querySelector(".stay-d-promo-image")).toBeNull();
+    expect(container.querySelector(".stay-d-home-image")).toBeNull();
   });
 
   it("loads the approved YouTube iframe only after interaction and can collapse it", () => {
     render(<StayDPromoCard language="zh-Hant" />);
 
     expect(screen.queryByTitle("Stay.D 介紹影片")).not.toBeInTheDocument();
-    const trigger = screen.getByRole("button", { name: "▶ 看 Stay.D 介紹影片" });
+    const trigger = screen.getByRole("button", { name: "看介紹影片" });
     expect(trigger).toHaveAttribute("aria-expanded", "false");
     expect(trigger).toHaveAttribute("data-stay-d-placement", "home-video");
 
@@ -68,7 +69,7 @@ describe("StayDPromoCard (#748 editorial)", () => {
     render(<StayDPromoCard language="en" />);
 
     const trigger = screen.getByRole("button", {
-      name: "▶ Watch the Stay.D introduction video"
+      name: "Watch introduction video"
     });
     await user.tab();
     await user.tab();
@@ -81,28 +82,42 @@ describe("StayDPromoCard (#748 editorial)", () => {
   it.each([
     [
       "zh-Hant",
-      "下一次來東京，不只是觀光。用學過的日文，和家人朋友一起更深入地享受東京的日常。",
-      "JABIKO 推薦｜東京住宿",
-      "在 Airbnb 查看 Stay.D"
+      "在東京，來一趟真正用上學過日文的旅行。",
+      "JABIKO 推薦 · 東京住宿",
+      "查看 Stay.D"
     ],
     [
       "ja",
-      "次の東京は、観光するだけじゃない。学んだ日本語を使いながら、家族や友人と東京の日常をもっと深く楽しもう。",
-      "JABIKOおすすめ｜東京ステイ",
-      "Stay.DをAirbnbで見る"
+      "東京で、学んだ日本語を使う旅へ。",
+      "JABIKOおすすめ · 東京ステイ",
+      "Stay.Dを見る"
     ],
     [
       "en",
-      "Next time in Tokyo, don’t just sightsee. Use the Japanese you’ve learned and enjoy more of everyday Tokyo with family or friends.",
-      "JABIKO PICK | TOKYO STAY",
-      "View Stay.D on Airbnb"
+      "Put your Japanese to use in Tokyo.",
+      "JABIKO PICK · TOKYO STAY",
+      "View Stay.D"
     ]
-  ] as const)("renders complete %s Home editorial copy", (language, title, kicker, cta) => {
-    render(<StayDPromoCard language={language} />);
-    expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
-    expect(screen.getByText(kicker)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: cta })).toBeInTheDocument();
-  });
+  ] as const)(
+    "renders complete frozen #750 %s Home teaser copy",
+    (language, headline, kicker, cta) => {
+      render(<StayDPromoCard language={language} />);
+      expect(screen.getByRole("heading", { name: headline })).toBeInTheDocument();
+      expect(screen.getByText(kicker)).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: cta })).toBeInTheDocument();
+    }
+  );
+
+  it.each(STAY_D_REQUIRED_LOCALES)(
+    "renders the frozen #750 %s teaser body and video CTA",
+    (language) => {
+      render(<StayDPromoCard language={language} />);
+      expect(screen.getByText(STAY_D_HOME_TEASER[language].body)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: STAY_D_HOME_TEASER[language].video.watch })
+      ).toBeInTheDocument();
+    }
+  );
 
   it.each(STAY_D_REQUIRED_LOCALES)(
     "keeps the stable analytics placement markers in %s",
@@ -116,4 +131,14 @@ describe("StayDPromoCard (#748 editorial)", () => {
       }
     }
   );
+
+  it("marks the Home primary action as a lightweight text link, not a filled conversion button", () => {
+    render(<StayDPromoCard language="zh-Hant" />);
+
+    const primary = screen.getByRole("link", { name: /查看 Stay\.D/ });
+    expect(primary).toHaveClass("stay-d-home-airbnb");
+    // #750: the Home CTA must no longer carry the heavy filled /stay-d button
+    // treatment (which stays for the /stay-d page).
+    expect(primary).not.toHaveClass("stay-d-airbnb-primary");
+  });
 });

--- a/src/components/StayDPromoCard.tsx
+++ b/src/components/StayDPromoCard.tsx
@@ -2,35 +2,38 @@ import { ExternalLink } from "lucide-react";
 import type { Language } from "../i18n";
 import {
   STAY_D_AIRBNB_URL,
-  STAY_D_EDITORIAL_COPY,
+  STAY_D_HOME_TEASER,
   isStayDLocale
 } from "../domain/stayD";
 import { StayDVideo } from "./StayDVideo";
 
+/** Home footer Stay.D recommendation (#750): a quiet editorial section, not a
+ *  campaign banner. Jabiko explains why the stay fits the learner context;
+ *  the direct Airbnb path stays one tap away as a lightweight text link. */
 export function StayDPromoCard({ language }: { language: Language }) {
   if (!isStayDLocale(language)) return null;
-  const text = STAY_D_EDITORIAL_COPY[language];
+  const text = STAY_D_HOME_TEASER[language];
 
   return (
     <section
-      className="stay-d-promo"
-      aria-label={text.title}
+      className="stay-d-home"
+      aria-label={text.headline}
       data-placement="home-bottom"
     >
-      <div className="stay-d-promo-copy">
-        <span className="stay-d-disclosure">{text.kicker}</span>
-        <h2>{text.title}</h2>
-        <p>{text.body}</p>
+      <div className="stay-d-home-copy">
+        <span className="stay-d-home-kicker">{text.kicker}</span>
+        <h2 className="stay-d-home-headline">{text.headline}</h2>
+        <p className="stay-d-home-body">{text.body}</p>
       </div>
-      <div className="stay-d-promo-actions">
+      <div className="stay-d-home-actions">
         <a
-          className="stay-d-airbnb-primary"
+          className="stay-d-home-airbnb"
           href={STAY_D_AIRBNB_URL}
           target="_blank"
           rel="noopener noreferrer"
           data-stay-d-placement="home-airbnb"
         >
-          {text.airbnbCta}
+          {text.primaryCta}
           <ExternalLink aria-hidden="true" />
         </a>
         <StayDVideo

--- a/src/domain/StayDLayout.test.mjs
+++ b/src/domain/StayDLayout.test.mjs
@@ -69,6 +69,13 @@ describe("stay-d editorial layout (#750)", () => {
     expect(trigger).toMatch(/color:\s*var\(--teal-dark\)/);
     expect(trigger).toMatch(/font-weight:\s*7\d0/);
     expect(trigger).toMatch(/text-align:\s*left/);
+    // CodeRabbit P2: the Home video action must drop the global <button>
+    // frame (border/radius) so it reads as a borderless text action,
+    // consistent with the adjacent Airbnb text link.
+    expect(trigger).toMatch(/border:\s*none/);
+    // Radius must be reset to 0, not carry an actual pill radius.
+    expect(trigger).toMatch(/border-radius:\s*0/);
+    expect(trigger).not.toMatch(/border-radius:\s*(?!0\b)\S/);
   });
 
   it("keeps the Home promo single-column and full-width actions at 320-390px", () => {
@@ -76,7 +83,10 @@ describe("stay-d editorial layout (#750)", () => {
     expect(home).toMatch(/flex-direction:\s*column/);
 
     const narrow = narrowBlock();
-    expect(narrow).toMatch(/\.stay-d-home\b[^}]*padding:\s*0/s);
+    // Only horizontal padding is cleared at narrow widths; the divider's
+    // top padding must stay so the kicker keeps its separation gap.
+    expect(narrow).toMatch(/\.stay-d-home\b[^}]*padding-inline:\s*0/s);
+    expect(narrow).not.toMatch(/\.stay-d-home\b[^}]*padding:\s*0[^;]*;/s);
     expect(narrow).toMatch(/\.stay-d-home-actions\b[^}]*flex-direction:\s*column/s);
     // The Home primary + video actions go full width in the narrow media block.
     expect(narrow).toMatch(/\.stay-d-home-airbnb,[\s\S]*?width:\s*100%/);

--- a/src/domain/StayDLayout.test.mjs
+++ b/src/domain/StayDLayout.test.mjs
@@ -4,45 +4,94 @@ import { describe, expect, it } from "vitest";
 
 const css = readFileSync(resolve(process.cwd(), "src/styles/stay-d.css"), "utf8");
 
-describe("stay-d editorial layout (#748)", () => {
-  it("keeps the Home promo single-column with a full-width primary CTA at 320-390px", () => {
-    // #748 removes the photo-led two-column card. The editorial block is a
-    // stacked column whose actions wrap, so a 320/390 px viewport has no
-    // horizontal overflow.
-    const promoStart = css.indexOf(".stay-d-promo {");
-    expect(promoStart).toBeGreaterThanOrEqual(0);
-    const promo = css.slice(promoStart, css.indexOf("}", promoStart));
-    expect(promo).toMatch(/flex-direction:\s*column/);
+// Find a rule whose selector starts exactly at the beginning of a line, so a
+// composite selector like ".stay-d-home .stay-d-video-trigger" never shadows
+// the standalone ".stay-d-video-trigger" rule.
+function rule(name) {
+  const start = css.indexOf(`\n${name} {`);
+  expect(start, name).toBeGreaterThanOrEqual(0);
+  return css.slice(start + 1, css.indexOf("}", start));
+}
 
-    const narrow = css.indexOf("@media (max-width: 440px) {");
-    expect(narrow).toBeGreaterThanOrEqual(0);
-    const narrowBlock = css.slice(narrow, css.indexOf("}", css.indexOf("}", narrow) + 1) + 1);
-    expect(narrowBlock).toMatch(/\.stay-d-airbnb-primary\b[^}]*width:\s*100%/s);
+function narrowBlock() {
+  const start = css.indexOf("@media (max-width: 440px) {");
+  expect(start).toBeGreaterThanOrEqual(0);
+  // Match the balanced @media { ... } block by counting braces.
+  let depth = 0;
+  for (let i = start; i < css.length; i += 1) {
+    if (css[i] === "{") depth += 1;
+    if (css[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  throw new Error("unterminated @media block");
+}
+
+describe("stay-d editorial layout (#750)", () => {
+  it("turns the Home recommendation into a quiet editorial footer section", () => {
+    const home = rule(".stay-d-home");
+    // Page-adjacent background instead of a tinted ad panel.
+    expect(home).toMatch(/background:\s*(transparent|var\(--app-bg\))/);
+    // No large card border / shadow / radius on the Home block.
+    expect(home).not.toMatch(/border:\s*1px solid/);
+    expect(home).not.toMatch(/box-shadow/);
+    expect(home).not.toMatch(/border-radius/);
+    // Quiet separation: a single top rule (like the home footer).
+    expect(home).toMatch(/border-top:\s*1px solid/);
+    expect(home).toMatch(/padding-top:\s*1\.3rem/);
+    // The copy column stays readable instead of spanning the full width.
+    const copy = rule(".stay-d-home-copy");
+    expect(copy).toMatch(/max-width:\s*(40|42|44)rem/);
+  });
+
+  it("shrinks the Home headline to editorial size", () => {
+    const headline = rule(".stay-d-home-headline");
+    expect(headline).toMatch(/font-size:\s*clamp\(1\.25rem/);
+  });
+
+  it("keeps the Home actions lightweight (no heavy filled conversion buttons)", () => {
+    const actions = rule(".stay-d-home-actions");
+    expect(actions).toMatch(/flex-wrap:\s*wrap/);
+
+    const primary = rule(".stay-d-home-airbnb");
+    // Text/outline link, not a filled vermilion block.
+    expect(primary).not.toMatch(/background:\s*var\(--vermilion\)/);
+    expect(primary).not.toMatch(/background:\s*var\(--gold\)/);
+    expect(primary).toMatch(/font-size:\s*0\.9rem/);
+
+    const trigger = rule(".stay-d-home .stay-d-video-trigger");
+    expect(trigger).toMatch(/color:\s*var\(--teal-dark\)/);
+    expect(trigger).toMatch(/font-weight:\s*7\d0/);
+    expect(trigger).toMatch(/text-align:\s*left/);
+  });
+
+  it("keeps the Home promo single-column and full-width actions at 320-390px", () => {
+    const home = rule(".stay-d-home");
+    expect(home).toMatch(/flex-direction:\s*column/);
+
+    const narrow = narrowBlock();
+    expect(narrow).toMatch(/\.stay-d-home\b[^}]*padding:\s*0/s);
+    expect(narrow).toMatch(/\.stay-d-home-actions\b[^}]*flex-direction:\s*column/s);
+    // The Home primary + video actions go full width in the narrow media block.
+    expect(narrow).toMatch(/\.stay-d-home-airbnb,[\s\S]*?width:\s*100%/);
   });
 
   it("keeps the video trigger and player contained within the viewport", () => {
-    const triggerStart = css.indexOf(".stay-d-video-trigger {");
-    expect(triggerStart).toBeGreaterThanOrEqual(0);
-    const trigger = css.slice(triggerStart, css.indexOf("}", triggerStart));
+    const trigger = rule(".stay-d-video-trigger");
     expect(trigger).toMatch(/max-width:\s*100%/);
 
-    const frameStart = css.indexOf(".stay-d-video-frame {");
-    expect(frameStart).toBeGreaterThanOrEqual(0);
-    const frame = css.slice(frameStart, css.indexOf("}", frameStart));
+    const frame = rule(".stay-d-video-frame");
     expect(frame).toMatch(/width:\s*100%/);
     expect(frame).toMatch(/aspect-ratio:\s*16 \/ 9/);
   });
 
   it("keeps the /stay-d hero copy and final CTA full-width-safe at narrow widths", () => {
-    const heroStart = css.indexOf(".stay-d-hero {");
-    expect(heroStart).toBeGreaterThanOrEqual(0);
-    const hero = css.slice(heroStart, css.indexOf("}", heroStart));
+    const hero = rule(".stay-d-hero");
     expect(hero).toMatch(/flex-direction:\s*column/);
     expect(hero).toMatch(/min-width:\s*0/);
 
-    const finalStart = css.indexOf(".stay-d-final {");
-    expect(finalStart).toBeGreaterThanOrEqual(0);
-    const final = css.slice(finalStart, css.indexOf("}", finalStart));
+    const final = rule(".stay-d-final");
     expect(final).toMatch(/flex-wrap:\s*wrap|flex-direction:\s*column/);
   });
 });

--- a/src/domain/StayDLayout.test.mjs
+++ b/src/domain/StayDLayout.test.mjs
@@ -47,7 +47,12 @@ describe("stay-d editorial layout (#750)", () => {
 
   it("shrinks the Home headline to editorial size", () => {
     const headline = rule(".stay-d-home-headline");
-    expect(headline).toMatch(/font-size:\s*clamp\(1\.25rem/);
+    // Must be smaller than the #749 promo headline clamp
+    // (1.15rem / 2.2vw / 1.45rem) so the footer reads lightweight (#750).
+    expect(headline).toMatch(/font-size:\s*clamp\(1\.1rem,\s*2\.1vw,\s*1\.35rem\)/);
+    // Sanity: still a headline, not body-size text.
+    const lower = headline.match(/clamp\(([0-9.]+)rem/);
+    expect(Number(lower?.[1])).toBeGreaterThanOrEqual(1);
   });
 
   it("keeps the Home actions lightweight (no heavy filled conversion buttons)", () => {

--- a/src/domain/StayDLayout.test.mjs
+++ b/src/domain/StayDLayout.test.mjs
@@ -58,12 +58,25 @@ describe("stay-d editorial layout (#750)", () => {
   it("keeps the Home actions lightweight (no heavy filled conversion buttons)", () => {
     const actions = rule(".stay-d-home-actions");
     expect(actions).toMatch(/flex-wrap:\s*wrap/);
+    // CodeRabbit P2: with the video expanded the actions row is tall, so the
+    // Airbnb link must stay pinned to the top (flex-start), not jump to the
+    // vertical center of the whole video block.
+    expect(actions).toMatch(/align-items:\s*flex-start/);
 
     const primary = rule(".stay-d-home-airbnb");
     // Text/outline link, not a filled vermilion block.
     expect(primary).not.toMatch(/background:\s*var\(--vermilion\)/);
     expect(primary).not.toMatch(/background:\s*var\(--gold\)/);
     expect(primary).toMatch(/font-size:\s*0\.9rem/);
+
+    // CodeRabbit P2: when the video is expanded the wrapper must keep the
+    // shared grow (flex: 1 1 24rem / min-width: min(100%, 20rem)) so the
+    // player gets the full remaining row width. No Home override should
+    // shrink the shared .stay-d-video wrapper.
+    expect(css.indexOf("\n.stay-d-home .stay-d-video {")).toBe(-1);
+    const baseVideo = rule(".stay-d-video");
+    expect(baseVideo).toMatch(/flex:\s*1 1 24rem/);
+    expect(baseVideo).toMatch(/min-width:\s*min\(100%,\s*20rem\)/);
 
     const trigger = rule(".stay-d-home .stay-d-video-trigger");
     expect(trigger).toMatch(/color:\s*var\(--teal-dark\)/);

--- a/src/domain/StayDLayout.test.mjs
+++ b/src/domain/StayDLayout.test.mjs
@@ -76,6 +76,14 @@ describe("stay-d editorial layout (#750)", () => {
     // Radius must be reset to 0, not carry an actual pill radius.
     expect(trigger).toMatch(/border-radius:\s*0/);
     expect(trigger).not.toMatch(/border-radius:\s*(?!0\b)\S/);
+
+    // CodeRabbit P2: on hover the global button:hover:not(:disabled) shadow
+    // + lift would reappear -- the Home hover rule must reset both.
+    const hoverStart = css.indexOf("\n.stay-d-home .stay-d-video-trigger:hover");
+    expect(hoverStart).toBeGreaterThanOrEqual(0);
+    const hoverBlock = css.slice(hoverStart, css.indexOf("}", hoverStart));
+    expect(hoverBlock).toMatch(/box-shadow:\s*none/);
+    expect(hoverBlock).toMatch(/transform:\s*none/);
   });
 
   it("keeps the Home promo single-column and full-width actions at 320-390px", () => {

--- a/src/domain/stayD.test.ts
+++ b/src/domain/stayD.test.ts
@@ -4,6 +4,7 @@ import {
   STAY_D_AIRBNB_ROOM_ID,
   STAY_D_AIRBNB_URL,
   STAY_D_EDITORIAL_COPY,
+  STAY_D_HOME_TEASER,
   STAY_D_REQUIRED_LOCALES,
   STAY_D_VIDEO_ID,
   STAY_D_VIDEO_START_SECONDS,
@@ -100,5 +101,98 @@ describe("Stay.D editorial domain contract (#748)", () => {
     expect(serialized).not.toMatch(
       /notion\.(?:so|site)|amazonaws\.com|airbnbstatic\.com|airbnbusercontent\.com|muscache\.com|X-Amz-|source_impression_id/i
     );
+  });
+});
+
+describe("Stay.D Home teaser domain contract (#750)", () => {
+  it("has the frozen #750 Home teaser copy for every launched locale", () => {
+    expect(STAY_D_HOME_TEASER).toBeDefined();
+    expect(Object.keys(STAY_D_HOME_TEASER).sort()).toEqual(
+      [...STAY_D_REQUIRED_LOCALES].sort()
+    );
+    for (const locale of STAY_D_REQUIRED_LOCALES) {
+      const strings = allStrings(STAY_D_HOME_TEASER[locale]);
+      expect(strings.length, locale).toBeGreaterThan(0);
+      expect(strings.every((value) => value.trim().length > 0), locale).toBe(true);
+    }
+  });
+
+  it("keeps the frozen #750 Home teaser kicker/headline/body in all three locales", () => {
+    expect(STAY_D_HOME_TEASER["zh-Hant"].kicker).toBe("JABIKO 推薦 · 東京住宿");
+    expect(STAY_D_HOME_TEASER["zh-Hant"].headline).toBe(
+      "在東京，來一趟真正用上學過日文的旅行。"
+    );
+    expect(STAY_D_HOME_TEASER["zh-Hant"].body).toBe(
+      "想和家人朋友一起感受觀光景點之外的東京日常嗎？JABIKO 推薦 Stay.D，作為另一種更貼近生活的東京停留方式。"
+    );
+
+    expect(STAY_D_HOME_TEASER.ja.kicker).toBe("JABIKOおすすめ · 東京ステイ");
+    expect(STAY_D_HOME_TEASER.ja.headline).toBe(
+      "東京で、学んだ日本語を使う旅へ。"
+    );
+    expect(STAY_D_HOME_TEASER.ja.body).toBe(
+      "家族や友人と、観光だけでは見えない東京の日常を楽しみたい人へ。JABIKOから Stay.D を紹介します。"
+    );
+
+    expect(STAY_D_HOME_TEASER.en.kicker).toBe("JABIKO PICK · TOKYO STAY");
+    expect(STAY_D_HOME_TEASER.en.headline).toBe(
+      "Put your Japanese to use in Tokyo."
+    );
+    expect(STAY_D_HOME_TEASER.en.body).toBe(
+      "For travelers who want to enjoy everyday Tokyo beyond sightseeing with family or friends, Jabiko recommends Stay.D as one way to stay closer to local life."
+    );
+  });
+
+  it("keeps the frozen #750 Home CTAs distinct from the /stay-d primary CTA", () => {
+    // Home primary CTA is the direct Airbnb path, intentionally shortened.
+    expect(STAY_D_HOME_TEASER["zh-Hant"].primaryCta).toBe("查看 Stay.D");
+    expect(STAY_D_HOME_TEASER.ja.primaryCta).toBe("Stay.Dを見る");
+    expect(STAY_D_HOME_TEASER.en.primaryCta).toBe("View Stay.D");
+
+    // Secondary video action stays lightweight on Home (#750).
+    expect(STAY_D_HOME_TEASER["zh-Hant"].video.watch).toBe("看介紹影片");
+    expect(STAY_D_HOME_TEASER.ja.video.watch).toBe("紹介動画を見る");
+    expect(STAY_D_HOME_TEASER.en.video.watch).toBe("Watch introduction video");
+
+    // #750: Home copy is split from /stay-d copy -- shortening the Home teaser
+    // must never rewrite the /stay-d editorial copy.
+    expect(STAY_D_HOME_TEASER["zh-Hant"].primaryCta).not.toBe(
+      STAY_D_EDITORIAL_COPY["zh-Hant"].airbnbCta
+    );
+    expect(STAY_D_HOME_TEASER["zh-Hant"].headline).not.toBe(
+      STAY_D_EDITORIAL_COPY["zh-Hant"].title
+    );
+    expect(STAY_D_EDITORIAL_COPY["zh-Hant"].title).toBe(
+      "下一次來東京，不只是觀光。用學過的日文，和家人朋友一起更深入地享受東京的日常。"
+    );
+  });
+
+  it("never enumerates listing-style property specs in the Home teaser", () => {
+    const serialized = JSON.stringify(STAY_D_HOME_TEASER);
+    for (const forbidden of [
+      "2025",
+      "52m",
+      "52 m",
+      "3階",
+      "三層",
+      "three-floor",
+      "10 Gbps",
+      "10Gbps",
+      "ダブルベッド",
+      "雙人床",
+      "double beds",
+      "キッチン",
+      "廚房",
+      "kitchen",
+      "徒歩",
+      "步行",
+      "5-minute walk",
+      "料金",
+      "空室",
+      "price & availability",
+      "最新價格"
+    ]) {
+      expect(serialized, forbidden).not.toContain(forbidden);
+    }
   });
 });

--- a/src/domain/stayD.ts
+++ b/src/domain/stayD.ts
@@ -16,6 +16,18 @@ export interface StayDVideoCopy {
   airbnbCta: string;
 }
 
+/** Frozen #750 Home teaser (#750): short editorial recommendation shown on
+ *  the Home footer, split from the /stay-d page copy so the two stay
+ *  independent. `video` reuses StayDVideoCopy -- the Home secondary CTA is
+ *  `watch`, and the video panel strings can come from the shared /stay-d copy. */
+export interface StayDHomeTeaser {
+  kicker: string;
+  headline: string;
+  body: string;
+  primaryCta: string;
+  video: StayDVideoCopy;
+}
+
 /** Editorial extension copy for the /stay-d page (not listing content). */
 export interface StayDPageExtras {
   videoTitle: string;
@@ -94,6 +106,51 @@ export const STAY_D_EDITORIAL_COPY = {
     }
   }
 } satisfies Record<StayDLocale, StayDEditorialCopy>;
+
+/** Frozen #750 Home teaser (#750): a short Jabiko editorial recommendation
+ *  shown on the Home footer. Intentionally split from STAY_D_EDITORIAL_COPY
+ *  so shortening the Home teaser never rewrites the /stay-d page copy.
+ *  Video panel strings (iframe title / collapse / assisted Airbnb CTA) are
+ *  shared with the /stay-d video panel -- only `watch` (the Home secondary
+ *  CTA) carries the frozen #750 short label. */
+export const STAY_D_HOME_TEASER: Record<StayDLocale, StayDHomeTeaser> = {
+  "zh-Hant": {
+    kicker: "JABIKO 推薦 · 東京住宿",
+    headline: "在東京，來一趟真正用上學過日文的旅行。",
+    body: "想和家人朋友一起感受觀光景點之外的東京日常嗎？JABIKO 推薦 Stay.D，作為另一種更貼近生活的東京停留方式。",
+    primaryCta: "查看 Stay.D",
+    video: {
+      watch: "看介紹影片",
+      collapse: STAY_D_EDITORIAL_COPY["zh-Hant"].video.collapse,
+      iframeTitle: STAY_D_EDITORIAL_COPY["zh-Hant"].video.iframeTitle,
+      airbnbCta: STAY_D_EDITORIAL_COPY["zh-Hant"].video.airbnbCta
+    }
+  },
+  ja: {
+    kicker: "JABIKOおすすめ · 東京ステイ",
+    headline: "東京で、学んだ日本語を使う旅へ。",
+    body: "家族や友人と、観光だけでは見えない東京の日常を楽しみたい人へ。JABIKOから Stay.D を紹介します。",
+    primaryCta: "Stay.Dを見る",
+    video: {
+      watch: "紹介動画を見る",
+      collapse: STAY_D_EDITORIAL_COPY.ja.video.collapse,
+      iframeTitle: STAY_D_EDITORIAL_COPY.ja.video.iframeTitle,
+      airbnbCta: STAY_D_EDITORIAL_COPY.ja.video.airbnbCta
+    }
+  },
+  en: {
+    kicker: "JABIKO PICK · TOKYO STAY",
+    headline: "Put your Japanese to use in Tokyo.",
+    body: "For travelers who want to enjoy everyday Tokyo beyond sightseeing with family or friends, Jabiko recommends Stay.D as one way to stay closer to local life.",
+    primaryCta: "View Stay.D",
+    video: {
+      watch: "Watch introduction video",
+      collapse: STAY_D_EDITORIAL_COPY.en.video.collapse,
+      iframeTitle: STAY_D_EDITORIAL_COPY.en.video.iframeTitle,
+      airbnbCta: STAY_D_EDITORIAL_COPY.en.video.airbnbCta
+    }
+  }
+};
 
 export function isStayDLocale(language: Language): language is StayDLocale {
   return (STAY_D_REQUIRED_LOCALES as readonly string[]).includes(language);

--- a/src/styles/stay-d.css
+++ b/src/styles/stay-d.css
@@ -1,59 +1,105 @@
-/* Stay.D editorial recommendation (#748). Jabiko explains why the stay fits
-   the learner / Tokyo-life context; Airbnb explains what the property contains.
-   No property photos or listing-style specs are rendered here. */
-.stay-d-promo {
+/* Stay.D editorial recommendation (#748) + Home teaser footer (#750).
+   Jabiko explains why the stay fits the learner / Tokyo-life context;
+   Airbnb explains what the property contains. No property photos or
+   listing-style specs are rendered here. */
+.stay-d-home {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
-  padding: 1.2rem;
-  border: 1px solid color-mix(in srgb, var(--gold) 45%, var(--panel-border));
-  border-radius: var(--radius-xl);
-  background: color-mix(in srgb, var(--gold) 7%, var(--paper));
-  box-shadow: var(--shadow);
+  gap: 0.55rem;
+  margin-top: 1.5rem;
+  padding-top: 1.3rem;
+  border-top: 1px solid var(--rule);
+  background: transparent;
 }
 
-.stay-d-promo-copy {
+.stay-d-home-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
   min-width: 0;
+  /* Editorial copy column: keeps the teaser readable instead of spanning
+     the full desktop width (#750). */
+  max-width: 44rem;
 }
 
-.stay-d-disclosure {
-  display: inline-block;
-  margin-bottom: 0.35rem;
-  color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 700;
+.stay-d-home-kicker {
+  color: var(--vermilion);
+  font-size: 0.8rem;
+  font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.stay-d-promo h2,
-.stay-d-promo p,
-.stay-d-page h1,
-.stay-d-page h2,
-.stay-d-page h3,
-.stay-d-page p {
+.stay-d-home-headline {
   margin: 0;
-}
-
-.stay-d-promo h2 {
   color: var(--ink);
-  font-size: clamp(1.15rem, 2.2vw, 1.45rem);
-  line-height: 1.35;
+  font-family: var(--font-title);
+  font-size: clamp(1.25rem, 2.4vw, 1.6rem);
+  line-height: 1.4;
 }
 
-.stay-d-promo p {
-  margin-top: 0.45rem;
+.stay-d-home-body {
+  margin: 0;
   color: var(--muted);
-  line-height: 1.65;
+  line-height: 1.7;
 }
 
-.stay-d-promo-actions {
+.stay-d-home-actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
-  gap: 0.7rem;
+  align-items: center;
+  gap: 1rem;
 }
 
+.stay-d-home-airbnb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 2.75rem;
+  padding: 0.4rem 0.1rem;
+  color: var(--teal-dark);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.stay-d-home-airbnb svg {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+}
+
+.stay-d-home-airbnb:hover,
+.stay-d-home-airbnb:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.stay-d-home .stay-d-video {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+/* Home video trigger: lightweight text action, no filled pill. */
+.stay-d-home .stay-d-video-trigger {
+  min-height: 2.75rem;
+  padding: 0.4rem 0.1rem;
+  background: transparent;
+  color: var(--teal-dark);
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-align: left;
+}
+
+.stay-d-home .stay-d-video-trigger:hover,
+.stay-d-home .stay-d-video-trigger:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Shared /stay-d action treatments. The filled vermilion primary CTA and the
+   video panel's assisted Airbnb link belong to the /stay-d page (#750 keeps
+   them there); the Home teaser uses the lightweight .stay-d-home-* above. */
 .stay-d-airbnb-primary,
 .stay-d-video-airbnb,
 .stay-d-back {
@@ -148,6 +194,13 @@
   margin: 0 auto;
 }
 
+.stay-d-page h1,
+.stay-d-page h2,
+.stay-d-page h3,
+.stay-d-page p {
+  margin: 0;
+}
+
 .stay-d-back {
   align-self: flex-start;
   min-height: 2.5rem;
@@ -238,11 +291,21 @@
 }
 
 @media (max-width: 440px) {
-  .stay-d-promo {
-    padding: 1rem;
+  .stay-d-home {
+    padding: 0;
   }
 
-  .stay-d-promo-actions,
+  .stay-d-home-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .stay-d-home-airbnb,
+  .stay-d-home .stay-d-video,
+  .stay-d-home .stay-d-video-trigger {
+    width: 100%;
+  }
+
   .stay-d-airbnb-primary,
   .stay-d-video,
   .stay-d-video-trigger,

--- a/src/styles/stay-d.css
+++ b/src/styles/stay-d.css
@@ -49,7 +49,10 @@
 .stay-d-home-actions {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  /* flex-start: with the video expanded the row is tall, so the Airbnb text
+     link stays pinned to the top instead of jumping to the vertical center
+     of the whole video block (CodeRabbit P2). */
+  align-items: flex-start;
   gap: 1rem;
 }
 
@@ -77,14 +80,6 @@
   text-underline-offset: 3px;
 }
 
-.stay-d-home .stay-d-video {
-  min-width: 0;
-  flex: 0 1 auto;
-}
-
-/* Home video trigger: lightweight text action, no filled pill. Strips the
-   global <button> frame (border/radius) so it reads as a borderless text
-   action consistent with the adjacent Airbnb text link (CodeRabbit P2). */
 .stay-d-home .stay-d-video-trigger {
   min-height: 2.75rem;
   padding: 0.4rem 0.1rem;

--- a/src/styles/stay-d.css
+++ b/src/styles/stay-d.css
@@ -82,11 +82,16 @@
   flex: 0 1 auto;
 }
 
-/* Home video trigger: lightweight text action, no filled pill. */
+/* Home video trigger: lightweight text action, no filled pill. Strips the
+   global <button> frame (border/radius) so it reads as a borderless text
+   action consistent with the adjacent Airbnb text link (CodeRabbit P2). */
 .stay-d-home .stay-d-video-trigger {
   min-height: 2.75rem;
   padding: 0.4rem 0.1rem;
   background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
   color: var(--teal-dark);
   font-weight: 700;
   font-size: 0.9rem;
@@ -293,8 +298,10 @@
 }
 
 @media (max-width: 440px) {
+  /* Keep the divider's top padding so the kicker keeps its separation gap;
+     only horizontal padding is cleared (CodeRabbit P2). */
   .stay-d-home {
-    padding: 0;
+    padding-inline: 0;
   }
 
   .stay-d-home-actions {

--- a/src/styles/stay-d.css
+++ b/src/styles/stay-d.css
@@ -34,7 +34,9 @@
   margin: 0;
   color: var(--ink);
   font-family: var(--font-title);
-  font-size: clamp(1.25rem, 2.4vw, 1.6rem);
+  /* Editorial size, smaller than the #749 promo headline clamp
+     (1.15rem/2.2vw/1.45rem) so the footer reads as lightweight (#750). */
+  font-size: clamp(1.1rem, 2.1vw, 1.35rem);
   line-height: 1.4;
 }
 

--- a/src/styles/stay-d.css
+++ b/src/styles/stay-d.css
@@ -100,6 +100,10 @@
 
 .stay-d-home .stay-d-video-trigger:hover,
 .stay-d-home .stay-d-video-trigger:focus-visible {
+  /* Reset the global button:hover:not(:disabled) shadow + lift so the text
+     action stays static on hover (CodeRabbit P2). */
+  box-shadow: none;
+  transform: none;
   text-decoration: underline;
   text-underline-offset: 3px;
 }


### PR DESCRIPTION
Closes #750

## 摘要

把 Home 底部 Stay.D 從「大型 promotion card / conversion banner」改成自然融入 Jabiko 的 **lightweight editorial recommendation/footer**。使用者第一眼讀到的是「Jabiko 在推薦一個實際用日文的東京體驗」，而不是「一則 Airbnb 廣告出現」。

只處理 Home `home-bottom`。`/stay-d` 不在 redesign 範圍，其 copy、route、lazy loading、SEO/prerender、Airbnb behavior、video behavior 全部原封不動。

## Home 如何從 promotion card 變成 editorial footer

| 視覺要素 | 之前（#749） | 現在（#750） |
|---|---|---|
| 卡片框 | gold 色全卡 border + radius-xl | 移除，無 border/radius |
| 陰影 | `box-shadow: var(--shadow)` | 移除（none） |
| 背景 | gold 7% tinted panel | transparent（頁面本身） |
| 分隔 | 無 | 單一 top rule divider（`--rule`），與 `.home-footer` 一致 |
| Copy column | 全寬 | `max-width: 44rem`（desktop 不再橫跨全寬） |
| Headline | `clamp(1.15rem, 2.2vw, 1.45rem)` | `clamp(1.1rem, 2.1vw, 1.35rem)`（約 17.6–21.6px，**明顯小於** #749 baseline，editorial 尺寸） |
| Primary CTA | filled vermilion `.stay-d-airbnb-primary` | lightweight teal **text link**（`.stay-d-home-airbnb`，hover underline + external 圖示） |
| Video trigger | `.stay-d-video-trigger` filled pill | scoped override 成無框 text action（border/radius/shadow 重設，hover 不浮起）；展開後播放器維持共用 grow（`flex: 1 1 24rem`）、Airbnb link 頂對齊（`flex-start`） |

## Copy 分離（frozen #750 Home teaser）

新增 `STAY_D_HOME_TEASER`（`src/domain/stayD.ts`），與 `STAY_D_EDITORIAL_COPY`（/stay-d，frozen #748）**完全分離**。縮短 Home teaser 不會改到 `/stay-d` 現有 editorial copy。三語 frozen teaser 逐字鎖定：

- **ja**：`JABIKOおすすめ · 東京ステイ` / `東京で、学んだ日本語を使う旅へ。` / CTA `Stay.Dを見る` + `紹介動画を見る`
- **zh-Hant**：`JABIKO 推薦 · 東京住宿` / `在東京，來一趟真正用上學過日文的旅行。` / `查看 Stay.D` + `看介紹影片`
- **en**：`JABIKO PICK · TOKYO STAY` / `Put your Japanese to use in Tokyo.` / `View Stay.D` + `Watch introduction video`

`/stay-d` 的 `STAY_D_EDITORIAL_COPY`、filled vermilion CTA、prerender `stayDBody()`、lazy chunk 全部零改動。

## 保留的 contracts

- **Airbnb**：`https://www.airbnb.com/rooms/1518015758376242668`、`target="_blank" rel="noopener noreferrer"`、Home 直接外連
- **Video**：click-to-load YouTube（`youtube-nocookie.com/embed/wXx_t8JTyDE?start=70`）、no autoplay、可收合；`StayDVideo.tsx` 未改動
- **Analytics**：`home-airbnb`、`home-video`、`home-video-airbnb` markers 保留；`src/lib/analytics.ts` 零改動
- **/stay-d**：lazy-loaded route、SEO/prerender、Airbnb、video、copy 皆不變
- 無 property image/spec、無新 dependency、無 unrelated Home redesign

## 測試覆蓋

- frozen #750 Home teaser 三語（`StayDPromoCard.test` + `stayD.test` domain contract）
- Home 無 property image/spec regression
- Airbnb URL/security
- video click-to-load / no autoplay / keyboard
- stable analytics markers
- 320/390px 無 horizontal overflow（CSS layout guard）
- `/stay-d` copy/behavior 不被 shared refactor 誤改（`StayDPage.test` + prerender test + CSS guard 保留 /stay-d filled CTA）

## Visual QA

透過 dev server 實測（Chrome browser）：

- **Desktop（940px panel）**：`.stay-d-home` background transparent、box-shadow none、只有 `1px` top rule divider；headline 17.6px（en，clamp 下限）、copy column 704px（44rem cap）；primary 是 teal text link（14.4px、transparent bg），非 filled vermilion
- **390px**：`scrollWidth === clientWidth === 390`，無 horizontal overflow；video trigger 點開後 iframe 364px < panel 366px；`autoplay` 不存在
- **320px**：`scrollWidth === clientWidth === 320`，無 horizontal overflow；primary/trigger 全寬
- **Hover**：video trigger hover 時 box-shadow none、transform none（無按鈕浮起），與 Airbnb text link 一致
- **展開影片（桌面）**：播放器填滿剩餘行寬（iframe 645px，共用 `flex: 1 1 24rem`），「查看 Stay.D」link 維持頂對齊（`flex-start`），不跳到影片區塊垂直中央
- **三語 copy**：zh-Hant / ja / en 逐字符合 frozen #750（browser 實測）
- **/stay-d**：hero h1 維持 frozen #748 copy、hero CTA 仍是 filled vermilion `.stay-d-airbnb-primary`、三 analytics placements 都在

## Validation

- `pnpm lint` PASS（`--max-warnings=0`）
- `pnpm typecheck` PASS
- `pnpm check:i18n` PASS（exit 0，僅既有 N5 exam overlay warnings）
- `pnpm test` **2060/2060 PASS**（排除 pre-existing flaky `scripts/gemini-correctness/red-stage-integration.test.ts`：該檔單獨跑 23/23 過、baseline main 亦失敗，與本 PR 零關聯，PR #749 已驗證）
- `pnpm build` PASS（107 static pages；`StayDPage` 維持獨立 lazy chunk）
- `git diff --check` PASS

Independent reviewer gate：`VERDICT: PASS`（無 blocking findings，diff-oriented read-only review）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

