### PR TITLE
fix(react): resolve remaining Hooks v7 runtime blockers (#742)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1599,6 +1599,27 @@ describe("App", () => {
     expect(desktopEntry).toHaveFocus();
   });
 
+  it("sign-out clears deletion UI so the same account cannot revive stale state", async () => {
+    deletionTest.active = true;
+    deletionTest.user = signedInUser;
+    const user = userEvent.setup();
+    const { rerender } = render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "刪除練習紀錄" }));
+    expect(screen.getByRole("dialog", { name: "刪除練習紀錄" })).toBeInTheDocument();
+
+    deletionTest.user = null;
+    rerender(<App />);
+    expect(screen.queryByRole("dialog", { name: "刪除練習紀錄" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    deletionTest.user = signedInUser;
+    rerender(<App />);
+    expect(screen.getByRole("button", { name: "刪除練習紀錄" })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "刪除練習紀錄" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
   it("signed in: the mobile 更多 entry opens the SAME dialog instance (#693)", async () => {
     deletionTest.active = true;
     deletionTest.user = signedInUser;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,14 @@ export default function App() {
   );
   // The article slug for the active /blog/<slug> route (#483); null = index.
   const [blogSlug, setBlogSlug] = useState<string | null>(() => initialRoute.blogSlug);
+  // The drill the challenge view starts with on its next mount. This state
+  // must exist before the popstate subscription below because back/forward
+  // restores a challenge deep link through its setter.
+  const [launch, setLaunch] = useState<SessionInit | undefined>(() =>
+    initialRoute.view === "challenge"
+      ? challengeInitFromQuery(window.location.search)
+      : undefined
+  );
 
   // Open a grammar point's study page (#282): from the post-answer feedback's
   // "深入學習這個文法 →" link, and deep-linkable directly via the URL.
@@ -307,49 +315,37 @@ export default function App() {
   const reviewCount = useMemo(() => countMistakes(progressAttempts), [progressAttempts]);
   // #693: ONE shared delete-history dialog instance, opened by both the
   // desktop heading-auth action and the mobile 更多 menu entry. The entry
-  // clicks record the actual trigger as the return-focus target and flip
-  // `deletionOpen`; the dialog closes itself on success/cancel, and a failed
-  // delete stays open with a retryable error. `deletionSuccess` is a one-shot
-  // flag so the localized success status stays readable until the learner
-  // navigates or reopens the dialog.
-  const [deletionOpen, setDeletionOpen] = useState(false);
-  const [deletionSuccess, setDeletionSuccess] = useState(false);
+  // clicks record the actual trigger as the return-focus target and open the
+  // user-owned UI state; the dialog closes itself on success/cancel, and a
+  // failed delete stays open with a retryable error. The success flag is
+  // one-shot so the localized status stays readable until the learner reopens
+  // the dialog or the authenticated owner changes.
+  const deletionOwnerId = user?.id ?? null;
+  const [deletionUi, setDeletionUi] = useState(() => ({
+    ownerId: deletionOwnerId,
+    open: false,
+    success: false
+  }));
+  // The confirmation protocol belongs to one authenticated user. Adjust the
+  // local UI state during render when that owner changes so children never
+  // commit stale dialog/success state for a signed-out or different account.
+  if (deletionUi.ownerId !== deletionOwnerId) {
+    setDeletionUi({ ownerId: deletionOwnerId, open: false, success: false });
+  }
   const deleteHistoryReturnRef = useRef<HTMLButtonElement | null>(null);
   const openDeleteHistory = useCallback((trigger: HTMLButtonElement) => {
     deleteHistoryReturnRef.current = trigger;
-    setDeletionSuccess(false);
-    setDeletionOpen(true);
-  }, []);
+    setDeletionUi({ ownerId: deletionOwnerId, open: true, success: false });
+  }, [deletionOwnerId]);
   const handleDeleteHistoryConfirm = useCallback(async (): Promise<boolean> => {
     const ok = await deleteSyncedPracticeHistory();
     if (ok) {
-      setDeletionSuccess(true);
+      setDeletionUi((current) =>
+        current.ownerId === deletionOwnerId ? { ...current, success: true } : current
+      );
     }
     return ok;
-  }, [deleteSyncedPracticeHistory]);
-  // If the user logs out / the account disappears mid-delete, collapse the
-  // dialog and clear the success status (the protocol is user-scoped; nothing
-  // left to confirm and the old account's "deleted" status must not linger).
-  // Note: a failed delete must NOT collapse the dialog -- the dialog stays
-  // open with its retryable error until the learner dismisses or retries.
-  useEffect(() => {
-    if (!user) {
-      setDeletionOpen(false);
-      setDeletionSuccess(false);
-    }
-  }, [user]);
-  // The drill the challenge view starts with on its next mount. Set by
-  // the "start X" actions just before navigating; undefined = the default
-  // basic drill. Read once when ChallengePanel mounts (it owns the
-  // session), so changing it while already in the challenge is a no-op.
-  // Seed from a /challenge?mode=&level= deep link on a direct hit / refresh
-  // (#264), so a shared or bookmarked drill restores; a bare /challenge or any
-  // other route stays undefined (default landing).
-  const [launch, setLaunch] = useState<SessionInit | undefined>(() =>
-    initialRoute.view === "challenge"
-      ? challengeInitFromQuery(window.location.search)
-      : undefined
-  );
+  }, [deleteSyncedPracticeHistory, deletionOwnerId]);
   // Global target-level preference (#199), read once at startup. Seeds the
   // fresh-pool level range (今日練習 / 綜合 / 単字) and drives the first-run
   // onboarding card; the home card persists it.
@@ -526,16 +522,16 @@ export default function App() {
           onClose={() => setFeedbackKind(null)}
         />
       ) : null}
-      {deletionSuccess ? (
+      {deletionUi.success ? (
         <p className="delete-history-status" role="status" aria-live="polite">
           {t.deleteHistorySuccess}
         </p>
       ) : null}
       <DeletePracticeHistoryDialog
-        open={deletionOpen}
+        open={deletionUi.open}
         status={historyDeletionStatus}
         onConfirm={handleDeleteHistoryConfirm}
-        onClose={() => setDeletionOpen(false)}
+        onClose={() => setDeletionUi((current) => ({ ...current, open: false }))}
         returnFocusRef={deleteHistoryReturnRef}
         copy={{
           title: t.deleteHistoryTitle,

--- a/src/components/DeletePracticeHistoryDialog.test.tsx
+++ b/src/components/DeletePracticeHistoryDialog.test.tsx
@@ -71,7 +71,7 @@ function Harness({
   };
   return (
     <>
-      <button type="button" ref={triggerRef}>
+      <button type="button" ref={triggerRef} onClick={() => setOpen(true)}>
         trigger
       </button>
       <DeletePracticeHistoryDialog {...props} />
@@ -151,6 +151,22 @@ describe("DeletePracticeHistoryDialog (#693)", () => {
 
     // Retry is possible: the error resets and confirm can be clicked again.
     expect(screen.getByRole("button", { name: "刪除" })).toBeEnabled();
+  });
+
+  it("reopens with a fresh confirmation and error state after a failed attempt", async () => {
+    const user = userEvent.setup();
+    render(<Harness onConfirm={vi.fn(async () => false)} />);
+
+    await user.click(screen.getByRole("checkbox", { name: "我了解此操作不可復原" }));
+    await user.click(screen.getByRole("button", { name: "刪除" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("刪除失敗，請再試一次。");
+
+    await user.click(screen.getByRole("button", { name: "取消" }));
+    await user.click(screen.getByRole("button", { name: "trigger" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "我了解此操作不可復原" })).not.toBeChecked();
+    expect(screen.getByRole("button", { name: "刪除" })).toBeDisabled();
   });
 
   it("lock: while deleting, confirm/cancel/close are all disabled and Escape is inert", async () => {

--- a/src/components/DeletePracticeHistoryDialog.tsx
+++ b/src/components/DeletePracticeHistoryDialog.tsx
@@ -47,12 +47,18 @@ export type DeletePracticeHistoryDialogProps = {
 
 export function DeletePracticeHistoryDialog({
   open,
+  ...props
+}: DeletePracticeHistoryDialogProps) {
+  return open ? <OpenDeletePracticeHistoryDialog {...props} /> : null;
+}
+
+function OpenDeletePracticeHistoryDialog({
   status,
   onConfirm,
   onClose,
   returnFocusRef,
   copy
-}: DeletePracticeHistoryDialogProps) {
+}: Omit<DeletePracticeHistoryDialogProps, "open">) {
   const [understood, setUnderstood] = useState(false);
   const [localError, setLocalError] = useState(false);
   const deleting = status === "deleting";
@@ -61,34 +67,24 @@ export function DeletePracticeHistoryDialog({
   const descriptionId = useId();
   const errorId = useId();
 
-  // Initial focus into the dialog whenever it opens (div is tabIndex=-1 so
-  // calling .focus() never adds it to the tab order). Runs on commit so no
-  // state write in render.
+  // The open subtree's mount/unmount is the reset boundary for checkbox and
+  // error state. Focus enters on mount and returns to the actual trigger
+  // (desktop action or mobile 更多 button) on unmount.
   useEffect(() => {
-    if (!open) return;
+    const returnFocusTarget = returnFocusRef.current;
     dialogRef.current?.focus();
-  }, [open]);
-
-  // Every close (cancel / Escape / backdrop / successful confirm) resets the
-  // checkbox + local error and returns focus to the trigger. `deleting` is
-  // excluded from the deps on purpose: mid-flight we never reset or return
-  // focus, and an in-flight state flip to "deleting" must not re-run this.
-  useEffect(() => {
-    if (!open && !deleting) {
-      setUnderstood(false);
-      setLocalError(false);
-      returnFocusRef.current?.focus();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+    return () => {
+      returnFocusTarget?.focus();
+    };
+  }, [returnFocusRef]);
 
   // A failed confirm moves focus to the error region so assistive tech lands
   // on the retryable message.
   useEffect(() => {
-    if (open && localError) {
+    if (localError) {
       document.getElementById(errorId)?.focus();
     }
-  }, [localError, open, errorId]);
+  }, [localError, errorId]);
 
   const handleConfirm = useCallback(async () => {
     const ok = await onConfirm();
@@ -101,7 +97,7 @@ export function DeletePracticeHistoryDialog({
 
   // Escape + backdrop click close only when idle/error (never while deleting).
   useEffect(() => {
-    if (!open || deleting) return;
+    if (deleting) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
@@ -110,7 +106,7 @@ export function DeletePracticeHistoryDialog({
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [open, deleting, onClose]);
+  }, [deleting, onClose]);
 
   // Focus trap: while open, Tab/Shift+Tab stay inside the dialog. Disabled
   // controls are skipped so the checkbox never traps when confirm is gated.
@@ -136,10 +132,6 @@ export function DeletePracticeHistoryDialog({
       first.focus();
     }
   };
-
-  if (!open) {
-    return null;
-  }
 
   return (
     <div

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
@@ -120,7 +120,12 @@ export function KanjiOnyomiPanel({
   // family) -- the sequence the arrow keys walk. Includes entries still behind
   // the load-more boundary so stepping past it can reveal them.
   const orderedEntries = useMemo(() => families.flatMap(([, entries]) => entries), [families]);
-  const cellRefs = useRef(new Map<string, HTMLButtonElement>());
+  const [cellRefs] = useState(
+    () =>
+      new Map(
+        kanjiOnyomi.map((entry) => [entry.kanji, createRef<HTMLButtonElement>()])
+      )
+  );
   const pendingFocus = useRef<string | null>(null);
 
   // Desktop shortcut (user request 2026-07): ← / → walk the grid so browsing a
@@ -174,12 +179,12 @@ export function KanjiOnyomiPanel({
   useEffect(() => {
     const kanji = pendingFocus.current;
     if (!kanji) return;
-    const node = cellRefs.current.get(kanji);
+    const node = cellRefs.get(kanji)?.current;
     if (!node) return; // just revealed; the next pass catches it
     pendingFocus.current = null;
     node.focus({ preventScroll: true });
     node.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
-  }, [selected, entryBudget]);
+  }, [selected, entryBudget, cellRefs]);
 
   const detail = selected ? kanjiOnyomi.find((entry) => entry.kanji === selected) ?? null : null;
   const examples = detail ? kanjiExamples(detail.kanji) : [];
@@ -302,10 +307,7 @@ export function KanjiOnyomiPanel({
                   <div className="kanji-cell-wrap" key={entry.kanji}>
                     <button
                       type="button"
-                      ref={(node) => {
-                        if (node) cellRefs.current.set(entry.kanji, node);
-                        else cellRefs.current.delete(entry.kanji);
-                      }}
+                      ref={cellRefs.get(entry.kanji)}
                       className={`kanji-cell${isSelected ? " selected" : ""}`}
                       aria-pressed={isSelected}
                       onClick={() => setSelected(entry.kanji)}


### PR DESCRIPTION
Closes #742

## Summary

- move challenge launch state before the popstate subscription so React Hooks v7 can prove lifecycle ordering without changing route/session restoration
- key deletion UI state to the authenticated user so sign-out/account transitions clear stale dialog and success state before commit
- use the dialog open subtree's mount/unmount boundary to reset confirmation/error state while preserving focus return, focus trap, Escape, and deleting locks
- replace callback-ref Map mutation with a stable per-kanji RefObject registry while preserving keyboard navigation and #683 filter-keyed budget behavior

## Validation

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm exec vitest run src/App.test.tsx src/components/DeletePracticeHistoryDialog.test.tsx src/components/KanjiOnyomiPanel.test.tsx` — 117/117 pass
- `pnpm exec vitest run --maxWorkers=1` — 141/141 files, 2062/2062 tests pass
- `pnpm build` — pass
- temporary in-memory `reactHooks.configs.flat.recommended` evaluation over all `src/**/*.{ts,tsx}` — zero diagnostics
- `git diff --check` and staged diff check — pass

The default parallel `pnpm test` run exposed unrelated fixed-5-second timeouts in the Gemini red-stage integration suite under load; the same exact HEAD passes all 2062 tests with one Vitest worker, and the isolated Gemini file passes 23/23.

## Independent review

Exact HEAD `339c758912db2105efb369b74a26ddc930a23378`: **No blocking findings.**

## Exclusions

- does not enable or alter ESLint config; #687 owns preset activation
- does not redesign navigation; #727 owns canonical routing/navigation
- does not add Kanji persistence/resume; #740 owns that feature
- no auth deletion protocol, content, i18n, dependency, or workflow changes
