### PR TITLE
feat(kanji): persist level filter and resume position

### DIFF
--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -218,6 +218,7 @@ describe("KanjiOnyomiPanel persisted resume (#740)", () => {
 
   it("reveals a deep resumed target only in the current filter-keyed budget", () => {
     render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const initialUnfilteredCount = cells().length;
     while (cells().length <= 110) {
       fireEvent.click(screen.getByRole("button", { name: /載入更多/ }));
     }
@@ -238,6 +239,9 @@ describe("KanjiOnyomiPanel persisted resume (#740)", () => {
 
     fireEvent.change(screen.getByRole("searchbox"), { target: { value: "き" } });
     expect(cells()).toHaveLength(43);
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "" } });
+    expect(cells()).toHaveLength(initialUnfilteredCount);
   });
 });
 

--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -1,7 +1,29 @@
 import { Profiler, StrictMode } from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  KANJI_LAST_READ_KEY,
+  KANJI_LEVEL_KEY,
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "../domain/kanjiPreferences";
+import { kanjiOnyomi } from "../domain/kanjiOnyomi";
 import { KanjiOnyomiPanel } from "./KanjiOnyomiPanel";
+
+const currentKanjiBank = new Set(kanjiOnyomi.map((entry) => entry.kanji));
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+afterEach(() => {
+  window.localStorage.removeItem(KANJI_LEVEL_KEY);
+  window.localStorage.removeItem(KANJI_LAST_READ_KEY);
+  if (originalScrollIntoView) {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  } else {
+    delete (Element.prototype as { scrollIntoView?: Element["scrollIntoView"] }).scrollIntoView;
+  }
+});
 
 // The default view renders the whole table (~hundreds of cells), which makes
 // testing-library's accessible-name scans slow in jsdom (not in a real
@@ -63,6 +85,159 @@ describe("KanjiOnyomiPanel (#195)", () => {
     render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
     expect(screen.getByRole("button", { name: "N2" })).toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: "全部" })).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+describe("KanjiOnyomiPanel persisted resume (#740)", () => {
+  const cells = () => Array.from(document.querySelectorAll<HTMLButtonElement>("button.kanji-cell"));
+  const charOf = (cell: Element) =>
+    cell.querySelector(".kanji-cell-char")?.textContent ?? "";
+  const selectedChar = () =>
+    document.querySelector(".kanji-cell.selected .kanji-cell-char")?.textContent ?? null;
+  const arrow = (key: "ArrowRight" | "ArrowLeft") => fireEvent.keyDown(document, { key });
+
+  it("restores a level chosen for the same default-level band", () => {
+    writeKanjiLevel("N2", "N5");
+
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
+
+    expect(screen.getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "N2" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("immediately resolves the level again when the default-level band changes", () => {
+    writeKanjiLevel("N2", "N5");
+    const { rerender } = render(
+      <KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />
+    );
+    expect(screen.getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "true");
+
+    rerender(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N1" />);
+
+    expect(screen.getByRole("button", { name: "N1" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("persists a level chosen in the current default-level band", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N2" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "N4" }));
+
+    expect(readKanjiLevel("N2")).toBe("N4");
+  });
+
+  it("marks the remembered card without selecting, opening, focusing, or scrolling", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const remembered = charOf(cells()[1]);
+    cleanup();
+    writeLastReadKanji(remembered);
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+
+    const marked = document.querySelector<HTMLButtonElement>(".kanji-cell.last-read");
+    expect(marked).not.toBeNull();
+    expect(charOf(marked!)).toBe(remembered);
+    expect(marked).toHaveAttribute("aria-pressed", "false");
+    expect(document.querySelector(".kanji-cell.selected")).toBeNull();
+    expect(document.querySelector(".kanji-card")).toBeNull();
+    expect(document.activeElement).not.toBe(marked);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("clears the marker and persists the new position after any session selection", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const remembered = charOf(cells()[1]);
+    const next = charOf(cells()[0]);
+    cleanup();
+    writeLastReadKanji(remembered);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+
+    fireEvent.click(cells()[0]);
+
+    expect(document.querySelector(".kanji-cell.last-read")).toBeNull();
+    expect(selectedChar()).toBe(next);
+    expect(readLastReadKanji(currentKanjiBank)).toBe(next);
+  });
+
+  it("uses the remembered position for arrows until this session selects a card", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const chars = cells().map(charOf);
+    cleanup();
+    writeLastReadKanji(chars[1]);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+
+    arrow("ArrowRight");
+    expect(selectedChar()).toBe(chars[2]);
+    expect(document.querySelector(".kanji-cell.last-read")).toBeNull();
+    expect(readLastReadKanji(currentKanjiBank)).toBe(chars[2]);
+
+    arrow("ArrowLeft");
+    expect(selectedChar()).toBe(chars[1]);
+  });
+
+  it("can resume backward from the remembered position", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const chars = cells().map(charOf);
+    cleanup();
+    writeLastReadKanji(chars[2]);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+
+    arrow("ArrowLeft");
+
+    expect(selectedChar()).toBe(chars[1]);
+  });
+
+  it("gives the current-session selection priority over the remembered position", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    const chars = cells().map(charOf);
+    cleanup();
+    writeLastReadKanji(chars[0]);
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+
+    fireEvent.click(cells()[3]);
+    arrow("ArrowLeft");
+
+    expect(selectedChar()).toBe(chars[2]);
+  });
+
+  it("falls back to the first card when the remembered kanji is hidden by the active filter", () => {
+    const hiddenN1Kanji = kanjiOnyomi.find((entry) => entry.level === "N1")?.kanji;
+    expect(hiddenN1Kanji).toBeDefined();
+    writeLastReadKanji(hiddenN1Kanji!);
+
+    render(<KanjiOnyomiPanel language="zh-Hant" defaultLevel="N5" />);
+    const firstVisible = charOf(cells()[0]);
+    expect(document.querySelector(".kanji-cell.last-read")).toBeNull();
+
+    arrow("ArrowRight");
+
+    expect(selectedChar()).toBe(firstVisible);
+  });
+
+  it("reveals a deep resumed target only in the current filter-keyed budget", () => {
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    while (cells().length <= 110) {
+      fireEvent.click(screen.getByRole("button", { name: /載入更多/ }));
+    }
+    const expandedChars = cells().map(charOf);
+    const remembered = expandedChars[100];
+    const expectedNext = expandedChars[101];
+    cleanup();
+    writeLastReadKanji(remembered);
+
+    render(<KanjiOnyomiPanel language="zh-Hant" />);
+    expect(cells().map(charOf)).not.toContain(remembered);
+
+    arrow("ArrowRight");
+
+    expect(selectedChar()).toBe(expectedNext);
+    expect(cells().map(charOf)).toContain(expectedNext);
+    expect(document.activeElement).toBe(cells().find((cell) => charOf(cell) === expectedNext));
+
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "き" } });
+    expect(cells()).toHaveLength(43);
   });
 });
 

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -46,42 +46,50 @@ export function KanjiOnyomiPanel({
   defaultLevel?: JlptLevel | "all";
 }) {
   const t = copy[language];
-  const [query, setQuery] = useState("");
+  const [queryFilter, setQueryFilter] = useState({ value: "", revision: 0 });
+  const query = queryFilter.value;
   const storedLevel = useMemo(() => readKanjiLevel(defaultLevel), [defaultLevel]);
   const [sessionLevel, setSessionLevel] = useState<{
     defaultLevel: JlptLevel | "all";
     level: JlptLevel | "all";
+    revision: number;
   } | null>(null);
   const level =
     sessionLevel?.defaultLevel === defaultLevel
       ? sessionLevel.level
       : storedLevel ?? defaultLevel;
-  const [readingType, setReadingType] = useState<ReadingType>("on");
+  const [readingFilter, setReadingFilter] = useState<{
+    value: ReadingType;
+    revision: number;
+  }>({ value: "on", revision: 0 });
+  const readingType = readingFilter.value;
   const [selected, setSelected] = useState<string | null>(null);
   const [lastRead] = useState<string | null>(() => readLastReadKanji(KANJI_BANK));
   const selectKanji = useCallback((kanji: string) => {
     setSelected(kanji);
     writeLastReadKanji(kanji);
   }, []);
-  // #683: the load-more budget is keyed by the active filter instead of being a
-  // plain number reset by a query/level/readingType effect (React hooks v7
-  // flags `set-state-in-effect`). A filter change is NOT a setState -- the
-  // stale-key state is simply ignored on the next render, and the effective
-  // budget falls back to FAMILY_ENTRY_BUDGET until the first load-more.
-  // language is deliberately NOT part of the key, so switching UI language
-  // never resets the already-loaded batch.
-  const [entryBudgetState, setEntryBudgetState] = useState<EntryBudgetState>(() => ({
-    filterKey: "",
-    value: FAMILY_ENTRY_BUDGET
-  }));
-
   const activeLabel = readingType === "on" ? t.kanjiOnyomiLabel : t.kanjiKunyomiLabel;
 
   // Pure, stable filter key: query + level + readingType. `language` is left
   // out on purpose (language switches must not reset the loaded count).
   // The :: separator can never collide with the search box or the level /
   // reading-type labels, so distinct filters always map to distinct keys.
-  const filterKey = `${query}::${level}::${readingType}`;
+  const levelRevision =
+    sessionLevel?.defaultLevel === defaultLevel ? sessionLevel.revision : 0;
+  const filterKey = `${query}::${level}::${readingType}::${queryFilter.revision}:${levelRevision}:${readingFilter.revision}`;
+
+  // #683: the load-more budget is keyed by the active filter instead of being a
+  // plain number reset by a query/level/readingType effect (React hooks v7
+  // flags `set-state-in-effect`). Each filter's existing event state carries a
+  // revision, so returning to a previous value produces a new key without any
+  // budget-state write during the filter transition.
+  // language is deliberately NOT part of the key, so switching UI language
+  // never resets the already-loaded batch.
+  const [entryBudgetState, setEntryBudgetState] = useState<EntryBudgetState>(() => ({
+    filterKey: "",
+    value: FAMILY_ENTRY_BUDGET
+  }));
   const entryBudget =
     entryBudgetState.filterKey === filterKey ? entryBudgetState.value : FAMILY_ENTRY_BUDGET;
   const increaseEntryBudget = useCallback((minimumValue = 0) => {
@@ -225,7 +233,15 @@ export function KanjiOnyomiPanel({
           type="search"
           className="kanji-search"
           value={query}
-          onChange={(event) => setQuery(event.target.value)}
+          onChange={(event) =>
+            setQueryFilter((current) => ({
+              value: event.target.value,
+              revision:
+                current.value === event.target.value
+                  ? current.revision
+                  : current.revision + 1
+            }))
+          }
           placeholder={t.kanjiSearchPlaceholder}
           aria-label={t.kanjiSearchPlaceholder}
         />
@@ -236,7 +252,13 @@ export function KanjiOnyomiPanel({
               type="button"
               className={readingType === type ? "selected" : ""}
               aria-pressed={readingType === type}
-              onClick={() => setReadingType(type)}
+              onClick={() =>
+                setReadingFilter((current) =>
+                  current.value === type
+                    ? current
+                    : { value: type, revision: current.revision + 1 }
+                )
+              }
             >
               {type === "on" ? t.kanjiReadingOn : t.kanjiReadingKun}
             </button>
@@ -250,7 +272,13 @@ export function KanjiOnyomiPanel({
               className={level === option ? "selected" : ""}
               aria-pressed={level === option}
               onClick={() => {
-                setSessionLevel({ defaultLevel, level: option });
+                if (level === option) return;
+                setSessionLevel((current) => ({
+                  defaultLevel,
+                  level: option,
+                  revision:
+                    current?.defaultLevel === defaultLevel ? current.revision + 1 : 1
+                }));
                 writeKanjiLevel(defaultLevel, option);
               }}
             >

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -2,12 +2,19 @@ import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "re
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
+import {
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "../domain/kanjiPreferences";
 import { kanjiMeaning } from "../domain/kanjiOnyomi.i18n";
 import { pickLocalized } from "../domain/localizedContent";
 import { SpeakButton } from "./SpeakButton";
 import { InkstoneSpot, MagnifierKanjiSpot } from "../illustrations";
 
 const LEVELS: Array<JlptLevel | "all"> = ["all", "N5", "N4", "N3", "N2", "N1"];
+const KANJI_BANK = new Set(kanjiOnyomi.map((entry) => entry.kanji));
 type ReadingType = "on" | "kun";
 
 // #683: budget state is keyed by the active filter (query + level + readingType)
@@ -40,9 +47,22 @@ export function KanjiOnyomiPanel({
 }) {
   const t = copy[language];
   const [query, setQuery] = useState("");
-  const [level, setLevel] = useState<JlptLevel | "all">(defaultLevel);
+  const storedLevel = useMemo(() => readKanjiLevel(defaultLevel), [defaultLevel]);
+  const [sessionLevel, setSessionLevel] = useState<{
+    defaultLevel: JlptLevel | "all";
+    level: JlptLevel | "all";
+  } | null>(null);
+  const level =
+    sessionLevel?.defaultLevel === defaultLevel
+      ? sessionLevel.level
+      : storedLevel ?? defaultLevel;
   const [readingType, setReadingType] = useState<ReadingType>("on");
   const [selected, setSelected] = useState<string | null>(null);
+  const [lastRead] = useState<string | null>(() => readLastReadKanji(KANJI_BANK));
+  const selectKanji = useCallback((kanji: string) => {
+    setSelected(kanji);
+    writeLastReadKanji(kanji);
+  }, []);
   // #683: the load-more budget is keyed by the active filter instead of being a
   // plain number reset by a query/level/readingType effect (React hooks v7
   // flags `set-state-in-effect`). A filter change is NOT a setState -- the
@@ -64,13 +84,13 @@ export function KanjiOnyomiPanel({
   const filterKey = `${query}::${level}::${readingType}`;
   const entryBudget =
     entryBudgetState.filterKey === filterKey ? entryBudgetState.value : FAMILY_ENTRY_BUDGET;
-  const increaseEntryBudget = useCallback(() => {
+  const increaseEntryBudget = useCallback((minimumValue = 0) => {
     setEntryBudgetState((prev) => {
       // The stored key may be stale (a filter changed in between). Always bump
       // on top of the CURRENT filter's effective budget so the batch keeps
       // growing from the initial value, never from a previous filter's count.
       const base = prev.filterKey === filterKey ? prev.value : FAMILY_ENTRY_BUDGET;
-      return { filterKey, value: base + FAMILY_ENTRY_BUDGET };
+      return { filterKey, value: Math.max(base + FAMILY_ENTRY_BUDGET, minimumValue) };
     });
   }, [filterKey]);
 
@@ -150,8 +170,9 @@ export function KanjiOnyomiPanel({
       if (orderedEntries.length === 0) {
         return;
       }
-      const currentIndex = selected
-        ? orderedEntries.findIndex((entry) => entry.kanji === selected)
+      const currentPosition = selected ?? lastRead;
+      const currentIndex = currentPosition
+        ? orderedEntries.findIndex((entry) => entry.kanji === currentPosition)
         : -1;
       // Nothing picked yet: the first press opens the first card.
       const nextIndex = currentIndex < 0 ? 0 : currentIndex + (event.key === "ArrowRight" ? 1 : -1);
@@ -162,16 +183,17 @@ export function KanjiOnyomiPanel({
       }
       event.preventDefault();
       // Stepping past the load-more boundary pulls the next batch in instead
-      // of dead-ending (one bump always covers the next whole family).
+      // of dead-ending. A deep remembered position requests enough of the
+      // CURRENT filter-keyed budget to reveal its next card in one update.
       if (nextIndex >= shownEntries) {
-        increaseEntryBudget();
+        increaseEntryBudget(nextIndex + 1);
       }
       pendingFocus.current = orderedEntries[nextIndex].kanji;
-      setSelected(orderedEntries[nextIndex].kanji);
+      selectKanji(orderedEntries[nextIndex].kanji);
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [orderedEntries, selected, shownEntries, increaseEntryBudget]);
+  }, [orderedEntries, selected, lastRead, shownEntries, increaseEntryBudget, selectKanji]);
 
   // Keyboard-driven selection follows the card: focus keeps the grid coherent
   // for keyboard and screen-reader users, and `block: "nearest"` only scrolls
@@ -227,7 +249,10 @@ export function KanjiOnyomiPanel({
               type="button"
               className={level === option ? "selected" : ""}
               aria-pressed={level === option}
-              onClick={() => setLevel(option)}
+              onClick={() => {
+                setSessionLevel({ defaultLevel, level: option });
+                writeKanjiLevel(defaultLevel, option);
+              }}
             >
               {option === "all" ? t.kanjiLevelAll : option}
             </button>
@@ -294,6 +319,7 @@ export function KanjiOnyomiPanel({
             <div className="kanji-grid">
               {entries.map((entry) => {
                 const isSelected = selected === entry.kanji;
+                const isLastRead = selected === null && lastRead === entry.kanji;
                 // Feedback 2026-07: listening used to mean scrolling back up to
                 // the detail card's TTS button after every selection. The
                 // selected cell grows an in-place speak button instead; it reads
@@ -308,9 +334,9 @@ export function KanjiOnyomiPanel({
                     <button
                       type="button"
                       ref={cellRefs.get(entry.kanji)}
-                      className={`kanji-cell${isSelected ? " selected" : ""}`}
+                      className={`kanji-cell${isSelected ? " selected" : ""}${isLastRead ? " last-read" : ""}`}
                       aria-pressed={isSelected}
-                      onClick={() => setSelected(entry.kanji)}
+                      onClick={() => selectKanji(entry.kanji)}
                     >
                       <span className="kanji-cell-char">{entry.kanji}</span>
                       <span className="kanji-cell-read">
@@ -345,7 +371,7 @@ export function KanjiOnyomiPanel({
         <button
           type="button"
           className="kanji-load-more"
-          onClick={increaseEntryBudget}
+          onClick={() => increaseEntryBudget()}
         >
           {t.kanjiLoadMore(remainingEntries)}
         </button>

--- a/src/domain/kanjiPreferences.test.ts
+++ b/src/domain/kanjiPreferences.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  KANJI_LAST_READ_KEY,
+  KANJI_LEVEL_KEY,
+  readKanjiLevel,
+  readLastReadKanji,
+  writeKanjiLevel,
+  writeLastReadKanji
+} from "./kanjiPreferences";
+
+afterEach(() => {
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("kanji level preference", () => {
+  it("restores a level chosen for the same default-level band", () => {
+    writeKanjiLevel("N2", "N5");
+
+    expect(readKanjiLevel("N2")).toBe("N5");
+  });
+
+  it("does not restore a level chosen for a different default-level band", () => {
+    writeKanjiLevel("N2", "N5");
+
+    expect(readKanjiLevel("N1")).toBeNull();
+  });
+
+  it.each(["N2", "N2|banana", "banana|N5", "N2|N5|extra"])(
+    "rejects an invalid stored token: %s",
+    (stored) => {
+      window.localStorage.setItem(KANJI_LEVEL_KEY, stored);
+
+      expect(readKanjiLevel("N2")).toBeNull();
+    }
+  );
+
+  it("fails safely when storage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readKanjiLevel("N2")).toBeNull();
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => writeKanjiLevel("N2", "N5")).not.toThrow();
+  });
+});
+
+describe("last-read kanji preference", () => {
+  const currentBank = new Set(["校", "考"]);
+
+  it("round-trips a current-bank kanji identifier", () => {
+    writeLastReadKanji("校");
+
+    expect(readLastReadKanji(currentBank)).toBe("校");
+  });
+
+  it("rejects a stale kanji that is absent from the current bank", () => {
+    window.localStorage.setItem(KANJI_LAST_READ_KEY, "鬱");
+
+    expect(readLastReadKanji(currentBank)).toBeNull();
+  });
+
+  it.each(["", "学校", "not-kanji"])("rejects an invalid identifier: %s", (stored) => {
+    window.localStorage.setItem(KANJI_LAST_READ_KEY, stored);
+
+    expect(readLastReadKanji(currentBank)).toBeNull();
+  });
+
+  it("does not write an invalid identifier", () => {
+    writeLastReadKanji("学校");
+
+    expect(window.localStorage.getItem(KANJI_LAST_READ_KEY)).toBeNull();
+  });
+
+  it("fails safely when storage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(readLastReadKanji(currentBank)).toBeNull();
+
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    expect(() => writeLastReadKanji("校")).not.toThrow();
+  });
+});

--- a/src/domain/kanjiPreferences.ts
+++ b/src/domain/kanjiPreferences.ts
@@ -1,0 +1,43 @@
+import { readStored, writeStored } from "./safeStorage";
+import type { JlptLevel } from "./types";
+
+export const KANJI_LEVEL_KEY = "jabiko:kanjiLevel";
+export const KANJI_LAST_READ_KEY = "jabiko:kanjiLastRead";
+
+export type KanjiLevelFilter = JlptLevel | "all";
+
+const LEVEL_FILTERS: readonly KanjiLevelFilter[] = ["all", "N5", "N4", "N3", "N2", "N1"];
+
+function isLevelFilter(value: string): value is KanjiLevelFilter {
+  return (LEVEL_FILTERS as readonly string[]).includes(value);
+}
+
+export function readKanjiLevel(defaultLevel: KanjiLevelFilter): KanjiLevelFilter | null {
+  const raw = readStored(KANJI_LEVEL_KEY);
+  if (raw === null) return null;
+  const [storedDefault, storedLevel, extra] = raw.split("|");
+  if (extra !== undefined || storedDefault !== defaultLevel || !isLevelFilter(storedLevel)) {
+    return null;
+  }
+  return storedLevel;
+}
+
+export function writeKanjiLevel(
+  defaultLevel: KanjiLevelFilter,
+  level: KanjiLevelFilter
+): void {
+  writeStored(KANJI_LEVEL_KEY, `${defaultLevel}|${level}`);
+}
+
+export function readLastReadKanji(currentBank: ReadonlySet<string>): string | null {
+  const stored = readStored(KANJI_LAST_READ_KEY);
+  if (stored === null || [...stored].length !== 1 || !currentBank.has(stored)) {
+    return null;
+  }
+  return stored;
+}
+
+export function writeLastReadKanji(kanji: string): void {
+  if ([...kanji].length !== 1) return;
+  writeStored(KANJI_LAST_READ_KEY, kanji);
+}

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -231,6 +231,11 @@
   background: color-mix(in srgb, var(--matcha) 12%, var(--paper));
 }
 
+.kanji-cell.last-read {
+  border-color: color-mix(in srgb, var(--matcha) 60%, var(--rule));
+  border-style: dashed;
+}
+
 .kanji-cell-char {
   font-size: 1.6rem;
   line-height: 1;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,6 +89,7 @@ export default defineConfig({
           ],
           exclude: [
             "src/domain/bookmarks.test.ts",
+            "src/domain/kanjiPreferences.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
             "src/domain/diagnostics.test.ts",
@@ -109,6 +110,7 @@ export default defineConfig({
             "src/i18n.test.ts",
             "src/lib/**/*.test.{ts,tsx}",
             "src/domain/bookmarks.test.ts",
+            "src/domain/kanjiPreferences.test.ts",
             "src/domain/levelPreference.test.ts",
             "src/domain/originMigration.test.ts",
             "src/domain/diagnostics.test.ts",


### PR DESCRIPTION
Closes #740

## Summary

- add safe, band-scoped persistence for the selected kanji level and validate stored values against the active target band
- persist and render a non-selected last-read marker, then resume keyboard navigation from it until the current session selects a card
- reveal deep resume targets through the existing #683 filter-keyed budget helper
- prevent historical deep budgets from reviving after switching away from a filter and back, without writing budget state during filter transitions

## Design and compatibility

- stores only the target-band/level token and kanji identifier through the existing safe-storage abstraction
- invalid, stale, or blocked storage falls back safely
- preserves #683's single keyed budget contract: stale keys are ignored and only the increase helper writes budget state
- preserves #742's stable `RefObject` registry and existing search, reading-type, level, keyboard, focus, and load-more behavior

## Validation

- `pnpm exec vitest run src/domain/kanjiPreferences.test.ts src/components/KanjiOnyomiPanel.test.tsx` — PASS (48/48)
- hostile regression `deep resume → switch filter without load-more → switch back` — PASS
- React Hooks v7 recommended scan over `src/**/*.{ts,tsx}` — PASS (zero diagnostics)
- `pnpm lint` — PASS
- `pnpm typecheck` — PASS
- `pnpm test` — executed; the parallel run hit machine-load 5-second timeouts across unrelated suites, without assertion regressions
- `pnpm exec vitest run --maxWorkers=1` — PASS (142/142 files, 2086/2086 tests)
- `pnpm build` — PASS (including PWA generation and 107-page prerender)
- `git diff --check` — PASS

## Exclusions and residual risk

- no changes to kanji content, i18n overlays, examples, TTS, navigation, Hooks configuration, dependencies, or lockfiles
- persistence remains intentionally local-only; unavailable storage degrades to normal defaults
- remembered kanji hidden by active filters are ignored for navigation; batching-only hidden targets are revealed through the current filter's budget helper
