### PR TITLE
refactor(navigation): centralize AppRoute and shared navigation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -99,6 +99,11 @@ async function gotoLearn(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: "學習" }));
 }
 
+async function gotoResource(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByRole("button", { name: /^資源/ }));
+  await user.click(screen.getByRole("menuitem", { name: label }));
+}
+
 describe("App", () => {
   // The challenge / mock / kanji views are React.lazy in App, and
   // React.lazy only suspends on its first resolution. Prime the chunks
@@ -121,7 +126,7 @@ describe("App", () => {
     await screen.findByRole("region", { name: "目前題目" }, { timeout: 30000 });
     await user.click(screen.getByRole("button", { name: "題型練習" }));
     await screen.findByRole("region", { name: "題型練習" }, { timeout: 30000 });
-    await user.click(screen.getByRole("button", { name: "漢字" }));
+    await gotoResource(user, "漢字");
     await screen.findByRole("heading", { name: /漢字音読み/ }, { timeout: 30000 });
     unmount();
     // Priming navigated the URL (the app now routes view -> path); reset so the
@@ -146,7 +151,7 @@ describe("App", () => {
     expect(screen.getByRole("heading", { name: /自習室/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "首頁" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "學習" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "規則表" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "資源" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "挑戰" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "題型練習" })).toBeInTheDocument();
     // Home hero copy + at least one entry card heading.
@@ -196,8 +201,8 @@ describe("App", () => {
     ).toHaveLength(1);
 
     // Navigating moves aria-current to the new tab and clears the old one.
-    await user.click(screen.getByRole("button", { name: "規則表" }));
-    expect(screen.getByRole("button", { name: "規則表" })).toHaveAttribute("aria-current", "page");
+    await gotoResource(user, "規則表");
+    expect(screen.getByRole("button", { name: "資源（目前：規則表）" })).toHaveClass("selected");
     expect(screen.getByRole("button", { name: "首頁" })).not.toHaveAttribute("aria-current");
   });
 
@@ -236,7 +241,7 @@ describe("App", () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "規則表" }));
+    await gotoResource(user, "規則表");
 
     // Rules page banner + the full v2 eight-table set.
     expect(screen.getByRole("heading", { name: /動詞變化 速查/ })).toBeInTheDocument();
@@ -1093,7 +1098,7 @@ describe("App", () => {
     const user = userEvent.setup();
     render(<App />);
 
-    await user.click(screen.getByRole("button", { name: "漢字" }));
+    await gotoResource(user, "漢字");
 
     // The table renders, grouped by homophone family.
     expect(await screen.findByRole("heading", { name: /漢字音読み/ })).toBeInTheDocument();
@@ -1365,7 +1370,7 @@ describe("App", () => {
 
     expect(window.location.pathname).toBe("/about");
     expect(localStorage.getItem("jabiko.lang")).toBe("zh-Hant");
-    expect(screen.getByRole("button", { name: "關於" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "資源（目前：關於）" })).toHaveClass("selected");
 
     window.history.replaceState({}, "", "/");
   });
@@ -1431,10 +1436,7 @@ describe("App", () => {
     expect(screen.queryByRole("menu", { name: "更多" })).not.toBeInTheDocument();
     // Same navigation contract as the plain nav button: URL + aria-current.
     expect(window.location.pathname).toBe("/about");
-    expect(within(nav).getByRole("button", { name: "關於" })).toHaveAttribute(
-      "aria-current",
-      "page"
-    );
+    expect(within(nav).getByRole("button", { name: "資源（目前：關於）" })).toHaveClass("selected");
     // The collapsed trigger carries the current location while a folded view
     // is active (PR #628 review).
     const selectedTrigger = within(nav).getByRole("button", { name: "更多（目前：關於）" });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -105,6 +105,17 @@ async function gotoResource(user: ReturnType<typeof userEvent.setup>, label: str
 }
 
 describe("App", () => {
+  it("constructs the language fallback through the canonical static route constructor", () => {
+    const normalization = appSource.match(
+      /function normalizeRouteForLanguage[\s\S]*?\n}\n\nexport default function App/
+    )?.[0];
+
+    expect(normalization).toContain('return staticRoute("home");');
+    expect(normalization).not.toContain(
+      'return { view: "home", grammarSurface: null, blogSlug: null };'
+    );
+  });
+
   // The challenge / mock / kanji views are React.lazy in App, and
   // React.lazy only suspends on its first resolution. Prime the chunks
   // once here so every test below renders them synchronously regardless of

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ const LANGUAGE_OPTIONS: readonly Language[] = LAUNCHED_LANGUAGES;
 // index, not a stale article.
 function normalizeRouteForLanguage(route: AppRoute, language: Language): AppRoute {
   if (route.view === "blog" && language !== "zh-Hant") {
-    return { view: "home", grammarSurface: null, blogSlug: null };
+    return staticRoute("home");
   }
   return route;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,11 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  BookA,
-  BookOpen,
   ChevronDown,
-  ClipboardList,
   Globe,
-  GraduationCap,
-  Home,
-  Info,
   Languages,
   MessageCircle,
   Moon,
-  Newspaper,
   Sun,
-  Table,
-  Target
 } from "lucide-react";
 import type { LearningBlockDrillPreset } from "./domain/learningBlocks";
 import type { SentencePatternId } from "./domain/sentencePatterns";
@@ -30,7 +21,7 @@ import { UpdateToast } from "./components/UpdateToast";
 import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
 import { usePwaUpdate } from "./hooks/usePwaUpdate";
 import { JabikoMark } from "./components/JabikoMark";
-import { MoreMenu, type MoreMenuNavItem } from "./components/MoreMenu";
+import { AppNavigation } from "./components/AppNavigation";
 import { DeletePracticeHistoryDialog } from "./components/DeletePracticeHistoryDialog";
 import { FuriganaContext } from "./components/furiganaContext";
 import { useTheme } from "./hooks/useTheme";
@@ -46,7 +37,15 @@ import { challengeInitFromQuery } from "./domain/challengeDeepLink";
 import { readLevelPreference, writeLevelPreference } from "./domain/levelPreference";
 import { kanjiDefaultLevel, type LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
-import { parseRoute, serializeRoute, type AppRoute, type AppView } from "./domain/routes";
+import {
+  blogRoute,
+  grammarRoute,
+  parseRoute,
+  serializeRoute,
+  staticRoute,
+  type AppRoute
+} from "./domain/routes";
+import { resolveNavigation, type NavigationId } from "./domain/navigation";
 import packageJson from "../package.json";
 import "./styles.css";
 
@@ -113,11 +112,6 @@ type DrillPreset = LearningBlockDrillPreset;
 // Locales with untranslated content stay hidden until they ship (i18n.ts).
 const LANGUAGE_OPTIONS: readonly Language[] = LAUNCHED_LANGUAGES;
 
-// Every view-switch tab carries a small icon (user feedback 2026-07: only
-// 文型/文章 had one, which looked half-finished). One shared style keeps
-// the nine call sites identical.
-const navIconStyle = { verticalAlign: "middle", marginRight: "0.2rem" } as const;
-
 // #686: the 文章 blog is zh-Hant-only original content, so any route that
 // resolves to the blog view is normalized to home when the active language
 // can't serve it. Every route ingress (initial load / refresh, popstate, and
@@ -150,13 +144,8 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
-  const [appView, setAppView] = useState<AppView>(() => initialRoute.view);
-  // The grammar-point surface for the active /grammar/<surface> route (#281).
-  const [grammarSurface, setGrammarSurface] = useState<string | null>(
-    () => initialRoute.grammarSurface
-  );
-  // The article slug for the active /blog/<slug> route (#483); null = index.
-  const [blogSlug, setBlogSlug] = useState<string | null>(() => initialRoute.blogSlug);
+  const [route, setRoute] = useState<AppRoute>(() => initialRoute);
+  const { view: appView, grammarSurface, blogSlug } = route;
   // The drill the challenge view starts with on its next mount. This state
   // must exist before the popstate subscription below because back/forward
   // restores a challenge deep link through its setter.
@@ -169,8 +158,7 @@ export default function App() {
   // Open a grammar point's study page (#282): from the post-answer feedback's
   // "深入學習這個文法 →" link, and deep-linkable directly via the URL.
   const openGrammar = (surface: string) => {
-    setGrammarSurface(surface);
-    setAppView("grammar");
+    setRoute(grammarRoute(surface));
   };
 
   // #437: determine whether the current grammar path points to a JLPT level
@@ -184,11 +172,11 @@ export default function App() {
   // Keep the URL in sync when the view changes (push a history entry only
   // when the path actually differs, so popstate-driven changes don't loop).
   useEffect(() => {
-    const target = serializeRoute({ view: appView, grammarSurface, blogSlug });
+    const target = serializeRoute(route);
     if (window.location.pathname !== target) {
-      window.history.pushState({ view: appView }, "", target);
+      window.history.pushState({ view: route.view }, "", target);
     }
-  }, [appView, grammarSurface, blogSlug]);
+  }, [route]);
 
   // Back/forward: read the view (and grammar surface) back off the URL. The
   // parsed route is normalized for the CURRENT language first, so a non-zh-Hant
@@ -200,9 +188,7 @@ export default function App() {
         parseRoute(window.location.pathname),
         language
       );
-      setAppView(route.view);
-      setGrammarSurface(route.grammarSurface);
-      setBlogSlug(route.blogSlug);
+      setRoute(route);
       // Restore the drill from a /challenge?mode=&level= deep link on back/forward.
       if (route.view === "challenge") {
         setLaunch(challengeInitFromQuery(window.location.search));
@@ -278,8 +264,7 @@ export default function App() {
   // language's preference is saved.
   const changeLanguage = (nextLanguage: Language) => {
     if (appView === "blog" && nextLanguage !== "zh-Hant") {
-      setBlogSlug(null);
-      setAppView("home");
+      setRoute(staticRoute("home"));
     }
     setLanguage(nextLanguage);
   };
@@ -365,12 +350,12 @@ export default function App() {
       // the #526 chip keep their current view -- no surprise navigation.
       // DELIBERATE exception (same-batch override): when this choice answers
       // the daily-CTA gate, HomePanel's auto-continue fires openChallenge
-      // right after and its setAppView("challenge") wins the batch -- the
+      // right after and its complete challenge route wins the batch -- the
       // learner asked to START PRACTISING, and the starter daily serves 入門
       // questions, so honouring that intent beats detouring to the chapter
       // list. Locked by the "gate -> 完全新手" App test.
       if (progressAttempts.length === 0 && appView === "home") {
-        setAppView("learn");
+        setRoute(staticRoute("learn"));
       }
     }
   };
@@ -389,48 +374,6 @@ export default function App() {
         ? t.authSyncedHint
         : t.authSyncingHint;
 
-  // #608: on phones the nav keeps five primary entries (home / learn /
-  // challenge / mock / grammar); these four secondary views collapse into the
-  // 更多 menu. Same handlers as the full nav buttons, so navigation contract
-  // (URL sync, aria-current) is identical whichever entry point is used.
-  const moreMenuItems: MoreMenuNavItem[] = [
-    {
-      key: "rules",
-      label: t.rules,
-      icon: <Table aria-hidden="true" size={16} style={navIconStyle} />,
-      selected: appView === "rules",
-      onSelect: () => setAppView("rules")
-    },
-    {
-      key: "kanji",
-      label: t.kanji,
-      icon: <BookA aria-hidden="true" size={16} style={navIconStyle} />,
-      selected: appView === "kanji",
-      onSelect: () => setAppView("kanji")
-    },
-    ...(blogAvailable
-      ? [
-          {
-            key: "blog",
-            label: t.blog,
-            icon: <Newspaper aria-hidden="true" size={16} style={navIconStyle} />,
-            selected: appView === "blog",
-            onSelect: () => {
-              setBlogSlug(null);
-              setAppView("blog");
-            }
-          }
-        ]
-      : []),
-    {
-      key: "about",
-      label: t.about,
-      icon: <Info aria-hidden="true" size={16} style={navIconStyle} />,
-      selected: appView === "about",
-      onSelect: () => setAppView("about")
-    }
-  ];
-
   const openChallenge = (request?: SessionInit) => {
     // `request` seeds the session when ChallengePanel MOUNTS (its
     // usePracticeSession reads init via useState initializers). Every
@@ -444,7 +387,7 @@ export default function App() {
     // cascade; re-clicking it while already in the challenge view is a
     // no-op since the mounted panel ignores re-seeds.)
     setLaunch(request);
-    setAppView("challenge");
+    setRoute(staticRoute("challenge"));
     // Phase 1 analytics (#404): every practice entry funnels through here.
     // Weak-point review gets its own event so we can tell "open review" apart
     // from "start a fresh drill"; payloads are metadata only (no question text).
@@ -479,6 +422,23 @@ export default function App() {
     openChallenge({ mode: "pattern", filter: { patternIds } });
   };
 
+  const navigation = resolveNavigation(route, language);
+  const navigateFromAppNavigation = (id: NavigationId) => {
+    if (id === "challenge") {
+      openChallenge({ mode: "daily" });
+      return;
+    }
+    if (id === "grammar") {
+      setRoute(grammarRoute());
+      return;
+    }
+    if (id === "blog") {
+      setRoute(blogRoute());
+      return;
+    }
+    setRoute(staticRoute(id));
+  };
+
   const routeResetKey = `${appView}:${grammarSurface ?? ""}:${blogSlug ?? ""}`;
 
   return (
@@ -491,9 +451,7 @@ export default function App() {
         clearCacheLabel={t.routeErrorClearCache}
         homeLabel={t.routeErrorGoHome}
         onGoHome={() => {
-          setGrammarSurface(null);
-          setBlogSlug(null);
-          setAppView("home");
+          setRoute(staticRoute("home"));
         }}
         context={{
           route: window.location.pathname,
@@ -644,104 +602,27 @@ export default function App() {
         </div>
       </div>
 
-      <nav className="view-switch segmented" aria-label={t.flowLabel}>
-        <button
-          type="button"
-          data-nav="home"
-          className={appView === "home" ? "selected" : ""}
-          aria-current={appView === "home" ? "page" : undefined}
-          onClick={() => setAppView("home")}
-        >
-          <Home aria-hidden="true" size={16} style={navIconStyle} />
-          {t.home}
-        </button>
-        <button
-          type="button"
-          data-nav="learn"
-          className={appView === "learn" ? "selected" : ""}
-          aria-current={appView === "learn" ? "page" : undefined}
-          onClick={() => setAppView("learn")}
-        >
-          <GraduationCap aria-hidden="true" size={16} style={navIconStyle} />
-          {t.learn}
-        </button>
-        <button
-          type="button"
-          data-nav="rules"
-          className={`nav-secondary${appView === "rules" ? " selected" : ""}`}
-          aria-current={appView === "rules" ? "page" : undefined}
-          onClick={() => setAppView("rules")}
-        >
-          <Table aria-hidden="true" size={16} style={navIconStyle} />
-          {t.rules}
-        </button>
-        <button
-          type="button"
-          data-nav="kanji"
-          className={`nav-secondary${appView === "kanji" ? " selected" : ""}`}
-          aria-current={appView === "kanji" ? "page" : undefined}
-          onClick={() => setAppView("kanji")}
-        >
-          <BookA aria-hidden="true" size={16} style={navIconStyle} />
-          {t.kanji}
-        </button>
-        <button
-          type="button"
-          data-nav="grammar"
-          className={appView === "grammar" && (grammarSurface === null || isGrammarLevelRoute) ? "selected" : ""}
-          aria-current={appView === "grammar" && (grammarSurface === null || isGrammarLevelRoute) ? "page" : undefined}
-          onClick={() => { setGrammarSurface(null); setAppView("grammar"); }}
-        >
-          <BookOpen aria-hidden="true" size={16} style={navIconStyle} />
-          {t.grammar}
-        </button>
-        {blogAvailable ? (
-          <button
-            type="button"
-            data-nav="blog"
-            className={`nav-secondary${appView === "blog" ? " selected" : ""}`}
-            aria-current={appView === "blog" ? "page" : undefined}
-            onClick={() => { setBlogSlug(null); setAppView("blog"); }}
-          >
-            <Newspaper aria-hidden="true" size={16} style={navIconStyle} />
-            {t.blog}
-          </button>
-        ) : null}
-        <button
-          type="button"
-          data-nav="challenge"
-          className={appView === "challenge" ? "selected" : ""}
-          aria-current={appView === "challenge" ? "page" : undefined}
-          onClick={() => openChallenge({ mode: "daily" })}
-        >
-          <Target aria-hidden="true" size={16} style={navIconStyle} />
-          {t.challenge}
-        </button>
-        <button
-          type="button"
-          data-nav="mock"
-          className={appView === "mock" ? "selected" : ""}
-          aria-current={appView === "mock" ? "page" : undefined}
-          onClick={() => setAppView("mock")}
-        >
-          <ClipboardList aria-hidden="true" size={16} style={navIconStyle} />
-          {t.mockExam}
-        </button>
-        <button
-          type="button"
-          data-nav="about"
-          className={`nav-secondary${appView === "about" ? " selected" : ""}`}
-          aria-current={appView === "about" ? "page" : undefined}
-          onClick={() => setAppView("about")}
-        >
-          <Info aria-hidden="true" size={16} style={navIconStyle} />
-          {t.about}
-        </button>
-        <MoreMenu
-          triggerLabel={t.navMore}
-          triggerCurrentLabel={t.navMoreWithCurrent}
-          items={moreMenuItems}
-          tools={{
+      <AppNavigation
+        ariaLabel={t.flowLabel}
+        navigation={navigation}
+        labels={{
+          home: t.home,
+          learn: t.learn,
+          challenge: t.challenge,
+          mockExam: t.mockExam,
+          grammar: t.grammar,
+          rules: t.rules,
+          kanji: t.kanji,
+          kanaPageTitle: t.kanaPageTitle,
+          blog: t.blog,
+          about: t.about
+        }}
+        resourcesLabel={t.navResources}
+        resourcesCurrentLabel={t.navResourcesWithCurrent}
+        moreLabel={t.navMore}
+        moreCurrentLabel={t.navMoreWithCurrent}
+        onSelect={navigateFromAppNavigation}
+        tools={{
             heading: t.navMoreTools,
             language:
               LANGUAGE_OPTIONS.length > 1
@@ -766,9 +647,8 @@ export default function App() {
                   onDeleteHistory: openDeleteHistory
                 }
               : undefined
-          }}
-        />
-      </nav>
+        }}
+      />
 
       <FuriganaContext.Provider value={{ enabled: furiganaEnabled }}>
       {appView === "home" ? (
@@ -783,8 +663,7 @@ export default function App() {
             }
             // Mirror the nav button: a stale grammar-point surface would
             // otherwise reopen the last-viewed point instead of the index.
-            if (target === "grammar") setGrammarSurface(null);
-            setAppView(target);
+            setRoute(target === "grammar" ? grammarRoute() : staticRoute(target));
           }}
           onStartReview={() => openChallenge({ mode: "review" })}
           onStartBookmarks={() => openChallenge({ mode: "bookmarks" })}
@@ -820,7 +699,7 @@ export default function App() {
             openChallenge({ mode: "kana", filter: { kanaScript: script } })
           }
           onStartStarterDrill={() => openChallenge({ mode: "starter" })}
-          onOpenKana={() => setAppView("kana")}
+          onOpenKana={() => setRoute(staticRoute("kana"))}
         />
       ) : appView === "rules" ? (
         <RulesPanel language={language} />
@@ -862,14 +741,14 @@ export default function App() {
             language={language}
             level={grammarLevel}
             onOpenPattern={(surface) => {
-              setGrammarSurface(surface);
+              setRoute(grammarRoute(surface));
             }}
-            onBack={() => setAppView("home")}
+            onBack={() => setRoute(staticRoute("home"))}
             onBackToOverview={() => {
-              setGrammarSurface(null);
+              setRoute(grammarRoute());
             }}
             onSelectLevel={(lvl) => {
-              setGrammarSurface(lvl);
+              setRoute(grammarRoute(lvl));
             }}
           />
         </Suspense>
@@ -881,18 +760,17 @@ export default function App() {
             onPractice={() => openChallenge({ mode: "daily" })}
             onBack={() => {
               // Go back to grammar index (overview or level index)
-              setGrammarSurface(null);
-              setAppView("grammar");
+              setRoute(grammarRoute());
             }}
-            onNavigate={(surface) => setGrammarSurface(surface)}
+            onNavigate={(surface) => setRoute(grammarRoute(surface))}
           />
         </Suspense>
       ) : appView === "blog" && blogAvailable && blogSlug === null ? (
         <Suspense fallback={<PanelFallback label={t.loading} />}>
           <BlogIndexPage
             language={language}
-            onOpenArticle={(slug) => setBlogSlug(slug)}
-            onBack={() => setAppView("home")}
+            onOpenArticle={(slug) => setRoute(blogRoute(slug))}
+            onBack={() => setRoute(staticRoute("home"))}
           />
         </Suspense>
       ) : appView === "blog" && blogAvailable ? (
@@ -900,7 +778,7 @@ export default function App() {
           <BlogArticlePage
             slug={blogSlug ?? ""}
             language={language}
-            onBack={() => setBlogSlug(null)}
+            onBack={() => setRoute(blogRoute())}
             onCta={(cta) =>
               cta.kind === "challenge"
                 ? openChallenge({ mode: cta.mode })
@@ -916,7 +794,7 @@ export default function App() {
             recordAttempt={recordAttempt}
             language={language}
             targetLevel={targetLevel}
-            onExit={() => setAppView("home")}
+            onExit={() => setRoute(staticRoute("home"))}
             onOpenFeedback={() => setFeedbackKind("wish")}
           />
         </Suspense>

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -94,4 +94,19 @@ describe("AppNavigation (#727)", () => {
     await user.click(screen.getByRole("menuitem", { name: "漢字" }));
     expect(onSelect).toHaveBeenCalledWith("kanji");
   });
+
+  it("supports keyboard-only resource selection from both folded navigation triggers", async () => {
+    const user = userEvent.setup();
+    const onSelect = renderNavigation();
+
+    const resources = screen.getByRole("button", { name: "資源" });
+    resources.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(onSelect).toHaveBeenCalledWith("kanji");
+
+    const more = screen.getByRole("button", { name: "更多" });
+    more.focus();
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    expect(onSelect).toHaveBeenLastCalledWith("kanji");
+  });
 });

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { resolveNavigation } from "../domain/navigation";
+import { staticRoute } from "../domain/routes";
+import { AppNavigation } from "./AppNavigation";
+import type { MoreMenuTools } from "./MoreMenu";
+
+const labels = {
+  home: "首頁",
+  learn: "學習",
+  challenge: "挑戰",
+  mockExam: "模擬考",
+  grammar: "文型",
+  rules: "規則表",
+  kanji: "漢字",
+  kanaPageTitle: "五十音",
+  blog: "文章",
+  about: "關於"
+} as const;
+
+const tools: MoreMenuTools = {
+  heading: "設定與工具",
+  furigana: { label: "顯示註音", pressed: false, onToggle: vi.fn() },
+  theme: { label: "深色模式", onToggle: vi.fn() },
+  feedback: { label: "意見回饋", onOpen: vi.fn() }
+};
+
+function renderNavigation(view: "home" | "kana" | "kanji" = "home") {
+  const onSelect = vi.fn();
+  render(
+    <AppNavigation
+      ariaLabel="學習流程"
+      navigation={resolveNavigation(staticRoute(view), "zh-Hant")}
+      labels={labels}
+      resourcesLabel="資源"
+      resourcesCurrentLabel={(page) => `資源（目前：${page}）`}
+      moreLabel="更多"
+      moreCurrentLabel={(page) => `更多（目前：${page}）`}
+      tools={tools}
+      onSelect={onSelect}
+    />
+  );
+  return onSelect;
+}
+
+describe("AppNavigation (#727)", () => {
+  it("renders five primary entries plus desktop Resources and mobile More", () => {
+    renderNavigation();
+    const nav = screen.getByRole("navigation", { name: "學習流程" });
+    for (const name of ["首頁", "學習", "挑戰", "模擬考", "文型"]) {
+      expect(within(nav).getByRole("button", { name })).toBeInTheDocument();
+    }
+    expect(within(nav).getByRole("button", { name: "資源" })).toBeInTheDocument();
+    expect(within(nav).getByRole("button", { name: "更多" })).toBeInTheDocument();
+    expect(within(nav).queryByRole("button", { name: "規則表" })).not.toBeInTheDocument();
+  });
+
+  it("derives both resource menus from the same labels, icons, order and visibility", async () => {
+    const user = userEvent.setup();
+    renderNavigation();
+    await user.click(screen.getByRole("button", { name: "資源" }));
+    const desktop = screen.getByRole("menu", { name: "資源" });
+    expect(within(desktop).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "規則表", "漢字", "五十音", "文章", "關於"
+    ]);
+    fireEvent.keyDown(within(desktop).getByRole("menuitem", { name: "規則表" }), { key: "Escape" });
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const mobile = screen.getByRole("menu", { name: "更多" });
+    expect(within(mobile).getByText("資源")).toBeInTheDocument();
+    expect(within(mobile).getByText("設定與工具")).toBeInTheDocument();
+    expect(within(mobile).getAllByRole("menuitem").slice(0, 5).map((item) => item.textContent)).toEqual([
+      "規則表", "漢字", "五十音", "文章", "關於"
+    ]);
+  });
+
+  it("marks Learn plus Kana, and Resources plus the exact resource", async () => {
+    const user = userEvent.setup();
+    renderNavigation("kana");
+    expect(screen.getByRole("button", { name: "學習" })).toHaveAttribute("aria-current", "page");
+    const resources = screen.getByRole("button", { name: "資源（目前：五十音）" });
+    expect(resources.className).toContain("selected");
+    await user.click(resources);
+    expect(screen.getByRole("menuitem", { name: "五十音" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("routes primary and resource actions through one event API", async () => {
+    const user = userEvent.setup();
+    const onSelect = renderNavigation();
+    await user.click(screen.getByRole("button", { name: "學習" }));
+    expect(onSelect).toHaveBeenCalledWith("learn");
+    await user.click(screen.getByRole("button", { name: "資源" }));
+    await user.click(screen.getByRole("menuitem", { name: "漢字" }));
+    expect(onSelect).toHaveBeenCalledWith("kanji");
+  });
+});

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { resolveNavigation } from "../domain/navigation";
@@ -101,12 +101,16 @@ describe("AppNavigation (#727)", () => {
 
     const resources = screen.getByRole("button", { name: "資源" });
     resources.focus();
-    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus());
+    await user.keyboard("{ArrowDown}{Enter}");
     expect(onSelect).toHaveBeenCalledWith("kanji");
 
     const more = screen.getByRole("button", { name: "更多" });
     more.focus();
-    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+    await user.keyboard("{ArrowDown}");
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus());
+    await user.keyboard("{ArrowDown}{Enter}");
     expect(onSelect).toHaveBeenLastCalledWith("kanji");
   });
 });

--- a/src/components/AppNavigation.tsx
+++ b/src/components/AppNavigation.tsx
@@ -1,0 +1,108 @@
+import {
+  BookA,
+  BookOpen,
+  ClipboardList,
+  GraduationCap,
+  Home,
+  Info,
+  Newspaper,
+  Table,
+  Target,
+  Type,
+  type LucideIcon
+} from "lucide-react";
+import type {
+  NavigationIcon,
+  NavigationId,
+  NavigationLabelKey,
+  ResolvedNavigationEntry
+} from "../domain/navigation";
+import { MoreMenu, type MoreMenuNavItem, type MoreMenuTools } from "./MoreMenu";
+
+const ICONS: Record<NavigationIcon, LucideIcon> = {
+  home: Home,
+  learn: GraduationCap,
+  challenge: Target,
+  mock: ClipboardList,
+  grammar: BookOpen,
+  rules: Table,
+  kanji: BookA,
+  kana: Type,
+  blog: Newspaper,
+  about: Info
+};
+
+const iconStyle = { verticalAlign: "middle", marginRight: "0.2rem" } as const;
+
+export interface ResolvedNavigation {
+  primary: ResolvedNavigationEntry[];
+  resources: ResolvedNavigationEntry[];
+  resourcesCurrent: boolean;
+}
+
+export function AppNavigation({
+  ariaLabel,
+  navigation,
+  labels,
+  resourcesLabel,
+  resourcesCurrentLabel,
+  moreLabel,
+  moreCurrentLabel,
+  tools,
+  onSelect
+}: {
+  ariaLabel: string;
+  navigation: ResolvedNavigation;
+  labels: Record<NavigationLabelKey, string>;
+  resourcesLabel: string;
+  resourcesCurrentLabel: (page: string) => string;
+  moreLabel: string;
+  moreCurrentLabel: (page: string) => string;
+  tools: MoreMenuTools;
+  onSelect: (id: NavigationId) => void;
+}) {
+  const resourceItems: MoreMenuNavItem[] = navigation.resources.map((entry) => {
+    const Icon = ICONS[entry.icon];
+    return {
+      key: entry.id,
+      label: labels[entry.labelKey],
+      icon: <Icon aria-hidden="true" size={16} style={iconStyle} />,
+      selected: entry.current,
+      onSelect: () => onSelect(entry.id)
+    };
+  });
+
+  return (
+    <nav className="view-switch segmented" aria-label={ariaLabel}>
+      {navigation.primary.map((entry) => {
+        const Icon = ICONS[entry.icon];
+        return (
+          <button
+            key={entry.id}
+            type="button"
+            data-nav={entry.id}
+            className={entry.current ? "selected" : ""}
+            aria-current={entry.current ? "page" : undefined}
+            onClick={() => onSelect(entry.id)}
+          >
+            <Icon aria-hidden="true" size={16} style={iconStyle} />
+            {labels[entry.labelKey]}
+          </button>
+        );
+      })}
+      <MoreMenu
+        className="nav-resources"
+        triggerLabel={resourcesLabel}
+        triggerCurrentLabel={resourcesCurrentLabel}
+        items={resourceItems}
+      />
+      <MoreMenu
+        triggerLabel={moreLabel}
+        triggerCurrentLabel={moreCurrentLabel}
+        resourcesHeading={resourcesLabel}
+        items={resourceItems}
+        tools={tools}
+      />
+    </nav>
+  );
+}

--- a/src/components/MoreMenu.test.tsx
+++ b/src/components/MoreMenu.test.tsx
@@ -46,6 +46,7 @@ function renderMenu(items = makeItems(), tools = makeTools()) {
     <MoreMenu
       triggerLabel="更多"
       triggerCurrentLabel={(page) => `更多（目前：${page}）`}
+      resourcesHeading="資源"
       items={items}
       tools={tools}
     />
@@ -74,6 +75,7 @@ describe("MoreMenu (#608)", () => {
       expect(within(menu).getByRole("menuitem", { name: label })).toBeInTheDocument();
     }
     expect(within(menu).getByText(tools.heading)).toBeInTheDocument();
+    expect(within(menu).getByText("資源")).toBeInTheDocument();
     expect(within(menu).getByRole("menuitem", { name: "切換語言" })).toBeInTheDocument();
     expect(within(menu).getByRole("menuitemcheckbox", { name: "顯示註音" })).toBeInTheDocument();
     expect(within(menu).getByRole("menuitem", { name: "深色模式" })).toBeInTheDocument();

--- a/src/components/MoreMenu.tsx
+++ b/src/components/MoreMenu.tsx
@@ -41,16 +41,20 @@ export interface MoreMenuTools {
 export function MoreMenu({
   triggerLabel,
   triggerCurrentLabel,
+  resourcesHeading,
   items,
-  tools
+  tools,
+  className = "nav-more"
 }: {
   triggerLabel: string;
   /** Accessible name for the collapsed trigger while a folded view is active,
    *  e.g. 更多（目前：文章）-- the trigger is then the only place the current
    *  location can show (PR #628 review). */
   triggerCurrentLabel: (page: string) => string;
+  resourcesHeading?: string;
   items: MoreMenuNavItem[];
-  tools: MoreMenuTools;
+  tools?: MoreMenuTools;
+  className?: string;
 }) {
   const [open, setOpen] = useState(false);
   // role="menu" is a single tab stop: only the focused entry keeps tabIndex 0
@@ -66,12 +70,12 @@ export function MoreMenu({
   // then the tools block). Opening and roving both derive their keys from this
   // so a key always resolves to the same DOM element.
   const toolKeys: string[] = [
-    tools.language ? "tool-language" : null,
-    "tool-furigana",
-    "tool-theme",
-    "tool-feedback",
-    tools.auth ? "tool-auth" : null,
-    tools.auth?.signedInAs ? "tool-delete-history" : null
+    tools?.language ? "tool-language" : null,
+    tools ? "tool-furigana" : null,
+    tools ? "tool-theme" : null,
+    tools ? "tool-feedback" : null,
+    tools?.auth ? "tool-auth" : null,
+    tools?.auth?.signedInAs ? "tool-delete-history" : null
   ].filter((key): key is string => key !== null);
 
   const allKeys = useCallback(() => [...items.map((item) => item.key), ...toolKeys], [items, toolKeys]);
@@ -174,7 +178,7 @@ export function MoreMenu({
   const rove = (key: string) => (effectiveFocusKey === key ? 0 : -1);
 
   return (
-    <div className="nav-more" ref={rootRef}>
+    <div className={className} ref={rootRef}>
       <button
         type="button"
         ref={triggerRef}
@@ -208,6 +212,11 @@ export function MoreMenu({
           aria-label={triggerLabel}
           onKeyDown={onPanelKeyDown}
         >
+          {resourcesHeading ? (
+            <p className="nav-more-heading" aria-hidden="true">
+              {resourcesHeading}
+            </p>
+          ) : null}
           {items.map((item) => (
             <button
               key={item.key}
@@ -224,10 +233,12 @@ export function MoreMenu({
             </button>
           ))}
 
-          <div className="nav-more-divider" role="separator" aria-hidden="true" />
-          <p className="nav-more-heading" aria-hidden="true">
-            {tools.heading}
-          </p>
+          {tools ? (
+            <>
+              <div className="nav-more-divider" role="separator" aria-hidden="true" />
+              <p className="nav-more-heading" aria-hidden="true">
+                {tools.heading}
+              </p>
 
           {tools.language ? (
             <button
@@ -332,6 +343,8 @@ export function MoreMenu({
                   {tools.auth.hint ? <span>{tools.auth.hint}</span> : null}
                 </p>
               ) : null}
+            </>
+          ) : null}
             </>
           ) : null}
         </div>

--- a/src/domain/navigation.test.ts
+++ b/src/domain/navigation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { NAVIGATION_REGISTRY, resolveNavigation } from "./navigation";
+import { blogRoute, grammarRoute, staticRoute } from "./routes";
+
+describe("navigation registry (#727)", () => {
+  it("has deterministic, duplicate-free primary and resource order", () => {
+    expect(NAVIGATION_REGISTRY.map((entry) => entry.id)).toEqual([
+      "home",
+      "learn",
+      "challenge",
+      "mock",
+      "grammar",
+      "rules",
+      "kanji",
+      "kana",
+      "blog",
+      "about"
+    ]);
+    expect(new Set(NAVIGATION_REGISTRY.map((entry) => entry.id)).size).toBe(
+      NAVIGATION_REGISTRY.length
+    );
+  });
+
+  it("keeps blog zh-Hant-only without changing other resources", () => {
+    expect(resolveNavigation(staticRoute("home"), "zh-Hant").resources.map((item) => item.id))
+      .toEqual(["rules", "kanji", "kana", "blog", "about"]);
+    expect(resolveNavigation(staticRoute("home"), "ja").resources.map((item) => item.id))
+      .toEqual(["rules", "kanji", "kana", "about"]);
+  });
+
+  it("resolves nested primary and resource ancestors", () => {
+    const grammar = resolveNavigation(grammarRoute("〜てもいい"), "zh-Hant");
+    expect(grammar.primary.find((item) => item.id === "grammar")?.current).toBe(true);
+
+    const kana = resolveNavigation(staticRoute("kana"), "zh-Hant");
+    expect(kana.primary.find((item) => item.id === "learn")?.current).toBe(true);
+    expect(kana.resources.find((item) => item.id === "kana")?.current).toBe(true);
+    expect(kana.resourcesCurrent).toBe(true);
+
+    const legal = resolveNavigation(staticRoute("privacy"), "en");
+    expect(legal.resources.find((item) => item.id === "about")?.current).toBe(true);
+    expect(legal.resourcesCurrent).toBe(true);
+
+    const article = resolveNavigation(blogRoute("an-article"), "zh-Hant");
+    expect(article.resources.find((item) => item.id === "blog")?.current).toBe(true);
+  });
+});

--- a/src/domain/navigation.ts
+++ b/src/domain/navigation.ts
@@ -1,0 +1,84 @@
+import type { LocaleCode } from "./types";
+import type { AppRoute, AppView } from "./routes";
+
+export type NavigationGroup = "primary" | "resource";
+export type NavigationId =
+  | "home"
+  | "learn"
+  | "challenge"
+  | "mock"
+  | "grammar"
+  | "rules"
+  | "kanji"
+  | "kana"
+  | "blog"
+  | "about";
+export type NavigationIcon =
+  | "home"
+  | "learn"
+  | "challenge"
+  | "mock"
+  | "grammar"
+  | "rules"
+  | "kanji"
+  | "kana"
+  | "blog"
+  | "about";
+export type NavigationLabelKey =
+  | "home"
+  | "learn"
+  | "challenge"
+  | "mockExam"
+  | "grammar"
+  | "rules"
+  | "kanji"
+  | "kanaPageTitle"
+  | "blog"
+  | "about";
+
+export interface NavigationDefinition {
+  readonly id: NavigationId;
+  readonly view: AppView;
+  readonly group: NavigationGroup;
+  readonly labelKey: NavigationLabelKey;
+  readonly icon: NavigationIcon;
+  readonly zhHantOnly?: true;
+}
+
+export interface ResolvedNavigationEntry extends NavigationDefinition {
+  readonly current: boolean;
+}
+
+export const NAVIGATION_REGISTRY: readonly NavigationDefinition[] = [
+  { id: "home", view: "home", group: "primary", labelKey: "home", icon: "home" },
+  { id: "learn", view: "learn", group: "primary", labelKey: "learn", icon: "learn" },
+  { id: "challenge", view: "challenge", group: "primary", labelKey: "challenge", icon: "challenge" },
+  { id: "mock", view: "mock", group: "primary", labelKey: "mockExam", icon: "mock" },
+  { id: "grammar", view: "grammar", group: "primary", labelKey: "grammar", icon: "grammar" },
+  { id: "rules", view: "rules", group: "resource", labelKey: "rules", icon: "rules" },
+  { id: "kanji", view: "kanji", group: "resource", labelKey: "kanji", icon: "kanji" },
+  { id: "kana", view: "kana", group: "resource", labelKey: "kanaPageTitle", icon: "kana" },
+  { id: "blog", view: "blog", group: "resource", labelKey: "blog", icon: "blog", zhHantOnly: true },
+  { id: "about", view: "about", group: "resource", labelKey: "about", icon: "about" }
+] as const;
+
+function isCurrent(entry: NavigationDefinition, route: AppRoute): boolean {
+  if (entry.id === "learn") return route.view === "learn" || route.view === "kana";
+  if (entry.id === "about") {
+    return route.view === "about" || route.view === "privacy" || route.view === "terms";
+  }
+  return route.view === entry.view;
+}
+
+export function resolveNavigation(route: AppRoute, language: LocaleCode): {
+  primary: ResolvedNavigationEntry[];
+  resources: ResolvedNavigationEntry[];
+  resourcesCurrent: boolean;
+} {
+  const visible = NAVIGATION_REGISTRY.filter(
+    (entry) => !entry.zhHantOnly || language === "zh-Hant"
+  ).map((entry) => ({ ...entry, current: isCurrent(entry, route) }));
+  const primary = visible.filter((entry) => entry.group === "primary");
+  const resources = visible.filter((entry) => entry.group === "resource");
+  return { primary, resources, resourcesCurrent: resources.some((entry) => entry.current) };
+}

--- a/src/domain/routes.test.ts
+++ b/src/domain/routes.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { APP_VIEW_PATHS, parseRoute, serializeRoute, type AppRoute, type AppView } from "./routes";
+import {
+  APP_VIEW_PATHS,
+  blogRoute,
+  grammarRoute,
+  parseRoute,
+  serializeRoute,
+  staticRoute,
+  type AppRoute,
+  type AppView
+} from "./routes";
 
-const staticRoute = (view: AppView): AppRoute => ({
+const legacyStaticRoute = (view: AppView): AppRoute => ({
   view,
   grammarSurface: null,
   blogSlug: null
@@ -10,9 +19,32 @@ const staticRoute = (view: AppView): AppRoute => ({
 describe("app route contract (#623)", () => {
   it("round-trips every top-level view through its shared static path", () => {
     for (const view of Object.keys(APP_VIEW_PATHS) as AppView[]) {
-      const route = staticRoute(view);
+      const route = legacyStaticRoute(view);
       expect(parseRoute(serializeRoute(route)), view).toEqual(route);
     }
+  });
+
+  it("constructs complete mutually-exclusive route identities", () => {
+    expect(staticRoute("learn")).toEqual({
+      view: "learn",
+      grammarSurface: null,
+      blogSlug: null
+    });
+    expect(grammarRoute("〜てもいい")).toEqual({
+      view: "grammar",
+      grammarSurface: "〜てもいい",
+      blogSlug: null
+    });
+    expect(grammarRoute()).toEqual({
+      view: "grammar",
+      grammarSurface: null,
+      blogSlug: null
+    });
+    expect(blogRoute("article-slug")).toEqual({
+      view: "blog",
+      grammarSurface: null,
+      blogSlug: "article-slug"
+    });
   });
 
   it("treats /stay-d as a normal public app route", () => {

--- a/src/domain/routes.ts
+++ b/src/domain/routes.ts
@@ -26,8 +26,16 @@ export interface AppRoute {
   blogSlug: string | null;
 }
 
-function staticRoute(view: AppView): AppRoute {
+export function staticRoute(view: AppView): AppRoute {
   return { view, grammarSurface: null, blogSlug: null };
+}
+
+export function grammarRoute(surface?: string | null): AppRoute {
+  return { view: "grammar", grammarSurface: surface ?? null, blogSlug: null };
+}
+
+export function blogRoute(slug?: string | null): AppRoute {
+  return { view: "blog", grammarSurface: null, blogSlug: slug ?? null };
 }
 
 function decodePathSegment(segment: string): string {
@@ -44,20 +52,12 @@ function decodePathSegment(segment: string): string {
 export function parseRoute(pathname: string): AppRoute {
   const grammar = pathname.match(/^\/grammar\/(.+)$/);
   if (grammar) {
-    return {
-      view: "grammar",
-      grammarSurface: decodePathSegment(grammar[1]),
-      blogSlug: null
-    };
+    return grammarRoute(decodePathSegment(grammar[1]));
   }
 
   const blog = pathname.match(/^\/blog\/(.+)$/);
   if (blog) {
-    return {
-      view: "blog",
-      grammarSurface: null,
-      blogSlug: canonicalArticleSlug(decodePathSegment(blog[1]))
-    };
+    return blogRoute(canonicalArticleSlug(decodePathSegment(blog[1])));
   }
 
   const view = (Object.keys(APP_VIEW_PATHS) as AppView[]).find(

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,6 +27,8 @@ export type Copy = {
   furiganaShow: string;
   furiganaHide: string;
   flowLabel: string;
+  navResources: string;
+  navResourcesWithCurrent: (page: string) => string;
   navMore: string;
   navMoreTools: string;
   /** Collapsed 更多 trigger's accessible name while a folded view is active. */

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -11,6 +11,8 @@ export const en: Copy = {
   furiganaShow: "Show furigana",
   furiganaHide: "Hide furigana",
   flowLabel: "Study flow",
+  navResources: "Resources",
+  navResourcesWithCurrent: (page) => `Resources (current: ${page})`,
   navMore: "More",
   navMoreTools: "Settings & tools",
   navMoreWithCurrent: (page) => `More (current: ${page})`,

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -11,6 +11,8 @@ export const id: Copy = {
   furiganaShow: "Tampilkan furigana",
   furiganaHide: "Sembunyikan furigana",
   flowLabel: "Alur belajar",
+  navResources: "Sumber daya",
+  navResourcesWithCurrent: (page) => `Sumber daya (saat ini: ${page})`,
   navMore: "Lainnya",
   navMoreTools: "Pengaturan & alat",
   navMoreWithCurrent: (page) => `Lainnya (saat ini: ${page})`,

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -11,6 +11,8 @@ export const ja: Copy = {
   furiganaShow: "ふりがなを表示",
   furiganaHide: "ふりがなを隠す",
   flowLabel: "学習の流れ",
+  navResources: "資料",
+  navResourcesWithCurrent: (page) => `資料（現在：${page}）`,
   navMore: "その他",
   navMoreTools: "設定・ツール",
   navMoreWithCurrent: (page) => `その他（現在：${page}）`,

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -11,6 +11,8 @@ export const ko: Copy = {
   furiganaShow: "후리가나 표시",
   furiganaHide: "후리가나 숨김",
   flowLabel: "학습 흐름",
+  navResources: "자료",
+  navResourcesWithCurrent: (page) => `자료(현재: ${page})`,
   navMore: "더보기",
   navMoreTools: "설정 및 도구",
   navMoreWithCurrent: (page) => `더보기(현재: ${page})`,

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -11,6 +11,8 @@ export const my: Copy = {
   furiganaShow: "ဖူရိဂါနာ ပြရန်",
   furiganaHide: "ဖူရိဂါနာ ဖျောက်ရန်",
   flowLabel: "လေ့လာမှု အဆင့်ဆင့်",
+  navResources: "အရင်းအမြစ်များ",
+  navResourcesWithCurrent: (page) => `အရင်းအမြစ်များ (လက်ရှိ - ${page})`,
   navMore: "နောက်ထပ်",
   navMoreTools: "ဆက်တင်နှင့် ကိရိယာများ",
   navMoreWithCurrent: (page) => `နောက်ထပ် (လက်ရှိ - ${page})`,

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -11,6 +11,8 @@ export const th: Copy = {
   furiganaShow: "แสดงคำอ่าน",
   furiganaHide: "ซ่อนคำอ่าน",
   flowLabel: "ขั้นตอนการเรียน",
+  navResources: "แหล่งข้อมูล",
+  navResourcesWithCurrent: (page) => `แหล่งข้อมูล (ปัจจุบัน: ${page})`,
   navMore: "เพิ่มเติม",
   navMoreTools: "การตั้งค่าและเครื่องมือ",
   navMoreWithCurrent: (page) => `เพิ่มเติม (ปัจจุบัน: ${page})`,

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -11,6 +11,8 @@ export const vi: Copy = {
   furiganaShow: "Hiện furigana",
   furiganaHide: "Ẩn furigana",
   flowLabel: "Lộ trình học",
+  navResources: "Tài nguyên",
+  navResourcesWithCurrent: (page) => `Tài nguyên (hiện tại: ${page})`,
   navMore: "Xem thêm",
   navMoreTools: "Cài đặt & công cụ",
   navMoreWithCurrent: (page) => `Xem thêm (hiện tại: ${page})`,

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -11,6 +11,8 @@ export const zhHant: Copy = {
   furiganaShow: "顯示註音",
   furiganaHide: "隱藏註音",
   flowLabel: "學習流程",
+  navResources: "資源",
+  navResourcesWithCurrent: (page) => `資源（目前：${page}）`,
   navMore: "更多",
   navMoreTools: "設定與工具",
   navMoreWithCurrent: (page) => `更多（目前：${page}）`,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -172,7 +172,6 @@
 
 body {
   margin: 0;
-  min-width: 320px;
   min-height: 100vh;
   /* Plain paper wash. The previous body had a teal/orange radial glow +
    * hairline grid that read as "SaaS dashboard"; this theme is wafuu

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -246,13 +246,16 @@
   font-weight: 800;
 }
 
-/* ---- #608: nav 更多 menu (mobile-only trigger) ------------------------- */
+/* ---- Shared route menus (#727) ----------------------------------------- */
 
-/* The menu block lives inside the nav; desktop shows all nine entries, so
-   the whole thing stays display:none until the phone breakpoint in
-   responsive.css flips it on. */
+/* Desktop exposes the registry's resource group; mobile replaces that trigger
+   with More, which renders the same resources followed by the tool section. */
 .nav-more {
   display: none;
+}
+
+.nav-more,
+.nav-resources {
   position: relative;
 }
 

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -296,10 +296,9 @@
     font-size: 1.3rem;
   }
 
-  /* Five primary entries + 更多; the secondary views fold into the menu.
-     `order` re-ranks the surviving buttons by importance without touching
-     the desktop DOM order. */
-  .view-switch .nav-secondary {
+  /* Five primary entries + More. Resources are shared by both menu renderers;
+     only their trigger changes at this breakpoint. */
+  .view-switch .nav-resources {
     display: none;
   }
 


### PR DESCRIPTION
Closes #727

## Summary

- centralize App location in one complete `AppRoute` state and route constructors
- add a pure navigation registry/resolver shared by desktop Resources and mobile More
- render five primary routes plus Resources on desktop, and five primary routes plus More with Resources and Tools on mobile
- retain Challenge's specialized launch/query-restoration and analytics flow
- remove the 320px minimum-width overflow and add keyboard-only resource-menu regression coverage

## Design

- all static, grammar, and blog identities are constructed through the canonical helpers; language normalization now uses `staticRoute("home")`
- the registry owns navigation IDs, order, labels, icons, visibility, and active ancestors; renderers only consume resolved entries
- no route URL/query schema changes, no router/menu dependency, no breadcrumb work (#729), and no auth/history-deletion protocol changes

## Validation

- `pnpm lint` — PASS
- `pnpm typecheck` — PASS
- `pnpm check:i18n` — PASS (existing content-overlay warnings only)
- focused navigation suite — PASS, 117/117
- `pnpm test` — executed; concurrent load caused six existing 5-second timeout flakes (Gemini integration and App lazy UI), with no assertion failures
- isolated reruns — PASS: App 79/79; Gemini integration 23/23
- `pnpm exec vitest run --maxWorkers=1` — PASS, 143/143 files and 2072/2072 tests
- `pnpm build` — PASS (PWA and 107-page prerender)
- browser smoke — PASS at 320/390/768/1280: no page-level horizontal overflow, 44px minimum visible nav target; keyboard-only Resources/More opening, roving focus, Escape return focus, and selection covered
- `git diff --check` — PASS
- independent exact-HEAD review — `No blocking findings.`

## Residual risks / exclusions

- the project-wide concurrent suite remains sensitive to host load because several unrelated tests have a fixed 5-second timeout; serialized and isolated reruns are green
- no #729 breadcrumbs, no navigation redesign beyond the frozen #727 contract, and no unrelated backlog changes
