### PR TITLE
feat(analytics): measure Stay.D funnel via Zaraz / GA4 (#745)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,8 +1,12 @@
-# Jabiko analytics (Cloudflare Zaraz, Phase 1)
+# Jabiko analytics (Cloudflare Zaraz)
 
-This document describes the **Phase 1** anonymous learning analytics layer
+This document describes the privacy-safe learning analytics layer
 introduced in issue #404. It is intentionally small: a single typed helper,
-an environment gate, nine coarse events, and a hard privacy contract.
+an environment gate, ten coarse events, and a hard privacy contract.
+Payloads are sanitized, metadata-only event shapes — no question text, user
+answers, emails, raw user IDs, or arbitrary free-form strings. GA4 is
+connected only as a downstream destination **through** the existing
+Zaraz layer (issue #745) — application code never talks to Google directly.
 
 ## Why Zaraz
 
@@ -13,8 +17,8 @@ open published articles.
 Cloudflare Zaraz is used as an event router / tag manager — it does **not**
 replace Jabiko's own learning-progress data model or Supabase sync.
 
-Zaraz provides 1,000,000 free events/month per Cloudflare account. Phase 1
-event volume is kept intentionally small (nine coarse flow events, not
+Zaraz provides 1,000,000 free events/month per Cloudflare account. Event
+volume is kept intentionally small (ten coarse flow events, not
 per-interaction UI events).
 
 ## Helper
@@ -53,7 +57,7 @@ is correctly treated as disabled.
 > production build AND the Zaraz snippet is installed in the Cloudflare
 > dashboard / `index.html`.
 
-## Phase 1 events
+## Events
 
 | event name           | when it fires                          | payload keys                                                    |
 |----------------------|----------------------------------------|-----------------------------------------------------------------|
@@ -66,20 +70,56 @@ is correctly treated as disabled.
 | `locale_changed`     | the learner switches the UI language   | `from` (LocaleCode), `to` (LocaleCode)                          |
 | `weak_review_started`| the learner opens weak-point review    | `dueCount` (a count, not content), `locale`                     |
 | `article_viewed`     | a published article is successfully displayed | `slug` (canonical article slug only)                       |
+| `promo_click`        | a Stay.D promotion interaction fires   | `promoId`, `action` (`"airbnb"` or `"video"`), `placement`, `locale` |
 
 `article_viewed` is emitted by `BlogArticlePage` after a published article has
 committed to the UI. The component keeps the last displayed slug in a ref, so
 StrictMode and re-renders do not duplicate an event; entering a different
 slug, or leaving and later re-entering an article route, is a new view.
 
+### `promo_click`
+
+Issue #745: one reusable outbound promotion interaction event, fired from the
+real Stay.D CTAs already on `main` (#744, landed via #747/#749/#751). It
+measures **interest** in the promoted destination — never a booking,
+reservation, or purchase.
+
+- `promoId` — bounded to approved promotion identifiers (`PROMO_IDENTIFIERS`;
+  currently `stay-d`). A free-form string such as an email is rejected at
+  compile time.
+- `action` — narrowed to `"airbnb"` (outbound Airbnb CTA) or `"video"`
+  (video-trigger interaction).
+- `placement` — bounded to the stable Stay.D funnel interaction placements
+  frozen by #744 (`PROMO_PLACEMENTS`):
+
+  ```text
+  home-airbnb          Home direct Airbnb CTA
+  home-video           Home video trigger
+  home-video-airbnb    Airbnb CTA with/after the Home video
+  stay-d-hero-airbnb   /stay-d hero Airbnb CTA
+  stay-d-video         /stay-d video trigger
+  stay-d-video-airbnb  Airbnb CTA with the /stay-d video section
+  stay-d-final-airbnb  /stay-d final Airbnb CTA
+  ```
+
+  Each placement is wired to the corresponding `data-stay-d-placement`
+  interaction point; a new funnel step extends the union. URLs, surface
+  slugs, or free text are rejected at compile time.
+- `locale` — the active UI locale.
+
+Firing is fire-and-forget: a missing or failing Zaraz must never block video
+opening, `/stay-d` navigation, or the Airbnb link (no `preventDefault` on the
+CTA; `trackEvent` swallows all failures).
+
 ### `view` allowed values
 
 `page_view.view` is the app view string (`home`, `learn`, `rules`, `kanji`,
-`kana`, `challenge`, `mock`, `about`, `privacy`, `terms`, `grammar`, or
-`blog`). It is typed as `string` in the
+`kana`, `challenge`, `mock`, `about`, `privacy`, `terms`, `grammar`, `blog`,
+or `stayD`). It is typed as `string` in the
 payload (the lib layer intentionally does not import the App-internal
 `AppView` union to keep layering clean — see decision boundaries in
-`.codex-spec.md`).
+`.codex-spec.md`). `/stay-d` uses the normal `page_view` (`view: "stayD"`);
+there is no separate `stay_d_view` event.
 
 ### `source` / `questionType` vocabulary
 
@@ -116,7 +156,9 @@ keys. The following are NOT present on any shape and cannot be passed through
 - article title, body, query string, referrer, or other navigation/free text
 
 `article_viewed` is deliberately limited to the canonical `slug`; it must not
-carry article prose or visitor/navigation data.
+carry article prose or visitor/navigation data. `promo_click` is limited to
+`promoId` / `action` / `placement` / `locale`; it must never carry the
+destination URL, listing content, or account data.
 
 This is enforced by a per-event allowlist of typed keys. To add a new payload
 field, the shape in `AnalyticsPayloadMap` must be extended first; ad-hoc keys
@@ -125,13 +167,74 @@ are rejected by the compiler.
 > Forbidden payload keys rejected by the type system (verified by tests):
 > `userAnswer`, `userId`, and any key not on the event's allowlist.
 
-## Out of scope (Phase 2+)
+## GA4 through Zaraz (issue #745)
 
-- GA4 or PostHog integration through Zaraz
-- Cloudflare Zaraz Consent Management (consent banner)
+GA4 is a **downstream destination** of Cloudflare Zaraz, not an application
+dependency. Application code sends events only through `trackEvent` →
+`window.zaraz.track(...)` → Zaraz; the GA4 managed tool and its Events action
+forward those custom events. No component, helper, or script adds `gtag.js`,
+Google Tag Manager, direct `gtag(...)` calls, or a GA SDK — a single app-facing
+analytics API is preserved.
+
+- Reuse the existing explicit `page_view` event. **Do not** enable the GA4
+  managed tool's automatic Pageviews action alongside it, or a single SPA
+  navigation would produce two logical page views (one automatic, one manual).
+  Leave the automatic action disabled and rely on the existing
+  `trackEvent("page_view", ...)` path.
+- Do **not** rely on GA4 Enhanced Measurement's generic outbound `click` as the
+  promotion source of truth. The #745 contract is the explicit `promo_click`
+  event, which carries the stable product-level `promoId` / `placement`.
+- `promo_click` measures Jabiko → Airbnb **interest only**. It is not a
+  booking-conversion event and is not configured as one.
+
+### GA4 reporting contract
+
+GA4 must answer at minimum: how many `promo_click` events / users, which
+`placement`, which `action`, which `promoId`, and which `locale`. Create
+event-scoped custom dimensions only for parameters GA4 does not already
+expose:
+
+```text
+promoId
+action
+placement
+locale
+```
+
+Do **not** create high-cardinality dimensions from full URLs, arbitrary text,
+question contents, user identifiers, timestamps, or session-specific values.
+
+### Production operator steps (Cloudflare / GA4)
+
+These are configuration steps performed in the Cloudflare dashboard and the
+GA4 property by the owner — they cannot be completed by editing this repo:
+
+1. Use the intended Jabiko GA4 property/data stream (owner supplies the
+   Measurement ID).
+2. In Cloudflare Zaraz, add/configure the native **Google Analytics 4** managed
+   tool for the production domain.
+3. Configure the Events action so `zaraz.track(...)` custom events reach GA4.
+4. Ensure the page-view configuration does **not** double-count the explicit
+   SPA `page_view` flow (disable the automatic pageview action if needed).
+5. Create only the required event-scoped custom dimensions
+   (`promoId`, `action`, `placement`, `locale`).
+6. Verify the production stream with Zaraz Debugger/Monitoring and GA4
+   Realtime/DebugView.
+
+Do not commit GA credentials, secrets, cookies, or account identifiers to the
+repository. If the GA4 Measurement ID/property has not yet been chosen,
+repository implementation may proceed, but production activation stays blocked
+until the owner supplies/configures the intended property in Cloudflare.
+
+## Out of scope
+
+- Cloudflare Zaraz Consent Management (consent banner) — if production
+  activation legally or operationally requires a materially different consent
+  architecture, stop activation and escalate rather than inventing one here.
 - server-side events through the Zaraz HTTP Events API
 - account/sync events (`sign_in_started`, `sync_enabled`, `sync_failed`, …)
 - deeper learning analytics stored in Jabiko's own DB
+- UTM / redirect / enhanced outbound tracking (#305 stays separate)
 
 ## Tests
 
@@ -139,6 +242,14 @@ are rejected by the compiler.
 `window.zaraz.track`, missing `window.zaraz`, `window.zaraz.track` throwing,
 `window.zaraz.track` not a function, unknown event name (compile error),
 wrong payload type (compile error), and sensitive-key rejection (compile
-error), including the slug-only `article_viewed` allowlist. `BlogArticlePage`
-tests cover published-only triggering, StrictMode/rerender deduplication, slug
-changes, unknown/draft suppression, and re-entry after route departure.
+error), including the slug-only `article_viewed` allowlist and the
+four-key `promo_click` allowlist (accept for airbnb + video actions, smuggle
+strip, compile-time rejection of destination URL / PII / non airbnb|video
+action). `StayDPromoCard` / `StayDPage` tests assert each of the seven
+funnel placements emits exactly one `promo_click` with the right
+action/placement/locale. `BlogArticlePage` tests cover published-only
+triggering, StrictMode/rerender deduplication, slug changes, unknown/draft
+suppression, and re-entry after route departure.
+`src/domain/legalContent.test.ts` asserts that every launched privacy locale
+discloses GA4 routing through Zaraz without over-claiming booking-conversion
+tracking or full anonymity.

--- a/src/components/StayDPage.test.tsx
+++ b/src/components/StayDPage.test.tsx
@@ -39,6 +39,22 @@ describe("StayDPage (#748 editorial)", () => {
     });
   });
 
+  it("does not fire a video promo_click again when the /stay-d video is collapsed", () => {
+    render(<StayDPage language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "▶ 看 Stay.D 介紹影片" }));
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+
+    // Collapsing must not be counted as a second video interaction.
+    fireEvent.click(screen.getByRole("button", { name: "收合介紹影片" }));
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "stay-d-video",
+      locale: "zh-Hant"
+    });
+  });
+
   it("emits stay-d-video-airbnb/airbnb promo_click from the video-section CTA", () => {
     render(<StayDPage language="zh-Hant" />);
     fireEvent.click(screen.getByRole("button", { name: "▶ 看 Stay.D 介紹影片" }));

--- a/src/components/StayDPage.test.tsx
+++ b/src/components/StayDPage.test.tsx
@@ -1,9 +1,75 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { STAY_D_AIRBNB_URL, STAY_D_EDITORIAL_COPY } from "../domain/stayD";
 import { StayDPage } from "./StayDPage";
 
+const analyticsMocks = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+
+vi.mock("../lib/analytics", () => analyticsMocks);
+
 describe("StayDPage (#748 editorial)", () => {
+  beforeEach(() => {
+    analyticsMocks.trackEvent.mockClear();
+  });
+
+  it("emits stay-d-hero-airbnb/airbnb promo_click on the hero Airbnb CTA", () => {
+    render(<StayDPage language="zh-Hant" />);
+    const heroCta = screen.getAllByRole("link", { name: "在 Airbnb 查看 Stay.D" })[0];
+    fireEvent.click(heroCta);
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "stay-d-hero-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("emits stay-d-video/video promo_click when the /stay-d video is opened", () => {
+    render(<StayDPage language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "▶ 看 Stay.D 介紹影片" }));
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "stay-d-video",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("emits stay-d-video-airbnb/airbnb promo_click from the video-section CTA", () => {
+    render(<StayDPage language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "▶ 看 Stay.D 介紹影片" }));
+    analyticsMocks.trackEvent.mockClear();
+    fireEvent.click(
+      screen.getByRole("link", { name: "喜歡 Stay.D？到 Airbnb 查看 Stay.D" })
+    );
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "stay-d-video-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("emits stay-d-final-airbnb/airbnb promo_click on the final Airbnb CTA", () => {
+    render(<StayDPage language="zh-Hant" />);
+    const ctas = screen.getAllByRole("link", { name: "在 Airbnb 查看 Stay.D" });
+    fireEvent.click(ctas[ctas.length - 1]);
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "stay-d-final-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
   it("renders the editorial extension page with direct, safely opened Airbnb CTAs", () => {
     const { container } = render(<StayDPage language="zh-Hant" />);
 

--- a/src/components/StayDPage.tsx
+++ b/src/components/StayDPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import type { Language } from "../i18n";
+import { trackEvent } from "../lib/analytics";
 import {
   STAY_D_AIRBNB_URL,
   STAY_D_EDITORIAL_COPY,
@@ -29,6 +30,14 @@ export function StayDPage({ language }: { language: Language }) {
             target="_blank"
             rel="noopener noreferrer"
             data-stay-d-placement="stay-d-hero-airbnb"
+            onClick={() =>
+              trackEvent("promo_click", {
+                promoId: "stay-d",
+                action: "airbnb",
+                placement: "stay-d-hero-airbnb",
+                locale: language
+              })
+            }
           >
             {text.airbnbCta}
             <ExternalLink aria-hidden="true" />
@@ -41,6 +50,7 @@ export function StayDPage({ language }: { language: Language }) {
         <p className="stay-d-section-intro">{text.page.videoIntro}</p>
         <StayDVideo
           copy={text.video}
+          locale={language}
           triggerPlacement="stay-d-video"
           airbnbPlacement="stay-d-video-airbnb"
         />
@@ -57,6 +67,14 @@ export function StayDPage({ language }: { language: Language }) {
           target="_blank"
           rel="noopener noreferrer"
           data-stay-d-placement="stay-d-final-airbnb"
+          onClick={() =>
+            trackEvent("promo_click", {
+              promoId: "stay-d",
+              action: "airbnb",
+              placement: "stay-d-final-airbnb",
+              locale: language
+            })
+          }
         >
           {text.airbnbCta}
           <ExternalLink aria-hidden="true" />

--- a/src/components/StayDPromoCard.test.tsx
+++ b/src/components/StayDPromoCard.test.tsx
@@ -44,6 +44,22 @@ describe("StayDPromoCard (#750 editorial footer)", () => {
     });
   });
 
+  it("does not fire a video promo_click again when the video is collapsed", () => {
+    render(<StayDPromoCard language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "看介紹影片" }));
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+
+    // Collapsing must not be counted as a second video interaction.
+    fireEvent.click(screen.getByRole("button", { name: "收合介紹影片" }));
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "home-video",
+      locale: "zh-Hant"
+    });
+  });
+
   it("emits exactly one home-video-airbnb/airbnb promo_click from the expanded video CTA", () => {
     render(<StayDPromoCard language="zh-Hant" />);
     fireEvent.click(screen.getByRole("button", { name: "看介紹影片" }));

--- a/src/components/StayDPromoCard.test.tsx
+++ b/src/components/StayDPromoCard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import {
   STAY_D_AIRBNB_URL,
@@ -9,7 +9,58 @@ import {
 } from "../domain/stayD";
 import { StayDPromoCard } from "./StayDPromoCard";
 
+const analyticsMocks = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+
+vi.mock("../lib/analytics", () => analyticsMocks);
+
 describe("StayDPromoCard (#750 editorial footer)", () => {
+  beforeEach(() => {
+    analyticsMocks.trackEvent.mockClear();
+  });
+
+  it("emits exactly one home-airbnb/airbnb promo_click on the direct Airbnb CTA", () => {
+    render(<StayDPromoCard language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("link", { name: /查看 Stay\.D/ }));
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("emits exactly one home-video/video promo_click when the video is opened", () => {
+    render(<StayDPromoCard language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "看介紹影片" }));
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "home-video",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("emits exactly one home-video-airbnb/airbnb promo_click from the expanded video CTA", () => {
+    render(<StayDPromoCard language="zh-Hant" />);
+    fireEvent.click(screen.getByRole("button", { name: "看介紹影片" }));
+    analyticsMocks.trackEvent.mockClear();
+    fireEvent.click(
+      screen.getByRole("link", { name: "喜歡 Stay.D？到 Airbnb 查看 Stay.D" })
+    );
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-video-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
   it("makes Airbnb the direct primary action at home-bottom", () => {
     render(<StayDPromoCard language="zh-Hant" />);
 

--- a/src/components/StayDPromoCard.tsx
+++ b/src/components/StayDPromoCard.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from "lucide-react";
 import type { Language } from "../i18n";
+import { trackEvent } from "../lib/analytics";
 import {
   STAY_D_AIRBNB_URL,
   STAY_D_HOME_TEASER,
@@ -32,12 +33,21 @@ export function StayDPromoCard({ language }: { language: Language }) {
           target="_blank"
           rel="noopener noreferrer"
           data-stay-d-placement="home-airbnb"
+          onClick={() =>
+            trackEvent("promo_click", {
+              promoId: "stay-d",
+              action: "airbnb",
+              placement: "home-airbnb",
+              locale: language
+            })
+          }
         >
           {text.primaryCta}
           <ExternalLink aria-hidden="true" />
         </a>
         <StayDVideo
           copy={text.video}
+          locale={language}
           triggerPlacement="home-video"
           airbnbPlacement="home-video-airbnb"
         />

--- a/src/components/StayDVideo.tsx
+++ b/src/components/StayDVideo.tsx
@@ -32,13 +32,17 @@ export function StayDVideo({
         aria-controls={panelId}
         data-stay-d-placement={triggerPlacement}
         onClick={() => {
+          // Only an expand counts as a video interaction; collapsing a panel
+          // must not be misreported as a second promo interest.
+          if (!expanded) {
+            trackEvent("promo_click", {
+              promoId: "stay-d",
+              action: "video",
+              placement: triggerPlacement,
+              locale
+            });
+          }
           setExpanded((current) => !current);
-          trackEvent("promo_click", {
-            promoId: "stay-d",
-            action: "video",
-            placement: triggerPlacement,
-            locale
-          });
         }}
       >
         {expanded ? <ChevronUp aria-hidden="true" /> : <PlayCircle aria-hidden="true" />}

--- a/src/components/StayDVideo.tsx
+++ b/src/components/StayDVideo.tsx
@@ -1,5 +1,7 @@
 import { useId, useState } from "react";
 import { ChevronUp, ExternalLink, PlayCircle } from "lucide-react";
+import type { Language } from "../i18n";
+import { trackEvent } from "../lib/analytics";
 import {
   STAY_D_AIRBNB_URL,
   STAY_D_VIDEO_ID,
@@ -9,10 +11,12 @@ import {
 
 export function StayDVideo({
   copy,
+  locale,
   triggerPlacement,
   airbnbPlacement
 }: {
   copy: StayDVideoCopy;
+  locale: Language;
   triggerPlacement: "home-video" | "stay-d-video";
   airbnbPlacement: "home-video-airbnb" | "stay-d-video-airbnb";
 }) {
@@ -27,7 +31,15 @@ export function StayDVideo({
         aria-expanded={expanded}
         aria-controls={panelId}
         data-stay-d-placement={triggerPlacement}
-        onClick={() => setExpanded((current) => !current)}
+        onClick={() => {
+          setExpanded((current) => !current);
+          trackEvent("promo_click", {
+            promoId: "stay-d",
+            action: "video",
+            placement: triggerPlacement,
+            locale
+          });
+        }}
       >
         {expanded ? <ChevronUp aria-hidden="true" /> : <PlayCircle aria-hidden="true" />}
         {expanded ? copy.collapse : copy.watch}
@@ -51,6 +63,14 @@ export function StayDVideo({
             target="_blank"
             rel="noopener noreferrer"
             data-stay-d-placement={airbnbPlacement}
+            onClick={() =>
+              trackEvent("promo_click", {
+                promoId: "stay-d",
+                action: "airbnb",
+                placement: airbnbPlacement,
+                locale
+              })
+            }
           >
             {copy.airbnbCta}
             <ExternalLink aria-hidden="true" />

--- a/src/domain/legalContent.test.ts
+++ b/src/domain/legalContent.test.ts
@@ -98,6 +98,60 @@ describe("legal content", () => {
     expect(en).not.toContain("all data");
   });
 
+  it("discloses GA4 routing through Zaraz in every launched privacy locale without over-claiming", () => {
+    const disclosureText = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .flatMap((section) => [section.title, ...(section.paragraphs ?? []), ...(section.items ?? [])])
+        .join("\n");
+
+    // GA4 is disclosed as a downstream analytics recipient routed through Zaraz.
+    const zh = disclosureText("zh-Hant");
+    expect(zh).toContain("Google Analytics");
+    expect(zh).toContain("轉交 Google Analytics");
+
+    const ja = disclosureText("ja");
+    expect(ja).toContain("Google Analytics");
+    expect(ja).toContain("Google Analytics に転送");
+
+    const en = disclosureText("en");
+    expect(en).toContain("Google Analytics");
+    expect(en).toContain("routed through Cloudflare Zaraz to Google Analytics");
+
+    // Google Analytics is listed as an analytics provider separately from the
+    // optional Google sign-in purpose.
+    expect(zh).toContain("Google Analytics：分析啟用時");
+    expect(ja).toContain("Google Analytics：分析が有効な場合");
+    expect(en).toContain("Google Analytics: recipient of aggregate usage analysis");
+
+    // The outbound promotion click is scoped to interest measurement, not to
+    // Airbnb booking conversion tracking.
+    expect(zh).toContain("不代表測量或追蹤");
+    expect(ja).toContain("測定・追跡するものではありません");
+    expect(en).toContain("does not measure or track");
+
+    // No claim that analytics is fully anonymous while GA4/Zaraz keep their
+    // own client/session mechanisms. The section title itself must not claim
+    // anonymity either. Titles carry a numbered prefix ("3. 使用分析"), so
+    // assert the wording, not an exact match.
+    expect(en).not.toContain("fully anonymous");
+    expect(zh).not.toContain("完全匿名");
+    expect(ja).not.toContain("完全に匿名");
+
+    const analyticsSectionTitle = (language: "zh-Hant" | "ja" | "en") =>
+      legalDocumentFor(language, "privacy").sections
+        .find((section) =>
+          language === "en" ? section.title.includes("analytics") : section.title.includes("分析")
+        )
+        ?.title ?? "";
+
+    expect(analyticsSectionTitle("zh-Hant")).toContain("使用分析");
+    expect(analyticsSectionTitle("zh-Hant")).not.toContain("匿名");
+    expect(analyticsSectionTitle("ja")).toContain("利用状況分析");
+    expect(analyticsSectionTitle("ja")).not.toContain("匿名");
+    expect(analyticsSectionTitle("en")).toContain("Usage analytics");
+    expect(analyticsSectionTitle("en")).not.toContain("Anonymous");
+  });
+
   it("does not claim that public source code is open source", () => {
     const terms = legalDocumentFor("zh-Hant", "terms");
     const text = terms.sections

--- a/src/domain/legalContent.ts
+++ b/src/domain/legalContent.ts
@@ -22,7 +22,7 @@ export interface LegalPageCopy extends LegalPageLabels {
   terms: LegalDocument;
 }
 
-const PRIVACY_UPDATED_AT = "2026-07-18";
+const PRIVACY_UPDATED_AT = "2026-08-12";
 const TERMS_UPDATED_AT = "2026-07-18";
 
 const LEGAL_COPY = {
@@ -50,10 +50,10 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. 匿名使用分析",
+          title: "3. 使用分析",
           paragraphs: [
-            "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。",
-            "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
+            "正式環境可能透過 Cloudflare Zaraz 收集粗略的使用事件，例如開啟哪個功能、練習模式、JLPT 級別、介面語言、是否答對、完成題數、文法頁識別碼或文章代稱。這些事件用來了解功能是否真的被使用。當分析啟用時，選定的淨化後使用事件（例如促銷外連互動）可能透過 Cloudflare Zaraz 轉交 Google Analytics，用於彙總使用分析。",
+            "Jabiko 的自訂分析事件不傳送題目全文、你輸入的答案、電子郵件、Supabase 使用者 ID、文章正文、查詢字串或自由輸入文字。促銷外連互動僅傳送促銷識別碼、動作類型、版面位置與介面語言，不代表測量或追蹤 Airbnb 訂房轉換。Cloudflare 等基礎設施供應商仍可能為傳輸、安全與防濫用處理 IP 位址、裝置或請求資訊，並依其自身政策處理。"
           ]
         },
         {
@@ -67,6 +67,7 @@ const LEGAL_COPY = {
           title: "5. 外部服務",
           items: [
             "Cloudflare：網站傳遞、安全與選用的 Zaraz 分析。",
+            "Google Analytics：分析啟用時，作為彙總使用分析的接收方。",
             "Supabase：Google 登入、登入狀態、練習同步與回報資料庫。",
             "Google：你主動選擇 Google 登入時的身分驗證。",
             "ECPay 與其他外部連結：只有在你主動點擊後才會前往第三方網站；付款資料不會由 Jabiko 前端保存。"
@@ -168,10 +169,10 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. 匿名の利用状況分析",
+          title: "3. 利用状況分析",
           paragraphs: [
-            "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。",
-            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
+            "本番環境では Cloudflare Zaraz を通じ、利用した機能、練習モード、JLPT レベル、表示言語、正誤、完了数、文法ページ ID、記事スラッグなどの大まかなイベントを収集する場合があります。分析が有効な場合、選定した浄化済みの利用イベント（プロモーションの外部リンクの操作など）は Cloudflare Zaraz を経由して Google Analytics に転送され、集計的な利用分析に使われることがあります。",
+            "Jabiko 独自の分析イベントには、問題全文、入力した回答、メールアドレス、Supabase のユーザー ID、記事本文、クエリ文字列、自由入力文を含めません。プロモーションの外部リンクの操作では、プロモーション ID、操作の種類、掲載位置、表示言語のみを送信し、Airbnb の予約転換を測定・追跡するものではありません。ただし Cloudflare などの基盤事業者は、通信・安全対策・不正防止のため IP アドレスや端末・リクエスト情報を処理する場合があります。"
           ]
         },
         {
@@ -185,6 +186,7 @@ const LEGAL_COPY = {
           title: "5. 外部サービス",
           items: [
             "Cloudflare：サイト配信、安全対策、任意の Zaraz 分析。",
+            "Google Analytics：分析が有効な場合の集計的な利用分析の受信者。",
             "Supabase：Google ログイン、セッション、練習同期、フィードバック保存。",
             "Google：利用者が Google ログインを選んだ場合の認証。",
             "ECPay その他の外部リンク：利用者がリンクを開いた後は第三者のサービスとなり、Jabiko のフロントエンドは決済情報を保存しません。"
@@ -286,10 +288,10 @@ const LEGAL_COPY = {
           ]
         },
         {
-          title: "3. Anonymous usage analytics",
+          title: "3. Usage analytics",
           paragraphs: [
-            "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used.",
-            "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."
+            "The production site may use Cloudflare Zaraz to collect coarse events such as the feature opened, practice mode, JLPT level, interface language, correctness, completion counts, grammar-page identifiers, or article slugs. These events help us understand whether features are being used. When analytics is enabled, selected sanitized usage events (such as promotion outbound interactions) may be routed through Cloudflare Zaraz to Google Analytics for aggregate usage analysis.",
+            "Jabiko's custom analytics events do not send full question text, your submitted answer, email address, Supabase user ID, article body, query string, or free-form input. A promotion outbound interaction carries only the promotion identifier, action, placement, and interface language; it does not measure or track Airbnb booking conversion. Infrastructure providers such as Cloudflare may still process IP addresses, device details, or request information for delivery, security, and abuse prevention under their own policies."
           ]
         },
         {
@@ -303,6 +305,7 @@ const LEGAL_COPY = {
           title: "5. External services",
           items: [
             "Cloudflare: site delivery, security, and optional Zaraz analytics.",
+            "Google Analytics: recipient of aggregate usage analysis when analytics is enabled.",
             "Supabase: Google sign-in, sessions, practice sync, and feedback storage.",
             "Google: authentication when you choose Google sign-in.",
             "ECPay and other external links: third-party services apply after you choose to open them; payment details are not stored by the Jabiko frontend."

--- a/src/domain/prerender/staticPages.test.ts
+++ b/src/domain/prerender/staticPages.test.ts
@@ -147,7 +147,7 @@ describe("buildStaticPages", () => {
     const terms = byPath.get("/terms");
 
     expect(privacy?.bodyHtml).toContain("Google 登入與跨裝置同步");
-    expect(privacy?.bodyHtml).toContain("匿名使用分析");
+    expect(privacy?.bodyHtml).toContain("使用分析");
     expect(terms?.bodyHtml).toContain("程式碼、內容與品牌");
     expect(terms?.bodyHtml).toContain("不代表已授權");
   });

--- a/src/domain/seo.ts
+++ b/src/domain/seo.ts
@@ -72,7 +72,7 @@ export const VIEW_SEO: Record<AppView, PageSeo> = {
   privacy: {
     title: "隱私政策｜Jabiko",
     description:
-      "了解 Jabiko 在瀏覽器、Google 登入、跨裝置同步、匿名使用分析與回報功能中如何處理資料。",
+      "了解 Jabiko 在瀏覽器、Google 登入、跨裝置同步、使用分析與回報功能中如何處理資料。",
     path: APP_VIEW_PATHS.privacy
   },
   terms: {

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -207,4 +207,133 @@ describe("analytics.trackEvent", () => {
       slug: "sweet-steady-sweet-step"
     });
   });
+
+  it("accepts promo_click with a Home direct Airbnb placement (action: airbnb)", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("accepts promo_click with a Home video trigger placement (action: video)", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "home-video",
+      locale: "ja"
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "video",
+      placement: "home-video",
+      locale: "ja"
+    });
+  });
+
+  it("accepts promo_click with a /stay-d final Airbnb placement", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "stay-d-final-airbnb",
+      locale: "en"
+    });
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "stay-d-final-airbnb",
+      locale: "en"
+    });
+  });
+
+  it("strips non-allowlisted keys from promo_click before forwarding to Zaraz", () => {
+    __setAnalyticsEnabledForTest(true);
+    const track = installZaraz();
+    // The promotion CTA must not forward the destination URL, account data,
+    // raw user ids, or arbitrary strings. Only the four allowlisted keys pass.
+    const smuggled = {
+      promoId: "stay-d" as const,
+      action: "airbnb" as const,
+      placement: "home-airbnb" as const,
+      locale: "zh-Hant" as const,
+      destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668",
+      email: "a@b.com",
+      userId: "supabase-123",
+      nested: { title: "秘密の宿" }
+    };
+    trackEvent("promo_click", smuggled);
+    expect(track).toHaveBeenCalledTimes(1);
+    const forwarded = track.mock.calls[0][1] as Record<string, unknown>;
+    expect(forwarded).not.toHaveProperty("destinationUrl");
+    expect(forwarded).not.toHaveProperty("email");
+    expect(forwarded).not.toHaveProperty("userId");
+    expect(forwarded).not.toHaveProperty("nested");
+    expect(forwarded).toEqual({
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects a non airbnb|video action for promo_click at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      // @ts-expect-error -- action is narrowed to "airbnb" | "video"; a free-form
+      // destination string (e.g. a booking provider) is not allowed
+      action: "hotel",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects destination URL or PII keys for promo_click at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant",
+      // @ts-expect-error -- destinationUrl is not an allowlisted key; the
+      // Airbnb URL must never travel inside the analytics payload
+      destinationUrl: "https://zh-t.airbnb.com/rooms/1518015758376242668"
+    });
+  });
+
+  it("rejects an arbitrary promoId at compile time", () => {
+    trackEvent("promo_click", {
+      // @ts-expect-error -- promoId is bounded to approved promotion ids; a
+      // free-form string such as an email must not pass the boundary
+      promoId: "user@example.com",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it("rejects an arbitrary placement at compile time", () => {
+    trackEvent("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      // @ts-expect-error -- placement is bounded to the frozen #744 funnel
+      // placements; a URL or free text must not pass the boundary
+      placement: "https://example.com/",
+      locale: "zh-Hant"
+    });
+  });
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -11,7 +11,8 @@ export type AnalyticsEventName =
   | "level_changed"
   | "locale_changed"
   | "weak_review_started"
-  | "article_viewed";
+  | "article_viewed"
+  | "promo_click";
 
 export interface PageViewPayload {
   view: string;
@@ -59,6 +60,35 @@ export interface WeakReviewStartedPayload {
 export interface ArticleViewedPayload {
   slug: string;
 }
+// Outbound promotion click (#745). promoId and placement are bounded to
+// approved identifiers so arbitrary free-form text or PII (an email, a URL)
+// cannot pass the analytics boundary at compile time. action distinguishes a
+// direct Airbnb CTA from a video-trigger interaction. Extend the unions below
+// when a new approved promotion or placement lands.
+export const PROMO_IDENTIFIERS = ["stay-d"] as const satisfies readonly string[];
+export type PromoIdentifier = (typeof PROMO_IDENTIFIERS)[number];
+
+// Stable Stay.D funnel interaction placements frozen by #744 (#745 analytics
+// boundary). Each value identifies a distinct user-facing funnel interaction,
+// not a raw URL, surface slug, or free-form copy. #744 wires exactly these
+// values when the Stay.D UI lands; adding a new funnel step extends the union.
+export const PROMO_PLACEMENTS = [
+  "home-airbnb",
+  "home-video",
+  "home-video-airbnb",
+  "stay-d-hero-airbnb",
+  "stay-d-video",
+  "stay-d-video-airbnb",
+  "stay-d-final-airbnb"
+] as const satisfies readonly string[];
+export type PromoPlacement = (typeof PROMO_PLACEMENTS)[number];
+
+export interface PromoClickPayload {
+  promoId: PromoIdentifier;
+  action: "airbnb" | "video";
+  placement: PromoPlacement;
+  locale: LocaleCode;
+}
 
 export interface AnalyticsPayloadMap {
   page_view: PageViewPayload;
@@ -70,6 +100,7 @@ export interface AnalyticsPayloadMap {
   locale_changed: LocaleChangedPayload;
   weak_review_started: WeakReviewStartedPayload;
   article_viewed: ArticleViewedPayload;
+  promo_click: PromoClickPayload;
 }
 
 const ZARAZ_ENABLED_FLAG = import.meta.env.VITE_ZARAZ_ENABLED;
@@ -89,7 +120,8 @@ const ALLOWED_PAYLOAD_KEYS: Record<AnalyticsEventName, readonly string[]> = {
   level_changed: ["scope", "levelRange", "locale"],
   locale_changed: ["from", "to"],
   weak_review_started: ["dueCount", "locale"],
-  article_viewed: ["slug"]
+  article_viewed: ["slug"],
+  promo_click: ["promoId", "action", "placement", "locale"]
 };
 
 function sanitizePayload<K extends AnalyticsEventName>(


### PR DESCRIPTION
Implements the **current** #745 contract (do not close #745 until the
production Zaraz/GA4 smoke below is complete).

## Repository-complete

- **`src/lib/analytics.ts`** — add typed `promo_click` with
  `{ promoId, action: "airbnb" | "video", placement, locale }`, bounded
  `PROMO_IDENTIFIERS = ["stay-d"]`, the seven frozen #744 funnel placements,
  and a four-key allowlist. `trackEvent` / `sanitizePayload` / the
  `VITE_ZARAZ_ENABLED` gate are unchanged — GA4 stays a Cloudflare Zaraz
  destination, never a new app dependency. No `gtag.js`, no GTM, no GA SDK,
  no UTM/redirect/second analytics stack.
- **Stay.D wiring (7 real interaction points)** — `StayDPromoCard`,
  `StayDVideo`, `StayDPage` fire exactly one `promo_click` per interaction:
  `home-airbnb` / `home-video` / `home-video-airbnb` /
  `stay-d-hero-airbnb` / `stay-d-video` / `stay-d-video-airbnb` /
  `stay-d-final-airbnb`, each with the correct `action` (airbnb vs video) and
  `locale`. Fire-and-forget: no `preventDefault`, `trackEvent` swallows all
  failures, so analytics never blocks video opening, `/stay-d` navigation, or
  the Airbnb link. `/stay-d` keeps the existing `page_view` (`view: "stayD"`);
  no separate `stay_d_view`, no duplicate page views.
- **Privacy** — zh-Hant / ja / en §3 titles drop "anonymous"
  (使用分析 / 利用状況分析 / Usage analytics); §3 discloses that selected
  sanitized funnel events may be routed through Cloudflare Zaraz to Google
  Analytics; §5 lists Google Analytics separately from the Google-login
  purpose; no fully-anonymous claim, no booking-conversion claim.
  `PRIVACY_UPDATED_AT` → 2026-08-12. `seo.ts` privacy meta drops the
  "匿名使用分析" wording.
- **Tests** — analytics allowlist (accept airbnb+video, smuggle strip,
  compile-time rejection of arbitrary promoId/placement/action) and focused
  Stay.D wiring tests asserting each of the seven placements emits exactly
  one `promo_click` with the right action/placement/locale; privacy tests
  assert GA4 disclosure and non-anonymous titles in every launched locale.
- **`docs/analytics.md`** — ten-event table, `promo_click` contract, the
  GA4-through-Zaraz contract, GA4 reporting contract (event-scoped custom
  dimensions `promoId` / `action` / `placement` / `locale`), and the
  owner-pending operator steps.

**Validation (all green):** `pnpm lint`, `pnpm typecheck`, `pnpm check:i18n`,
analytics + Stay.D + legal focused (152 passed), `pnpm build`, `git diff
--check`. Full suite locally shows only pre-existing unrelated host-load 5s
timeout flakes (gemini-correctness / GrammarIndex / KanjiOnyomi / Learning)
that pass standalone; GitHub CI is the repository-wide authority.
`rg "gtag\(|googletagmanager|Google Tag Manager|gtag\.js" src package.json` →
no hits.

**Independent review:** read-only reviewer → `VERDICT: APPROVE`.

## Production operator steps remaining (owner, in Cloudflare / GA4)

These cannot be completed by editing the repository and are **not** claimed done:

1. Use the intended Jabiko GA4 property/data stream (owner supplies the Measurement ID).
2. In Cloudflare Zaraz, add/configure the native **Google Analytics 4** managed tool for the production domain.
3. Configure the Events action so `zaraz.track(...)` custom events reach GA4.
4. Ensure the page-view configuration does **not** double-count the explicit SPA `page_view` flow (leave the GA4 tool's automatic Pageviews action disabled).
5. Create only the required event-scoped custom dimensions (`promoId`, `action`, `placement`, `locale`).
6. Verify the production stream with Zaraz Debugger/Monitoring and GA4 Realtime/DebugView.

No GA credentials / secrets / cookies committed.

## Supersedes #746

#746 (parked draft, `feat/analytics-ga4-promo-click`) was implemented against an
older #745 contract (`destinationType: "airbnb"`). This PR implements the
current `action: "airbnb" | "video"` contract against the Stay.D UI already on
main; #746's reusable bounding / privacy / docs work was selectively carried
over. #746 will be closed as superseded without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
