### PR TITLE
chore(lint): 啟用 React Hooks v7 完整 flat.recommended preset (#687)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,13 +7,12 @@ import tseslint from "typescript-eslint";
 // ESLint 9 flat config (#663). Baseline scope: repo-wide lint gate that must
 // stay behaviour-neutral on the existing codebase.
 //
-// react-hooks: v7's `flat.recommended` ships the React Compiler rule set
-// (refs, set-state-in-effect, purity, immutability, ...) whose reports would
-// force restructuring deliberately-designed render-phase refs / effect
-// setState in the current code. Those rules are deliberately NOT enabled here
-// (tracked in a follow-up issue); we enable the classic rules-of-hooks +
-// exhaustive-deps only. exhaustive-deps is "error" so lint cannot pass with
-// stale deps silently degrading a drill/review hook.
+// react-hooks: the full `flat.recommended` preset from the installed
+// eslint-plugin-react-hooks v7 is enabled (rules-of-hooks, exhaustive-deps,
+// refs, set-state-in-effect, purity, immutability,
+// preserve-manual-memoization, static-components, ...). The only deviation is
+// exhaustive-deps upgraded from the preset's "warn" to "error" (#687), so lint
+// cannot pass with stale deps silently degrading a drill/review hook.
 export default tseslint.config(
   {
     ignores: [
@@ -47,11 +46,11 @@ export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     files: ["**/*.{ts,tsx}"],
-    plugins: {
-      "react-hooks": reactHooks
-    },
+    ...reactHooks.configs.flat.recommended,
     rules: {
-      "react-hooks/rules-of-hooks": "error",
+      ...reactHooks.configs.flat.recommended.rules,
+      // flat.recommended ships exhaustive-deps as "warn"; #687 contract keeps
+      // it at "error" (allowed severity upgrade, not a downgrade).
       "react-hooks/exhaustive-deps": "error"
     }
   },


### PR DESCRIPTION
## Summary
- 在 ESLint 9 flat config 中啟用已安裝 `eslint-plugin-react-hooks@7.1.1` 的完整 `reactHooks.configs.flat.recommended` preset。
- 移除舊的 hand-written classic-only rules block（原本只開 `rules-of-hooks` + `exhaustive-deps`）。
- 唯一偏差：`exhaustive-deps` 依 #687 合約由 preset 的 `warn` 升為 `error`（允許的必要 severity upgrade，非 downgrade）。
- 未動 `src/**`、`AGENTS.md`、`CLAUDE.md`；無新 ignores / disables / downgrades；未啟用 React Compiler transforms；無 dependency churn（已安裝即 v7，提供 `flat.recommended`）。

## Effective config（--print-config 實測）
TSX/TS effective config 中下列 8 條 boundary rules 全為 `error`：
`rules-of-hooks`、`exhaustive-deps`、`refs`、`set-state-in-effect`、`purity`、`immutability`、`preserve-manual-memoization`、`static-components`

（另有 preset 內建 `use-memo`、`globals`、`error-boundaries`、`set-state-in-render`、`config`、`gating` 為 error；`incompatible-library`、`unsupported-syntax` 為 warn。）

## Validation
- `pnpm install --frozen-lockfile` — OK
- `pnpm lint`（`eslint . --max-warnings=0`）— exit 0，zero warnings/errors
- `pnpm typecheck` — OK
- `pnpm test` — 141 files / 2055 tests 全過
- `pnpm build`（tsc + vite build + prerender 100 頁）— OK
- `git diff --check` — clean

## 注意
既有 `src/**` 中 4 處 `eslint-disable-next-line react-hooks/exhaustive-deps` 為 pre-existing suppression，本次未新增、未修改（diff 僅 `eslint.config.js`）。

**請勿 merge——等 fresh independent review。**