### PR TITLE
fix(analytics): pin official gcloud CLI image and GA4 scopes in Docker ADC helper

### DIFF
--- a/ops/analytics/docker-compose.yml
+++ b/ops/analytics/docker-compose.yml
@@ -5,7 +5,13 @@
 # (gitignored), which bin/google-auth and the scripts also check.
 services:
   gcloud:
-    image: google/cloud-sdk:latest
-    command: ["gcloud", "auth", "application-default", "login", "--no-launch-browser"]
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
+    command:
+      - gcloud
+      - auth
+      - application-default
+      - login
+      - --no-launch-browser
+      - --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/analytics.edit
     volumes:
       - ./state/gcloud:/root/.config/gcloud

--- a/ops/analytics/src/cli/google-auth.mjs
+++ b/ops/analytics/src/cli/google-auth.mjs
@@ -22,11 +22,11 @@ if (!credential) {
   report.bullet("     - Create a JSON key and save it to:");
   report.bullet(`       ${join(SECRETS_DIR, "gcp-service-account.json")}  (or export GOOGLE_APPLICATION_CREDENTIALS=…)`);
   report.bullet("  B) Your own Google account (gcloud):");
-  report.bullet(`     - docker compose -f ${join(OPS_DIR, "docker-compose.yml")} run --rm gcloud gcloud auth application-default login`);
+  report.bullet(`     - docker compose -f ${join(OPS_DIR, "docker-compose.yml")} run --rm gcloud`);
   report.bullet("     - the ADC credentials land in a docker volume the scripts also look at.");
   report.bullet("  C) One-shot access token for a single run:");
   report.bullet("     - export GA4_ACCESS_TOKEN=$(… via any OAuth tool …)");
-  report.bullet(`   Scopes needed: analytics.readonly (plan/smoke), analytics.edit (apply).`);
+  report.bullet(`   Scopes needed: cloud-platform, analytics.readonly (plan/smoke), analytics.edit (apply).`);
   report.printGate("GOOGLE_OAUTH");
   process.exitCode = 1;
 } else {

--- a/ops/analytics/test/gcloud-helper.test.mjs
+++ b/ops/analytics/test/gcloud-helper.test.mjs
@@ -1,0 +1,72 @@
+// ops/analytics gcloud-in-Docker helper contract tests.
+//
+// Guards the host-gcloud-free ADC bootstrap surface (image, scopes, mount) and
+// the operator guidance printed by google-auth against drift. Mechanical only:
+// no live Google credentials, no network access, no YAML parser dependency.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const OPS_DIR = fileURLToPath(new URL("..", import.meta.url));
+
+// Scopes required by the Jabiko operator contract (analytics.edit is needed
+// when apply creates GA4 custom dimensions; analytics.readonly covers plan and
+// smoke reads). Must stay aligned with docker-compose.yml.
+const REQUIRED_SCOPES = [
+  "https://www.googleapis.com/auth/cloud-platform",
+  "https://www.googleapis.com/auth/analytics.readonly",
+  "https://www.googleapis.com/auth/analytics.edit"
+];
+
+test("compose gcloud service uses the current official stable Google Cloud CLI image", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  assert.match(
+    compose,
+    /image:\s*gcr\.io\/google\.com\/cloudsdktool\/google-cloud-cli:stable/
+  );
+  assert.doesNotMatch(compose, /google\/cloud-sdk/, "legacy cloud-sdk image must not remain");
+});
+
+test("compose ADC login explicitly requests the GA4 production scopes", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  assert.match(compose, /--no-launch-browser/);
+  const scopesMatch = compose.match(/--scopes=(\S+)/);
+  assert.ok(scopesMatch, "compose command must pass --scopes=...");
+  for (const scope of REQUIRED_SCOPES) {
+    assert.ok(
+      scopesMatch[1].includes(scope),
+      `--scopes must include ${scope}`
+    );
+  }
+});
+
+test("compose persists ADC only under the gitignored state/gcloud mount", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  assert.match(compose, /\.\/state\/gcloud:\/root\/\.config\/gcloud/);
+  const gitignore = readFileSync(join(OPS_DIR, ".gitignore"), "utf8");
+  assert.match(gitignore, /^state\//m, "state/ must stay gitignored");
+});
+
+test("compose mount and credential resolution agree on the state/gcloud ADC path", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  const creds = readFileSync(join(OPS_DIR, "src/creds.mjs"), "utf8");
+  assert.match(compose, /state\/gcloud/);
+  // creds.mjs builds the ADC path via join(OPS_DIR, "state", "gcloud", ...).
+  assert.match(creds, /"state",\s*"gcloud"/);
+  assert.match(creds, /"application_default_credentials\.json"/);
+});
+
+test("google-auth guidance keeps docker compose run --rm gcloud canonical and scope-safe", () => {
+  const auth = readFileSync(join(OPS_DIR, "src/cli/google-auth.mjs"), "utf8");
+  // The canonical bootstrap command must not append a raw `gcloud ...` after
+  // `run --rm gcloud`, which would override the Compose command and silently
+  // drop the GA4 scopes.
+  assert.match(auth, /docker compose -f .*run --rm gcloud/);
+  assert.doesNotMatch(auth, /run --rm gcloud\s+gcloud\b/, "google-auth must not print a scope-less override of the Compose command");
+  // The printed scope note must mirror the Compose scope set.
+  for (const short of ["cloud-platform", "analytics.readonly", "analytics.edit"]) {
+    assert.match(auth, new RegExp(short.replace(".", "\\.")));
+  }
+});


### PR DESCRIPTION
Closes #765.

## Summary
Hardens the gcloud-in-Docker ADC bootstrap used for #745 production activation:

- Replace legacy `google/cloud-sdk:latest` with the official stable
  `gcr.io/google.com/cloudsdktool/google-cloud-cli:stable` image (verified
  against Google's cloud-sdk-docker migration guide).
- Compose default command now runs `gcloud auth application-default login
  --no-launch-browser --scopes=...` explicitly requesting
  `cloud-platform`, `analytics.readonly`, `analytics.edit`.
- `docker compose run --rm gcloud` stays the canonical host-gcloud-free
  bootstrap command; `google-auth` guidance no longer appends a scope-less
  login that would override the safe Compose command.
- ADC stays under the existing gitignored `ops/analytics/state/gcloud/` mount.
- Adds mechanical regression coverage (`gcloud-helper.test.mjs`) for
  image/scope/guidance drift — no live credentials, no network.

## Scope
Three files only. No production credentials, no GA4/Zaraz behavior change, no
credential-resolution redesign, no Realtime/event contract change, no new
dependency.

## Validation
- `docker compose -f ops/analytics/docker-compose.yml config` — pass
- `node --test ops/analytics/test/` — 191 tests, 0 fail
- `pnpm lint` / `pnpm typecheck` / `pnpm build` — pass
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)