### PR TITLE
fix(analytics): support custom OAuth client for Docker gcloud GA4 ADC login (#767)

### DIFF
--- a/ops/analytics/README.md
+++ b/ops/analytics/README.md
@@ -133,10 +133,33 @@ Any one of:
 2. exported `GOOGLE_APPLICATION_CREDENTIALS` pointing at a service-account JSON;
 3. `ops/analytics/.secrets/gcp-service-account.json`;
 4. `ops/analytics/.secrets/google-oauth.json`;
-5. gcloud ADC, including the Docker helper in `docker-compose.yml`.
+5. gcloud ADC via the Docker helper in `docker-compose.yml`.
 
 Use `./ops/analytics/bin/google-auth` to inspect the active source without
 printing secret values.
+
+#### gcloud ADC with a Desktop OAuth client (#767)
+
+`docker compose run --rm gcloud` (run from `ops/analytics/`) bootstraps
+Application Default Credentials inside the official gcloud CLI image, so the
+host needs no gcloud. Google blocks gcloud's default OAuth client for the GA4
+scopes, so the helper requires a Jabiko-owned **Desktop app** OAuth client:
+
+1. In the Google Cloud Console open **APIs & Services → Credentials →
+   Create Credentials → OAuth client ID → Desktop app** and download the JSON.
+2. Save it at `ops/analytics/.secrets/google-oauth-client.json`.
+   `.secrets/` is gitignored — the client secret is never committed.
+3. Run `docker compose run --rm gcloud`. The container mounts the JSON
+   read-only and passes it via `--client-id-file` together with the required
+   scopes (`cloud-platform`, `analytics.readonly`, `analytics.edit`), then
+   prints a one-time authorization URL; paste the returned code to finish.
+4. The resulting ADC JSON lands in `ops/analytics/state/gcloud/` (gitignored),
+   which `bin/google-auth` and the scripts also read.
+
+If the client JSON is absent the container fails fast with an actionable
+message instead of falling back to gcloud's blocked default OAuth client. If a
+prior run created an empty directory at that path, remove it before saving the
+JSON.
 
 ## Apply workflow and production publication
 

--- a/ops/analytics/docker-compose.yml
+++ b/ops/analytics/docker-compose.yml
@@ -1,17 +1,36 @@
 # gcloud-in-Docker for the Google OAuth step, so the host needs no gcloud.
 #   docker compose run --rm gcloud
-# prints a one-time authorization URL; paste the returned code to finish
-# `gcloud auth application-default login`. The ADC JSON lands in ./state/gcloud/
+# prints a one-time authorization URL; paste the returned code to finish the
+# Application Default Credentials login. The ADC JSON lands in ./state/gcloud/
 # (gitignored), which bin/google-auth and the scripts also check.
+#
+# #767: gcloud's default OAuth client is blocked by Google for the GA4 scopes,
+# so the login requires a Jabiko-owned Desktop OAuth client JSON at
+# ops/analytics/.secrets/google-oauth-client.json (gitignored). The container
+# mounts it read-only and passes it via --client-id-file. If the JSON is absent
+# the helper fails fast instead of silently falling back to the blocked default
+# client.
 services:
   gcloud:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
     command:
-      - gcloud
-      - auth
-      - application-default
-      - login
-      - --no-launch-browser
-      - --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/analytics.edit
+      - sh
+      - -c
+      - |
+        if [ ! -f /root/google-oauth-client.json ]; then
+          echo "ERROR: Google OAuth Desktop client JSON not found at /root/google-oauth-client.json." >&2
+          echo "Create a Desktop app OAuth client in the Google Cloud Console" >&2
+          echo "(APIs & Services > Credentials > Create Credentials > OAuth client ID > Desktop app)," >&2
+          echo "download its JSON and save it to ops/analytics/.secrets/google-oauth-client.json" >&2
+          echo "(gitignored, mounted read-only, never committed)." >&2
+          echo "If a prior run without the file left an empty directory at that path, remove it first." >&2
+          echo "See ops/analytics/README.md for the full bootstrap." >&2
+          exit 1
+        fi
+        exec gcloud auth application-default login \
+          --client-id-file=/root/google-oauth-client.json \
+          --no-launch-browser \
+          --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/analytics.edit
     volumes:
       - ./state/gcloud:/root/.config/gcloud
+      - ./.secrets/google-oauth-client.json:/root/google-oauth-client.json:ro

--- a/ops/analytics/src/cli/google-auth.mjs
+++ b/ops/analytics/src/cli/google-auth.mjs
@@ -22,7 +22,10 @@ if (!credential) {
   report.bullet("     - Create a JSON key and save it to:");
   report.bullet(`       ${join(SECRETS_DIR, "gcp-service-account.json")}  (or export GOOGLE_APPLICATION_CREDENTIALS=…)`);
   report.bullet("  B) Your own Google account (gcloud):");
+  report.bullet("     - Google Cloud Console → APIs & Services → Credentials → Create Credentials → OAuth client ID → Desktop app → Download JSON.");
+  report.bullet(`     - Save it as ${join(SECRETS_DIR, "google-oauth-client.json")}  (gitignored, never committed)`);
   report.bullet(`     - docker compose -f ${join(OPS_DIR, "docker-compose.yml")} run --rm gcloud`);
+  report.bullet("     - the container mounts the JSON read-only and passes it via --client-id-file; it fails fast if the JSON is missing instead of using gcloud's blocked default client.");
   report.bullet("     - the ADC credentials land in a docker volume the scripts also look at.");
   report.bullet("  C) One-shot access token for a single run:");
   report.bullet("     - export GA4_ACCESS_TOKEN=$(… via any OAuth tool …)");

--- a/ops/analytics/test/gcloud-helper.test.mjs
+++ b/ops/analytics/test/gcloud-helper.test.mjs
@@ -5,11 +5,13 @@
 // no live Google credentials, no network access, no YAML parser dependency.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const OPS_DIR = fileURLToPath(new URL("..", import.meta.url));
+const REPO_ROOT = join(OPS_DIR, "..", "..");
 
 // Scopes required by the Jabiko operator contract (analytics.edit is needed
 // when apply creates GA4 custom dimensions; analytics.readonly covers plan and
@@ -69,4 +71,88 @@ test("google-auth guidance keeps docker compose run --rm gcloud canonical and sc
   for (const short of ["cloud-platform", "analytics.readonly", "analytics.edit"]) {
     assert.match(auth, new RegExp(short.replace(".", "\\.")));
   }
+});
+
+// #767: gcloud's default OAuth client is blocked by Google for the GA4 scopes,
+// so the operator contract now requires a Jabiko-owned Desktop OAuth client
+// JSON mounted read-only and passed via --client-id-file.
+
+test("compose mounts the Desktop OAuth client JSON read-only and keeps it gitignored", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  const gitignore = readFileSync(join(OPS_DIR, ".gitignore"), "utf8");
+  // The operator-provided Desktop OAuth client lives under .secrets/, so it is
+  // never committed.
+  assert.match(gitignore, /^\.secrets\//m, ".secrets/ must stay gitignored");
+  // Compose bind-mounts exactly that file, read-only, at the container path
+  // that --client-id-file points at.
+  assert.match(
+    compose,
+    /\.\/\.secrets\/google-oauth-client\.json:.*google-oauth-client\.json:ro/,
+    "client JSON must be mounted read-only from .secrets/"
+  );
+  // Git itself must classify the path as ignored even before the file exists.
+  const ignored = spawnSync(
+    "git",
+    ["check-ignore", "ops/analytics/.secrets/google-oauth-client.json"],
+    { cwd: REPO_ROOT }
+  );
+  assert.equal(ignored.status, 0, "git check-ignore must report the client JSON as ignored");
+});
+
+test("compose ADC login passes --client-id-file pointing at the mounted path", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  assert.match(
+    compose,
+    /--client-id-file=\/root\/google-oauth-client\.json/,
+    "login must use --client-id-file with the mounted path"
+  );
+  assert.match(
+    compose,
+    /\/root\/google-oauth-client\.json:ro/,
+    "the mounted path must be read-only"
+  );
+});
+
+test("compose ADC login fails fast with a clear message when the client JSON is absent", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  assert.match(
+    compose,
+    /\[ ! -f \/root\/google-oauth-client\.json \]/,
+    "guard must check for the mounted client JSON before invoking gcloud"
+  );
+  assert.match(compose, /exit 1/, "guard must exit non-zero when the client JSON is absent");
+  assert.match(
+    compose,
+    /\.secrets\/google-oauth-client\.json/,
+    "the error must name the operator-side file path"
+  );
+});
+
+test("compose ADC login has exactly one gcloud invocation and no default-client fallback", () => {
+  const compose = readFileSync(join(OPS_DIR, "docker-compose.yml"), "utf8");
+  const logins = compose.match(/gcloud\s+auth\s+application-default\s+login/g) ?? [];
+  assert.ok(logins.length >= 1, "compose must invoke gcloud application-default login");
+  assert.equal(
+    logins.length,
+    1,
+    "there must be exactly one login invocation, and it must carry --client-id-file (no scope-less default-client fallback)"
+  );
+  assert.match(compose, /--client-id-file=/);
+});
+
+test("google-auth guidance directs operators to a Desktop OAuth client JSON and --client-id-file", () => {
+  const auth = readFileSync(join(OPS_DIR, "src/cli/google-auth.mjs"), "utf8");
+  assert.match(auth, /google-oauth-client\.json/, "guidance must name the Desktop client JSON path");
+  assert.match(auth, /--client-id-file/, "guidance must explain --client-id-file");
+  assert.match(auth, /Desktop app|Desktop OAuth client/i, "guidance must say to create a Desktop app OAuth client");
+});
+
+test("README documents the Desktop OAuth client bootstrap and the canonical command", () => {
+  const readme = readFileSync(join(OPS_DIR, "README.md"), "utf8");
+  assert.match(readme, /docker compose run --rm gcloud/, "README must keep the canonical command");
+  assert.match(readme, /google-oauth-client\.json/, "README must name the client JSON path");
+  assert.match(readme, /\.secrets\//, "README must say the JSON lives under gitignored .secrets/");
+  assert.match(readme, /Desktop app|Desktop OAuth client/i, "README must say to create a Desktop app OAuth client");
+  assert.match(readme, /--client-id-file/, "README must explain the --client-id-file flag");
+  assert.doesNotMatch(readme, /run --rm gcloud\s+gcloud auth/, "README must not append a raw scope-less gcloud command");
 });


### PR DESCRIPTION
## Summary

Fixes #767. During real #745 production activation, `docker compose run --rm gcloud` reached Google OAuth but was blocked by Google's default gcloud OAuth client ("This app is blocked"). The Docker ADC helper now requires a Jabiko-owned **Desktop app** OAuth client JSON instead of silently falling back to the blocked default client.

## Changes

- `ops/analytics/docker-compose.yml` — the `gcloud` service now runs a `sh -c` wrapper that:
  - requires `/root/google-oauth-client.json` (mounted read-only from `ops/analytics/.secrets/google-oauth-client.json`);
  - fails fast with an actionable message **before** invoking OAuth if the client JSON is absent (never falls back to gcloud's blocked default client);
  - runs `gcloud auth application-default login --client-id-file=/root/google-oauth-client.json --no-launch-browser --scopes=<cloud-platform,analytics.readonly,analytics.edit>`.
- `ops/analytics/.gitignore` — already covers `.secrets/` (no change); new test asserts `git check-ignore` treats the client JSON path as ignored.
- `ops/analytics/src/cli/google-auth.mjs` — Option B guidance now explains how to create/download a Desktop OAuth client, where to place it, that it is never committed, and that `docker compose run --rm gcloud` uses it automatically.
- `ops/analytics/README.md` — new "gcloud ADC with a Desktop OAuth client (#767)" section.
- `ops/analytics/test/gcloud-helper.test.mjs` — focused offline regression tests for gitignore protection, read-only mount, `--client-id-file` flag/path, all three scopes, canonical guidance, and no default-client fallback.

## Why this is safe

- The Desktop OAuth route is confirmed viable against primary Google docs: `--client-id-file` exists specifically for non-Google-Cloud scopes, and the standard Desktop (`installed`) client JSON is accepted by gcloud.
- The client JSON is a host **bind mount**, read-only — no credentials in Docker image layers, nothing committed, never read or printed by any code.
- No GA4/Zaraz production behavior, property/stream discovery, custom-dimension ordering, Realtime/event contracts, or credential-resolution logic changed. No dependencies added.
- No production `plan`/`apply`/`smoke` was run.

## Validation (all passed)

- `docker compose -f ops/analytics/docker-compose.yml config` — renders the `sh -c` command, `--client-id-file`, all three scopes, and `read_only: true` bind mount.
- `node --test ops/analytics/test/` — 197 pass.
- `pnpm lint` — pass. `pnpm typecheck` — pass. `pnpm build` — pass.
- `pnpm test` — 145 files / 2142 tests pass.
- `git diff --check` — clean.

After merge, resume #745 manually from latest `main` per the issue runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)