### PR TITLE
docs: establish English technical-artifact policy and critical-doc baseline (#723)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,30 @@
-## 什麼改動
+<!-- Optional Japanese summary for team-facing visibility; keep detailed technical specifications in English (see the Technical Artifact Language Policy in CLAUDE.md). -->
 
-<!-- 簡短描述這個 PR 做了什麼 -->
+## Summary (概要)
 
-## 為什麼
+<!-- Concise summary of what this PR does. A short Japanese summary is welcome; detailed technical specs go in the English sections below. -->
 
-<!-- 說明動機或解決的問題 -->
+## What changes
 
-## 測試方式
+<!-- Briefly describe what this PR does -->
 
-- [ ] `pnpm test` 通過
-- [ ] `pnpm build` 通過
-- [ ] `pnpm check:exam` 通過
-- [ ] 手動驗證（描述步驟）
+## Why
+
+<!-- Motivation or problem being solved -->
+
+## Tests
+
+- [ ] `pnpm test` passes
+- [ ] `pnpm build` passes
+- [ ] `pnpm check:exam` passes
+- [ ] Manual verification (describe steps)
 
 ## Scope
 
-- 關聯 issue：#
-- Depends on：<!-- 若有前置 PR，填入連結；否則刪除此行 -->
-- 超出範圍：<!-- 刻意不處理的事項 -->
+- Related issue: #
+- Depends on: <!-- if there are prerequisite PRs, add links; otherwise delete this line -->
+- Out of scope: <!-- things intentionally not handled -->
 
-## 備註
+## Notes
 
-<!-- 審閱者需要知道的其他事項 -->
+<!-- Anything else reviewers need to know -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,73 +1,74 @@
 # Jabiko — Codex Agent Guidelines
 
-> **Source of truth：`CLAUDE.md`。** 本檔是給 Codex 的精簡鏡像；兩檔衝突時以 CLAUDE.md 為準。（#314）
+> **Source of truth: `CLAUDE.md`.** This file is a concise mirror for Codex; on conflict, `CLAUDE.md` wins. (#314)
 
-## 語言設定
+## Language
 
-永遠使用台灣正體中文回覆。日文只用於學習材料、例句、UI 標籤或語法說明。
+- Always reply in Taiwan Traditional Chinese. Japanese is used only for learning materials, example sentences, UI labels, or grammar explanations.
+- Per the Technical Artifact Language Policy in `CLAUDE.md`, technical artifacts (code comments/docstrings, developer errors/logs, tests, architecture/API/schema docs, CI/CD docs, implementation plans, branches/commits, and detailed issue/PR technical specifications) are written in English; concise Japanese summaries in team-facing issue/PR descriptions are optional.
 
-## 專案定位（2026-07 現況）
+## Project Positioning (current as of 2026-07)
 
-Jabiko（jabiko.app）是免費、免註冊的 **JLPT N5–N1 日檢自習室**：文法／單字／漢字讀音／官方題型練習／模擬考／學習文章。題庫 3,600+、學習章 73+、文章區已上線。
+Jabiko (jabiko.app) is a free, registration-free **JLPT N5–N1 self-study room**: grammar / vocabulary / kanji readings / official question types / mock exams / learning articles. Item bank 3,600+, learning sections 73+, article section live.
 
-- 技術棧：React 19 + TypeScript strict + Vite 7 + Vitest 4 + jsdom、pnpm、PWA（vite-plugin-pwa）
-- 資料：local-first（localStorage）＋**選配** Supabase 跨裝置同步（Google 登入）；Cloudflare Pages 部署＋prerender
-- i18n：上線語系 zh-Hant／ja／en（`LAUNCHED_LANGUAGES`），另有 ko/th/id/vi/my Copy 檔未上線
+- Tech stack: React 19 + TypeScript strict + Vite 7 + Vitest 4 + jsdom, pnpm, PWA (vite-plugin-pwa)
+- Data: local-first (localStorage) + **optional** Supabase cross-device sync (Google login); Cloudflare Pages deployment + prerender
+- i18n: launched languages zh-Hant / ja / en (`LAUNCHED_LANGUAGES`); ko/th/id/vi/my Copy files present but not launched
 
-舊描述（《大家的日本語》動詞變化工具、無後端無登入）已過時，勿依其做設計假設。`docs/superpowers/specs/` 是 2026-05 的歷史設計稿，非現行 spec。
+The old description (a 《大家的日本語》verb-conjugation tool with no backend and no login) is outdated; don't make design assumptions from it. `docs/superpowers/specs/` are 2026-05 historical design drafts, not the current spec.
 
-## Shell 指令
+## Shell Commands
 
-直接執行指令即可（**沒有 `rtk` 這個工具**——舊規範遺留，勿再等待或宣稱缺它而跳過驗證）。
+Run commands directly (**there is no `rtk` tool** — leftover from an old convention; don't wait for it or claim it's missing to skip verification).
 
-- Node／frontend tooling 一律 `pnpm`；不得使用 npm/yarn/bun（也不得產生其 lockfile）
-- 驗證採階梯（#760，source of truth＝CLAUDE.md「驗證階梯」）：**L0** 定向 `pnpm vitest run <file>` → **L1** affected → **L2** path gate（`pnpm verify` 依 changed-path 自動選級）→ **L3** full `pnpm lint && pnpm test && pnpm build`。PR 前必跑 L3
-- 新增／修改**文章**後必跑 `pnpm build:sitemap`（sitemap drift guard 會擋 CI——這是 Codex 歷史上最常漏的一步）
-- 新增 exam 例句／題幹後跑 `pnpm build:furigana`
+- Node/frontend tooling is always `pnpm`; never use npm/yarn/bun (and never generate their lockfiles)
+- Verification ladder (#760, source of truth = the "Verification Ladder" section of `CLAUDE.md`): **L0** targeted `pnpm vitest run <file>` → **L1** affected → **L2** path gate (`pnpm verify` picks the level by changed paths) → **L3** full `pnpm lint && pnpm test && pnpm build`. Always run L3 before a PR
+- After adding/modifying **articles**, always run `pnpm build:sitemap` (the sitemap drift guard blocks CI — historically the step Codex most often misses)
+- After adding exam example sentences/stems, run `pnpm build:furigana`
 
-## 政策關鍵規則（CLAUDE.md 摘要，違反=擋 merge）
+## Policy Key Rules (CLAUDE.md summary; violating = blocks merge)
 
-- **TDD 強制**：先寫測試觀察 RED 再實作；例外僅限一次性 prototype、純設定檔、自動產生程式碼（要先告知）
-- **contentGuard 不變條件**：不得改 `src/domain/contentGuard.ts` 驗證規則，除非透過 issue 討論
-- **語言隔離**：`*Zh` 欄位不得對 zh-Hant 以外渲染，除非走 `pickLocalized()`＋有效 i18n overlay；`isZhHant` 是唯一閘門變數；不得動 `LAUNCHED_LANGUAGES`／`LocaleCode`／`pickLocalized()` fallback
-- **分層**：領域邏輯在 `src/domain/`，React 元件不放商業邏輯；TypeScript strict、禁 `any`
-- **Bundle 紀律**：examBlocks／furigana 資料／文章 body 只准進 lazy chunk，勿從 eager 路徑（App／components barrel／首頁）import
-- **EOL**：`exam/items/*.ts` 是 `-text`，暫存用 `git -c core.autocrlf=false add <files>`（明列檔名），commit 前 `git diff --cached --check` 必須乾淨
+- **TDD mandatory**: write the test and observe RED first; exceptions only for one-off prototypes, pure config files, auto-generated code (tell the user first)
+- **contentGuard invariant**: don't change the validation rules in `src/domain/contentGuard.ts` except through issue discussion
+- **Language isolation**: `*Zh` fields must not be rendered to languages other than zh-Hant unless via `pickLocalized()` with a valid i18n overlay; `isZhHant` is the only gate variable; don't touch `LAUNCHED_LANGUAGES` / `LocaleCode` / the `pickLocalized()` fallback
+- **Layering**: domain logic in `src/domain/`, React components don't hold business logic; TypeScript strict, no `any`
+- **Bundle discipline**: examBlocks / furigana data / article bodies may only enter lazy chunks; don't import them from eager paths (App / components barrel / home page)
+- **EOL**: `exam/items/*.ts` is `-text`; stage with `git -c core.autocrlf=false add <files>` (list files explicitly); `git diff --cached --check` must be clean before committing
 
-## Scope 邊界
+## Scope Boundaries
 
-- 不把未要求的功能、重構或 future work 混進同一個變更
-- 需要新增依賴、調整架構或擴大範圍時，先回報理由與替代方案
-- 內容批次（題庫／文章）天然 diff 大，屬正常，不必為 diff 大小道歉
+- Don't mix unrequested features, refactors, or future work into the same change
+- When you need a new dependency, an architecture change, or scope growth, report the reason and alternatives first
+- Content batches (item banks / articles) are naturally large diffs; that's normal, no apology needed for diff size
 
-## Git／PR 規範
+## Git / PR Conventions
 
-- Branch 命名 `codex/<short-description>`；commit 訊息簡潔（英文祈使句或 `<type>: <desc>`）
-- 不用 `git add -A`／`git add .`；只 stage 本次任務檔案
-- GitHub／git 指令必須 non-interactive
-- **PR 開出來請轉為 ready**（draft 會擋 merge）
-- **勿開 stacked PR**（base 指向另一個 PR 的分支）：前面的 PR squash 合併刪分支時，後面的會被 GitHub 自動關閉且無法 reopen。多篇內容各自從 main 開分支
-- CI 必過閘只有「Test and build」；CodeRabbit 綠勾可能是 rate-limit skip，不算真審
+- Branch naming `codex/<short-description>`; concise commit messages (English imperative or `<type>: <desc>`)
+- Don't use `git add -A` / `git add .`; stage only this task's files
+- GitHub/git commands must be non-interactive
+- **Set the PR to ready when opened** (draft blocks merge)
+- **Don't open stacked PRs** (base pointing at another PR's branch): when the earlier PR is squash-merged and its branch deleted, the later ones get auto-closed by GitHub and can't be reopened. Open each content PR from main
+- The only required CI gate is "Test and build"; a CodeRabbit green check may be a rate-limit skip, not a real review
 
-## 供應鏈安全
+## Supply Chain Security
 
-- 不得自行新增依賴，除非任務需要且已在回報中說明原因
-- 不得執行 `npx`、`pnpm dlx`、`npm exec`、`curl | bash`、`wget | sh` 這類遠端即時執行指令
-- `package.json` 與 lockfile 改動必須在回報中明確說明
+- Don't add dependencies on your own unless the task requires it and the reason is stated in the report
+- Don't run `npx`, `pnpm dlx`, `npm exec`, `curl | bash`, `wget | sh`, or similar remote ad-hoc executions
+- `package.json` and lockfile changes must be explicitly explained in the report
 
-## 內容品質（出題／文章）
+## Content Quality (item banks / articles)
 
-- 出題先讀 `docs/item-quality-rubric.md`：唯一正解、干擾誘答、不洩漏、格式
-- 最大雷＝近義雙解與接續秒殺；教學句最大雷＝**顧客句用「〜ますか」問聽話者動作**（主語錯位）
-- 文章不轉載歌詞（外連＋片段佔位）；例句一律原創
+- Before writing items, read `docs/item-quality-rubric.md`: unique correct answer, distractor lure answers, no leaks, format
+- Biggest traps = near-synonym double answers and continuation instant-kills; biggest teaching-sentence trap = **customer sentences asking the listener's action with 〜ますか** (subject misplacement)
+- Articles don't reproduce lyrics (external links + fragment placeholders); example sentences are always original
 
-## 測試與驗證
+## Testing and Verification
 
-- 驗證階梯（#760）：L0 targeted → L1 affected → L2 path gate → L3 full。執行器：`pnpm verify`（changed-path 選級）、`pnpm verify --dry-run`、`pnpm verify:full`。selector＝`scripts/select-verification.mjs`（deterministic explicit 規則，非 LLM 猜）；unknown／高爆炸半徑改動 fail-safe 升 L3。完整 mapping 以 CLAUDE.md 與該檔為準，本檔不重複。
-- 宣稱完成前回報實際執行過的驗證（最高層級＋指令＋pass/fail）。優先測：變化邏輯（音便／ない形／不規則）、答案 normalization、contentGuard／contentStats drift、主要練習流程。
+- Verification ladder (#760): L0 targeted → L1 affected → L2 path gate → L3 full. Executor: `pnpm verify` (level selected by changed paths), `pnpm verify --dry-run`, `pnpm verify:full`. Selector = `scripts/select-verification.mjs` (deterministic explicit rules, not LLM guessing); unknown / high-blast-radius changes fail-safe to L3. Full mapping in `CLAUDE.md` and that file; not duplicated here.
+- Before claiming completion, report the actual verification executed (highest level + commands + pass/fail). Priority tests: changed logic (音便 / ない形 / irregular), answer normalization, contentGuard/contentStats drift, main practice flows.
 
-## 回報格式
+## Report Format
 
-- 只列關鍵變更：檔案＋一句說明
-- 測試結果只報 pass/fail 與失敗原因，不貼完整 log
-- 遇到錯誤先給診斷與建議修法，再問是否繼續
+- List only key changes: file + one-line explanation
+- Test results: report only pass/fail and failure reasons, not full logs
+- On errors, give a diagnosis and suggested fix first, then ask whether to continue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 
 ## Project Positioning (current as of 2026-07)
 
-Jabiko (jabiko.app) is a free, registration-free **JLPT N5–N1 self-study room**: grammar / vocabulary / kanji readings / official question types / mock exams / learning articles. Item bank 3,600+, learning sections 73+, article section live.
+Jabiko (jabiko.app) is a free, registration-free **JLPT N5–N1 self-study room**: grammar / vocabulary / kanji readings / official question types / mock exams. Item bank 3,600+, learning sections 73+.
 
 - Tech stack: React 19 + TypeScript strict + Vite 7 + Vitest 4 + jsdom, pnpm, PWA (vite-plugin-pwa)
 - Data: local-first (localStorage) + **optional** Supabase cross-device sync (Google login); Cloudflare Pages deployment + prerender

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Adding exam items (grammar/vocabulary, etc.) always goes through this loop, one 
    - codex usage: `codex exec --skip-git-repo-check "$(cat prompt.txt)" < /dev/null` (stdin must be closed or it hangs). codex sometimes writes explanations in Japanese; translate them to Traditional Chinese when consolidating.
 3. **Convert**: convert the simplified shape (`question/answer/...`) into the importer's `ExamQuestionInput` (`id,level,surface,reading,meaningZh,promptLabel,instructionZh,promptText,promptContextZh,hintZh,expectedAnswer,options[4],explanation`) in `scripts/exam-batches/<name>.json`.
    - **contentGuard hard rules**: `hintZh` non-empty and **sharing no ≥2-char substring with `meaningZh`**; exactly 4 mutually distinct `options`; `expectedAnswer ∈ options`; `promptLabel` must not contain N1–N5 strings.
-4. **Verify**: pass `node scripts/import-exam-items.mjs <file> --dry-run`, then run `--dry-run` without the actual append.
+4. **Verify**: run `node scripts/import-exam-items.mjs <file> --dry-run` first; once it passes, rerun **without** `--dry-run` to perform the actual append.
 5. **contentStats sync** (`src/domain/contentStats.ts`, hardcoded numbers; `contentStats.test.ts` is the drift guard):
    - `examItems` counts **all** levels; `n1Grammar` counts only N1 grammar form-selection items.
    - **N1 batches: both `examItems` and `n1Grammar` +N; N2/N3 batches: only `examItems`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,140 +1,162 @@
-# Jabiko 專案規則
+# Jabiko Project Rules
 
-## 技術棧
+## Technical Artifact Language Policy
+
+**English is the canonical language for new technical artifacts**: code-facing comments/docstrings, developer errors/logs, tests, architecture/API/schema documentation, CI/CD documentation, implementation plans, branch/commit messages, and detailed issue/PR technical specifications.
+
+- Concise Japanese summaries in team-facing issue/PR descriptions are allowed when useful; detailed engineering specifications must be in English.
+- **Never translated by this policy:** user-facing product localization, Japanese-learning content, test fixtures/test data whose language is part of behavior, and external/public contracts.
+- Legacy documents that predate this policy follow **touch-to-migrate** — they are migrated to English only when a concrete maintenance edit touches them, never in a blind repository-wide translation pass. See “Touch-to-migrate” below.
+- `CLAUDE.md` is the authoritative project rules; `AGENTS.md` is its concise mirror. On conflict, `CLAUDE.md` wins.
+
+### Touch-to-migrate (legacy Traditional Chinese artifacts)
+
+These documents still contain Traditional Chinese and are migrated on touch (a concrete maintenance edit), not proactively:
+
+- `docs/item-quality-rubric.md` — question-quality rubric used by the exam content pipeline
+- `docs/future-development-directions.md` — future-direction vision notes
+- `docs/exam-grammar-original-question-list.md`, `docs/exam-grammar-rewrite-backlog.md`, `docs/exam-public-practice-quality-review-and-batch-2.md` — exam content working notes
+- `docs/claude-exam-batch-2-short-prompt.md`, `docs/claude-exam-grammar-review-prompt.md` — exam batch prompt drafts
+- `docs/learning-tracking-system-proposal.md`, `docs/llm-judge-quality.md` — proposals
+- `docs/superpowers/specs/*.md`, `docs/superpowers/plans/*.md` — 2026-05/06 historical design drafts (already flagged as non-authoritative in `AGENTS.md`); out of scope for migration
+- `.planning/codebase/*.md` are already English and serve as the English source of truth for architecture/testing/structure/stack/conventions/integrations/concerns.
+- The Japanese-learning content itself (`src/domain/**`, `src/locales/**`) is product content and is out of scope for this policy.
+
+## Tech Stack
 
 - React 19 + TypeScript strict mode + Vite 7 + Vitest 4 + jsdom
-- pnpm 套件管理
-- 領域驅動設計：`src/domain/`（商業邏輯）、`src/components/`（React UI）、`src/hooks/`
+- pnpm package management
+- Domain-driven design: `src/domain/` (business logic), `src/components/` (React UI), `src/hooks/`
 
-## 修改前必讀
+## Read Before Modifying
 
-- `src/domain/vocabulary.ts` 和 `src/domain/vocabulary-jlpt.ts` 是熱路徑
-- `src/domain/types.ts` 是所有領域型別的定義處
-- `src/domain/contentGuard.test.ts` 是題目內容的正確性驗證關卡
-- 修改任何 domain 檔案時，先讀對應的 `.test.ts` 了解預期行為
-- 新增／修改題庫題目前，先讀 [`docs/item-quality-rubric.md`](docs/item-quality-rubric.md)（出題品質規範：唯一正解、干擾、不洩漏、格式）
+- `src/domain/vocabulary.ts` and `src/domain/vocabulary-jlpt.ts` are hot paths
+- `src/domain/types.ts` defines all domain types
+- `src/domain/contentGuard.test.ts` is the correctness gate for item content
+- Before modifying any domain file, read its corresponding `.test.ts` to understand expected behavior
+- Before adding/modifying exam items, read [`docs/item-quality-rubric.md`](docs/item-quality-rubric.md) (item-quality rubric: unique correct answer, distractors, no leaks, format)
 
-## 驗證階梯（L0–L3，issue #760）
+## Verification Ladder (L0–L3, issue #760)
 
-開發驗證採分層制，越接近交付驗證越強。**不可**把 repo-wide 全量驗證當作最小 TDD 單位。
+Development verification is tiered; the closer to delivery, the stronger the verification. **Do not** use a repo-wide full verification run as the minimal TDD unit.
 
-| 層級 | 時機 | 執行內容 |
+| Level | When | What to run |
 | --- | --- | --- |
-| **L0 Targeted** | TDD RED/GREEN 每次迭代 | 直接跑受測檔的同目錄測試：`pnpm vitest run <file>.test.ts` |
-| **L1 Affected** | 一個實作/重構單元完成後 | 受影響測試（同目錄 sibling + 已知整合測試 + 改動的測試檔） |
-| **L2 Feature Gate** | commit / PR-ready 前 | L1 + path-aware domain gate（`check:exam` / `check:i18n`）＋ drift guard |
-| **L3 Full** | PR ready / 最終 review / merge 前 | `pnpm lint`、`pnpm test`、`pnpm build`（＋非 test 子集的 path gate） |
+| **L0 Targeted** | each TDD RED/GREEN iteration | tests in the same directory as the file under test: `pnpm vitest run <file>.test.ts` |
+| **L1 Affected** | after one implementation/refactor unit | affected tests (same-directory siblings + known integration tests + the changed test files) |
+| **L2 Feature Gate** | before commit / PR-ready | L1 + path-aware domain gate (`check:exam` / `check:i18n`) + drift guard |
+| **L3 Full** | PR ready / final review / before merge | `pnpm lint`, `pnpm test`, `pnpm build` (+ non-test-subset path gates) |
 
-**執行器**：`pnpm verify` 依 git changed-path 自動選 L1/L2（必要時升 L3）；`pnpm verify --dry-run` 只看計畫；**`pnpm verify:full` 是唯一最終交付指令**（＝ `--level 3`：L3 full + 依 changed-path 保留 applicable 非 test path gate，如 `check:i18n`）。selector 在 [`scripts/select-verification.mjs`](scripts/select-verification.mjs)，是 deterministic、可測試、conservative 的 explicit 規則表（**不用 LLM 猜**、不做 dependency graph）。
+**Executor:** `pnpm verify` picks L1/L2 automatically from git changed paths (escalating to L3 when necessary); `pnpm verify --dry-run` only shows the plan; **`pnpm verify:full` is the single final-delivery command** (= `--level 3`: L3 full + applicable non-test path gates retained by changed paths, e.g. `check:i18n`). The selector lives in [`scripts/select-verification.mjs`](scripts/select-verification.mjs) and is a deterministic, testable, conservative explicit rule table (**no LLM guessing**, no dependency graph).
 
-**Escalation（fail-safe）**：unknown 或高爆炸半徑的改動一律升 L3，寧可過度驗證也不靜默少測。至少涵蓋：test setup/config、Vite/Vitest/TS/build 設定、`package.json`/lockfile、共用 routing、cross-cutting domain contract/type、語言/fallback 合約、驗證 tooling 本身（含 `scripts/*.test.ts`）；base diff 失敗或 production source 無既有 affected test 也升 L3（不 no-op）。
+**Escalation (fail-safe):** unknown or high-blast-radius changes always escalate to L3 — prefer over-verification over silently testing less. At minimum this covers: test setup/config, Vite/Vitest/TS/build config, `package.json`/lockfile, shared routing, cross-cutting domain contract/type, language/fallback contracts, and the verification tooling itself (incl. `scripts/*.test.ts`); a failing base diff, or production source with no existing affected test, also escalates to L3 (never a no-op).
 
-**代表性 mapping**（完整規則以 `scripts/select-verification.mjs` 為準）：
+**Representative mapping** (full rules in `scripts/select-verification.mjs`):
 - component / domain / hooks / lib → L1 sibling test
-- exam/content（`src/domain/exam/**`、vocabulary/grammar/sentencePatterns/learningBlocks/kanjiOnyomi/wordOrder/cloze/starterVocabulary）→ L2 `check:exam`＋contentStats/furigana drift
-- i18n（`src/locales/**`、`*.i18n.ts`）→ L2 `check:i18n`＋`i18n.test.ts`
-- furigana/reading（`src/domain/furigana*`、readingConfusers/readingLookup）→ L2 furigana drift＋（`build:furigana` 重產）
-- article/content（`src/domain/articles*`、articleBodies、prerender、public/sitemap.xml）→ L2 `sitemap.test.ts` drift＋（`build:sitemap` 重產）
-- `src/i18n.ts`、`src/domain/types.ts`、`contentGuard.ts`、`contentStats.ts`、`examBlocks.ts`、`src/App.tsx`/`main.tsx`/`routes.ts`/`components/index.ts` → L3
+- exam/content (`src/domain/exam/**`, vocabulary/grammar/sentencePatterns/learningBlocks/kanjiOnyomi/wordOrder/cloze/starterVocabulary) → L2 `check:exam` + contentStats/furigana drift
+- i18n (`src/locales/**`, `*.i18n.ts`) → L2 `check:i18n` + `i18n.test.ts`
+- furigana/reading (`src/domain/furigana*`, readingConfusers/readingLookup) → L2 furigana drift + (`build:furigana` regeneration)
+- article/content (`src/domain/articles*`, articleBodies, prerender, public/sitemap.xml) → L2 `sitemap.test.ts` drift + (`build:sitemap` regeneration)
+- `src/i18n.ts`, `src/domain/types.ts`, `contentGuard.ts`, `contentStats.ts`, `examBlocks.ts`, `src/App.tsx`/`main.tsx`/`routes.ts`/`components/index.ts` → L3
 
-**去重（只有 mechanically equivalent 才可省略物理執行，不削弱語意 gate）**：
-- `pnpm typecheck`（`tsc --noEmit`）是 `pnpm build` 的第一段 → L3 不需重複跑 typecheck。
-- `pnpm check:exam`（`vitest run contentGuard.test.ts`）⊂ `pnpm test` → L3 與 CI 不需重複跑。
-- 只有能證明 semantic equivalence 時才能消除物理重複，不可只刪驗證。
+**Deduplication** (only skip a physical run when mechanically equivalent — never weaken a semantic gate):
+- `pnpm typecheck` (`tsc --noEmit`) is the first stage of `pnpm build` → no separate typecheck run needed at L3.
+- `pnpm check:exam` (`vitest run contentGuard.test.ts`) ⊂ `pnpm test` → no separate run needed at L3 or in CI.
+- Only proven semantic equivalence may eliminate a physical duplicate run; never delete a verification step without proof.
 
-其他既有規則：
-- TypeScript 改動後跑 `pnpm build` 確保編譯通過
-- 領域邏輯改動後跑 `pnpm test` 確保回歸
-- build 失敗時先讀錯誤再修，不要盲目重試
+Other existing rules:
+- After TypeScript changes, run `pnpm build` to ensure it compiles
+- After domain-logic changes, run `pnpm test` to ensure no regression
+- When a build fails, read the error first and fix it, don't blindly retry
 
-## TDD 開發流程（強制）
+## TDD Development Workflow (mandatory)
 
-所有開發必須遵循 **Red-Green-Refactor** 循環（對映到驗證階梯）：
+All development must follow the **Red-Green-Refactor** loop (mapped onto the verification ladder):
 
-1. **RED** — 先寫測試，用 **L0** 跑該測試檔確認因功能不存在而失敗（`pnpm vitest run <file>.test.ts`）
-2. **GREEN** — 寫最少程式碼讓該測試（L0）通過
-3. **REFACTOR** — 重構後跑 **L1**（affected）保持綠燈
-4. commit 前 — 跑 **L2** path-specific gate
-5. PR ready / final review / merge 前 — 跑 **L3** full
+1. **RED** — write the test first; use **L0** to run that test file and confirm it fails because the feature doesn't exist (`pnpm vitest run <file>.test.ts`)
+2. **GREEN** — write the minimal code to make that test (L0) pass
+3. **REFACTOR** — after refactoring, run **L1** (affected) to stay green
+4. Before commit — run **L2** path-specific gate
+5. Before PR ready / final review / merge — run **L3** full
 
-每次回報必須註明**實際完成的最高層級**與**實際跑過的指令／結果**（pass/fail），不可只寫「已測試」。
+Every report must state the **highest level actually completed** and the **exact commands/results run** (pass/fail), never just “tested”.
 
-### 鐵則
+### Iron rules
 
-- **沒有先寫測試就不准寫 production code**
-- 每個新功能／修 bug 必須先有對應的測試
-- 未觀察到測試失敗就直接通過，代表測錯了東西
-- 若先寫了程式碼才想到要補測試，刪掉重來
-- 例外（告知使用者後可豁免）：一次性 prototype、純設定檔、自動產生程式碼
+- **No production code without a test written first**
+- Every new feature / bug fix must have a corresponding test
+- Passing without ever observing a test failure means you tested the wrong thing
+- If you wrote code before thinking of the test, delete and start over
+- Exceptions (waivable after informing the user): one-off prototypes, pure config files, auto-generated code
 
-## 不變條件
+## Invariants
 
-- 不要改變 `src/domain/contentGuard.ts` 的驗證規則，除非透過 issue 討論
-- `src/domain/types.ts` 的型別是合約，不要隨意刪除或破壞向後相容
-- 所有領域邏輯必須在 `src/domain/`，不要在 `src/components/` 放商業邏輯
-- pnpm 為唯一套件管理工具，不產生 npm/yarn/bun lockfile
+- Don't change the validation rules in `src/domain/contentGuard.ts` except through issue discussion
+- `src/domain/types.ts` types are a contract; don't delete or break backward compatibility casually
+- All domain logic must live in `src/domain/`; don't put business logic in `src/components/`
+- pnpm is the only package manager; never generate an npm/yarn/bun lockfile
 
-## 內容可見性規則（Content visibility — product ownership boundary）
+## Content Visibility Rules (content visibility — product ownership boundary)
 
-這些是產品決定，不是工程決定。AI **禁止**在沒有人工明確批准的情況下變更。
+These are product decisions, not engineering decisions. AI is **forbidden** to change them without explicit human approval.
 
-### 語言隔離規則
+### Language isolation rules
 
-- `*Zh` 結尾的欄位（`meaningZh`、`hintZh`、`instructionZh`、`lineZh`、`contextZh`、
-  `promptContextZh`、`explanation`、`commonMistakes`）是未翻譯的中文內容，**不得**對
-  `zh-Hant` 以外的語言渲染，除非透過 `pickLocalized()` 或 `pickLocalizedOptional()`
-  並有有效的 i18n overlay。
-- `formation` 是單向中文接續規則，等同 `meaningZh` 處理。
-- `lineZh` 和 `contextZh` 即使在子元件內部也必須受 `isZhHant` 保護。
-- `isZhHant`（`language === "zh-Hant"`）是唯一的閘門變數。**禁止**引入其他閘門慣例。
+- `*Zh`-suffixed fields (`meaningZh`, `hintZh`, `instructionZh`, `lineZh`, `contextZh`,
+  `promptContextZh`, `explanation`, `commonMistakes`) are untranslated Chinese content and **must
+  not** be rendered to any language other than `zh-Hant`, unless through `pickLocalized()` or
+  `pickLocalizedOptional()` with a valid i18n overlay.
+- `formation` is a one-direction Chinese continuation rule; treat it like `meaningZh`.
+- `lineZh` and `contextZh` must be guarded by `isZhHant` even inside child components.
+- `isZhHant` (`language === "zh-Hant"`) is the only gate variable. **No** other gate conventions allowed.
 
-### 禁止事項（AI 必須先問）
+### Forbidden (AI must ask first)
 
-- 移除保護 `*Zh` 欄位的 `isZhHant`。
-- 新增渲染 `*Zh` 欄位但沒有語言閘門的元件。
-- 變更 `src/i18n.ts` 的 `LAUNCHED_LANGUAGES`（決定使用者看到哪些語系）。
-- 新增語系代碼到 `LocaleCode`（需要內容翻譯計畫）。
-- 變更 `pickLocalized()` 的行為或其 fallback chain。
-- 如果認為應該移除語言閘門：**停下來問使用者**。正確的做法是先在
-  data model 新增 i18n overlay 欄位（例如 `GrammarPattern` 上的 `meaningI18n`），
-  再透過 `pickLocalized()` 路由。這是產品決定，不是工程決定。
+- Removing the `isZhHant` guard that protects `*Zh` fields.
+- Adding components that render `*Zh` fields without a language gate.
+- Changing `LAUNCHED_LANGUAGES` in `src/i18n.ts` (it decides which languages users see).
+- Adding a language code to `LocaleCode` (requires a content translation plan).
+- Changing the behavior of `pickLocalized()` or its fallback chain.
+- If you think a language gate should be removed: **stop and ask the user**. The correct approach
+  is to add an i18n overlay field to the data model first (e.g. `meaningI18n` on `GrammarPattern`)
+  and route through `pickLocalized()`. This is a product decision, not an engineering decision.
 
-## 工作空間隔離
+## Workspace Isolation
 
-- 所有會修改檔案的實作任務**必須**在 git worktree 中進行（`EnterWorktree`），不得直接在工作目錄上修改
-- 純查詢、讀取、搜尋不需 worktree
+- All implementation tasks that modify files **must** be done in a git worktree (`EnterWorktree`); never modify the working directory directly
+- Pure queries, reads, and searches don't need a worktree
 
-## 程式碼慣例
+## Code Conventions
 
-- TypeScript strict mode 全開，禁止 `any`，除非有明確註解說明
-- 測試檔與原始檔放在同目錄，命名為 `*.test.ts` 或 `*.test.tsx`
-- React 元件用函式元件 + hooks，不用 class component
-- import 用 ES module 路徑（相對路徑）
+- TypeScript strict mode fully on; `any` forbidden unless explicitly justified in a comment
+- Test files live next to source files, named `*.test.ts` or `*.test.tsx`
+- React components are function components + hooks, never class components
+- Imports use ES module paths (relative paths)
 
-## 題庫內容工作流（exam content pipeline）
+## Exam Content Pipeline
 
-新增 exam 題目（文法／詞彙等）一律走這條 loop，每批一個 PR：
+Adding exam items (grammar/vocabulary, etc.) always goes through this loop, one PR per batch:
 
-1. **驗真缺**：對 `src/domain/exam/items/<level>.ts` grep 既有點，**同時搜 surface 與 expectedAnswer、漢字與假名**，確認不是已散見於其他題型。
-2. **雙審設計**：subagent + codex 平行各出一份（每點 2 題），再**交叉判**（codex 判 subagent 檔、subagent 判 codex 檔），最後跑一次**終審** subagent 掃雙解/接續秒殺/洩漏。
-   - 最大雷＝**近義雙解**與**接續秒殺**。鎖法：選項放完整述部、干擾用反義、用語境/時間副詞鎖死方向。codex 抓雙解通常比 subagent 準。
-   - codex 用法：`codex exec --skip-git-repo-check "$(cat prompt.txt)" < /dev/null`（須關 stdin，否則卡住）。codex 有時寫日文解說，consolidate 時翻成繁中。
-3. **轉檔**：簡化 shape（`question/answer/...`）轉成 importer 的 `ExamQuestionInput`（`id,level,surface,reading,meaningZh,promptLabel,instructionZh,promptText,promptContextZh,hintZh,expectedAnswer,options[4],explanation`），放 `scripts/exam-batches/<name>.json`。
-   - **contentGuard 硬規則**：`hintZh` 非空且**與 `meaningZh` 不可共用任何 ≥2 字片段**；`options` 恰 4 個互不重複；`expectedAnswer ∈ options`；`promptLabel` 不含 N1–N5 字樣。
-4. **驗證**：`node scripts/import-exam-items.mjs <file> --dry-run` 過 → 再去 `--dry-run` 拿掉實際 append。
-5. **contentStats 同步**（`src/domain/contentStats.ts`，硬編碼數字、`contentStats.test.ts` 是 drift guard）：
-   - `examItems` 計**所有**等級；`n1Grammar` 只計 N1 文法形式選擇。
-   - **N1 批次：examItems 與 n1Grammar 都 +N；N2/N3 批次：只 +examItems。**
-   - **furigana 重產**（#134 P4）：本批有新 exam 例句／題幹時跑 `pnpm build:furigana` 重產 `src/domain/furiganaData.ts`（從 vocab＋jlpt＋exam 全來源烤；新句的注音才會出現、漢字読み 題幹自動排除）。kuromoji 誤讀加進腳本的 `READING_OVERRIDES`（用複合詞 key、勿用 後/九 這種歧義單字）。`furiganaData` 只進 lazy challenge chunk，勿從 eager 路徑 import（[[jabiko-bundle-codesplit]]）。
-6. **EOL**：`exam/items/*.ts` 在 git 是 `-text`，CRLF 會被 `git diff --check` 報。暫存時用 `git -c core.autocrlf=false add <files>`，commit 前確認 `git diff --cached --check` EXIT=0。
-7. **三閘＋build**：`pnpm check:exam`、`pnpm test`（含 contentGuard/contentStats drift）、`pnpm build`（確認 `examBlocks` 仍是 lazy 獨立 chunk、`index` 不膨脹）。
-8. **PR**：branch → push（pre-push hook 會跑 build）→ `gh pr create`。**CI 必過閘只有 `Test and build`**；CodeRabbit/Cloudflare 常是 rate-limit skip，不阻擋。green 後 `gh pr merge --squash --delete-branch`。
-   - ⚠ 不要開背景 CI waiter 無限 loop（PR merge + branch 刪除後 `gh` 回空、`jq` 對 null 拋錯，條件永不成立 → 殭屍）。要等就用**有迭代上限**的 bounded loop，或 inline 查 `gh pr checks`。
+1. **Verify the gap**: grep existing items in `src/domain/exam/items/<level>.ts`, searching **both** surface and expectedAnswer, kanji and kana, to confirm the point isn't already covered by another question type.
+2. **Double-blinded design**: a subagent and codex each produce a draft in parallel (2 items per point), then **cross-review** (codex reviews the subagent file, the subagent reviews the codex file), and finally one **final-review** subagent scans for double answers / instant continuation kills / leaks.
+   - Biggest traps = **near-synonym double answers** and **continuation instant-kills**. Locking approach: put full predicates in options, use antonyms for distractors, lock the direction with context/time adverbs. codex is usually better than the subagent at catching double answers.
+   - codex usage: `codex exec --skip-git-repo-check "$(cat prompt.txt)" < /dev/null` (stdin must be closed or it hangs). codex sometimes writes explanations in Japanese; translate them to Traditional Chinese when consolidating.
+3. **Convert**: convert the simplified shape (`question/answer/...`) into the importer's `ExamQuestionInput` (`id,level,surface,reading,meaningZh,promptLabel,instructionZh,promptText,promptContextZh,hintZh,expectedAnswer,options[4],explanation`) in `scripts/exam-batches/<name>.json`.
+   - **contentGuard hard rules**: `hintZh` non-empty and **sharing no ≥2-char substring with `meaningZh`**; exactly 4 mutually distinct `options`; `expectedAnswer ∈ options`; `promptLabel` must not contain N1–N5 strings.
+4. **Verify**: pass `node scripts/import-exam-items.mjs <file> --dry-run`, then run `--dry-run` without the actual append.
+5. **contentStats sync** (`src/domain/contentStats.ts`, hardcoded numbers; `contentStats.test.ts` is the drift guard):
+   - `examItems` counts **all** levels; `n1Grammar` counts only N1 grammar form-selection items.
+   - **N1 batches: both `examItems` and `n1Grammar` +N; N2/N3 batches: only `examItems`.**
+   - **furigana regeneration** (#134 P4): when the batch has new exam example sentences/stems, run `pnpm build:furigana` to regenerate `src/domain/furiganaData.ts` (baked from vocab + jlpt + exam sources; new sentences' readings appear, kanji-reading stems are auto-excluded). Add kuromoji misreadings to the script's `READING_OVERRIDES` (use compound-word keys, not ambiguous single kanji like 後/九). `furiganaData` only goes into the lazy challenge chunk; don't import it from eager paths ([[jabiko-bundle-codesplit]]).
+6. **EOL**: `exam/items/*.ts` is `-text` in git; CRLF is reported by `git diff --check`. Stage with `git -c core.autocrlf=false add <files>`, and confirm `git diff --cached --check` EXIT=0 before committing.
+7. **Three gates + build**: `pnpm check:exam`, `pnpm test` (incl. contentGuard/contentStats drift), `pnpm build` (confirm `examBlocks` is still a lazy independent chunk and `index` doesn't grow).
+8. **PR**: branch → push (pre-push hook runs build) → `gh pr create`. **The only required CI gate is `Test and build`**; CodeRabbit/Cloudflare are often rate-limit skips and don't block. After green, `gh pr merge --squash --delete-branch`.
+   - ⚠ Don't start a background CI waiter infinite loop (after PR merge + branch deletion `gh` returns empty, `jq` throws on null, and the condition never holds → zombie). To wait, use a **bounded loop with an iteration cap**, or query `gh pr checks` inline.
 
-## 目前進度快照（2026-06-25）
+## Current Progress Snapshot (2026-06-25)
 
-- **JLPT 文法 coverage 全數補完**：N1(#164)/N2(#165)/N3(#166) 三子議題已關閉，父議題 #157 收束。
-- **N1 文字・語彙補平衡完成**（#152，三批 N1 vocab 用法/類義/詞彙填空）。`examItems = 989`、`n1Grammar = 265`。
-- **跨裝置同步（#151）已完成並端到端驗證**：Supabase `attempts` 表 + RLS + 明確 grant（#196 補上，**別靠 Supabase 隱性 default privileges**）；prod 實測雲端 1065 列吻合本機。#181/#151 已關。詳見使用者 memory `jabiko-cross-device-sync`。
-- 各 batch 來源 JSON 保留在 `scripts/exam-batches/`；grammar loop 細節另記於使用者 memory `jabiko-grammar-coverage-loop`。
-- **下一步候選**（與使用者討論後再開工）：#195 漢字讀音速查表擴充全等級、#135 SRS 現代化 epic、#134 Furigana toggle、#124 題型分布補平衡。
+- **JLPT grammar coverage complete**: N1(#164)/N2(#165)/N3(#166) sub-issues closed, parent #157 wrapped up.
+- **N1 characters & vocabulary (文字・語彙) rebalancing complete** (#152, three N1 vocab usage/synonym/cloze batches). `examItems = 989`, `n1Grammar = 265`.
+- **Cross-device sync (#151) complete and end-to-end verified**: Supabase `attempts` table + RLS + explicit grant (#196 added; **don't rely on Supabase implicit default privileges**); prod test confirmed 1065 cloud rows match local. #181/#151 closed. See user memory `jabiko-cross-device-sync`.
+- Batch source JSONs are kept in `scripts/exam-batches/`; grammar-loop details are in user memory `jabiko-grammar-coverage-loop`.
+- **Next-step candidates** (start only after discussing with the user): #195 kanji-reading lookup table expansion to all levels, #135 SRS modernization epic, #134 furigana toggle, #124 question-type distribution rebalancing.

--- a/docs/automation/gemini-correctness-autofix.md
+++ b/docs/automation/gemini-correctness-autofix.md
@@ -94,8 +94,10 @@ Configure in GitHub repo **Settings → Secrets and variables → Actions**:
 1. Set the secret `GEMINI_API_KEY` (required).
 2. **Do not** set `GEMINI_AUTOFIX_MODE` (or keep it `off`) → the daily cron only
    safe-skips; it will never call Gemini or write the repo on its own.
-3. Set the remaining variables (`GEMINI_AUTOFIX_MODEL` etc.); you may leave them all blank
-   initially and let the code use the tighten-only defaults.
+3. Set `GEMINI_AUTOFIX_MODEL` to an allowlisted model — it has **no implicit default**, and
+   observe/repair fail closed when it is missing or empty. The numeric tighten-only variables
+   (`GEMINI_AUTOFIX_MIN_CONFIDENCE`, `GEMINI_AUTOFIX_MAX_FILES`, `GEMINI_AUTOFIX_MAX_LINES`)
+   may be left blank to use the code defaults.
 4. Manually run **`workflow_dispatch` → mode = `observe`** (1–2 times) and verify:
    - The step summary shows `Status: observed` (or `no-finding` / a fail-closed reason).
    - The `gemini-correctness-results` artifact contains only allowlisted files.

--- a/docs/automation/gemini-correctness-autofix.md
+++ b/docs/automation/gemini-correctness-autofix.md
@@ -1,259 +1,262 @@
 # Gemini correctness autofix — owner / security runbook
 
-> 本文件是 **owner / security runbook**：說明如何把已合併的 Gemini correctness
-> automation（#688 orchestration 狀態機 + #689 publication adapter 的 #690
-> workflow 接線）從 `off` → `observe` → manual `repair` → scheduled `repair`
-> 逐步上線，包含 rollout 證據、即時停止條件與復原、以及 orphan branch 清理。
+> This document is an **owner / security runbook**: it describes how to roll out the merged
+> Gemini correctness automation (#688 orchestration state machine + #689 publication adapter,
+> wired up by the #690 workflow) from `off` → `observe` → manual `repair` → scheduled `repair`
+> step by step, including rollout evidence, immediate-stop conditions and recovery, and orphan
+> branch cleanup.
 >
-> 本 runbook **只描述已合併的實作（#690 / PR #736）**，不重新設計任何行為。
-> 若本文件與 `.github/workflows/gemini-correctness-autofix.yml` 或
-> `scripts/gemini-correctness/**` 不符，以 workflow 與 scripts 為準並回報。
+> This runbook **only describes the merged implementation (#690 / PR #736)**; it does not
+> redesign any behavior. If this document disagrees with
+> `.github/workflows/gemini-correctness-autofix.yml` or `scripts/gemini-correctness/**`, the
+> workflow and scripts win — please report the discrepancy.
 
-相關 issue：#638（parent）、#688（orchestration 狀態機）、#689（publication
-adapter）、#690（workflow 接線）、#691（本 runbook）。
+Related issues: #638 (parent), #688 (orchestration state machine), #689 (publication adapter),
+#690 (workflow wiring), #691 (this runbook).
 
 ---
 
-## 1. 系統概觀
+## 1. System overview
 
-單一 workflow：`.github/workflows/gemini-correctness-autofix.yml`
-（名稱：`Gemini correctness autofix`），包含兩個 job：
+A single workflow: `.github/workflows/gemini-correctness-autofix.yml`
+(name: `Gemini correctness autofix`), with two jobs:
 
-- **`evaluate`**（Evaluate correctness (observe / repair)）
-  - read-only permissions：`contents: read` + `pull-requests: read`。
-  - 跑 #688 的 `runWorkflowOrchestration` 狀態機：open-PR gate → baseline →
-    discovery →（repair 模式才）RED → clean reset → GREEN。
-  - `GEMINI_API_KEY` **只注入這個 job 的 `orchestrate` step**。
-  - 輸出：`mode`、`publicationAllowed`、`status` 三個 job outputs。
-- **`publish`**（Publish verified repair）
-  - 僅在 `evaluate` 輸出 `publicationAllowed == 'true' && mode == 'repair'`
-    時執行（condition gate，見 workflow line 404）。
-  - 最小 write scopes：`contents: write` + `pull-requests: write`。
-  - **永不看到 model secret**，只呼叫 #689 的 `publishVerifiedRepair`
-    adapter，不重跑 Gemini stage。
-  - 行為：重新驗證 candidate → 重讀 remote main 比對 baseline →
-    建 branch → 一個 commit → push → 開一個 **Draft PR**。
+- **`evaluate`** (Evaluate correctness (observe / repair))
+  - read-only permissions: `contents: read` + `pull-requests: read`.
+  - Runs #688's `runWorkflowOrchestration` state machine: open-PR gate → baseline →
+    discovery → (repair mode only) RED → clean reset → GREEN.
+  - `GEMINI_API_KEY` **is injected only into this job's `orchestrate` step**.
+  - Outputs: `mode`, `publicationAllowed`, `status` as three job outputs.
+- **`publish`** (Publish verified repair)
+  - Runs only when `evaluate` outputs `publicationAllowed == 'true' && mode == 'repair'`
+    (condition gate, workflow line 404).
+  - Minimal write scopes: `contents: write` + `pull-requests: write`.
+  - **Never sees the model secret**; it only calls #689's `publishVerifiedRepair`
+    adapter and does not re-run the Gemini stage.
+  - Behavior: re-validates the candidate → re-reads remote main and compares the baseline →
+    creates a branch → a single commit → pushes → opens a **Draft PR**.
 
-觸發：
+Triggers:
 
-- `workflow_dispatch`：`mode` 輸入（`observe` | `repair`，預設 `observe`）。
-  **輸入永遠不能調整 limits、model policy 或 permissions。**
-- `schedule`：固定 cron `17 19 * * *`（UTC 19:17 每日）。排程模式讀 repository
-  variable `GEMINI_AUTOFIX_MODE`；缺失/空/未知值一律當 `off`，checkout 後立刻
-  safe-skip（不呼叫 Gemini、不寫 repo）。
+- `workflow_dispatch`: `mode` input (`observe` | `repair`, default `observe`).
+  **The input can never adjust limits, model policy, or permissions.**
+- `schedule`: fixed cron `17 19 * * *` (UTC 19:17 daily). Scheduled mode reads the repository
+  variable `GEMINI_AUTOFIX_MODE`; missing/empty/unknown values are treated as `off` and
+  safe-skip immediately after checkout (no Gemini call, no repo write).
 
-共用設定：`runs-on: ubuntu-latest`、`timeout-minutes: 30`、Node 22、
-`pnpm/action-setup@v4`（10.33.0）、`pnpm install --frozen-lockfile`、
-concurrency group `gemini-correctness-autofix`（`cancel-in-progress: false`）。
+Shared settings: `runs-on: ubuntu-latest`, `timeout-minutes: 30`, Node 22,
+`pnpm/action-setup@v4` (10.33.0), `pnpm install --frozen-lockfile`,
+concurrency group `gemini-correctness-autofix` (`cancel-in-progress: false`).
 
-## 2. Repository 設定（exact names）
+## 2. Repository settings (exact names)
 
-在 GitHub repo **Settings → Secrets and variables → Actions** 設定：
+Configure in GitHub repo **Settings → Secrets and variables → Actions**:
 
-### Secret（`secrets.*`）
+### Secret (`secrets.*`)
 
-| 名稱 | 用途 |
+| Name | Purpose |
 | --- | --- |
-| `GEMINI_API_KEY` | Gemini REST API key（`AIza...`）。只有 `evaluate.orchestrate` step 讀到。缺失時 observe/repair **fail closed**（不會呼叫 Gemini）。 |
+| `GEMINI_API_KEY` | Gemini REST API key (`AIza...`). Read only by the `evaluate.orchestrate` step. When missing, observe/repair **fail closed** (Gemini is not called). |
 
-### Repository variables（`vars.*`）
+### Repository variables (`vars.*`)
 
-| 名稱 | 允許值 | 預設行為 |
+| Name | Allowed values | Default behavior |
 | --- | --- | --- |
-| `GEMINI_AUTOFIX_MODE` | `off` \| `observe` \| `repair` | 只供 **schedule** 路徑讀取；缺失/空/未知 → `off`（safe skip）。`workflow_dispatch` 的 `mode` input 具更高優先權。 |
-| `GEMINI_AUTOFIX_MODEL` | 必須在 model policy allowlist 內 | allowlist：`gemini-2.5-flash`、`gemini-2.5-pro`、`gemini-2.5-flash-lite`。缺失/空/未知 → **fail closed**（無隱式預設）。 |
-| `GEMINI_AUTOFIX_MIN_CONFIDENCE` | 數值，`[0,1]` | 預設 `0.8`；**tighten-only**：不可低於程式預設值。非數值或超界 → fail closed。 |
-| `GEMINI_AUTOFIX_MAX_FILES` | 整數，`[1,200]` | 預設 `200`；hard cap `200`（**tighten-only**，變數不可能放寬）。 |
-| `GEMINI_AUTOFIX_MAX_LINES` | 整數，`[1,250]` | 預設 `250`；hard cap `250`（**tighten-only**）。 |
+| `GEMINI_AUTOFIX_MODE` | `off` \| `observe` \| `repair` | Read only by the **schedule** path; missing/empty/unknown → `off` (safe skip). The `workflow_dispatch` `mode` input takes precedence. |
+| `GEMINI_AUTOFIX_MODEL` | must be in the model policy allowlist | allowlist: `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-2.5-flash-lite`. Missing/empty/unknown → **fail closed** (no implicit default). |
+| `GEMINI_AUTOFIX_MIN_CONFIDENCE` | numeric, `[0,1]` | default `0.8`; **tighten-only**: cannot be below the code default. Non-numeric or out of range → fail closed. |
+| `GEMINI_AUTOFIX_MAX_FILES` | integer, `[1,200]` | default `200`; hard cap `200` (**tighten-only**; the variable can never loosen it). |
+| `GEMINI_AUTOFIX_MAX_LINES` | integer, `[1,250]` | default `250`; hard cap `250` (**tighten-only**). |
 
-> 這些 limits/model/secret 全部由 workflow 的 `orchestrate` step 以 **fail-closed**
-> 方式驗證（model policy allowlist + tighten-only numeric limits +
-> secret missing fail closed），任何不合規值都會讓 `evaluate` job 失敗並
-> 標記 `config-error`，**不會**產生候選或 publish。
+> These limits/model/secret are all validated **fail-closed** by the workflow's `orchestrate`
+> step (model policy allowlist + tighten-only numeric limits + secret-missing fail closed); any
+> non-compliant value fails the `evaluate` job and marks `config-error`, producing **no**
+> candidate and no publish.
 
-### 固定常數（程式內，不可被變數放寬）
+### Fixed constants (in code, cannot be loosened by variables)
 
-- GREEN hard budgets（`policy.mjs`）：`MAX_GREEN_PRODUCTION_FILES = 3`、
-  `MAX_GREEN_DIFF_LINES = 250`。
-- Prompt 上限（`prompt-builder.mjs`）：`MAX_TOTAL_CHARS = 500_000`、
-  `MAX_PROJECT_RULES_CHARS = 100_000`；`DEFAULT_MODEL = "gemini-2.5-flash"`。
-- Gemini client（`gemini-client.mjs`）：`DEFAULT_TIMEOUT_MS = 30_000`、
-  `DEFAULT_MAX_RETRIES = 2`；retryable HTTP `429, 500, 502, 503, 504`；
-  exponential backoff（1s, 2s, 4s… 上限 30s）。
-- Path policy（`policy.mjs`）：allowlist `src/domain/**` + `src/hooks/**`；
-  大量 protected paths（`.github/`、`.env*`、`package.json`、`src/i18n.ts`、
-  `src/domain/types.ts`、`src/domain/contentGuard.ts`、`src/domain/exam/items/`、
-  `scripts/exam-batches/`、`supabase/`、`public/`、`vite.config.ts` …）。
+- GREEN hard budgets (`policy.mjs`): `MAX_GREEN_PRODUCTION_FILES = 3`,
+  `MAX_GREEN_DIFF_LINES = 250`.
+- Prompt caps (`prompt-builder.mjs`): `MAX_TOTAL_CHARS = 500_000`,
+  `MAX_PROJECT_RULES_CHARS = 100_000`; `DEFAULT_MODEL = "gemini-2.5-flash"`.
+- Gemini client (`gemini-client.mjs`): `DEFAULT_TIMEOUT_MS = 30_000`,
+  `DEFAULT_MAX_RETRIES = 2`; retryable HTTP `429, 500, 502, 503, 504`;
+  exponential backoff (1s, 2s, 4s… capped at 30s).
+- Path policy (`policy.mjs`): allowlist `src/domain/**` + `src/hooks/**`;
+  a broad set of protected paths (`.github/`, `.env*`, `package.json`, `src/i18n.ts`,
+  `src/domain/types.ts`, `src/domain/contentGuard.ts`, `src/domain/exam/items/`,
+  `scripts/exam-batches/`, `supabase/`, `public/`, `vite.config.ts` …).
 
-## 3. 四階段 rollout
+## 3. Four-phase rollout
 
-### Phase 1 — manual observe（scheduled mode 保持 `off`）
+### Phase 1 — manual observe (scheduled mode stays `off`)
 
-1. 設定 secret `GEMINI_API_KEY`（必填）。
-2. **不要**設定 `GEMINI_AUTOFIX_MODE`（或保持 `off`）→ schedule 每日 cron 只會
-   safe-skip，絕不會自己呼叫 Gemini 或寫 repo。
-3. 設好其餘變數（`GEMINI_AUTOFIX_MODEL` 等）；初次可全部留白，讓程式用
-   tighten-only 預設值。
-4. 手動跑 **`workflow_dispatch` → mode = `observe`**（1–2 次），人工核對：
-   - step summary 顯示 `Status: observed`（或 `no-finding` / fail-closed 理由）。
-   - artifact `gemini-correctness-results` 內只有 allowlisted 檔案。
-   - **沒有**任何 branch / commit / PR 被建立。
-5. 檢視 discovery artifact 品質；先不要切 repair。
+1. Set the secret `GEMINI_API_KEY` (required).
+2. **Do not** set `GEMINI_AUTOFIX_MODE` (or keep it `off`) → the daily cron only
+   safe-skips; it will never call Gemini or write the repo on its own.
+3. Set the remaining variables (`GEMINI_AUTOFIX_MODEL` etc.); you may leave them all blank
+   initially and let the code use the tighten-only defaults.
+4. Manually run **`workflow_dispatch` → mode = `observe`** (1–2 times) and verify:
+   - The step summary shows `Status: observed` (or `no-finding` / a fail-closed reason).
+   - The `gemini-correctness-results` artifact contains only allowlisted files.
+   - **No** branch / commit / PR was created.
+5. Review the discovery artifact quality; don't switch to repair yet.
 
-證據門檻（進入 Phase 2 前）：
+Evidence threshold (before entering Phase 2):
 
-- [ ] 至少 1 次成功的 manual observe 且有合理 finding（或可信的 no-finding）。
-- [ ] step summary 未出現 secrets、env 值、絕對 runner 路徑或 raw model response。
-- [ ] 確認無任何 branch/PR 被 observe 建立。
+- [ ] At least 1 successful manual observe with a reasonable finding (or a credible no-finding).
+- [ ] The step summary shows no secrets, env values, absolute runner paths, or raw model responses.
+- [ ] Confirmed no branch/PR was created by observe.
 
-### Phase 2 — scheduled observe（owner opt-in）
+### Phase 2 — scheduled observe (owner opt-in)
 
-1. 設定 `GEMINI_AUTOFIX_MODE = observe`（這是 owner 明確 opt-in 的信號）。
-2. 等 1–2 個 cron 週期（`17 19 * * *`），核對：
-   - schedule run 的 `mode` 確實為 `observe`（step summary `## Gemini correctness observe`）。
-   - `evaluate` 正常產生 artifacts；`publish` job 不執行。
-   - 沒有任何 branch/commit/PR。
-3. 若 schedule run 顯示 `mode=off`，檢查 variable 名是否拼錯或未存到 repo level。
+1. Set `GEMINI_AUTOFIX_MODE = observe` (this is the owner's explicit opt-in signal).
+2. Wait 1–2 cron periods (`17 19 * * *`) and verify:
+   - The scheduled run's `mode` is indeed `observe` (step summary `## Gemini correctness observe`).
+   - `evaluate` produces artifacts normally; the `publish` job does not run.
+   - No branch/commit/PR.
+3. If a scheduled run shows `mode=off`, check that the variable name is spelled correctly and stored at repo level.
 
-證據門檻（進入 Phase 3 前）：
+Evidence threshold (before entering Phase 3):
 
-- [ ] 至少 2 個連續 schedule observe 週期正常。
-- [ ] observe 累積的 finding 品質足以判斷 candidate 值得修。
-- [ ] 沒有意外 publish、沒有 branch/PR、沒有 secret 洩漏跡象。
+- [ ] At least 2 consecutive scheduled observe periods run cleanly.
+- [ ] The findings accumulated in observe are good enough to judge whether a candidate is worth fixing.
+- [ ] No unexpected publish, no branch/PR, no sign of secret leaks.
 
-### Phase 3 — manual repair（fixture-backed Draft PR + independent review）
+### Phase 3 — manual repair (fixture-backed Draft PR + independent review)
 
-> `repair` 只開 **Draft** PR。合併前必須經人工 independent review；workflow
-> **不會 auto-approve / auto-merge**。
+> `repair` only opens **Draft** PRs. A human independent review is required before merging; the
+> workflow **does not auto-approve / auto-merge**.
 
-1. 保持 `GEMINI_AUTOFIX_MODE = observe`（schedule 維持 observe，不要排程 repair）。
-2. 手動跑 **`workflow_dispatch` → mode = `repair`**。執行流程：
-   - `evaluate`：open-PR gate → baseline（`pnpm lint` / `typecheck` / `test` /
-     `build` / `git diff --check`）→ discovery → RED（fixture-backed：在
-     `.tmp` 寫 test patch，initial run + replay 都 replay-confirmed）→ clean
-     reset → GREEN（production diff 受 `3 files / 250 lines` 硬上限約束）。
-   - `evaluate` 產出 sanitized `candidate`（內嵌 production diff 與 regression
-     test source），`publicationAllowed=true`。
-   - `publish`：re-validate candidate → 重讀 remote main 與 `baselineSha` 比對 →
-     branch → 單一 commit → push → **一個 Draft PR**。
-3. 預期 branch / commit / PR 契約：
-   - Branch：`gemini/auto-fix-<runId>`（`runId` 由 `GITHUB_RUN_ID` slug 化，
-     最長 80 chars；prefix 固定 `gemini/auto-fix-`）。
-   - Commit：**恰一個**，message 為 `fix: <findingTitle>`（≤140 chars，strip
-     control characters），內容 = regression test（`.regression.test.ts` /
-     `.regression.test.tsx`，與 production file 同目錄）+ allowlisted
-     production diff；**不含** `.tmp/**`、raw、secret 內容。
-   - PR：**Draft**（`draft: true`），title `fix: <findingTitle>`，body 由
-     validated candidate 欄位確定性生成，含 RED/GREEN evidence、checks、
-     stats、branch、run URL、model。body 永不拼接 raw model Markdown。
-4. **Independent review**：Draft PR 上的變更由 owner / 第二人獨立 review；
-   approve 後才手動 merge。先看 regression test 是否真能復現、production diff
-   是否只動 finding 相關檔、有無洩漏或測試竄改。
+1. Keep `GEMINI_AUTOFIX_MODE = observe` (schedule stays in observe; do not schedule repair).
+2. Manually run **`workflow_dispatch` → mode = `repair`**. Flow:
+   - `evaluate`: open-PR gate → baseline (`pnpm lint` / `typecheck` / `test` /
+     `build` / `git diff --check`) → discovery → RED (fixture-backed: writes a test patch in
+     `.tmp`; both the initial run and the replay are replay-confirmed) → clean
+     reset → GREEN (production diff constrained by the hard `3 files / 250 lines` budget).
+   - `evaluate` produces a sanitized `candidate` (with the production diff and the regression
+     test source embedded), `publicationAllowed=true`.
+   - `publish`: re-validates the candidate → re-reads remote main and compares with `baselineSha` →
+     branch → single commit → push → **one Draft PR**.
+3. Expected branch / commit / PR contract:
+   - Branch: `gemini/auto-fix-<runId>` (`runId` is a slugified `GITHUB_RUN_ID`,
+     max 80 chars; fixed prefix `gemini/auto-fix-`).
+   - Commit: **exactly one**, message `fix: <findingTitle>` (≤140 chars, control characters
+     stripped), content = regression test (`.regression.test.ts` / `.regression.test.tsx`,
+     same directory as the production file) + allowlisted production diff; **no** `.tmp/**`,
+     raw, or secret content.
+   - PR: **Draft** (`draft: true`), title `fix: <findingTitle>`, body deterministically generated
+     from validated candidate fields, including RED/GREEN evidence, checks, stats, branch, run
+     URL, model. The body never concatenates raw model Markdown.
+4. **Independent review**: an owner / second person independently reviews the Draft PR's changes;
+   merge manually only after approval. First check whether the regression test truly reproduces,
+   whether the production diff only touches finding-related files, and whether there are leaks or
+   test tampering.
 
-證據門檻（進入 Phase 4 前）：
+Evidence threshold (before entering Phase 4):
 
-- [ ] 至少 1 次 manual repair 產生 Draft PR，且其 branch/commit/diff 符合上述契約。
-- [ ] Draft PR 經人工 independent review 並（選擇性）合併，未發生 scope escape /
-  test tampering / secret 洩漏。
-- [ ] 過程中的無效/失敗 run 皆未留下 orphan branch 或意外 PR。
+- [ ] At least 1 manual repair produced a Draft PR whose branch/commit/diff matches the above contract.
+- [ ] The Draft PR went through human independent review and was (optionally) merged, with no scope escape / test tampering / secret leak.
+- [ ] No invalid/failed run during the process left an orphan branch or an unexpected PR.
 
-### Phase 4 — scheduled repair（prior evidence 通過 + 明確 owner opt-in）
+### Phase 4 — scheduled repair (prior evidence passed + explicit owner opt-in)
 
-1. 只有在前三階段證據全過、且 owner **明確**把 `GEMINI_AUTOFIX_MODE` 改成
-   `repair` 後才啟用。
-2. 設定 `GEMINI_AUTOFIX_MODE = repair`，每天 `17 19 * * *` 會自動：
-   - 跑完整 discover → RED → GREEN；通過才 `publicationAllowed=true`。
-   - `publish` 只在此條件成立時開一個 Draft PR。
-3. 每個排程 repair 週期後，owner 應檢查：
-   - 是否有新的 Draft PR（**最多一個**）且符合契約。
-   - 沒有新 PR = no-finding / fail-closed，**不**代表有問題。
-4. **回退條件**：任何一次違反本 runbook 的 stop condition（見 §4）發生，立刻把
-   `GEMINI_AUTOFIX_MODE` 設回 `observe`（或 `off`）→ 回到較低階段重新累積證據。
+1. Enable only after all three previous phases' evidence passes and the owner **explicitly** sets
+   `GEMINI_AUTOFIX_MODE` to `repair`.
+2. Set `GEMINI_AUTOFIX_MODE = repair`; every day at `17 19 * * *` it will:
+   - Run the full discover → RED → GREEN; only if it passes is `publicationAllowed=true`.
+   - `publish` opens one Draft PR only when that condition holds.
+3. After each scheduled repair cycle, the owner should check:
+   - Whether there is a new Draft PR (**at most one**) matching the contract.
+   - No new PR = no-finding / fail-closed, **not** a problem.
+4. **Rollback condition**: if any run violates this runbook's stop condition (see §4), immediately
+   set `GEMINI_AUTOFIX_MODE` back to `observe` (or `off`) → return to a lower phase to re-accumulate evidence.
 
-## 4. Per-run acceptance（每次 run 的驗收）
+## 4. Per-run acceptance
 
-每次 run（手動或排程）完成後核對：
+Verify after each run (manual or scheduled):
 
-1. **baseline SHA 匹配 current main**：`evaluate` 的 baseline = `git rev-parse
-   HEAD`（checkout 後的 current main）；`publish` 在寫入前會再讀一次 remote
-   main，與 `candidate.baselineSha` 不一致 → `baseline-stale`，零寫入。
-2. **no-finding / failure 不建立任何 branch/commit/PR**：只有 `repair-verified`
-   且 `publicationAllowed=true` 的 run 才會進入 `publish`。
-3. **successful repair 至多一個 Draft PR**，且 branch/commit/diff 符合 §3 契約
-   （`gemini/auto-fix-<runId>`、單一 commit、allowlisted diff + regression test）。
-4. **無 secrets / env 值 / 絕對 runner 路徑 / raw model response** 出現在
-   summaries、artifacts 或 PR body（redaction + scrub 強制；§6 再講）。
-5. **無 auto-approve / auto-merge**：Draft PR 一律人工 review 後才 merge。
+1. **baseline SHA matches current main**: `evaluate`'s baseline = `git rev-parse
+   HEAD` (current main after checkout); `publish` re-reads remote main before writing and, if it
+   differs from `candidate.baselineSha` → `baseline-stale`, zero writes.
+2. **no-finding / failure creates no branch/commit/PR**: only a `repair-verified`
+   run with `publicationAllowed=true` enters `publish`.
+3. **a successful repair creates at most one Draft PR**, with branch/commit/diff matching the §3
+   contract (`gemini/auto-fix-<runId>`, single commit, allowlisted diff + regression test).
+4. **No secrets / env values / absolute runner paths / raw model responses** appear in
+   summaries, artifacts, or PR bodies (redaction + scrub enforced; see §6).
+5. **No auto-approve / auto-merge**: Draft PRs are merged only after human review.
 
-## 5. Immediate-stop conditions 與復原
+## 5. Immediate-stop conditions and recovery
 
-發生以下任一情況：**立即停止**（取消進行中的 run、把 mode 設回 `off` /
-`observe`）、依下表復原、記錄事件，未確認 root cause 前不重啟。
+When any of the following happens: **stop immediately** (cancel the in-flight run, set the mode
+back to `off` / `observe`), recover per the table, log the event, and don't restart until the
+root cause is confirmed.
 
-| 情況 | 停止動作 | 復原 |
+| Situation | Stop action | Recovery |
 | --- | --- | --- |
-| **懷疑 secret 洩漏**（step summary / artifact / PR body 出現 `AIza...`、`ghp_...`、`sk-...`、`AKIA...`、env 值） | 立即取消 run；關閉/刪除該 PR 與 branch | 到 GitHub **Settings → Secrets** 撤銷並輪替 `GEMINI_API_KEY`；檢查 Actions run log（官方 log 對 secret 有 mask，但不要依賴）；審視該 run 的 artifact 下載權限；找出洩漏源後才重啟 |
-| **scope escape 或 test tampering**（production diff 觸及 protected/非 allowlisted 路徑，或 regression test 被改寫成不真正失敗） | 取消 run；不 merge；關閉該 PR | 檢查 `publication-adapter` 的 candidate 驗證失敗原因（`invalid-candidate`）；確認 GREEN 硬上限（3 files / 250 lines）與 allowlist；人工重建 repro 後才重試 |
-| **stale-baseline publication**（`publish` 回報 `baseline-stale`） | 系統已 fail closed 零寫入；不需額外動作 | 確認 remote main 與 candidate 差距；重新跑一次 repair（會抓最新 main 當 baseline） |
-| **multiple PRs / orphan branch**（一次 run 出現 >1 個 PR，或發現無 PR 的 `gemini/auto-fix-*` branch） | 停止後續 run；不要直接刪 branch | 先 `gh pr list` 檢查**所有 open PR 的 head branch 與 owner**（見 §6 清理流程），確認某 branch 確實沒有 open PR 且屬本次 automation 才刪除；用 `gh pr close <n> --delete-branch` 或 `git push origin --delete`，**絕不用 force push** |
-| **failed checks 仍 publish**（baseline 或 GREEN checks 失敗卻產生 PR） | 立即關閉該 PR 並標記 | 這是違反契約的嚴重事件：檢查 `evaluate` 是否真的跑完 baseline 五項（lint/typecheck/test/build/diff-check）與 `publicationAllowed` gate；未確認 root cause 前禁止排程 repair |
-| **workflow cancellation**（run 被取消 / concurrency 擋住） | `cancel-in-progress: false`，不會自動 cancel 既有 run；人工確認沒有半成品 | 檢查該 run 是否留下 branch（push 後才被 cancel）；若有，依 §6 清理；重新觸發一次 |
-| **missing artifact**（`publish` 找不到 `command-summary.json` 或 candidate） | 系統 fail closed（`invalid-candidate`） | 重新檢查 `evaluate` 的 artifact upload 是否成功（`if-no-files-found: warn`）；缺 stage artifact 時只有 sanitized summary 會被上傳；重跑該 run |
-| **Gemini quota / API failure**（429 / 5xx / timeout / network） | client 會 retry（429/5xx/network/timeout）；非 retryable（400/401/403）立即停 | 確認 `GEMINI_API_KEY` 額度與 quota；檢查 `quota-api-error` / `finding-rejected` 狀態；錯誤訊息已 truncate + redact，不會含 raw body 或 key；重試前一併檢查 model allowlist |
-| **GitHub outage**（`gh` / API 失敗） | adapter 有 bounded retry（3 次）無窮重試；仍失敗則 fail closed | 等 GitHub 恢復後重新觸發；檢查是否有 push 成功但 PR 失敗留下的 branch（`publication-cleaned-up` / `cleanup-failed` 狀態，後者=orphan，依 §6 清理） |
+| **Suspected secret leak** (`AIza...`, `ghp_...`, `sk-...`, `AKIA...`, env values appear in step summary / artifact / PR body) | cancel the run immediately; close/delete the PR and branch | revoke and rotate `GEMINI_API_KEY` in GitHub **Settings → Secrets**; check the Actions run log (official logs mask secrets, but don't rely on it); review that run's artifact download permissions; restart only after finding the leak source |
+| **Scope escape or test tampering** (production diff touches protected/non-allowlisted paths, or the regression test was rewritten so it doesn't really fail) | cancel the run; don't merge; close the PR | check the `publication-adapter` candidate validation failure reason (`invalid-candidate`); confirm the GREEN hard caps (3 files / 250 lines) and the allowlist; retry only after manually rebuilding the repro |
+| **Stale-baseline publication** (`publish` reports `baseline-stale`) | the system already fail-closed with zero writes; no extra action | confirm the gap between remote main and the candidate; re-run repair once (it picks up the latest main as the baseline) |
+| **Multiple PRs / orphan branch** (one run produced >1 PR, or a `gemini/auto-fix-*` branch with no PR) | stop subsequent runs; don't delete the branch directly | first run `gh pr list` to check **all open PRs' head branches and owners** (see §6 cleanup), confirm a branch truly has no open PR and belongs to this automation before deleting; use `gh pr close <n> --delete-branch` or `git push origin --delete`, **never force push** |
+| **Publish despite failed checks** (baseline or GREEN checks failed yet a PR was produced) | close that PR immediately and flag it | this is a serious contract violation: check whether `evaluate` actually completed all five baseline items (lint/typecheck/test/build/diff-check) and the `publicationAllowed` gate; ban scheduled repair until the root cause is confirmed |
+| **Workflow cancellation** (run cancelled / blocked by concurrency) | `cancel-in-progress: false`, existing runs aren't auto-cancelled; manually confirm no half-finished output | check whether the run left a branch (pushed before cancellation); if so, clean up per §6; re-trigger once |
+| **Missing artifact** (`publish` can't find `command-summary.json` or the candidate) | system fail-closed (`invalid-candidate`) | re-check whether `evaluate`'s artifact upload succeeded (`if-no-files-found: warn`); when a stage artifact is missing, only the sanitized summary is uploaded; re-run the run |
+| **Gemini quota / API failure** (429 / 5xx / timeout / network) | the client retries (429/5xx/network/timeout); non-retryable (400/401/403) stops immediately | confirm `GEMINI_API_KEY` quota; check `quota-api-error` / `finding-rejected` status; error messages are truncated + redacted and won't contain raw bodies or the key; also check the model allowlist before retrying |
+| **GitHub outage** (`gh` / API failure) | the adapter has bounded retry (3 attempts), no infinite retry; still failing → fail closed | wait for GitHub to recover and re-trigger; check whether a push succeeded but PR creation failed, leaving a branch (`publication-cleaned-up` / `cleanup-failed` status; the latter = orphan, clean up per §6) |
 
-## 6. Orphan branch 清理（無 force push）
+## 6. Orphan branch cleanup (no force push)
 
-場景：push 成功但 PR 建立失敗（adapter 自己會嘗試清掉**本次 run 的 branch**；
-成功 → `publication-cleaned-up`，失敗 → `cleanup-failed` 且留下 orphan）；或
-run 在 push 後被取消。
+Scenario: push succeeded but PR creation failed (the adapter itself tries to clean up **this run's
+branch**; success → `publication-cleaned-up`, failure → `cleanup-failed` and an orphan is left); or
+a run was cancelled after pushing.
 
-安全清理流程（**先檢查 open PR ownership 再刪**）：
+Safe cleanup flow (**check open-PR ownership before deleting**):
 
-1. 列出所有 open PR，對每個 `gemini/auto-fix-*` branch 確認其 head branch：
+1. List all open PRs and confirm the head branch of each `gemini/auto-fix-*` branch:
    ```bash
    gh pr list --state open --json headRefName,author,number
    ```
-2. 只有當該 branch **沒有 open PR 指向它**（或被確認為本次 automation 留下的
-   orphan）才刪除。
-3. 用以下任一方式刪除，**絕不用 force push**：
+2. Delete a branch only when it has **no open PR pointing at it** (or is confirmed to be an orphan
+   left by this automation).
+3. Delete with one of these, **never force push**:
    ```bash
-   gh pr close <number> --delete-branch   # 有 open PR 且確認該關
-   git push origin --delete gemini/auto-fix-<runId>   # 純 orphan branch
+   gh pr close <number> --delete-branch   # has an open PR and confirmed to close
+   git push origin --delete gemini/auto-fix-<runId>   # pure orphan branch
    ```
-4. 刪除後確認 `gh pr list` / `git ls-remote --heads origin` 無殘留。
+4. After deletion, confirm `gh pr list` / `git ls-remote --heads origin` has no residue.
 
-## 7. 防洩漏與紅acted 保證（已內建於實作）
+## 7. Leak prevention and redaction guarantees (built into the implementation)
 
-- `discover.mjs` / `workflow-orchestrator.mjs` / `publication-adapter.mjs` 共用
-  `redactForOutput`（redact `AIza...` + 精確 secret），再疊加 pattern scrub：
-  `ghp_*`、`sk-*`、`AKIA*`、env-dump assignment（`KEY=value`）、絕對 POSIX 路徑
-  （`/tmp|/var|/home|/Users|/etc|/usr|/opt|/root|/private|/Applications|/Library`）。
-  URL（`https://...`）不受影響。
-- `gemini-client.mjs`：API key 永不進 log / error / artifact；error 會 truncate
-  response body 並 redact key；timeout + bounded retry。
-- Artifact upload 只有 allowlisted 檔：`finding.json`、`red-result.json`、
-  `repair-result.json`、`command-summary.json`、`publication-result.json`
-  （retention 7 天）。raw prompt / response / env dump / headers / debug log /
-  patch / source archive 永不 upload。
-- PR body 由 validated candidate 欄位確定性生成；narrative 欄位（title、root
-  cause、fix summary、test name）經 scrub + control-character 壓平，無法注入
-  Markdown 結構或 secret。
+- `discover.mjs` / `workflow-orchestrator.mjs` / `publication-adapter.mjs` share
+  `redactForOutput` (redacts `AIza...` + exact secrets), then layer pattern scrubbing:
+  `ghp_*`, `sk-*`, `AKIA*`, env-dump assignments (`KEY=value`), absolute POSIX paths
+  (`/tmp|/var|/home|/Users|/etc|/usr|/opt|/root|/private|/Applications|/Library`).
+  URLs (`https://...`) are unaffected.
+- `gemini-client.mjs`: the API key never enters logs / errors / artifacts; errors truncate the
+  response body and redact the key; timeout + bounded retry.
+- Artifact upload only allows allowlisted files: `finding.json`, `red-result.json`,
+  `repair-result.json`, `command-summary.json`, `publication-result.json`
+  (7-day retention). Raw prompt / response / env dump / headers / debug log / patch / source
+  archive are never uploaded.
+- The PR body is deterministically generated from validated candidate fields; narrative fields
+  (title, root cause, fix summary, test name) are scrubbed and control characters flattened, so
+  no Markdown structure or secret can be injected.
 
-## 8. Rollout 決策速查
+## 8. Rollout decision quick reference
 
-| 階段 | `GEMINI_AUTOFIX_MODE` | 觸發方式 | 可能產出 |
+| Phase | `GEMINI_AUTOFIX_MODE` | Trigger | Possible output |
 | --- | --- | --- | --- |
-| 1. manual observe | （留空 / `off`） | 手動 `workflow_dispatch: observe` | 只有 artifacts + summary |
-| 2. scheduled observe | `observe` | cron `17 19 * * *` | 只有 artifacts + summary |
-| 3. manual repair | `observe`（排程保持 observe） | 手動 `workflow_dispatch: repair` | ≤1 個 Draft PR |
-| 4. scheduled repair | `repair` | cron `17 19 * * *` | 每次 ≤1 個 Draft PR |
+| 1. manual observe | (leave blank / `off`) | manual `workflow_dispatch: observe` | artifacts + summary only |
+| 2. scheduled observe | `observe` | cron `17 19 * * *` | artifacts + summary only |
+| 3. manual repair | `observe` (schedule stays observe) | manual `workflow_dispatch: repair` | ≤1 Draft PR |
+| 4. scheduled repair | `repair` | cron `17 19 * * *` | ≤1 Draft PR per cycle |
 
-任何 stop condition 觸發 → 把 mode 設回 `observe` 或 `off` → 處理後重跑
-Phase 2/3 累積證據，才考慮回到 Phase 4。
+Any stop condition triggers → set the mode back to `observe` or `off` → re-run Phase 2/3 to
+accumulate evidence before considering Phase 4 again.
 
 ---
 
-_本 runbook 對應 merged implementation #690（PR #736）。任何行為描述以
-`.github/workflows/gemini-correctness-autofix.yml` 與
-`scripts/gemini-correctness/**` 為準。_
+_This runbook corresponds to the merged implementation #690 (PR #736). Any behavior description
+takes `.github/workflows/gemini-correctness-autofix.yml` and `scripts/gemini-correctness/**` as
+authoritative._

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,17 +1,17 @@
-# Supabase（跨裝置進度同步 / #151）
+# Supabase (cross-device progress sync / #151)
 
-本資料夾存放 Jabiko 跨裝置「錯題與進度（attempts）同步」用的資料庫結構。應用程式平時把資料存在本機 localStorage（`src/domain/storage.ts`），登入後才與這裡的 `attempts` 表雙向同步。
+This folder holds the database structure for Jabiko's cross-device "mistakes and progress (attempts) sync". The app normally stores data in localStorage on the device (`src/domain/storage.ts`); after login it two-way syncs with the `attempts` table here.
 
 ## migrations
 
-- [`migrations/0001_create_attempts.sql`](migrations/0001_create_attempts.sql) — 建 `attempts` 表（每筆 attempt 一列、**複合主鍵 `(user_id, id)`**、`id` 為 deterministic key／hash、append-only）＋ 開 RLS（每位使用者只能讀寫自己的列）。複合主鍵讓不同使用者的相同 attempt 不會撞鍵丟資料。
+- [`migrations/0001_create_attempts.sql`](migrations/0001_create_attempts.sql) — creates the `attempts` table (one row per attempt, **composite primary key `(user_id, id)`**, `id` is a deterministic key/hash, append-only) + enables RLS (each user can only read/write their own rows). The composite primary key means identical attempts from different users don't collide and lose data.
 
-## 手動步驟（agent 無專案登入，需你執行）
+## Manual steps (the agent has no project login; you must run these)
 
-1. **建表**：把 `migrations/0001_create_attempts.sql` 全文貼到 Supabase Dashboard → SQL Editor → Run（或 `supabase db push`）。冪等、可重跑。
-2. **端到端驗證**（待同步程式碼 P2/P3 上線後）：真人 Google 登入（最好兩個瀏覽器/裝置）確認進度確實同步 —— 驗證通過後才會放行 P5 的「已同步」UI 文案。
-3. 確認 Supabase Auth 的 redirect / allowed URL 含你的部署網址（多半已 OK）。
+1. **Create the table**: paste the full contents of `migrations/0001_create_attempts.sql` into Supabase Dashboard → SQL Editor → Run (or `supabase db push`). Idempotent, safe to re-run.
+2. **End-to-end verification** (after the sync code P2/P3 ships): a real user signs in with Google (ideally on two browsers/devices) and confirms the progress actually syncs — the "synced" UI copy (P5) ships only after this verification passes.
+3. Confirm Supabase Auth's redirect / allowed URLs include your deployed origin (usually already OK).
 
-**不需**新環境變數或密鑰：anon key 已設定，存取一律靠 RLS ＋ 使用者 JWT。
+**No new environment variables or secrets needed**: the anon key is already set; access relies entirely on RLS + the user JWT.
 
-> 相關程式碼：`src/domain/attemptSync.ts`（合併邏輯, #153）、後續 `attemptRemote.ts`（P2 遠端 repo）、`useProgressAttempts.ts`（P3 串接）。追蹤見 issue #151。
+> Related code: `src/domain/attemptSync.ts` (merge logic, #153), later `attemptRemote.ts` (P2 remote repo), `useProgressAttempts.ts` (P3 wiring). Tracked in issue #151.


### PR DESCRIPTION
## Summary

Closes #723 — establish English as the canonical language for new technical artifacts, and migrate only the maintenance-critical Traditional Chinese documents that otherwise lack an English source of truth. This is a policy + critical-baseline vertical slice, not a repository-wide translation campaign.

## What changes

| File | Change |
| --- | --- |
| `CLAUDE.md` | Migrated to English (authoritative project rules). Added **Technical Artifact Language Policy** section (canonical English for new technical artifacts; optional concise Japanese summaries in team-facing issue/PR descriptions; preserved-content list; touch-to-migrate list). |
| `AGENTS.md` | Migrated to English (concise, non-contradictory mirror of `CLAUDE.md`). |
| `.github/PULL_REQUEST_TEMPLATE.md` | English template with an optional Japanese summary (`## Summary (概要)`) plus English technical detail. |
| `docs/automation/gemini-correctness-autofix.md` | Gemini correctness owner/security runbook migrated to English (all commands, env var names, file paths, workflow line references, and issue numbers preserved). |
| `supabase/README.md` | Cross-device sync setup/maintenance doc migrated to English (create-table / e2e-verification / redirect-URL steps; composite PK `(user_id, id)` and RLS facts preserved). |

## Scope notes

- **Migrated (maintenance-critical, sole Chinese source):** `CLAUDE.md`, `AGENTS.md`, PR template, the Gemini correctness runbook, and `supabase/README.md` (deployment/setup documentation).
- **Touch-to-migrate (listed, not migrated):** `docs/item-quality-rubric.md`, `docs/future-development-directions.md`, exam content working notes, `docs/claude-exam-*` prompt drafts, and the two proposal docs. Migrated on concrete maintenance touch; no translation-ticket tree created.
- **Already English (no action):** `.planning/codebase/*.md` (architecture/testing/structure/stack/conventions/integrations/concerns), `docs/analytics.md`, `ops/analytics/README.md`, `.github/workflows/*.yml`, `README.md`.
- **Preserved untouched:** product localization, Japanese-learning content, test fixtures whose language is behavioral, external/public contracts. `src/` is not modified.
- **Historical input only:** stale PR #743 (DeepSeek/Sol model-routing proposal) was treated as historical context and intentionally **not** reintroduced — model routing stays in the user-global config and is out of scope for repo docs.

## Validation

- `git diff --check` and staged `git diff --cached --check`: **exit 0**.
- Final verification: `pnpm verify:full` — **PASS** (exit 0; L3 `pnpm lint` + `pnpm test` + `pnpm build` all green).
- Exact-head CI "Test and build": green on the reviewed HEAD.
- Before/after documentation inventory compared; remaining CJK in migrated files is intentional Japanese content vocabulary (e.g. 後/九 kanji examples, 文字・語彙 JLPT section name, 音便/ない形 grammar terms, the 概要 template label).
- Independent read-only arbiter review: **NO BLOCKING FINDINGS** (all referenced commands/scripts/paths/env vars/constants/issue numbers cross-verified against the repo; touch-to-migrate list now also notes the historical `docs/superpowers/**` drafts).

## Out of scope

- Repository-wide translation, historical rewrites, contract/API renames, and unrelated refactors.
