### PR TITLE
fix(automation): enforce per-stage timeouts in Gemini correctness workflow (#770)

### DIFF
--- a/.github/workflows/gemini-correctness-autofix.yml
+++ b/.github/workflows/gemini-correctness-autofix.yml
@@ -235,7 +235,7 @@ jobs:
                 ["build", "pnpm build"],
                 ["diff-check", "git diff --check"]
               ]) {
-                const run = runShell(cmd, { timeoutMs: 10 * 60 * 1000 });
+                const run = runShell(cmd, { timeout: 10 * 60 * 1000 });
                 checks.push({ name, status: run.ok ? "passed" : "failed" });
               }
               if (checks.some((c) => c.status !== "passed")) {
@@ -250,7 +250,7 @@ jobs:
               // gemini-correctness/<file> (it lands at .tmp/gemini-correctness/).
               const run = runShell(
                 `node scripts/gemini-correctness/discover.mjs --commit-sha ${sha} --model ${model} --output gemini-correctness/finding.json --summary gemini-correctness/discovery-summary.md`,
-                { timeoutMs: 8 * 60 * 1000 }
+                { timeout: 8 * 60 * 1000 }
               );
               if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "discovery failed" };
               let raw;
@@ -268,7 +268,7 @@ jobs:
               return { valid: true, result: finding };
             },
             red: async () => {
-              const run = runShell(`node scripts/gemini-correctness/red-stage.mjs --model ${model}`, { timeoutMs: 8 * 60 * 1000 });
+              const run = runShell(`node scripts/gemini-correctness/red-stage.mjs --model ${model}`, { timeout: 8 * 60 * 1000 });
               if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "RED stage failed" };
               try {
                 const redResult = JSON.parse(fs.readFileSync(path.join(artifactDir, "red-result.json"), "utf8"));
@@ -278,7 +278,7 @@ jobs:
               }
             },
             green: async () => {
-              const run = runShell(`node scripts/gemini-correctness/green-stage.mjs --model ${model}`, { timeoutMs: 8 * 60 * 1000 });
+              const run = runShell(`node scripts/gemini-correctness/green-stage.mjs --model ${model}`, { timeout: 8 * 60 * 1000 });
               if (!run.ok) return { valid: false, error: (run.stderr || run.stdout).trim() || "GREEN stage failed" };
               try {
                 const greenResult = JSON.parse(fs.readFileSync(path.join(artifactDir, "repair-result.json"), "utf8"));

--- a/scripts/gemini-workflow-timeout-contract.test.ts
+++ b/scripts/gemini-workflow-timeout-contract.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+// Mechanical regression guard for the Gemini correctness workflow's per-stage
+// timeouts. `runShell()` spreads its options straight into Node `spawnSync()`,
+// which recognizes `timeout` (milliseconds) and silently ignores `timeoutMs`.
+// If a future change reintroduces the dead `timeoutMs` option, or edits the
+// documented 10-minute baseline / 8-minute discovery/RED/GREEN limits, this
+// test fails.
+const workflowPath = new URL("../.github/workflows/gemini-correctness-autofix.yml", import.meta.url);
+const workflow = readFileSync(workflowPath, "utf8");
+
+describe("gemini-correctness-autofix per-stage timeouts", () => {
+  it("never passes the dead `timeoutMs` option to runShell", () => {
+    expect(workflow).not.toContain("timeoutMs");
+  });
+
+  it("keeps the baseline command timeout at 10 minutes", () => {
+    expect(workflow).toContain("timeout: 10 * 60 * 1000");
+  });
+
+  it("keeps discovery, RED, and GREEN stage timeouts at 8 minutes each", () => {
+    const matches = workflow.match(/timeout: 8 \* 60 \* 1000/g) ?? [];
+    expect(matches).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #770 — enforce the documented per-stage timeouts in `.github/workflows/gemini-correctness-autofix.yml`. `runShell()` spreads its options straight into Node `spawnSync()`, which recognizes `timeout` (ms) and silently ignores `timeoutMs`, so the baseline/discovery/RED/GREEN limits were dead.

## What changes

- `.github/workflows/gemini-correctness-autofix.yml`: switch the four `runShell()` call sites from `timeoutMs` to `timeout` — baseline 10 minutes (`timeout: 10 * 60 * 1000`), discovery / RED / GREEN 8 minutes each (`timeout: 8 * 60 * 1000`). A timeout is just a failed command, so orchestration stays fail-closed and publication stays disallowed.
- `scripts/gemini-workflow-timeout-contract.test.ts`: mechanical offline regression — fails if `timeoutMs` is reintroduced or the 10m/8m/8m/8m limits drift.

## Scope

Focused workflow defect fix only. No #688/#689 redesign, no model/limit policy change, no permission broadening, no scheduled-repair enablement, no production product code, no live Gemini calls.

## Verification

- TDD: regression observed RED on current main (3 failures on the intended reason), then GREEN after the fix (3/3).
- Gemini correctness focused tests: `pnpm vitest run scripts/gemini-correctness scripts/gemini-workflow-timeout-contract.test.ts` → 29 files, 642 tests PASS.
- `git diff --check`: exit 0.
- `pnpm lint`: PASS; `pnpm build`: PASS. (Local full-suite vitest intermittently times out on pre-existing flaky tests under parallel load — documented in project memory, clean main is also affected, CI is authoritative.)
- Exact-head CI "Test and build": pending.

## Out of scope

- Any behavior change beyond making the per-stage timeouts actually enforced.