### PR TITLE
refactor(stay-d): surface native Home recommendation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -143,25 +143,25 @@ describe("App", () => {
     expect(screen.queryByRole("heading", { name: "一章一章解鎖" })).not.toBeInTheDocument();
   });
 
-  it("reaches the partnership page from the primary nav and lazy-loads its route", async () => {
+  it("reaches the partnership page from Resources and lazy-loads its route", async () => {
     expect(appSource).toMatch(/const PartnersPage = lazy\(\(\) =>/);
     expect(appSource).toContain('import("./components/PartnersPage")');
 
     // Make the expected localized route copy an explicit test precondition.
     localStorage.setItem("jabiko.lang", "zh-Hant");
-    window.history.replaceState({}, "", "/stay-d");
+    const user = userEvent.setup();
     render(<App />);
+    await gotoResource(user, "合作推廣");
 
     // This is the first cold import of the partnership route chunk. CI runners
     // can spend longer than Testing Library's default 1s transforming that
     // chunk, so allow the same bounded warm-up window as the grammar route.
     await screen.findByRole("heading", { name: "合作推廣", level: 1 }, { timeout: 15000 });
 
-    // The tab is part of the primary row, and it is the current page.
-    const tab = within(screen.getByRole("navigation", { name: "學習流程" })).getByRole("button", {
-      name: "合作推廣"
-    });
-    expect(tab).toHaveAttribute("aria-current", "page");
+    expect(window.location.pathname).toBe("/stay-d");
+    expect(screen.getByRole("button", { name: "資源（目前：合作推廣）" })).toHaveClass(
+      "selected"
+    );
   });
 
   it("marks the active nav tab with aria-current=page and moves it on navigation", async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,8 +102,8 @@ const GrammarIndexPage = lazy(() =>
 const LegalPanel = lazy(() =>
   import("./components/LegalPanel").then((module) => ({ default: module.LegalPanel }))
 );
-// Stay.D's long-form conversion copy remains isolated from the eager Home
-// bundle. Home imports only its compact promotion card and shared essentials.
+// Stay.D's partnership page remains isolated from the eager Home bundle.
+// Home imports only the small editorial recommendation and shared essentials.
 const PartnersPage = lazy(() =>
   import("./components/PartnersPage").then((module) => ({ default: module.PartnersPage }))
 );

--- a/src/components/AppNavigation.test.tsx
+++ b/src/components/AppNavigation.test.tsx
@@ -62,7 +62,7 @@ describe("AppNavigation (#727)", () => {
     await user.click(screen.getByRole("button", { name: "資源" }));
     const desktop = screen.getByRole("menu", { name: "資源" });
     expect(within(desktop).getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
-      "規則表", "漢字", "五十音", "關於"
+      "合作推廣", "規則表", "漢字", "五十音", "關於"
     ]);
     fireEvent.keyDown(within(desktop).getByRole("menuitem", { name: "規則表" }), { key: "Escape" });
 
@@ -70,8 +70,8 @@ describe("AppNavigation (#727)", () => {
     const mobile = screen.getByRole("menu", { name: "更多" });
     expect(within(mobile).getByText("資源")).toBeInTheDocument();
     expect(within(mobile).getByText("設定與工具")).toBeInTheDocument();
-    expect(within(mobile).getAllByRole("menuitem").slice(0, 4).map((item) => item.textContent)).toEqual([
-      "規則表", "漢字", "五十音", "關於"
+    expect(within(mobile).getAllByRole("menuitem").slice(0, 5).map((item) => item.textContent)).toEqual([
+      "合作推廣", "規則表", "漢字", "五十音", "關於"
     ]);
   });
 
@@ -116,15 +116,15 @@ describe("AppNavigation (#727)", () => {
     const resources = screen.getByRole("button", { name: "資源" });
     resources.focus();
     await user.keyboard("{ArrowDown}");
-    await waitFor(() => expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus());
-    await user.keyboard("{ArrowDown}{Enter}");
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "合作推廣" })).toHaveFocus());
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
     expect(onSelect).toHaveBeenCalledWith("kanji");
 
     const more = screen.getByRole("button", { name: "更多" });
     more.focus();
     await user.keyboard("{ArrowDown}");
-    await waitFor(() => expect(screen.getByRole("menuitem", { name: "規則表" })).toHaveFocus());
-    await user.keyboard("{ArrowDown}{Enter}");
+    await waitFor(() => expect(screen.getByRole("menuitem", { name: "合作推廣" })).toHaveFocus());
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
     expect(onSelect).toHaveBeenLastCalledWith("kanji");
   });
 });

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -436,11 +436,16 @@ describe("HomePanel continue banner i18n (#427)", () => {
 });
 
 describe("HomePanel promotion placement", () => {
-  it("no longer renders any Stay.D promotion on Home", () => {
-    renderHome({ language: "zh-Hant" });
+  it("places the Stay.D recommendation after the learner's next step and before self-serve practice", () => {
+    renderHome({ language: "zh-Hant", targetLevel: "n4n5" });
 
-    expect(document.querySelector('[data-placement="home-bottom"]')).toBeNull();
-    expect(document.querySelector(".stay-d-home")).toBeNull();
-    expect(document.querySelector("[data-stay-d-placement]")).toBeNull();
+    const nextStep = screen.getByRole("button", { name: /開始 N4＋N5 備考/ });
+    const recommendation = screen.getByRole("complementary", {
+      name: "JABIKO 推薦 · 東京住宿"
+    });
+    const practiceHeading = screen.getByRole("heading", { name: "自己挑一區練習" });
+
+    expect(nextStep.compareDocumentPosition(recommendation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(recommendation.compareDocumentPosition(practiceHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -18,6 +18,7 @@ import { ShareButtons } from "./challenge/ShareButtons";
 import { LegalLinks } from "./LegalLinks";
 import type { FeedbackCategory } from "../domain/feedbackRemote";
 import { getBookmarkedIds } from "../domain/bookmarks";
+import { StayDHomeRecommendation } from "./StayDHomeRecommendation";
 
 // External walkthrough / 使用說明書: the author's blog post about Jabiko.
 // Surfaced in the hero so first-time visitors can read how to use the app.
@@ -459,6 +460,8 @@ export function HomePanel({
           <ArrowRight aria-hidden="true" />
         </button>
       ) : null}
+
+      <StayDHomeRecommendation language={language} />
 
       {/* Names the entry-card grid as a self-serve section (a plain,
           non-anaphoric label -- no "or" -- so it can't dangle in any of the

--- a/src/components/StayDHomeRecommendation.test.tsx
+++ b/src/components/StayDHomeRecommendation.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StayDHomeRecommendation } from "./StayDHomeRecommendation";
+
+const analyticsMocks = vi.hoisted(() => ({ trackEvent: vi.fn() }));
+
+vi.mock("../lib/analytics", () => analyticsMocks);
+
+describe("StayDHomeRecommendation", () => {
+  beforeEach(() => {
+    analyticsMocks.trackEvent.mockClear();
+  });
+
+  it("tracks one home-airbnb click from the direct Airbnb recommendation", () => {
+    render(<StayDHomeRecommendation language="zh-Hant" />);
+
+    fireEvent.click(screen.getByRole("link", { name: "在 Airbnb 查看 Stay.D" }));
+
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
+      promoId: "stay-d",
+      action: "airbnb",
+      placement: "home-airbnb",
+      locale: "zh-Hant"
+    });
+  });
+
+  it.each([
+    ["zh-Hant", "JABIKO 推薦 · 東京住宿", "在 Airbnb 查看 Stay.D"],
+    ["ja", "JABIKOおすすめ · 東京ステイ", "Stay.DをAirbnbで見る"],
+    ["en", "JABIKO PICK · TOKYO STAY", "View Stay.D on Airbnb"]
+  ] as const)("leaves %s property media and listing details on Airbnb", (language, label, cta) => {
+    render(<StayDHomeRecommendation language={language} />);
+
+    const recommendation = screen.getByRole("complementary", { name: label });
+    const link = within(recommendation).getByRole("link", { name: cta });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.airbnb.com/rooms/1518015758376242668"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(link).toHaveAttribute("data-stay-d-placement", "home-airbnb");
+    expect(recommendation.querySelector("img")).toBeNull();
+    expect(recommendation).not.toHaveTextContent(
+      /2025|52\s*m|10\s*Gbps|三層|3階|three-floor|廚房|キッチン|kitchen/i
+    );
+  });
+});

--- a/src/components/StayDHomeRecommendation.tsx
+++ b/src/components/StayDHomeRecommendation.tsx
@@ -1,0 +1,45 @@
+import { ExternalLink } from "lucide-react";
+import type { Language } from "../i18n";
+import { trackEvent } from "../lib/analytics";
+import {
+  isStayDLocale,
+  STAY_D_AIRBNB_URL,
+  STAY_D_EDITORIAL_COPY,
+  STAY_D_HOME_RECOMMENDATION
+} from "../domain/stayD";
+
+/** A small editorial note in the Home reading flow. It connects learning to
+ *  a real Tokyo trip without reproducing Airbnb's listing content. */
+export function StayDHomeRecommendation({ language }: { language: Language }) {
+  if (!isStayDLocale(language)) return null;
+
+  const text = STAY_D_HOME_RECOMMENDATION[language];
+
+  return (
+    <aside className="home-stay-recommendation" aria-label={text.kicker}>
+      <div className="home-stay-recommendation-copy">
+        <p className="home-stay-recommendation-kicker">{text.kicker}</p>
+        <h2>{text.headline}</h2>
+        <p>{text.body}</p>
+      </div>
+      <a
+        className="home-stay-recommendation-link"
+        href={STAY_D_AIRBNB_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-stay-d-placement="home-airbnb"
+        onClick={() =>
+          trackEvent("promo_click", {
+            promoId: "stay-d",
+            action: "airbnb",
+            placement: "home-airbnb",
+            locale: language
+          })
+        }
+      >
+        {STAY_D_EDITORIAL_COPY[language].airbnbCta}
+        <ExternalLink aria-hidden="true" />
+      </a>
+    </aside>
+  );
+}

--- a/src/domain/navigation.test.ts
+++ b/src/domain/navigation.test.ts
@@ -21,21 +21,22 @@ describe("navigation registry (#727)", () => {
     );
   });
 
-  // The zhHantOnly gate is still part of the registry contract (it kept the
-  // retired 文章 entry zh-Hant-only); no entry uses it today, so every locale
-  // sees the same resource list.
-  it("shows the same resources in every locale while no entry is gated", () => {
+  it("keeps the shared reference entries in every launched locale", () => {
     expect(NAVIGATION_REGISTRY.some((entry) => entry.zhHantOnly)).toBe(false);
     for (const locale of ["zh-Hant", "ja", "en"] as const) {
-      expect(resolveNavigation(staticRoute("home"), locale).resources.map((item) => item.id), locale)
-        .toEqual(["rules", "kanji", "kana", "about"]);
+      expect(
+        resolveNavigation(staticRoute("home"), locale).resources.map((item) => item.id).slice(-4),
+        locale
+      ).toEqual(["rules", "kanji", "kana", "about"]);
     }
   });
 
-  it("puts the partnership tab at the end of the primary row where Stay.D has copy", () => {
+  it("keeps primary navigation learning-only and exposes partnership with the resources", () => {
     for (const locale of ["zh-Hant", "ja", "en"] as const) {
       expect(resolveNavigation(staticRoute("home"), locale).primary.map((item) => item.id), locale)
-        .toEqual(["home", "learn", "challenge", "mock", "grammar", "stayD"]);
+        .toEqual(["home", "learn", "challenge", "mock", "grammar"]);
+      expect(resolveNavigation(staticRoute("home"), locale).resources.map((item) => item.id), locale)
+        .toEqual(["stayD", "rules", "kanji", "kana", "about"]);
     }
   });
 
@@ -43,12 +44,14 @@ describe("navigation registry (#727)", () => {
     for (const locale of ["ko", "vi", "th", "id", "my"] as const) {
       const nav = resolveNavigation(staticRoute("home"), locale);
       expect(nav.primary.some((item) => item.id === "stayD"), locale).toBe(false);
+      expect(nav.resources.some((item) => item.id === "stayD"), locale).toBe(false);
     }
   });
 
-  it("marks the partnership tab current on the /stay-d route", () => {
+  it("marks the partnership resource current on the /stay-d route", () => {
     const nav = resolveNavigation(staticRoute("stayD"), "zh-Hant");
-    expect(nav.primary.find((item) => item.id === "stayD")?.current).toBe(true);
+    expect(nav.resources.find((item) => item.id === "stayD")?.current).toBe(true);
+    expect(nav.resourcesCurrent).toBe(true);
   });
 
   it("resolves nested primary and resource ancestors", () => {

--- a/src/domain/navigation.ts
+++ b/src/domain/navigation.ts
@@ -63,7 +63,7 @@ export const NAVIGATION_REGISTRY: readonly NavigationDefinition[] = [
   {
     id: "stayD",
     view: "stayD",
-    group: "primary",
+    group: "resource",
     labelKey: "navPartnership",
     icon: "stayD",
     locales: STAY_D_REQUIRED_LOCALES

--- a/src/domain/stayD.ts
+++ b/src/domain/stayD.ts
@@ -16,6 +16,14 @@ export interface StayDVideoCopy {
   airbnbCta: string;
 }
 
+/** Short Home recommendation copy. Airbnb owns the property details; this
+ *  copy only explains why Stay.D fits Jabiko learners planning a Tokyo trip. */
+export interface StayDHomeRecommendationCopy {
+  kicker: string;
+  headline: string;
+  body: string;
+}
+
 /** Editorial extension copy for the /stay-d page (not listing content). */
 export interface StayDPageExtras {
   videoTitle: string;
@@ -94,6 +102,24 @@ export const STAY_D_EDITORIAL_COPY = {
     }
   }
 } satisfies Record<StayDLocale, StayDEditorialCopy>;
+
+export const STAY_D_HOME_RECOMMENDATION = {
+  "zh-Hant": {
+    kicker: "JABIKO 推薦 · 東京住宿",
+    headline: "在東京，來一趟真正用上學過日文的旅行。",
+    body: "想和家人朋友一起感受觀光景點之外的東京日常嗎？Jabiko 推薦 Stay.D，作為另一種更貼近生活的東京停留方式。"
+  },
+  ja: {
+    kicker: "JABIKOおすすめ · 東京ステイ",
+    headline: "東京で、学んだ日本語を使う旅へ。",
+    body: "家族や友人と、観光だけでは見えない東京の日常を楽しみたい人へ。Jabikoから Stay.D を紹介します。"
+  },
+  en: {
+    kicker: "JABIKO PICK · TOKYO STAY",
+    headline: "Put your Japanese to use in Tokyo.",
+    body: "For travelers who want to enjoy everyday Tokyo beyond sightseeing with family or friends, Jabiko recommends Stay.D as one way to stay closer to local life."
+  }
+} satisfies Record<StayDLocale, StayDHomeRecommendationCopy>;
 
 export function isStayDLocale(language: Language): language is StayDLocale {
   return (STAY_D_REQUIRED_LOCALES as readonly string[]).includes(language);

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -34,6 +34,95 @@
   font-size: 0.9rem;
 }
 
+/* Stay.D sits inside Home's editorial reading flow: a recommendation with
+   the same rules and type hierarchy as Jabiko content, never a campaign card. */
+.home-stay-recommendation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem 1.5rem;
+  padding: 1.05rem 0;
+  border-block: 1px solid var(--rule);
+}
+
+.home-stay-recommendation-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+  min-width: 0;
+  max-width: 46rem;
+}
+
+.home-stay-recommendation-kicker,
+.home-stay-recommendation-copy h2,
+.home-stay-recommendation-copy p {
+  margin: 0;
+}
+
+.home-stay-recommendation-kicker {
+  color: var(--vermilion);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-stay-recommendation-copy h2 {
+  color: var(--ink);
+  font-family: var(--font-title);
+  font-size: clamp(1.05rem, 1.8vw, 1.22rem);
+  line-height: 1.4;
+  text-wrap: balance;
+}
+
+.home-stay-recommendation-copy > p:last-child {
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.65;
+  text-wrap: pretty;
+}
+
+.home-stay-recommendation-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  min-height: 2.75rem;
+  padding: 0.45rem 0.1rem;
+  color: var(--teal-dark);
+  font-size: 0.9rem;
+  font-weight: 750;
+  line-height: 1.4;
+  text-decoration: none;
+}
+
+.home-stay-recommendation-link svg {
+  flex: 0 0 auto;
+  width: 1rem;
+  height: 1rem;
+}
+
+.home-stay-recommendation-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.home-stay-recommendation-link:focus-visible {
+  outline: 3px solid var(--focus-outline);
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .home-stay-recommendation {
+    grid-template-columns: 1fr;
+    gap: 0.6rem;
+  }
+
+  .home-stay-recommendation-link {
+    justify-self: start;
+  }
+}
+
 .home-feedback {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- Add a compact editorial Stay.D recommendation to Home after the personalized next step and before self-serve practice.
- Link directly to Airbnb with the stable home-airbnb analytics placement, without property media or listing details.
- Move Partnership from the primary learning row into Resources so the main navigation stays focused and the mobile layout returns to three rows.
- Cover placement order, localized CTA behavior, analytics, content constraints, navigation hierarchy, and route access.

## Design rationale
The Home position is visible during the normal learning entry flow, but it follows the learner-specific action. Rule-separated typography, a text CTA, and a transparent surface make it read as a Jabiko recommendation instead of an ad card. Desktop uses a two-column treatment; mobile stacks the CTA with a 44 px target and no horizontal overflow.

## TDD
- Observed RED for the missing Home recommendation placement.
- Observed RED for the missing home-airbnb click event.
- Observed RED for the desired learning-only primary navigation.
- Implemented the smallest changes needed to make each expectation GREEN.

## Verification
- pnpm vitest run src/components/StayDHomeRecommendation.test.tsx src/components/HomePanel.test.tsx src/components/AppNavigation.test.tsx src/components/MoreMenu.test.tsx src/components/PartnersPage.test.tsx src/domain/navigation.test.ts src/domain/partners.test.ts src/domain/stayD.test.ts src/lib/analytics.test.ts src/App.test.tsx (211 passed)
- pnpm typecheck
- pnpm verify:full (L3: lint, full test suite, production build)
- Manual responsive QA at 390 px and 1280 px; no horizontal overflow; CTA target is 44 px high.