### PR TITLE
refactor(stay-d): tighten Home placement

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -436,16 +436,18 @@ describe("HomePanel continue banner i18n (#427)", () => {
 });
 
 describe("HomePanel promotion placement", () => {
-  it("places the Stay.D recommendation after the learner's next step and before self-serve practice", () => {
+  it("places the Stay.D recommendation after the primary learning controls and before the hero", () => {
     renderHome({ language: "zh-Hant", targetLevel: "n4n5" });
 
-    const nextStep = screen.getByRole("button", { name: /開始 N4＋N5 備考/ });
+    const dailyPractice = screen.getByRole("button", { name: /開始今日練習/ });
+    const levelControl = screen.getByRole("group", { name: "目標級別" });
     const recommendation = screen.getByRole("complementary", {
-      name: "JABIKO 推薦 · 東京住宿"
+      name: "JABIKO 推薦 · 合作夥伴"
     });
-    const practiceHeading = screen.getByRole("heading", { name: "自己挑一區練習" });
+    const heroHeading = screen.getByRole("heading", { name: "今天想練什麼？" });
 
-    expect(nextStep.compareDocumentPosition(recommendation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(recommendation.compareDocumentPosition(practiceHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(dailyPractice.compareDocumentPosition(levelControl) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(levelControl.compareDocumentPosition(recommendation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(recommendation.compareDocumentPosition(heroHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -361,6 +361,8 @@ export function HomePanel({
         </div>
       ) : null}
 
+      <StayDHomeRecommendation language={language} />
+
       <header className="home-hero">
         {/* Decorative hero -- the heading below carries the actual
             message, so alt is intentionally empty (avoids the screen
@@ -460,8 +462,6 @@ export function HomePanel({
           <ArrowRight aria-hidden="true" />
         </button>
       ) : null}
-
-      <StayDHomeRecommendation language={language} />
 
       {/* Names the entry-card grid as a self-serve section (a plain,
           non-anaphoric label -- no "or" -- so it can't dangle in any of the

--- a/src/components/StayDHomeRecommendation.test.tsx
+++ b/src/components/StayDHomeRecommendation.test.tsx
@@ -14,7 +14,7 @@ describe("StayDHomeRecommendation", () => {
   it("tracks one home-airbnb click from the direct Airbnb recommendation", () => {
     render(<StayDHomeRecommendation language="zh-Hant" />);
 
-    fireEvent.click(screen.getByRole("link", { name: "在 Airbnb 查看 Stay.D" }));
+    fireEvent.click(screen.getByRole("link", { name: "在 Airbnb 查看" }));
 
     expect(analyticsMocks.trackEvent).toHaveBeenCalledTimes(1);
     expect(analyticsMocks.trackEvent).toHaveBeenCalledWith("promo_click", {
@@ -26,24 +26,44 @@ describe("StayDHomeRecommendation", () => {
   });
 
   it.each([
-    ["zh-Hant", "JABIKO 推薦 · 東京住宿", "在 Airbnb 查看 Stay.D"],
-    ["ja", "JABIKOおすすめ · 東京ステイ", "Stay.DをAirbnbで見る"],
-    ["en", "JABIKO PICK · TOKYO STAY", "View Stay.D on Airbnb"]
-  ] as const)("leaves %s property media and listing details on Airbnb", (language, label, cta) => {
-    render(<StayDHomeRecommendation language={language} />);
+    [
+      "zh-Hant",
+      "JABIKO 推薦 · 合作夥伴",
+      "東京住宿 Stay.D｜把學過的日文帶進旅程。",
+      "在 Airbnb 查看"
+    ],
+    [
+      "ja",
+      "JABIKOおすすめ · 提携パートナー",
+      "東京ステイ Stay.D｜学んだ日本語を旅で使おう。",
+      "Airbnbで見る"
+    ],
+    [
+      "en",
+      "JABIKO PICK · PARTNER",
+      "Tokyo stay Stay.D — put your Japanese to use.",
+      "View on Airbnb"
+    ]
+  ] as const)(
+    "keeps the %s partnership recommendation compact and leaves listing details on Airbnb",
+    (language, label, headline, cta) => {
+      render(<StayDHomeRecommendation language={language} />);
 
-    const recommendation = screen.getByRole("complementary", { name: label });
-    const link = within(recommendation).getByRole("link", { name: cta });
-    expect(link).toHaveAttribute(
-      "href",
-      "https://www.airbnb.com/rooms/1518015758376242668"
-    );
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
-    expect(link).toHaveAttribute("data-stay-d-placement", "home-airbnb");
-    expect(recommendation.querySelector("img")).toBeNull();
-    expect(recommendation).not.toHaveTextContent(
-      /2025|52\s*m|10\s*Gbps|三層|3階|three-floor|廚房|キッチン|kitchen/i
-    );
-  });
+      const recommendation = screen.getByRole("complementary", { name: label });
+      const link = within(recommendation).getByRole("link", { name: cta });
+      expect(within(recommendation).getByRole("heading", { name: headline })).toBeInTheDocument();
+      expect(recommendation.textContent).toBe(`${label}${headline}${cta}`);
+      expect(link).toHaveAttribute(
+        "href",
+        "https://www.airbnb.com/rooms/1518015758376242668"
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      expect(link).toHaveAttribute("data-stay-d-placement", "home-airbnb");
+      expect(recommendation.querySelector("img")).toBeNull();
+      expect(recommendation).not.toHaveTextContent(
+        /2025|52\s*m|10\s*Gbps|三層|3階|three-floor|廚房|キッチン|kitchen/i
+      );
+    }
+  );
 });

--- a/src/components/StayDHomeRecommendation.tsx
+++ b/src/components/StayDHomeRecommendation.tsx
@@ -4,7 +4,6 @@ import { trackEvent } from "../lib/analytics";
 import {
   isStayDLocale,
   STAY_D_AIRBNB_URL,
-  STAY_D_EDITORIAL_COPY,
   STAY_D_HOME_RECOMMENDATION
 } from "../domain/stayD";
 
@@ -20,7 +19,6 @@ export function StayDHomeRecommendation({ language }: { language: Language }) {
       <div className="home-stay-recommendation-copy">
         <p className="home-stay-recommendation-kicker">{text.kicker}</p>
         <h2>{text.headline}</h2>
-        <p>{text.body}</p>
       </div>
       <a
         className="home-stay-recommendation-link"
@@ -37,7 +35,7 @@ export function StayDHomeRecommendation({ language }: { language: Language }) {
           })
         }
       >
-        {STAY_D_EDITORIAL_COPY[language].airbnbCta}
+        {text.cta}
         <ExternalLink aria-hidden="true" />
       </a>
     </aside>

--- a/src/domain/stayD.ts
+++ b/src/domain/stayD.ts
@@ -21,7 +21,7 @@ export interface StayDVideoCopy {
 export interface StayDHomeRecommendationCopy {
   kicker: string;
   headline: string;
-  body: string;
+  cta: string;
 }
 
 /** Editorial extension copy for the /stay-d page (not listing content). */
@@ -105,19 +105,19 @@ export const STAY_D_EDITORIAL_COPY = {
 
 export const STAY_D_HOME_RECOMMENDATION = {
   "zh-Hant": {
-    kicker: "JABIKO 推薦 · 東京住宿",
-    headline: "在東京，來一趟真正用上學過日文的旅行。",
-    body: "想和家人朋友一起感受觀光景點之外的東京日常嗎？Jabiko 推薦 Stay.D，作為另一種更貼近生活的東京停留方式。"
+    kicker: "JABIKO 推薦 · 合作夥伴",
+    headline: "東京住宿 Stay.D｜把學過的日文帶進旅程。",
+    cta: "在 Airbnb 查看"
   },
   ja: {
-    kicker: "JABIKOおすすめ · 東京ステイ",
-    headline: "東京で、学んだ日本語を使う旅へ。",
-    body: "家族や友人と、観光だけでは見えない東京の日常を楽しみたい人へ。Jabikoから Stay.D を紹介します。"
+    kicker: "JABIKOおすすめ · 提携パートナー",
+    headline: "東京ステイ Stay.D｜学んだ日本語を旅で使おう。",
+    cta: "Airbnbで見る"
   },
   en: {
-    kicker: "JABIKO PICK · TOKYO STAY",
-    headline: "Put your Japanese to use in Tokyo.",
-    body: "For travelers who want to enjoy everyday Tokyo beyond sightseeing with family or friends, Jabiko recommends Stay.D as one way to stay closer to local life."
+    kicker: "JABIKO PICK · PARTNER",
+    headline: "Tokyo stay Stay.D — put your Japanese to use.",
+    cta: "View on Airbnb"
   }
 } satisfies Record<StayDLocale, StayDHomeRecommendationCopy>;
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -40,46 +40,39 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 1rem 1.5rem;
-  padding: 1.05rem 0;
+  gap: 0.65rem 1.1rem;
+  margin-block: -0.45rem;
+  padding: 0.6rem 0;
   border-block: 1px solid var(--rule);
 }
 
 .home-stay-recommendation-copy {
   display: flex;
-  flex-direction: column;
-  gap: 0.28rem;
+  align-items: baseline;
+  gap: 0.35rem 1rem;
   min-width: 0;
-  max-width: 46rem;
 }
 
 .home-stay-recommendation-kicker,
-.home-stay-recommendation-copy h2,
-.home-stay-recommendation-copy p {
+.home-stay-recommendation-copy h2 {
   margin: 0;
 }
 
 .home-stay-recommendation-kicker {
+  flex: 0 0 auto;
   color: var(--vermilion);
-  font-size: 0.76rem;
+  font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
 .home-stay-recommendation-copy h2 {
   color: var(--ink);
   font-family: var(--font-title);
-  font-size: clamp(1.05rem, 1.8vw, 1.22rem);
-  line-height: 1.4;
+  font-size: clamp(0.96rem, 1.5vw, 1.06rem);
+  line-height: 1.35;
   text-wrap: balance;
-}
-
-.home-stay-recommendation-copy > p:last-child {
-  color: var(--muted);
-  font-size: 0.9rem;
-  line-height: 1.65;
-  text-wrap: pretty;
 }
 
 .home-stay-recommendation-link {
@@ -90,10 +83,13 @@
   min-height: 2.75rem;
   padding: 0.45rem 0.1rem;
   color: var(--teal-dark);
-  font-size: 0.9rem;
+  font-size: 0.86rem;
   font-weight: 750;
   line-height: 1.4;
-  text-decoration: none;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--teal-dark) 42%, transparent);
+  text-underline-offset: 3px;
+  white-space: nowrap;
 }
 
 .home-stay-recommendation-link svg {
@@ -103,8 +99,7 @@
 }
 
 .home-stay-recommendation-link:hover {
-  text-decoration: underline;
-  text-underline-offset: 3px;
+  text-decoration-color: currentColor;
 }
 
 .home-stay-recommendation-link:focus-visible {
@@ -114,12 +109,18 @@
 
 @media (max-width: 640px) {
   .home-stay-recommendation {
-    grid-template-columns: 1fr;
-    gap: 0.6rem;
+    gap: 0.5rem 0.75rem;
+    padding-block: 0.55rem;
   }
 
-  .home-stay-recommendation-link {
-    justify-self: start;
+  .home-stay-recommendation-copy {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .home-stay-recommendation-copy h2 {
+    font-size: 0.96rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Move the Stay.D recommendation directly below the primary daily-practice and target-level controls, before the Home hero.
- Reduce the recommendation from a multi-line editorial block to a thin native strip with an explicit partner label, one Stay.D headline, and a short Airbnb link.
- Keep the transparent surface, rule-separated treatment, 44 px CTA target, home-airbnb analytics placement, and Resources-only navigation.
- Keep all property media and listing details on Airbnb.

## Placement and density
- Desktop 1280 x 900: top moved from 1004 px to 351 px; height reduced from 113 px to 65 px; fully visible in the first viewport.
- Mobile 390 x 844: top moved from 1073 px to 444 px in zh-Hant and ja, and 595 px in en; height reduced from 210 px to about 79 px; no horizontal overflow.
- The strip stays transparent with no radius or shadow. The CTA remains underlined and 44 px high.

## TDD
- Observed RED for the recommendation remaining after the hero instead of after the primary learning controls.
- Observed RED for the old verbose copy, old disclosure label, and old CTA.
- Implemented the smallest DOM, copy, and CSS changes needed to make both slices GREEN.

## Verification
- pnpm vitest run src/components/StayDHomeRecommendation.test.tsx src/components/HomePanel.test.tsx (54 passed)
- Affected suite including App and Stay.D domain tests (136 passed)
- pnpm typecheck (passed)
- pnpm lint (passed)
- pnpm vitest run --testTimeout=15000 (2257 passed)
- pnpm build (passed; TypeScript, Vite, PWA, and 100 prerendered pages)
- Manual responsive QA at 390 px and 1280 px for zh-Hant, ja, and en

## Baseline timeout note
The exact pnpm verify:full command was attempted twice. Lint passed both times, but the full-suite run hit the existing 5 second per-test timeout in unchanged Gemini correctness integration cases and once in an unchanged Kanji panel case. The Gemini file passes 23 of 23 with a 15 second timeout; the Kanji panel passes 34 of 34 targeted; the complete suite passes 2257 of 2257 with the same 15 second timeout. No timeout or unrelated test configuration is changed in this PR. The required GitHub Test and build check remains the delivery gate.