### PR TITLE
fix: harden Japanese speech playback (#785)

### DIFF
--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -730,7 +730,10 @@ describe("FeedbackPanel answer-key TTS on reading questions", () => {
       }
     );
   });
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 
   it("offers TTS for the correct reading once the question is answered", () => {
     const question = readingPool[0];
@@ -746,6 +749,8 @@ describe("FeedbackPanel answer-key TTS on reading questions", () => {
   });
 
   it("uses the canonical kana answer for the reported exam readings", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2400, 0, 1));
     const speak = vi.fn();
     vi.stubGlobal("speechSynthesis", {
       getVoices: () => [],
@@ -779,6 +784,7 @@ describe("FeedbackPanel answer-key TTS on reading questions", () => {
       );
       fireEvent.click(container.querySelector(".answer-key .speak-button")!);
       unmount();
+      vi.advanceTimersByTime(130);
       expect((speak.mock.calls.at(-1)![0] as { text: string }).text).toBe(reading);
     }
 

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -745,6 +745,46 @@ describe("FeedbackPanel answer-key TTS on reading questions", () => {
     expect(speak).not.toBeNull();
   });
 
+  it("uses the canonical kana answer for the reported exam readings", () => {
+    const speak = vi.fn();
+    vi.stubGlobal("speechSynthesis", {
+      getVoices: () => [],
+      speak,
+      cancel: () => {},
+      speaking: false,
+      pending: false
+    });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        constructor(public text: string) {}
+        lang = "";
+        rate = 1;
+        addEventListener() {}
+      }
+    );
+    const expected = [
+      ["n1-read-hedataru", "へだたった"],
+      ["n3-kanji-korobu", "ころぶ"]
+    ] as const;
+
+    for (const [id, reading] of expected) {
+      const question = examStyleQuestions.find((candidate) => candidate.id === id)!;
+      const { container, unmount } = render(
+        <FeedbackPanel
+          feedback={{ status: "incorrect", question, submittedAnswer: null }}
+          language="zh-Hant"
+          options={question.options ?? []}
+        />
+      );
+      fireEvent.click(container.querySelector(".answer-key .speak-button")!);
+      unmount();
+      expect((speak.mock.calls.at(-1)![0] as { text: string }).text).toBe(reading);
+    }
+
+    expect(speak).toHaveBeenCalledTimes(expected.length);
+  });
+
   it("does not add a speak button to non-reading questions (no UI bloat)", () => {
     const grammar = examStyleQuestions.find((q) => q.promptLabel === "文法形式選擇")!;
     const { container } = render(

--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -569,10 +569,15 @@ function firstCellReading(cell: HTMLElement, type: "on" | "kun"): string {
 
 describe("KanjiOnyomiPanel in-place cell TTS", () => {
   let synth: MockSynth;
+  let now = Date.UTC(2200, 0, 1);
   beforeEach(() => {
+    vi.useFakeTimers();
+    now += 1_000;
+    vi.setSystemTime(now);
     synth = setupSynth();
   });
   afterEach(() => {
+    vi.useRealTimers();
     delete (window as unknown as { speechSynthesis?: unknown }).speechSynthesis;
     delete (window as unknown as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
   });
@@ -611,6 +616,21 @@ describe("KanjiOnyomiPanel in-place cell TTS", () => {
     fireEvent.click(cell!);
     const wrap = cell!.closest(".kanji-cell-wrap") as HTMLElement;
     fireEvent.click(within(wrap).getByRole("button", { name: "朗讀日文" }));
+
+    expect((synth.speak.mock.calls[0][0] as { text: string }).text).toBe(expectedReading);
+  });
+
+  it("reads a displayed example word through its canonical reading", () => {
+    renderNarrowed("機");
+    const grid = document.querySelector(".kanji-grid") as HTMLElement;
+    const cell = grid.querySelector<HTMLButtonElement>("button.kanji-cell");
+    expect(cell).not.toBeNull();
+    fireEvent.click(cell!);
+
+    const example = document.querySelector(".kanji-examples li") as HTMLElement;
+    const expectedReading = example.querySelector(".kanji-example-reading")?.textContent;
+    expect(expectedReading).toBeTruthy();
+    fireEvent.click(within(example).getByRole("button", { name: "朗讀日文" }));
 
     expect((synth.speak.mock.calls[0][0] as { text: string }).text).toBe(expectedReading);
   });

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -321,7 +321,7 @@ export function KanjiOnyomiPanel({
                 <li key={example.surface}>
                   <span className="kanji-example-surface">
                     {example.surface}
-                    <SpeakButton text={example.surface} language={language} />
+                    <SpeakButton text={example.reading} language={language} />
                   </span>
                   <span className="kanji-example-reading">{example.reading}</span>
                   <span className="kanji-example-mean">

--- a/src/components/SpeakButton.test.tsx
+++ b/src/components/SpeakButton.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SpeakButton } from "./SpeakButton";
+import { writeTtsRate } from "../lib/ttsRate";
 
 // The reported TTS bug (爆音 / 缺失一小段 / 卡頓): Chrome drops the start of an
 // utterance when speak() runs in the same tick as cancel(). So when the engine
@@ -51,6 +52,7 @@ describe("SpeakButton", () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+    window.localStorage.removeItem("jabiko.ttsRate");
     delete (window as unknown as { speechSynthesis?: unknown }).speechSynthesis;
     delete (window as unknown as { SpeechSynthesisUtterance?: unknown }).SpeechSynthesisUtterance;
   });
@@ -72,6 +74,66 @@ describe("SpeakButton", () => {
     expect(synth.speak).not.toHaveBeenCalled();
     vi.advanceTimersByTime(200);
     expect(synth.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts only the latest request when a second click arrives before a cancelled restart", () => {
+    const synth = setupSynth({ speaking: true });
+    render(<SpeakButton text="ねこ" language="zh-Hant" />);
+    const button = screen.getByRole("button");
+
+    fireEvent.click(button);
+    // `cancel()` leaves the engine idle; a second user action before the
+    // anti-clipping delay must replace, not accompany, the deferred request.
+    fireEvent.click(button);
+
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(200);
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels active playback when its owning button unmounts", () => {
+    const synth = setupSynth({ speaking: false });
+    const { unmount } = render(<SpeakButton text="ねこ" language="zh-Hant" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    unmount();
+
+    expect(synth.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cancel another button's playback when speech access fails", () => {
+    const synth = setupSynth({ speaking: false });
+    render(
+      <>
+        <SpeakButton text="ねこ" language="zh-Hant" />
+        <SpeakButton text="いぬ" language="zh-Hant" />
+      </>
+    );
+    const [first, second] = screen.getAllByRole("button");
+    fireEvent.click(first);
+    Object.defineProperty(window, "speechSynthesis", {
+      configurable: true,
+      get: () => {
+        throw new Error("unavailable");
+      }
+    });
+
+    fireEvent.click(second);
+
+    expect(synth.cancel).not.toHaveBeenCalled();
+  });
+
+  it("keeps the stored speech rate on the utterance", () => {
+    const synth = setupSynth({ speaking: false });
+    writeTtsRate(0.7);
+    render(<SpeakButton text="ねこ" language="zh-Hant" />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect((synth.speak.mock.calls[0][0] as { lang: string; rate: number })).toMatchObject({
+      lang: "ja-JP",
+      rate: 0.7
+    });
   });
 
   it("renders nothing when speech synthesis is unavailable", () => {

--- a/src/components/SpeakButton.test.tsx
+++ b/src/components/SpeakButton.test.tsx
@@ -11,6 +11,7 @@ import { writeTtsRate } from "../lib/ttsRate";
 type MockSynth = {
   speaking: boolean;
   pending: boolean;
+  utterances: MockUtterance[];
   speak: ReturnType<typeof vi.fn>;
   cancel: ReturnType<typeof vi.fn>;
   pause: ReturnType<typeof vi.fn>;
@@ -18,37 +19,69 @@ type MockSynth = {
   getVoices: () => unknown[];
 };
 
-function setupSynth({ speaking = false } = {}): MockSynth {
+type MockUtterance = {
+  text: string;
+  lang: string;
+  rate: number;
+  voice: unknown;
+  emit: (type: "end" | "error") => void;
+};
+
+function setupSynth({ speaking = false, pending = false } = {}): MockSynth {
+  const utterances: MockUtterance[] = [];
+  class MockUtteranceImpl implements MockUtterance {
+    lang = "";
+    rate = 1;
+    voice: unknown = null;
+    private listeners = new Map<string, Set<() => void>>();
+
+    constructor(public text: string) {
+      utterances.push(this);
+    }
+
+    addEventListener(type: string, listener: () => void) {
+      const listeners = this.listeners.get(type) ?? new Set<() => void>();
+      listeners.add(listener);
+      this.listeners.set(type, listeners);
+    }
+
+    removeEventListener(type: string, listener: () => void) {
+      this.listeners.get(type)?.delete(listener);
+    }
+
+    emit(type: "end" | "error") {
+      for (const listener of this.listeners.get(type) ?? []) listener();
+    }
+  }
+
   const synth: MockSynth = {
     speaking,
-    pending: false,
-    speak: vi.fn(),
+    pending,
+    utterances,
+    speak: vi.fn(() => {
+      synth.speaking = true;
+      synth.pending = false;
+    }),
     cancel: vi.fn(function (this: MockSynth) {
       synth.speaking = false;
+      synth.pending = false;
     }),
     pause: vi.fn(),
     resume: vi.fn(),
     getVoices: () => []
   };
   (window as unknown as { speechSynthesis: MockSynth }).speechSynthesis = synth;
-  (window as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance =
-    class {
-      text: string;
-      lang = "";
-      rate = 1;
-      voice: unknown = null;
-      constructor(t: string) {
-        this.text = t;
-      }
-      addEventListener() {}
-      removeEventListener() {}
-    };
+  (window as unknown as { SpeechSynthesisUtterance: unknown }).SpeechSynthesisUtterance = MockUtteranceImpl;
   return synth;
 }
 
 describe("SpeakButton", () => {
+  let now = Date.UTC(2300, 0, 1);
+
   beforeEach(() => {
     vi.useFakeTimers();
+    now += 1_000;
+    vi.setSystemTime(now);
   });
   afterEach(() => {
     vi.useRealTimers();
@@ -76,19 +109,25 @@ describe("SpeakButton", () => {
     expect(synth.speak).toHaveBeenCalledTimes(1);
   });
 
-  it("starts only the latest request when a second click arrives before a cancelled restart", () => {
+  it("waits through the cancellation cooldown and speaks only the latest rapid request", () => {
     const synth = setupSynth({ speaking: true });
-    render(<SpeakButton text="ねこ" language="zh-Hant" />);
-    const button = screen.getByRole("button");
+    render(
+      <>
+        <SpeakButton text="ねこ" language="zh-Hant" />
+        <SpeakButton text="いぬ" language="zh-Hant" />
+      </>
+    );
+    const [first, second] = screen.getAllByRole("button");
 
-    fireEvent.click(button);
-    // `cancel()` leaves the engine idle; a second user action before the
-    // anti-clipping delay must replace, not accompany, the deferred request.
-    fireEvent.click(button);
+    fireEvent.click(first);
+    fireEvent.click(second);
 
+    expect(synth.speak).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(129);
+    expect(synth.speak).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
     expect(synth.speak).toHaveBeenCalledTimes(1);
-    vi.advanceTimersByTime(200);
-    expect(synth.speak).toHaveBeenCalledTimes(1);
+    expect((synth.speak.mock.calls[0][0] as MockUtterance).text).toBe("いぬ");
   });
 
   it("cancels active playback when its owning button unmounts", () => {
@@ -142,7 +181,35 @@ describe("SpeakButton", () => {
       </>
     );
 
-    expect(synth.cancel).not.toHaveBeenCalled();
+    // The second button must hand off the active first utterance once. The
+    // first button's text cleanup must not add a second cancellation.
+    expect(synth.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the newer owner active when a cancelled utterance later ends", () => {
+    const synth = setupSynth({ speaking: false });
+    const { rerender } = render(
+      <>
+        <SpeakButton text="ねこ" language="zh-Hant" />
+        <SpeakButton text="いぬ" language="zh-Hant" />
+      </>
+    );
+    const [first, second] = screen.getAllByRole("button");
+    fireEvent.click(first);
+    fireEvent.click(second);
+    vi.advanceTimersByTime(130);
+
+    synth.utterances[0].emit("end");
+    rerender(
+      <>
+        <SpeakButton text="ねこ" language="zh-Hant" />
+        <SpeakButton text="うさぎ" language="zh-Hant" />
+      </>
+    );
+
+    // One cancel hands off the first utterance; the second proves the newer
+    // owner stayed active despite the stale first utterance's end event.
+    expect(synth.cancel).toHaveBeenCalledTimes(2);
   });
 
   it("does not cancel another button's playback when speech access fails", () => {

--- a/src/components/SpeakButton.test.tsx
+++ b/src/components/SpeakButton.test.tsx
@@ -101,6 +101,50 @@ describe("SpeakButton", () => {
     expect(synth.cancel).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels its active utterance when the button text changes", () => {
+    const synth = setupSynth({ speaking: false });
+    const { rerender } = render(<SpeakButton text="ねこ" language="zh-Hant" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    rerender(<SpeakButton text="いぬ" language="zh-Hant" />);
+
+    expect(synth.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears its pending restart when the button text changes", () => {
+    const synth = setupSynth({ speaking: true });
+    const { rerender } = render(<SpeakButton text="ねこ" language="zh-Hant" />);
+
+    fireEvent.click(screen.getByRole("button"));
+    rerender(<SpeakButton text="いぬ" language="zh-Hant" />);
+    vi.advanceTimersByTime(200);
+
+    expect(synth.cancel).toHaveBeenCalledTimes(2);
+    expect(synth.speak).not.toHaveBeenCalled();
+  });
+
+  it("does not cancel a newer button's playback when its own text changes", () => {
+    const synth = setupSynth({ speaking: false });
+    const { rerender } = render(
+      <>
+        <SpeakButton text="ねこ" language="zh-Hant" />
+        <SpeakButton text="いぬ" language="zh-Hant" />
+      </>
+    );
+    const [first, second] = screen.getAllByRole("button");
+    fireEvent.click(first);
+    fireEvent.click(second);
+
+    rerender(
+      <>
+        <SpeakButton text="うさぎ" language="zh-Hant" />
+        <SpeakButton text="いぬ" language="zh-Hant" />
+      </>
+    );
+
+    expect(synth.cancel).not.toHaveBeenCalled();
+  });
+
   it("does not cancel another button's playback when speech access fails", () => {
     const synth = setupSynth({ speaking: false });
     render(

--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -72,13 +72,13 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
   const playbackIdRef = useRef<number | null>(null);
 
   // SpeechSynthesis is document-global. If this button owns the active
-  // utterance, leaving its view also owns stopping it; another button's newer
-  // utterance is left alone.
+  // utterance, leaving its view or changing its payload owns stopping it;
+  // another button's newer utterance is left alone.
   useEffect(
     () => () => {
       if (playbackIdRef.current !== null) cancelPlayback(playbackIdRef.current);
     },
-    []
+    [text]
   );
 
   const supported =

--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -14,6 +14,8 @@ let delayedSpeakTimer: ReturnType<typeof setTimeout> | null = null;
 let nextPlaybackId = 0;
 let activePlaybackId: number | null = null;
 let activeSynth: SpeechSynthesis | null = null;
+const CANCEL_COOLDOWN_MS = 130;
+let cancelCooldownUntil = 0;
 
 function stopKeepAlive() {
   if (keepAliveTimer !== null) {
@@ -27,6 +29,11 @@ function clearDelayedSpeak() {
     clearTimeout(delayedSpeakTimer);
     delayedSpeakTimer = null;
   }
+}
+
+function cancelSynthesis(synth: SpeechSynthesis) {
+  cancelCooldownUntil = Math.max(cancelCooldownUntil, Date.now() + CANCEL_COOLDOWN_MS);
+  synth.cancel();
 }
 
 function finishPlayback(playbackId: number) {
@@ -43,8 +50,9 @@ function cancelPlayback(playbackId?: number) {
   stopKeepAlive();
   const synth = activeSynth;
   activeSynth = null;
+  if (!synth) return;
   try {
-    synth?.cancel();
+    cancelSynthesis(synth);
   } catch {
     // An unavailable engine has the same fail-soft result as an unsupported API.
   }
@@ -123,15 +131,18 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
 
       // The reported "缺失一小段" (clipped start) / 爆音: Chrome drops the
       // beginning of an utterance when speak() is called in the same tick as
-      // cancel(). So only cancel when something is actually playing, and give
-      // the engine a beat before the new utterance; when idle, speak now --
-      // no clip, no needless latency.
+      // cancel(). Each app cancellation creates a short global cooldown: a
+      // replacement request may replace the payload, but cannot call speak()
+      // before the engine has had that beat to settle.
       if (wasActive) {
-        synth.cancel();
+        cancelSynthesis(synth);
+      }
+      const remainingCooldown = Math.max(0, cancelCooldownUntil - Date.now());
+      if (remainingCooldown > 0) {
         delayedSpeakTimer = setTimeout(() => {
           delayedSpeakTimer = null;
           speak();
-        }, 130);
+        }, remainingCooldown);
       } else {
         speak();
       }

--- a/src/components/SpeakButton.tsx
+++ b/src/components/SpeakButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Volume2 } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import { getJapaneseVoice } from "../lib/speech";
@@ -9,10 +10,43 @@ import { readTtsRate } from "../lib/ttsRate";
 // (which finish first) are never touched. One shared timer -- there is a
 // single global speechSynthesis engine.
 let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+let delayedSpeakTimer: ReturnType<typeof setTimeout> | null = null;
+let nextPlaybackId = 0;
+let activePlaybackId: number | null = null;
+let activeSynth: SpeechSynthesis | null = null;
+
 function stopKeepAlive() {
   if (keepAliveTimer !== null) {
     clearInterval(keepAliveTimer);
     keepAliveTimer = null;
+  }
+}
+
+function clearDelayedSpeak() {
+  if (delayedSpeakTimer !== null) {
+    clearTimeout(delayedSpeakTimer);
+    delayedSpeakTimer = null;
+  }
+}
+
+function finishPlayback(playbackId: number) {
+  if (activePlaybackId !== playbackId) return;
+  activePlaybackId = null;
+  activeSynth = null;
+  stopKeepAlive();
+}
+
+function cancelPlayback(playbackId?: number) {
+  if (playbackId !== undefined && activePlaybackId !== playbackId) return;
+  activePlaybackId = null;
+  clearDelayedSpeak();
+  stopKeepAlive();
+  const synth = activeSynth;
+  activeSynth = null;
+  try {
+    synth?.cancel();
+  } catch {
+    // An unavailable engine has the same fail-soft result as an unsupported API.
   }
 }
 function startKeepAlive(synth: SpeechSynthesis) {
@@ -35,6 +69,18 @@ function startKeepAlive(synth: SpeechSynthesis) {
 // JA voice isn't available, the component renders nothing rather than a
 // broken-feeling button.
 export function SpeakButton({ text, language }: { text: string; language: Language }) {
+  const playbackIdRef = useRef<number | null>(null);
+
+  // SpeechSynthesis is document-global. If this button owns the active
+  // utterance, leaving its view also owns stopping it; another button's newer
+  // utterance is left alone.
+  useEffect(
+    () => () => {
+      if (playbackIdRef.current !== null) cancelPlayback(playbackIdRef.current);
+    },
+    []
+  );
+
   const supported =
     typeof window !== "undefined" &&
     "speechSynthesis" in window &&
@@ -46,6 +92,13 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
   const handleClick = () => {
     try {
       const synth = window.speechSynthesis;
+      const wasActive = synth.speaking || synth.pending;
+      clearDelayedSpeak();
+      stopKeepAlive();
+      const playbackId = ++nextPlaybackId;
+      playbackIdRef.current = playbackId;
+      activePlaybackId = playbackId;
+      activeSynth = synth;
       const utterance = new window.SpeechSynthesisUtterance(text);
       // iOS/iPadOS ignores `lang` alone and may read kanji with a Chinese
       // voice -- pin an explicit ja-* voice when one is available.
@@ -55,12 +108,17 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
       // Read the rate fresh each click so a change in the 語速 control (#527)
       // applies immediately; defaults to the long-standing 0.95 when unset.
       utterance.rate = readTtsRate();
-      utterance.addEventListener("end", stopKeepAlive);
-      utterance.addEventListener("error", stopKeepAlive);
+      utterance.addEventListener("end", () => finishPlayback(playbackId));
+      utterance.addEventListener("error", () => finishPlayback(playbackId));
 
       const speak = () => {
-        startKeepAlive(synth);
-        synth.speak(utterance);
+        if (activePlaybackId !== playbackId) return;
+        try {
+          startKeepAlive(synth);
+          synth.speak(utterance);
+        } catch {
+          finishPlayback(playbackId);
+        }
       };
 
       // The reported "缺失一小段" (clipped start) / 爆音: Chrome drops the
@@ -68,9 +126,12 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
       // cancel(). So only cancel when something is actually playing, and give
       // the engine a beat before the new utterance; when idle, speak now --
       // no clip, no needless latency.
-      if (synth.speaking || synth.pending) {
+      if (wasActive) {
         synth.cancel();
-        setTimeout(speak, 130);
+        delayedSpeakTimer = setTimeout(() => {
+          delayedSpeakTimer = null;
+          speak();
+        }, 130);
       } else {
         speak();
       }
@@ -78,7 +139,7 @@ export function SpeakButton({ text, language }: { text: string; language: Langua
       // Voice synthesis can throw if the engine is in a bad state; the
       // worst case here is "no sound played", which is better than
       // crashing the practice flow.
-      stopKeepAlive();
+      if (playbackIdRef.current !== null) cancelPlayback(playbackIdRef.current);
     }
   };
 

--- a/src/components/challenge/DrillPanel.test.tsx
+++ b/src/components/challenge/DrillPanel.test.tsx
@@ -56,7 +56,12 @@ const baseProps = {
   onExit: vi.fn()
 };
 
-afterEach(() => vi.unstubAllGlobals());
+let speechTestNow = Date.UTC(2100, 0, 1);
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 function renderPanel(language: Language) {
   return render(<DrillPanel {...baseProps} language={language} />);
@@ -101,6 +106,9 @@ function renderDone(opts: {
 
 describe("DrillPanel", () => {
   it("sends the canonical kana payload for each reported vocabulary reading", () => {
+    vi.useFakeTimers();
+    speechTestNow += 1_000;
+    vi.setSystemTime(speechTestNow);
     const speak = vi.fn();
     vi.stubGlobal("speechSynthesis", {
       getVoices: () => [],
@@ -135,6 +143,52 @@ describe("DrillPanel", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: "朗讀日文" }));
       unmount();
+      vi.advanceTimersByTime(130);
+      expect((speak.mock.calls.at(-1)![0] as { text: string }).text).toBe(expectedReading);
+    }
+
+    expect(speak).toHaveBeenCalledTimes(readings.length);
+  });
+
+  it("sends canonical kana when reviewing the meaning of each reported vocabulary item", () => {
+    vi.useFakeTimers();
+    speechTestNow += 1_000;
+    vi.setSystemTime(speechTestNow);
+    const speak = vi.fn();
+    vi.stubGlobal("speechSynthesis", {
+      getVoices: () => [],
+      speak,
+      cancel: () => {},
+      speaking: false,
+      pending: false
+    });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        constructor(public text: string) {}
+        lang = "";
+        rate = 1;
+        addEventListener() {}
+      }
+    );
+    const readings = [
+      ["n3-履歴書", "りれきしょ"],
+      ["n1-把持", "はじ"]
+    ] as const;
+
+    for (const [id, expectedReading] of readings) {
+      const vocabulary = jlptVocabulary.find((item) => item.id === id)!;
+      const meaningQuestion = buildQuestionPool([vocabulary], {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["meaning"]
+      })[0]!;
+      const { unmount } = render(
+        <DrillPanel {...baseProps} language="zh-Hant" currentQuestion={meaningQuestion} />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "朗讀日文" }));
+      unmount();
+      vi.advanceTimersByTime(130);
       expect((speak.mock.calls.at(-1)![0] as { text: string }).text).toBe(expectedReading);
     }
 

--- a/src/components/challenge/DrillPanel.test.tsx
+++ b/src/components/challenge/DrillPanel.test.tsx
@@ -1,11 +1,13 @@
 import type { ComponentProps } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { DrillPanel } from "./DrillPanel";
 import { FuriganaContext } from "../furiganaContext";
 import type { Attempt, PracticeQuestion } from "../../domain/types";
 import type { Language } from "../../i18n";
+import { buildQuestionPool } from "../../domain/practice";
+import { jlptVocabulary } from "../../domain/vocabulary-jlpt";
 
 const question: PracticeQuestion = {
   id: "kaku:te",
@@ -54,6 +56,8 @@ const baseProps = {
   onExit: vi.fn()
 };
 
+afterEach(() => vi.unstubAllGlobals());
+
 function renderPanel(language: Language) {
   return render(<DrillPanel {...baseProps} language={language} />);
 }
@@ -96,6 +100,47 @@ function renderDone(opts: {
 }
 
 describe("DrillPanel", () => {
+  it("sends the canonical kana payload for each reported vocabulary reading", () => {
+    const speak = vi.fn();
+    vi.stubGlobal("speechSynthesis", {
+      getVoices: () => [],
+      speak,
+      cancel: () => {},
+      speaking: false,
+      pending: false
+    });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        constructor(public text: string) {}
+        lang = "";
+        rate = 1;
+        addEventListener() {}
+      }
+    );
+    const readings = [
+      ["n3-履歴書", "りれきしょ"],
+      ["n1-把持", "はじ"]
+    ] as const;
+
+    for (const [id, expectedReading] of readings) {
+      const vocabulary = jlptVocabulary.find((item) => item.id === id)!;
+      const readingQuestion = buildQuestionPool([vocabulary], {
+        partOfSpeech: "mixed",
+        verbGroup: "all",
+        targetForms: ["reading"]
+      })[0]!;
+      const { unmount } = render(
+        <DrillPanel {...baseProps} language="zh-Hant" currentQuestion={readingQuestion} />
+      );
+      fireEvent.click(screen.getByRole("button", { name: "朗讀日文" }));
+      unmount();
+      expect((speak.mock.calls.at(-1)![0] as { text: string }).text).toBe(expectedReading);
+    }
+
+    expect(speak).toHaveBeenCalledTimes(readings.length);
+  });
+
   it("localizes the pre-answer meaning gloss (#427)", () => {
     renderPanel("en");
     expect(screen.getByText("to write")).toBeInTheDocument();

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -202,11 +202,7 @@ export function DrillPanel({
                     plain={isReadingPrompt(currentQuestion.promptLabel, currentQuestion.targetForm)}
                   />
                   <SpeakButton
-                    text={
-                      currentQuestion.targetForm === "reading"
-                        ? currentQuestion.vocabulary.reading
-                        : currentQuestion.vocabulary.surface
-                    }
+                    text={currentQuestion.vocabulary.reading}
                     language={language}
                   />
                 </p>

--- a/src/components/challenge/DrillPanel.tsx
+++ b/src/components/challenge/DrillPanel.tsx
@@ -202,7 +202,11 @@ export function DrillPanel({
                     plain={isReadingPrompt(currentQuestion.promptLabel, currentQuestion.targetForm)}
                   />
                   <SpeakButton
-                    text={currentQuestion.vocabulary.surface}
+                    text={
+                      currentQuestion.targetForm === "reading"
+                        ? currentQuestion.vocabulary.reading
+                        : currentQuestion.vocabulary.surface
+                    }
                     language={language}
                   />
                 </p>


### PR DESCRIPTION
## Summary

- send trusted canonical kana for direct word-level vocabulary and kanji-example speech payloads
- serialize Web Speech cancellation/restart ownership so rapid requests, payload changes, unmounts, and stale callbacks cannot overlap or bypass the anti-clipping cooldown
- preserve Japanese voice selection, stored speech rate, kana/romaji safeguards, sentence-level context playback, and fail-soft unsupported-browser behavior

## Latest-main feedback dispositions

| Report | Disposition |
| --- | --- |
| `69fd573c` (`n3-履歴書:reading`) | Reproduced app payload defect. Reading playback sent raw `履歴書`; fixed to send trusted `りれきしょ`. |
| `ef59bc94` (`n1-read-hedataru`) | Already payload-safe on the starting `main`: pre-answer reading TTS is suppressed and answer playback sends canonical `へだたった`. Regression coverage added. Residual pronunciation quality is OS/voice dependent. |
| `89ca7bd0` (`n3-kanji-korobu`) | Already payload-safe on the starting `main`: answer playback sends canonical `ころぶ`. Regression coverage added. Residual pronunciation quality is OS/voice dependent. |
| `0ddd3f0b` (`n1-把持:reading`) | Reproduced app payload defect. Word playback could send raw `把持`; fixed to send trusted `はじ`. App-created stale restart overlap was also removed. Residual voice stutter inside the OS engine remains platform dependent. |
| `ef25f786` (generic clipping/cutout) | Reproduced app lifecycle defect: a stale delayed restart and rapid replacement could overlap or bypass the post-cancel delay. Fixed with global ownership identities and a cancellation cooldown; covered for rapid replacement, payload changes, unmount, and stale listeners. |

No private feedback diagnostics, contact data, or account data were read or added.

## Validation

- TDD RED/GREEN recorded in the implementation report for payload, lifecycle, cooldown, and navigation seams
- focused speech/payload component suites: pass
- `pnpm verify`: pass
- `pnpm verify:full`: pass on exact final HEAD (`lint`, full `test`, `build`)
- `git diff origin/main...HEAD --check`: pass
- independent task review, two scoped fix re-reviews, and exact-final whole-branch code review: no remaining code Critical/Important findings

## Browser / platform limitations

- Local Vite preview returned HTTP 200.
- Automated Chromium and Safari/WebKit interaction smoke could not run because the installed browser-control skill was missing its required `scripts/browser-client.mjs`; its contract prohibited switching to an unapproved automation surface.
- Actual pronunciation, stuttering, clipping inside a browser/OS voice implementation, and Japanese voice availability remain platform dependent. The application now guarantees its own payload and sequencing contracts but does not claim perfect OS synthesis.

Closes #785
