### PR TITLE
test: cover preserved grammar study detour

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -828,6 +828,63 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps an answered grammar drill mounted when deep study opens separately (#786)", async () => {
+    const { StrictMode } = await import("react");
+    const { examStyleQuestions } = await import("./domain/examBlocks");
+    const user = userEvent.setup();
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+
+    await user.click(screen.getByRole("button", { name: "題型練習" }));
+    await user.click(screen.getByRole("button", { name: /文の文法 1/ }));
+
+    const panel = await screen.findByRole("region", { name: "目前題目" });
+    const questionId = panel.getAttribute("data-question-id");
+    const question = examStyleQuestions.find((candidate) => candidate.id === questionId);
+    if (!question) {
+      throw new Error(`Expected current exam question ${String(questionId)} in the item bank`);
+    }
+    const wrongAnswer = question.options?.find(
+      (option) => !question.expectedAnswers.includes(option)
+    );
+    if (!wrongAnswer) {
+      throw new Error(`Expected grammar question ${question.id} to have a wrong option`);
+    }
+
+    const progressBefore = panel.querySelector(".prompt-header span")?.textContent;
+    await user.click(within(panel).getByRole("button", { name: wrongAnswer }));
+
+    expect(panel).toHaveAttribute("data-question-id", questionId);
+    expect(panel).toHaveAttribute("data-question-type", "文法形式選擇");
+    expect(panel).toHaveAttribute("data-selected", wrongAnswer);
+    expect(panel).toHaveAttribute("data-result", "wrong");
+    expect(panel.querySelector(".prompt-header span")?.textContent).toBe(progressBefore);
+    const scoreBefore = screen.getByLabelText("今日戰報").textContent;
+    const studyLink = screen.getByRole("link", { name: "深入學習這個文法" });
+    expect(studyLink).toHaveAttribute(
+      "href",
+      `/grammar/${encodeURIComponent(question.vocabulary.surface)}`
+    );
+    expect(studyLink).toHaveAttribute("target", "_blank");
+    expect(studyLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    await user.click(studyLink);
+
+    const restoredPanel = screen.getByRole("region", { name: "目前題目" });
+    expect(window.location.pathname).toBe("/challenge");
+    expect(restoredPanel).toBe(panel);
+    expect(restoredPanel).toHaveAttribute("data-question-id", questionId);
+    expect(restoredPanel).toHaveAttribute("data-question-type", "文法形式選擇");
+    expect(restoredPanel).toHaveAttribute("data-selected", wrongAnswer);
+    expect(restoredPanel).toHaveAttribute("data-result", "wrong");
+    expect(restoredPanel.querySelector(".prompt-header span")?.textContent).toBe(progressBefore);
+    expect(screen.getByLabelText("今日戰報").textContent).toBe(scoreBefore);
+    expect(document.activeElement).toBe(studyLink);
+  });
+
   it("starts the challenge from the learning path", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/src/components/FeedbackPanel.test.tsx
+++ b/src/components/FeedbackPanel.test.tsx
@@ -278,6 +278,38 @@ describe("FeedbackPanel grammar study link (#282, #469)", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
+  it("uses the same isolated study link after a correct grammar answer", () => {
+    render(
+      <FeedbackPanel
+        feedback={{
+          status: "correct",
+          question: grammarBase,
+          submittedAnswer: grammarBase.expectedAnswers[0]
+        }}
+        language="zh-Hant"
+        options={grammarBase.options ?? []}
+      />
+    );
+    const link = screen.getByRole("link", { name: linkName });
+    expect(link).toHaveAttribute("href", `/grammar/${encodeURIComponent(grammarBase.vocabulary.surface)}`);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("keeps a revealed grammar answer in the source tab while study opens separately", () => {
+    render(
+      <FeedbackPanel
+        feedback={{ status: "revealed", question: grammarBase, submittedAnswer: null }}
+        language="zh-Hant"
+        options={grammarBase.options ?? []}
+      />
+    );
+    const link = screen.getByRole("link", { name: linkName });
+    expect(link).toHaveAttribute("href", `/grammar/${encodeURIComponent(grammarBase.vocabulary.surface)}`);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
   it("hides the link for a non-grammar (reading) item", () => {
     render(
       <FeedbackPanel


### PR DESCRIPTION
## Summary

- confirm the reported same-page grammar detour was already fixed by the current isolated browsing-context link contract
- add production-equivalent App/StrictMode regressions for wrong-answer session preservation
- cover the same isolated study link after correct and revealed answers without changing production routing/session code

## Disposition

Feedback `bcc18e20` no longer reproduces on current `main`. Historical commit `2fb279a` / #469 replaced the old App callback that switched views and unmounted `ChallengePanel` with a native `/grammar/<surface>` link using `target="_blank"` and `rel="noopener noreferrer"`. The source `/challenge` page therefore remains mounted with the same question, filter/session snapshot, selected answer, result/reveal state, progress, score, and focus.

Browser Back and an in-page explanation close are not current practice-origin actions because the reference opens in a separate browsing context. Direct grammar navigation remains a normal standalone route with no fabricated return target.

No production feedback rows or contact/account data were read or modified.

## Validation

- mutation TDD: temporarily changing `_blank` to `_self` made the new App regression fail; restoring current production behavior passed
- focused and affected tests: pass
- `pnpm verify`: pass (test-only L1)
- `VITEST_MAX_WORKERS=1 pnpm verify:full`: pass on exact HEAD `55b4626907ec708abd52af119d3cd52bb8ae40e4`
- diff checks: pass; worktree clean
- independent exact-final review: PASS, no findings

Closes #786
