### PR TITLE
fix: keep Kanji details near selection

### DIFF
--- a/src/components/KanjiOnyomiPanel.test.tsx
+++ b/src/components/KanjiOnyomiPanel.test.tsx
@@ -521,6 +521,67 @@ describe("KanjiOnyomiPanel arrow-key browsing", () => {
   });
 });
 
+describe("KanjiOnyomiPanel local selected detail (#788)", () => {
+  const cells = () => Array.from(document.querySelectorAll<HTMLButtonElement>("button.kanji-cell"));
+  const detail = () => document.querySelector<HTMLElement>(".kanji-card");
+  const selectedWrap = () => document.querySelector<HTMLElement>(".kanji-cell.selected")?.closest(
+    ".kanji-cell-wrap"
+  );
+
+  it("renders one detail surface immediately after the selected card in its grid", () => {
+    renderNarrowed("高");
+    fireEvent.click(cells()[1]);
+
+    expect(detail()).not.toBeNull();
+    expect(document.querySelectorAll(".kanji-card")).toHaveLength(1);
+    expect(selectedWrap()?.nextElementSibling).toBe(detail());
+    expect(detail()?.closest(".kanji-grid")).toBe(selectedWrap()?.closest(".kanji-grid"));
+    expect(detail()?.querySelector(".kanji-card-char")?.textContent).toBe(
+      cells()[1].querySelector(".kanji-cell-char")?.textContent
+    );
+  });
+
+  it("moves the sole detail with ArrowRight while keeping focus on the new card", () => {
+    renderNarrowed("高");
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    const firstWrap = selectedWrap();
+
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+
+    const selected = document.querySelector<HTMLButtonElement>(".kanji-cell.selected");
+    expect(selected).not.toBeNull();
+    expect(selectedWrap()).not.toBe(firstWrap);
+    expect(document.querySelectorAll(".kanji-card")).toHaveLength(1);
+    expect(selectedWrap()?.nextElementSibling).toBe(detail());
+    expect(detail()?.querySelector(".kanji-card-char")?.textContent).toBe(
+      selected?.querySelector(".kanji-cell-char")?.textContent
+    );
+    expect(document.activeElement).toBe(selected);
+  });
+
+  it("keeps the keyboard-selected card and its detail in the nearest scroll region", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    renderNarrowed("高");
+
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+
+    const selected = document.querySelector<HTMLButtonElement>(".kanji-cell.selected");
+    expect(selected).not.toBeNull();
+    expect(detail()).not.toBeNull();
+    expect(scrollIntoView.mock.instances).toEqual([selected, detail()]);
+    expect(scrollIntoView).toHaveBeenNthCalledWith(1, {
+      block: "nearest",
+      behavior: "smooth"
+    });
+    expect(scrollIntoView).toHaveBeenNthCalledWith(2, {
+      block: "nearest",
+      behavior: "smooth"
+    });
+    expect(document.activeElement).toBe(selected);
+  });
+});
+
 // Feedback 2026-07: hearing a kanji's reading used to require selecting the
 // cell, scrolling up to the detail card's TTS button, then scrolling back down
 // to pick the next kanji. The selected cell now grows an in-place speak button
@@ -596,7 +657,7 @@ describe("KanjiOnyomiPanel in-place cell TTS", () => {
     const wrap = cell!.closest(".kanji-cell-wrap");
     expect(wrap).not.toBeNull();
     const speak = within(wrap as HTMLElement).getByRole("button", { name: "朗讀日文" });
-    expect(within(grid).getAllByRole("button", { name: "朗讀日文" })).toHaveLength(1);
+    expect(grid.querySelectorAll(".kanji-cell-speak .speak-button")).toHaveLength(1);
 
     fireEvent.click(speak);
     expect(synth.speak).toHaveBeenCalledTimes(1);

--- a/src/components/KanjiOnyomiPanel.tsx
+++ b/src/components/KanjiOnyomiPanel.tsx
@@ -1,4 +1,4 @@
-import { createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, createRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { copy, type Language } from "../i18n";
 import type { JlptLevel } from "../domain/types";
 import { kanjiOnyomi, kanjiExamples, type KanjiOnyomiEntry } from "../domain/kanjiOnyomi";
@@ -155,6 +155,7 @@ export function KanjiOnyomiPanel({
       )
   );
   const pendingFocus = useRef<string | null>(null);
+  const detailRef = useRef<HTMLDivElement>(null);
 
   // Desktop shortcut (user request 2026-07): ← / → walk the grid so browsing a
   // level or a search result doesn't mean clicking every card. A GLOBAL
@@ -214,11 +215,56 @@ export function KanjiOnyomiPanel({
     pendingFocus.current = null;
     node.focus({ preventScroll: true });
     node.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+    detailRef.current?.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
   }, [selected, entryBudget, cellRefs]);
 
   const detail = selected ? kanjiOnyomi.find((entry) => entry.kanji === selected) ?? null : null;
   const examples = detail ? kanjiExamples(detail.kanji) : [];
   const detailSpeak = detail ? detail.onyomi[0] ?? detail.kunyomi[0] : "";
+  const detailCard = detail ? (
+    <div className="kanji-card" ref={detailRef} aria-live="polite">
+      <div className="kanji-card-head">
+        <span className="kanji-card-char">{detail.kanji}</span>
+        <div>
+          {detail.onyomi.length > 0 ? (
+            <p className="kanji-card-onyomi">
+              {detail.onyomi.join("・")}
+              <small>{t.kanjiOnyomiLabel}</small>
+            </p>
+          ) : null}
+          {detail.kunyomi.length > 0 ? (
+            <p className="kanji-card-kunyomi">
+              {detail.kunyomi.join("・")}
+              <small>{t.kanjiKunyomiLabel}</small>
+            </p>
+          ) : null}
+          <p className="kanji-card-mean">
+            {kanjiMeaning(detail, language)}
+            {detailSpeak ? <SpeakButton text={detailSpeak} language={language} /> : null}
+          </p>
+        </div>
+      </div>
+      <p className="kanji-examples-label">{t.kanjiExamplesLabel}</p>
+      {examples.length > 0 ? (
+        <ul className="kanji-examples">
+          {examples.map((example) => (
+            <li key={example.surface}>
+              <span className="kanji-example-surface">
+                {example.surface}
+                <SpeakButton text={example.reading} language={language} />
+              </span>
+              <span className="kanji-example-reading">{example.reading}</span>
+              <span className="kanji-example-mean">
+                {pickLocalized(example.meaningZh, example.meaningI18n, language)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="kanji-no-examples">{t.kanjiNoExamples}</p>
+      )}
+    </div>
+  ) : null;
 
   return (
     <section className="kanji-panel" aria-label={t.kanjiTitle}>
@@ -291,51 +337,6 @@ export function KanjiOnyomiPanel({
       {/* Hidden on touch devices (no keyboard to hint at) via CSS. */}
       <p className="kanji-key-hint">{t.kanjiArrowHint}</p>
 
-      {detail ? (
-        <div className="kanji-card" aria-live="polite">
-          <div className="kanji-card-head">
-            <span className="kanji-card-char">{detail.kanji}</span>
-            <div>
-              {detail.onyomi.length > 0 ? (
-                <p className="kanji-card-onyomi">
-                  {detail.onyomi.join("・")}
-                  <small>{t.kanjiOnyomiLabel}</small>
-                </p>
-              ) : null}
-              {detail.kunyomi.length > 0 ? (
-                <p className="kanji-card-kunyomi">
-                  {detail.kunyomi.join("・")}
-                  <small>{t.kanjiKunyomiLabel}</small>
-                </p>
-              ) : null}
-              <p className="kanji-card-mean">
-                {kanjiMeaning(detail, language)}
-                {detailSpeak ? <SpeakButton text={detailSpeak} language={language} /> : null}
-              </p>
-            </div>
-          </div>
-          <p className="kanji-examples-label">{t.kanjiExamplesLabel}</p>
-          {examples.length > 0 ? (
-            <ul className="kanji-examples">
-              {examples.map((example) => (
-                <li key={example.surface}>
-                  <span className="kanji-example-surface">
-                    {example.surface}
-                    <SpeakButton text={example.reading} language={language} />
-                  </span>
-                  <span className="kanji-example-reading">{example.reading}</span>
-                  <span className="kanji-example-mean">
-                    {pickLocalized(example.meaningZh, example.meaningI18n, language)}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="kanji-no-examples">{t.kanjiNoExamples}</p>
-          )}
-        </div>
-      ) : null}
-
       {families.length > 0 ? (
         visibleFamilies.map(([reading, entries]) => (
           <div className="kanji-family" key={reading}>
@@ -358,31 +359,34 @@ export function KanjiOnyomiPanel({
                     ? entry.onyomi[0] ?? entry.kunyomi[0]
                     : entry.kunyomi[0] ?? entry.onyomi[0];
                 return (
-                  <div className="kanji-cell-wrap" key={entry.kanji}>
-                    <button
-                      type="button"
-                      ref={cellRefs.get(entry.kanji)}
-                      className={`kanji-cell${isSelected ? " selected" : ""}${isLastRead ? " last-read" : ""}`}
-                      aria-pressed={isSelected}
-                      onClick={() => selectKanji(entry.kanji)}
-                    >
-                      <span className="kanji-cell-char">{entry.kanji}</span>
-                      <span className="kanji-cell-read">
-                        {entry.onyomi.length > 0 ? (
-                          <span className="kanji-cell-on">{t.kanjiCellOnPrefix} {entry.onyomi.join("・")}</span>
-                        ) : null}
-                        {entry.kunyomi.length > 0 ? (
-                          <span className="kanji-cell-kun">{t.kanjiCellKunPrefix} {entry.kunyomi.join("・")}</span>
-                        ) : null}
-                      </span>
-                      <span className="kanji-cell-mean">{kanjiMeaning(entry, language)}</span>
-                    </button>
-                    {isSelected && cellSpeak ? (
-                      <span className="kanji-cell-speak">
-                        <SpeakButton text={cellSpeak} language={language} />
-                      </span>
-                    ) : null}
-                  </div>
+                  <Fragment key={entry.kanji}>
+                    <div className="kanji-cell-wrap">
+                      <button
+                        type="button"
+                        ref={cellRefs.get(entry.kanji)}
+                        className={`kanji-cell${isSelected ? " selected" : ""}${isLastRead ? " last-read" : ""}`}
+                        aria-pressed={isSelected}
+                        onClick={() => selectKanji(entry.kanji)}
+                      >
+                        <span className="kanji-cell-char">{entry.kanji}</span>
+                        <span className="kanji-cell-read">
+                          {entry.onyomi.length > 0 ? (
+                            <span className="kanji-cell-on">{t.kanjiCellOnPrefix} {entry.onyomi.join("・")}</span>
+                          ) : null}
+                          {entry.kunyomi.length > 0 ? (
+                            <span className="kanji-cell-kun">{t.kanjiCellKunPrefix} {entry.kunyomi.join("・")}</span>
+                          ) : null}
+                        </span>
+                        <span className="kanji-cell-mean">{kanjiMeaning(entry, language)}</span>
+                      </button>
+                      {isSelected && cellSpeak ? (
+                        <span className="kanji-cell-speak">
+                          <SpeakButton text={cellSpeak} language={language} />
+                        </span>
+                      ) : null}
+                    </div>
+                    {isSelected ? detailCard : null}
+                  </Fragment>
                 );
               })}
             </div>

--- a/src/styles/kanji.css
+++ b/src/styles/kanji.css
@@ -52,6 +52,14 @@
   padding: 1rem;
 }
 
+/* Keep the selected detail in the same browsing context as its card. As a
+   full-width grid item it opens immediately below that card without nesting
+   interactive controls or creating a second detail surface. */
+.kanji-grid > .kanji-card {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
 .kanji-card-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- move the existing single Kanji detail surface into the selected card's local grid position
- keep the selected card and local detail visible during keyboard navigation and deep resume
- preserve #740 Arrow navigation, filter/resume state, Speak accessibility, mobile layouts, and the v1 no-vocabulary-expansion scope

## Dispositions

- `98297596`: partially fixed on current main by selected-cell Speak, but reproduced for the full detail/example reading controls; fixed by local detail placement.
- `9055cc63`: detail-locality defect reproduced and fixed. Related vocabulary/synonym expansion remains explicitly out of scope per the issue contract.

The page still renders exactly one selected detail surface. Mouse selection does not gain forced scrolling; keyboard selection keeps focus on the selected card and scrolls the same nearest region just enough to reveal the adjacent detail. Desktop, 390px, and 320px smoke checks show no horizontal overflow.

No production feedback rows or contact/account data were read or modified.

## Validation

- strict TDD RED 35/2, then GREEN 37/0; final keyboard scroll regression RED 37/1, then GREEN 38/0
- #740 focused regressions: pass 51/51
- browser smoke: 1440, 390, 320 pass; consecutive ArrowRight/deep resume keep detail visible
- `VITEST_MAX_WORKERS=1 pnpm verify:full`: pass on exact HEAD `518ed4a812954bfc9b9eb94d09c2199f969c41e7`
- build/diff checks: pass; worktree clean
- independent exact-final review: Standards/Spec PASS; one non-blocking automated coverage suggestion, no blocking findings

Closes #788
