### PR TITLE
fix: make desktop Learn drill reachable

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -364,19 +364,19 @@ describe("App", () => {
     expect(screen.getByText("あ a・い i・う u・え e・お o")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "練五十音認讀" })).toBeInTheDocument();
     // The former default chapter is still one click away with its content intact.
-    await user.click(screen.getByRole("button", { name: "查看：先分清楚く / に" }));
+    await user.click(screen.getByRole("tab", { name: "查看：先分清楚く / に" }));
     expect(screen.getByText("高い -> 高く")).toBeInTheDocument();
     expect(screen.getByText("静か -> 静かに")).toBeInTheDocument();
     expect(screen.getByText("学生 -> 学生に")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "練く/に修飾" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "查看：ない形家族" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "查看：ない形家族" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "查看：動詞て形 / た形（一類音便重點）" })
+      screen.getByRole("tab", { name: "查看：動詞て形 / た形（一類音便重點）" })
     ).toBeInTheDocument();
     // 必要過去 is always clickable now (no lock UI); only the active
     // chapter's body content is rendered, so its examples should not
     // appear in the default view.
-    expect(screen.getByRole("button", { name: "查看：必要過去" })).toBeEnabled();
+    expect(screen.getByRole("tab", { name: "查看：必要過去" })).toBeEnabled();
     expect(screen.queryByText("学生 -> 学生にならなければならなかった")).not.toBeInTheDocument();
     expect(screen.queryByText("否定て形・ないで")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "開始挑戰" })).toBeInTheDocument();
@@ -388,7 +388,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    await user.click(screen.getByRole("button", { name: "查看：ない形家族" }));
+    await user.click(screen.getByRole("tab", { name: "查看：ない形家族" }));
 
     expect(screen.getByRole("heading", { name: "ない形家族" })).toBeInTheDocument();
     expect(screen.getAllByText("書かない -> 書かなかった").length).toBeGreaterThan(1);
@@ -415,7 +415,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    await user.click(screen.getByRole("button", { name: "查看：ない形家族" }));
+    await user.click(screen.getByRole("tab", { name: "查看：ない形家族" }));
     await user.click(screen.getByRole("button", { name: "練否定整理" }));
 
     expect(screen.getByText("練習重點")).toBeInTheDocument();
@@ -429,7 +429,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    await user.click(screen.getByRole("button", { name: "查看：先分清楚く / に" }));
+    await user.click(screen.getByRole("tab", { name: "查看：先分清楚く / に" }));
     await user.click(screen.getByRole("button", { name: "練な形容詞" }));
 
     expect(screen.getByRole("button", { name: "な形容詞" })).toHaveClass("selected");
@@ -442,7 +442,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    await user.click(screen.getByRole("button", { name: "查看：先分清楚く / に" }));
+    await user.click(screen.getByRole("tab", { name: "查看：先分清楚く / に" }));
     await user.click(screen.getByRole("button", { name: "練く/に修飾" }));
 
     expect(screen.getByRole("button", { name: "く/に修飾" })).toHaveClass("selected");
@@ -457,12 +457,12 @@ describe("App", () => {
 
     await gotoLearn(user);
     // The new chapters surface in the chapter list.
-    expect(screen.getByRole("button", { name: "查看：ます形" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "查看：可能形 (V られる)" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "查看：使役形 (V せる/させる)" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "查看：ます形" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "查看：可能形 (V られる)" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "查看：使役形 (V せる/させる)" })).toBeInTheDocument();
 
     // Open the ます chapter; its example formulas and drill button render.
-    await user.click(screen.getByRole("button", { name: "查看：ます形" }));
+    await user.click(screen.getByRole("tab", { name: "查看：ます形" }));
     expect(screen.getByText("書く → 書きます")).toBeInTheDocument();
     expect(screen.getByText("食べる → 食べます")).toBeInTheDocument();
 
@@ -479,14 +479,14 @@ describe("App", () => {
     await gotoLearn(user);
     // All four B2 chapters surface in the chapter list (smoke check).
     expect(
-      screen.getByRole("button", { name: "查看：てください / てもいい / てはいけない" })
+      screen.getByRole("tab", { name: "查看：てください / てもいい / てはいけない" })
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "查看：なくてもいい（不必）" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "查看：なくてもいい（不必）" })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "查看：てもらう / てくれる / てあげる" })
+      screen.getByRole("tab", { name: "查看：てもらう / てくれる / てあげる" })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "查看：と思う / と言う（引用・意見）" })
+      screen.getByRole("tab", { name: "查看：と思う / と言う（引用・意見）" })
     ).toBeInTheDocument();
 
     // For each new chapter, walk: open chapter → confirm an example
@@ -527,7 +527,7 @@ describe("App", () => {
     for (const { chapter, example, drill, form } of cases) {
       // Return to the learning view (idempotent if already there).
       await gotoLearn(user);
-      await user.click(screen.getByRole("button", { name: chapter }));
+      await user.click(screen.getByRole("tab", { name: chapter }));
       expect(screen.getByText(example)).toBeInTheDocument();
 
       await user.click(screen.getByRole("button", { name: drill }));
@@ -574,7 +574,7 @@ describe("App", () => {
 
     for (const { chapter, drill, promptLabelFragment } of cases) {
       await gotoLearn(user);
-      await user.click(screen.getByRole("button", { name: chapter }));
+      await user.click(screen.getByRole("tab", { name: chapter }));
       await user.click(screen.getByRole("button", { name: drill }));
       // Challenge page: "句型練習" mode card is selected and the
       // question header includes the pattern label.
@@ -595,10 +595,10 @@ describe("App", () => {
 
     await gotoLearn(user);
 
-    const referenceChapter = screen.getByRole("button", { name: "查看：動詞三類怎麼分" });
+    const referenceChapter = screen.getByRole("tab", { name: "查看：動詞三類怎麼分" });
     expect(referenceChapter.textContent).toContain("參考");
 
-    const patternChapter = screen.getByRole("button", {
+    const patternChapter = screen.getByRole("tab", {
       name: "查看：てください / てもいい / てはいけない"
     });
     expect(patternChapter.textContent).not.toContain("參考");
@@ -619,7 +619,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    const obligationButton = screen.getByRole("button", { name: "查看：必要過去" });
+    const obligationButton = screen.getByRole("tab", { name: "查看：必要過去" });
     expect(obligationButton.textContent).toContain("建議先看");
     expect(obligationButton.textContent).toContain("先分清楚く / に");
     expect(obligationButton).toBeEnabled();
@@ -633,7 +633,7 @@ describe("App", () => {
     render(<App />);
 
     await gotoLearn(user);
-    await user.click(screen.getByRole("button", { name: "查看：必要過去" }));
+    await user.click(screen.getByRole("tab", { name: "查看：必要過去" }));
     await user.click(screen.getAllByRole("button", { name: "練必要過去" })[0]);
 
     expect(screen.getByRole("button", { name: "必要過去" })).toHaveClass("selected");

--- a/src/components/LearningPanel.test.tsx
+++ b/src/components/LearningPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { LearningPanel } from "./LearningPanel";
 import { learningBlocks } from "../domain/learningBlocks";
 import { FuriganaContext } from "./furiganaContext";
@@ -107,6 +108,46 @@ describe("LearningPanel mobile chapter bar (#608)", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(index.className).not.toContain("mobile-open");
     expect(screen.getByRole("heading", { level: 3 }).textContent).toBe(basicBlocks[2].title);
+  });
+});
+
+describe("LearningPanel chapter navigation (#787)", () => {
+  it("keeps the long chapter index to one tab stop and supports arrow navigation", () => {
+    renderPanel();
+    const chapterButtons = screen.getAllByRole("button", {
+      name: (name) => name.startsWith("查看：")
+    });
+
+    expect(chapterButtons[0]).toHaveAttribute("tabindex", "0");
+    expect(chapterButtons.slice(1).every((button) => button.tabIndex === -1)).toBe(true);
+
+    chapterButtons[0].focus();
+    fireEvent.keyDown(chapterButtons[0], { key: "ArrowDown" });
+
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(basicBlocks[1].title);
+    expect(chapterButtons[1]).toHaveFocus();
+
+    fireEvent.keyDown(chapterButtons[1], { key: "ArrowUp" });
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(basicBlocks[0].title);
+    expect(chapterButtons[0]).toHaveFocus();
+  });
+
+  it("moves keyboard focus from a chosen chapter into its content and primary action", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const chapterButtons = screen.getAllByRole("button", {
+      name: (name) => name.startsWith("查看：")
+    });
+
+    chapterButtons[0].focus();
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    const heading = screen.getByRole("heading", { level: 3 });
+    expect(heading).toHaveTextContent(basicBlocks[1].title);
+    expect(heading).toHaveFocus();
+
+    await user.tab();
+    expect(document.activeElement).toHaveClass("inline-drill-button");
   });
 });
 

--- a/src/components/LearningPanel.test.tsx
+++ b/src/components/LearningPanel.test.tsx
@@ -134,8 +134,42 @@ describe("LearningPanel chapter navigation (#787)", () => {
     expect(tabs.slice(1).every((tab) => tab.getAttribute("aria-selected") === "false")).toBe(true);
 
     const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("id", "active-chapter-panel");
+    for (const tab of tabs) {
+      expect(tab).toHaveAttribute("aria-controls", panel.id);
+      expect(document.getElementById(tab.getAttribute("aria-controls")!)).toBe(panel);
+    }
     expect(panel).toHaveAttribute("aria-labelledby", tabs[0].id);
     expect(document.getElementById(panel.getAttribute("aria-labelledby")!)).toBe(tabs[0]);
+  });
+
+  it("wraps arrow focus and selection at both ends of the vertical tablist", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    renderPanel();
+    const tabs = screen.getAllByRole("tab", {
+      name: (name) => name.startsWith("查看：")
+    });
+    const firstTab = tabs[0];
+    const lastTab = tabs.at(-1)!;
+
+    firstTab.focus();
+    fireEvent.keyDown(firstTab, { key: "ArrowUp" });
+
+    expect(lastTab).toHaveFocus();
+    expect(lastTab).toHaveAttribute("aria-selected", "true");
+    expect(firstTab).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", lastTab.id);
+
+    fireEvent.keyDown(lastTab, { key: "ArrowDown" });
+
+    expect(firstTab).toHaveFocus();
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+    expect(lastTab).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", firstTab.id);
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    expect(scrollIntoView).toHaveBeenNthCalledWith(1, { block: "nearest" });
+    expect(scrollIntoView).toHaveBeenNthCalledWith(2, { block: "nearest" });
   });
 
   it("keeps an Arrow-navigated chapter visible within the bounded index", () => {

--- a/src/components/LearningPanel.test.tsx
+++ b/src/components/LearningPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LearningPanel } from "./LearningPanel";
@@ -29,6 +29,15 @@ function renderPanel(onOpenKana = vi.fn()) {
 }
 
 const basicBlocks = learningBlocks.filter((block) => block.group === "basic");
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+afterEach(() => {
+  if (originalScrollIntoView) {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  } else {
+    delete (Element.prototype as { scrollIntoView?: Element["scrollIntoView"] }).scrollIntoView;
+  }
+});
 
 function renderPanelWithFurigana(enabled: boolean) {
   return render(
@@ -112,6 +121,22 @@ describe("LearningPanel mobile chapter bar (#608)", () => {
 });
 
 describe("LearningPanel chapter navigation (#787)", () => {
+  it("keeps an Arrow-navigated chapter visible within the bounded index", () => {
+    const scrollIntoView = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoView;
+    renderPanel();
+    const chapterButtons = screen.getAllByRole("button", {
+      name: (name) => name.startsWith("查看：")
+    });
+
+    chapterButtons[0].focus();
+    fireEvent.keyDown(chapterButtons[0], { key: "ArrowDown" });
+
+    expect(chapterButtons[1]).toHaveFocus();
+    expect(scrollIntoView).toHaveBeenCalledOnce();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
   it("keeps the long chapter index to one tab stop and supports arrow navigation", () => {
     renderPanel();
     const chapterButtons = screen.getAllByRole("button", {

--- a/src/components/LearningPanel.test.tsx
+++ b/src/components/LearningPanel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LearningPanel } from "./LearningPanel";
 import { learningBlocks } from "../domain/learningBlocks";
@@ -100,7 +100,7 @@ describe("LearningPanel mobile chapter bar (#608)", () => {
   it("toggles the chapter index open and closes it again when a chapter is picked", () => {
     renderPanel();
     const toggle = screen.getByTestId("chapter-mobile-toggle");
-    const index = screen.getByLabelText("學習章節");
+    const index = screen.getByRole("complementary", { name: "學習章節" });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(index.className).not.toContain("mobile-open");
 
@@ -110,7 +110,7 @@ describe("LearningPanel mobile chapter bar (#608)", () => {
 
     // Picking a chapter from the list selects it AND collapses the index so
     // the material is immediately in view.
-    const target = screen.getByRole("button", {
+    const target = screen.getByRole("tab", {
       name: (name) => name.includes(basicBlocks[2].title)
     });
     fireEvent.click(target);
@@ -121,11 +121,28 @@ describe("LearningPanel mobile chapter bar (#608)", () => {
 });
 
 describe("LearningPanel chapter navigation (#787)", () => {
+  it("exposes the chapter rail as a labelled vertical tabs composite", () => {
+    renderPanel();
+
+    const tablist = screen.getByRole("tablist", { name: "學習章節" });
+    expect(tablist).toHaveAttribute("aria-orientation", "vertical");
+    const tabs = within(tablist).getAllByRole("tab");
+    expect(tabs).toHaveLength(basicBlocks.length);
+    expect(tabs[0]).toHaveAttribute("id", `chapter-tab-${basicBlocks[0].id}`);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).not.toHaveAttribute("aria-pressed");
+    expect(tabs.slice(1).every((tab) => tab.getAttribute("aria-selected") === "false")).toBe(true);
+
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveAttribute("aria-labelledby", tabs[0].id);
+    expect(document.getElementById(panel.getAttribute("aria-labelledby")!)).toBe(tabs[0]);
+  });
+
   it("keeps an Arrow-navigated chapter visible within the bounded index", () => {
     const scrollIntoView = vi.fn();
     Element.prototype.scrollIntoView = scrollIntoView;
     renderPanel();
-    const chapterButtons = screen.getAllByRole("button", {
+    const chapterButtons = screen.getAllByRole("tab", {
       name: (name) => name.startsWith("查看：")
     });
 
@@ -139,7 +156,7 @@ describe("LearningPanel chapter navigation (#787)", () => {
 
   it("keeps the long chapter index to one tab stop and supports arrow navigation", () => {
     renderPanel();
-    const chapterButtons = screen.getAllByRole("button", {
+    const chapterButtons = screen.getAllByRole("tab", {
       name: (name) => name.startsWith("查看：")
     });
 
@@ -151,6 +168,9 @@ describe("LearningPanel chapter navigation (#787)", () => {
 
     expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(basicBlocks[1].title);
     expect(chapterButtons[1]).toHaveFocus();
+    expect(chapterButtons[0]).toHaveAttribute("aria-selected", "false");
+    expect(chapterButtons[1]).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel")).toHaveAttribute("aria-labelledby", chapterButtons[1].id);
 
     fireEvent.keyDown(chapterButtons[1], { key: "ArrowUp" });
     expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(basicBlocks[0].title);
@@ -160,7 +180,7 @@ describe("LearningPanel chapter navigation (#787)", () => {
   it("moves keyboard focus from a chosen chapter into its content and primary action", async () => {
     const user = userEvent.setup();
     renderPanel();
-    const chapterButtons = screen.getAllByRole("button", {
+    const chapterButtons = screen.getAllByRole("tab", {
       name: (name) => name.startsWith("查看：")
     });
 
@@ -181,7 +201,7 @@ describe("LearningPanel furigana (#618)", () => {
 
   function openTargetChapter() {
     fireEvent.click(
-      screen.getByRole("button", {
+      screen.getByRole("tab", {
         name: (name) => name.includes(target.title)
       })
     );

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -256,7 +256,12 @@ export function LearningPanel({
             <p>{t.chapterIntro}</p>
           </div>
 
-          <div className="chapter-list">
+          <div
+            className="chapter-list"
+            role="tablist"
+            aria-label={t.chapterIndexLabel}
+            aria-orientation="vertical"
+          >
             {chapterGroups.map(({ category, label, cards }) => (
               <div className="chapter-group" key={category}>
                 <p className="chapter-group-title">{label}</p>
@@ -273,10 +278,12 @@ export function LearningPanel({
                   return (
                     <button
                       key={block.id}
+                      id={`chapter-tab-${block.id}`}
                       type="button"
+                      role="tab"
                       className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
                       aria-label={t.chapterViewLabel(disp.title)}
-                      aria-pressed={block.id === active.id}
+                      aria-selected={block.id === active.id}
                       ref={(button) => {
                         if (button) chapterButtonRefs.current.set(block.id, button);
                         else chapterButtonRefs.current.delete(block.id);
@@ -314,7 +321,11 @@ export function LearningPanel({
         </aside>
 
         <LearningFuriganaBoundary>
-        <section className="chapter-content" aria-labelledby="active-chapter-title">
+        <section
+          className="chapter-content"
+          role="tabpanel"
+          aria-labelledby={`chapter-tab-${active.id}`}
+        >
           <div className="chapter-content-head">
             <p className="eyebrow">{active.kicker ?? active.category}</p>
             <h3 id="active-chapter-title" ref={activeHeadingRef} tabIndex={-1}>{active.title}</h3>

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { AlertTriangle, ArrowRight, ChevronDown } from "lucide-react";
 import { copy, type Language } from "../i18n";
 import type { Attempt } from "../domain/types";
@@ -93,6 +93,46 @@ export function LearningPanel({
   // logic field (id / drills / examDrill / requiredForms …) and only swaps the
   // Chinese display text, so it's safe to use for both rendering and handlers.
   const active = localizeLearningBlock(activeCard.block, language, overlays);
+  const chapterButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const activeHeadingRef = useRef<HTMLHeadingElement>(null);
+  const pendingFocusTarget = useRef<"chapter" | "content" | null>(null);
+
+  useEffect(() => {
+    const focusTarget = pendingFocusTarget.current;
+    pendingFocusTarget.current = null;
+    if (focusTarget === "chapter") {
+      chapterButtonRefs.current.get(activeCard.block.id)?.focus({ preventScroll: true });
+      return;
+    }
+    if (focusTarget === "content") {
+      activeHeadingRef.current?.focus({ preventScroll: true });
+      activeHeadingRef.current?.scrollIntoView?.({ block: "start" });
+    }
+  }, [activeCard.block.id]);
+
+  const selectChapter = (blockId: string, focusTarget: "chapter" | "content") => {
+    if (blockId === activeCard.block.id) {
+      if (focusTarget === "chapter") {
+        chapterButtonRefs.current.get(blockId)?.focus({ preventScroll: true });
+      } else {
+        activeHeadingRef.current?.focus({ preventScroll: true });
+        activeHeadingRef.current?.scrollIntoView?.({ block: "start" });
+      }
+      return;
+    }
+    pendingFocusTarget.current = focusTarget;
+    setSelectedBlockId(blockId);
+  };
+
+  const handleChapterKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    let nextIndex: number | null = null;
+    if (event.key === "ArrowDown") nextIndex = Math.min(index + 1, blockCards.length - 1);
+    if (event.key === "ArrowUp") nextIndex = Math.max(index - 1, 0);
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    selectChapter(blockCards[nextIndex].block.id, "chapter");
+  };
 
   // Group chapters by category so the rail reads as a few labelled sections
   // instead of one long flat list where every card repeats a coloured kicker
@@ -233,8 +273,17 @@ export function LearningPanel({
                       className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
                       aria-label={t.chapterViewLabel(disp.title)}
                       aria-pressed={block.id === active.id}
+                      ref={(button) => {
+                        if (button) chapterButtonRefs.current.set(block.id, button);
+                        else chapterButtonRefs.current.delete(block.id);
+                      }}
+                      tabIndex={block.id === active.id ? 0 : -1}
+                      onKeyDown={(event) => handleChapterKeyDown(
+                        event,
+                        blockCards.findIndex((card) => card.block.id === block.id)
+                      )}
                       onClick={() => {
-                        setSelectedBlockId(block.id);
+                        selectChapter(block.id, "content");
                         // Collapse the mobile index so the picked material is
                         // immediately in view (no-op visually on desktop).
                         setIndexOpen(false);
@@ -264,7 +313,7 @@ export function LearningPanel({
         <section className="chapter-content" aria-labelledby="active-chapter-title">
           <div className="chapter-content-head">
             <p className="eyebrow">{active.kicker ?? active.category}</p>
-            <h3 id="active-chapter-title">{active.title}</h3>
+            <h3 id="active-chapter-title" ref={activeHeadingRef} tabIndex={-1}>{active.title}</h3>
             <p>{active.explanation}</p>
             {active.subtitle ? (
               <div className="focus-formula" aria-label={t.chapterExampleLabel(active.title)}>

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -101,7 +101,9 @@ export function LearningPanel({
     const focusTarget = pendingFocusTarget.current;
     pendingFocusTarget.current = null;
     if (focusTarget === "chapter") {
-      chapterButtonRefs.current.get(activeCard.block.id)?.focus({ preventScroll: true });
+      const chapterButton = chapterButtonRefs.current.get(activeCard.block.id);
+      chapterButton?.focus({ preventScroll: true });
+      chapterButton?.scrollIntoView?.({ block: "nearest" });
       return;
     }
     if (focusTarget === "content") {
@@ -113,7 +115,9 @@ export function LearningPanel({
   const selectChapter = (blockId: string, focusTarget: "chapter" | "content") => {
     if (blockId === activeCard.block.id) {
       if (focusTarget === "chapter") {
-        chapterButtonRefs.current.get(blockId)?.focus({ preventScroll: true });
+        const chapterButton = chapterButtonRefs.current.get(blockId);
+        chapterButton?.focus({ preventScroll: true });
+        chapterButton?.scrollIntoView?.({ block: "nearest" });
       } else {
         activeHeadingRef.current?.focus({ preventScroll: true });
         activeHeadingRef.current?.scrollIntoView?.({ block: "start" });

--- a/src/components/LearningPanel.tsx
+++ b/src/components/LearningPanel.tsx
@@ -130,8 +130,8 @@ export function LearningPanel({
 
   const handleChapterKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
     let nextIndex: number | null = null;
-    if (event.key === "ArrowDown") nextIndex = Math.min(index + 1, blockCards.length - 1);
-    if (event.key === "ArrowUp") nextIndex = Math.max(index - 1, 0);
+    if (event.key === "ArrowDown") nextIndex = (index + 1) % blockCards.length;
+    if (event.key === "ArrowUp") nextIndex = (index - 1 + blockCards.length) % blockCards.length;
     if (nextIndex === null) return;
 
     event.preventDefault();
@@ -284,6 +284,7 @@ export function LearningPanel({
                       className={`chapter-list-button${block.id === active.id ? " selected" : ""}${complete ? " complete" : ""}`}
                       aria-label={t.chapterViewLabel(disp.title)}
                       aria-selected={block.id === active.id}
+                      aria-controls="active-chapter-panel"
                       ref={(button) => {
                         if (button) chapterButtonRefs.current.set(block.id, button);
                         else chapterButtonRefs.current.delete(block.id);
@@ -322,6 +323,7 @@ export function LearningPanel({
 
         <LearningFuriganaBoundary>
         <section
+          id="active-chapter-panel"
           className="chapter-content"
           role="tabpanel"
           aria-labelledby={`chapter-tab-${active.id}`}

--- a/src/styles/learning.css
+++ b/src/styles/learning.css
@@ -22,13 +22,11 @@
   display: none;
 }
 
-/* With the long chapter list, keep the detail panel in view as you scroll
-   the index rather than leaving it stranded above the fold. Cap it to the
-   viewport and let it scroll on its own: a sticky panel taller than the
-   screen pins its overflow out of reach until the page bottom (reported
-   as "content won't scroll" / "chapter drill only visible at the very
-   bottom"). */
-.chapter-content {
+/* The chapter index is intentionally the bounded desktop rail. Keeping its
+   74 entries out of page flow lets the selected lesson and drill use the
+   document scrollbar, instead of trapping them in a second full-height
+   scrollbar that is easy to miss. */
+.chapter-index {
   max-height: calc(100vh - 2rem);
   overflow-y: auto;
   position: sticky;

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -36,6 +36,9 @@
      and the sidebar intro copy is desktop-only. */
   .chapter-index {
     display: contents;
+    max-height: none;
+    overflow-y: visible;
+    position: static;
   }
 
   .chapter-index-copy {


### PR DESCRIPTION
## Summary

- move the bounded desktop scroller from selected Learn content to the long chapter index
- keep selected chapter content and its primary drill in normal document flow
- add roving keyboard navigation, predictable heading focus, and nearest visibility for long-rail Arrow navigation while preserving #608 mobile behavior

## Dispositions

- `7d2a0c72`: reproduced on current desktop. A prior change avoided literal page-bottom traversal, but the selected CTA remained hidden inside an undiscoverable right-column inner scroller.
- `6132d5c2`: partially reproduced on desktop as the wrong-column/nested-scroll trap. It does not reproduce at 768px or 390×844, where #608 already restores one document scroller.

At 1280×844, the page measured 8,348px with 74 chapter buttons and a 1,243px content pane inside an 812px inner scroller. After the fix, the page is 1,478px, the long chapter index is the intentional sticky/bounded scroller, and selected content/drill use document scroll. Wheel input at the rail boundary propagates to the page. The keyboard path is one roving Tab stop → Arrow navigation → Enter/click → focused chapter heading → Tab to the primary action.

The final browser backend was unavailable for replay after the roving-visibility follow-up; earlier 1280/768/390 measured smoke evidence remains applicable because the final commit changes only keyboard `scrollIntoView({ block: "nearest" })`, not layout CSS. This limitation is not presented as completed browser evidence.

PR review follow-up: the chapter rail now implements a conforming labelled vertical tabs composite. Every stable-id `tab` exposes `aria-selected`, roving `tabIndex`, and `aria-controls` resolving to the stable `tabpanel`; the panel uses `aria-labelledby` for the selected tab. ArrowDown wraps last→first and ArrowUp wraps first→last while preserving focus, selection, panel association, and nearest rail visibility. Conflicting `aria-pressed` state was removed.

No production feedback rows or contact/account data were read or modified.

## Validation

- strict TDD initial RED 6/2, then GREEN 8/0
- review follow-up RED 8/1, then GREEN 9/0 for nearest roving visibility
- affected App/Learning tests: pass 85/85
- measured browser smoke before follow-up: 1280×844, 768×844, 390×844 pass
- `VITEST_MAX_WORKERS=1 pnpm verify:full`: pass on exact HEAD `7fde373a84559de00bd4efc16698fdd98f6219aa`
- diff checks: pass; worktree clean
- independent exact-final review: Standards/Spec PASS; no code findings

Closes #787
