### PR TITLE
Add composable focused-practice filters

### DIFF
--- a/src/components/challenge/ModePicker.test.tsx
+++ b/src/components/challenge/ModePicker.test.tsx
@@ -1,23 +1,22 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ModePicker } from "./ModePicker";
-import type { PracticeSession } from "../../hooks/usePracticeSession";
-import type { Language } from "../../i18n";
-import type { LevelRange } from "../../domain/levelRange";
+
+type ModePickerProps = Parameters<typeof ModePicker>[0];
 
 // ModePicker is a pure presentation component over the practice session's
 // state + handlers, so a full mock prop object exercises the render paths
 // without mounting the hook.
-const base = {
-  language: "zh-Hant" as Language,
+const base: ModePickerProps = {
+  language: "zh-Hant",
   partOfSpeech: "mixed",
-  verbGroup: "all",
+  practiceFilter: {},
   practiceFocus: "single",
   practiceMode: "vocab",
-  levelRange: "all" as LevelRange,
+  levelRange: "all",
   showLevelRange: true,
   selectedForm: "reading",
-  setVerbGroup: vi.fn(),
   setTargetForm: vi.fn(),
   compatibleForms: ["reading", "meaning"],
   isVerbCapable: true,
@@ -37,14 +36,13 @@ const base = {
   },
   handlePartOfSpeechChange: vi.fn(),
   handlePracticeFocusChange: vi.fn(),
+  handlePracticeFilterChange: vi.fn(),
   applyModePreset: vi.fn(),
   handleLevelRangeChange: vi.fn(),
   resetSession: vi.fn()
-} satisfies Pick<PracticeSession, "partOfSpeech" | "verbGroup" | "practiceFocus" | "practiceMode" | "levelRange" | "showLevelRange" | "selectedForm" | "setVerbGroup" | "setTargetForm" | "compatibleForms" | "isVerbCapable" | "availableFocusOptions" | "focusSummary" | "reviewQueue" | "bookmarkedQuestions" | "modeCounts" | "handlePartOfSpeechChange" | "handlePracticeFocusChange" | "applyModePreset" | "handleLevelRangeChange" | "resetSession"> & {
-  language: Language;
 };
 
-function renderPicker(overrides: Partial<typeof base> = {}) {
+function renderPicker(overrides: Partial<ModePickerProps> = {}) {
   return render(<ModePicker {...base} {...overrides} />);
 }
 
@@ -68,5 +66,136 @@ describe("ModePicker vocab level-range picker (#668)", () => {
   it("does not offer the starter band (完全新手 drills 入門 content, never 単字)", () => {
     renderPicker();
     expect(screen.queryByRole("button", { name: "完全新手" })).not.toBeInTheDocument();
+  });
+});
+
+describe("ModePicker basic composable filters (#789)", () => {
+  it("renders compact accessible level and verb-group multi-selects", () => {
+    const { container } = renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      practiceFilter: {
+        levels: ["N3", "N4", "N5"],
+        verbGroups: ["godan", "ichidan"]
+      }
+    });
+
+    const levels = screen.getByRole("group", { name: "題庫範圍" });
+    expect(Array.from(levels.querySelectorAll("button")).map((button) => button.textContent)).toEqual([
+      "全部",
+      "N1",
+      "N2",
+      "N3",
+      "N4",
+      "N5"
+    ]);
+    expect(within(levels).getByRole("button", { name: "全部" })).toHaveAttribute("aria-pressed", "false");
+    expect(within(levels).getByRole("button", { name: "N3" })).toHaveAttribute("aria-pressed", "true");
+    expect(within(levels).getByRole("button", { name: "N4" })).toHaveAttribute("aria-pressed", "true");
+    expect(within(levels).getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "true");
+
+    const groups = screen.getByRole("group", { name: "動詞類別" });
+    expect(Array.from(groups.querySelectorAll("button")).map((button) => button.textContent)).toEqual([
+      "全部",
+      "一類",
+      "二類",
+      "三類"
+    ]);
+    expect(within(groups).getByRole("button", { name: "一類" })).toHaveAttribute("aria-pressed", "true");
+    expect(within(groups).getByRole("button", { name: "二類" })).toHaveAttribute("aria-pressed", "true");
+    expect(within(groups).getByRole("button", { name: "三類" })).toHaveAttribute("aria-pressed", "false");
+    expect(container.querySelectorAll(".level-segmented")).toHaveLength(2);
+  });
+
+  it("adds a level with keyboard activation and starts one canonical filter change", async () => {
+    const user = userEvent.setup();
+    const handlePracticeFilterChange = vi.fn();
+    renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      practiceFilter: {
+        levels: ["N3", "N5"],
+        verbGroups: ["godan", "ichidan"]
+      },
+      handlePracticeFilterChange
+    });
+
+    const levels = screen.getByRole("group", { name: "題庫範圍" });
+    const n4 = within(levels).getByRole("button", { name: "N4" });
+    n4.focus();
+    await user.keyboard("{Enter}");
+
+    expect(handlePracticeFilterChange).toHaveBeenCalledTimes(1);
+    expect(handlePracticeFilterChange).toHaveBeenCalledWith({
+      levels: ["N3", "N4", "N5"],
+      verbGroups: ["godan", "ichidan"]
+    });
+  });
+
+  it("toggles multiple verb groups without collapsing to one scalar value", () => {
+    const handlePracticeFilterChange = vi.fn();
+    renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      practiceFilter: { levels: ["N5"], verbGroups: ["godan"] },
+      handlePracticeFilterChange
+    });
+
+    const groups = screen.getByRole("group", { name: "動詞類別" });
+    fireEvent.click(within(groups).getByRole("button", { name: "二類" }));
+
+    expect(handlePracticeFilterChange).toHaveBeenCalledWith({
+      levels: ["N5"],
+      verbGroups: ["godan", "ichidan"]
+    });
+  });
+
+  it("uses All to remove each restriction without changing the other filter", () => {
+    const handlePracticeFilterChange = vi.fn();
+    renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      practiceFilter: {
+        levels: ["N3", "N4", "N5"],
+        verbGroups: ["godan", "ichidan"]
+      },
+      handlePracticeFilterChange
+    });
+
+    const levels = screen.getByRole("group", { name: "題庫範圍" });
+    fireEvent.click(within(levels).getByRole("button", { name: "全部" }));
+    expect(handlePracticeFilterChange).toHaveBeenLastCalledWith({
+      levels: undefined,
+      verbGroups: ["godan", "ichidan"]
+    });
+
+    const groups = screen.getByRole("group", { name: "動詞類別" });
+    fireEvent.click(within(groups).getByRole("button", { name: "全部" }));
+    expect(handlePracticeFilterChange).toHaveBeenLastCalledWith({
+      levels: ["N3", "N4", "N5"],
+      verbGroups: undefined
+    });
+  });
+
+  it("keeps both compact multi-select rows available at a mobile viewport", () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 360 });
+
+    const { container } = renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      practiceFilter: {}
+    });
+
+    expect(container.querySelectorAll(".level-segmented")).toHaveLength(2);
+    expect(screen.getByRole("group", { name: "題庫範圍" }).querySelectorAll("button")).toHaveLength(6);
+    expect(screen.getByRole("group", { name: "動詞類別" }).querySelectorAll("button")).toHaveLength(4);
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
   });
 });

--- a/src/components/challenge/ModePicker.test.tsx
+++ b/src/components/challenge/ModePicker.test.tsx
@@ -19,7 +19,8 @@ const base: ModePickerProps = {
   selectedForm: "reading",
   setTargetForm: vi.fn(),
   compatibleForms: ["reading", "meaning"],
-  isVerbCapable: true,
+  availableBasicLevels: ["N1", "N2", "N3", "N4", "N5"],
+  selectedVerbGroups: undefined,
   availableFocusOptions: [],
   focusSummary: "N1〜N5 漢字詞 · 選正確讀音（よみ）",
   reviewQueue: [],
@@ -37,6 +38,7 @@ const base: ModePickerProps = {
   handlePartOfSpeechChange: vi.fn(),
   handlePracticeFocusChange: vi.fn(),
   handlePracticeFilterChange: vi.fn(),
+  handleVerbGroupsChange: vi.fn(),
   applyModePreset: vi.fn(),
   handleLevelRangeChange: vi.fn(),
   resetSession: vi.fn()
@@ -70,13 +72,15 @@ describe("ModePicker vocab level-range picker (#668)", () => {
 });
 
 describe("ModePicker basic composable filters (#789)", () => {
-  it("renders compact accessible level and verb-group multi-selects", () => {
+  it("renders accessible level and verb-group multi-selects", () => {
     const { container } = renderPicker({
       practiceMode: "basic",
       showLevelRange: false,
       partOfSpeech: "verb",
+      availableBasicLevels: ["N5"],
+      selectedVerbGroups: ["godan", "ichidan"],
       practiceFilter: {
-        levels: ["N3", "N4", "N5"],
+        levels: ["N5"],
         verbGroups: ["godan", "ichidan"]
       }
     });
@@ -91,8 +95,6 @@ describe("ModePicker basic composable filters (#789)", () => {
       "N5"
     ]);
     expect(within(levels).getByRole("button", { name: "全部" })).toHaveAttribute("aria-pressed", "false");
-    expect(within(levels).getByRole("button", { name: "N3" })).toHaveAttribute("aria-pressed", "true");
-    expect(within(levels).getByRole("button", { name: "N4" })).toHaveAttribute("aria-pressed", "true");
     expect(within(levels).getByRole("button", { name: "N5" })).toHaveAttribute("aria-pressed", "true");
 
     const groups = screen.getByRole("group", { name: "動詞類別" });
@@ -114,10 +116,9 @@ describe("ModePicker basic composable filters (#789)", () => {
     renderPicker({
       practiceMode: "basic",
       showLevelRange: false,
-      partOfSpeech: "verb",
+      partOfSpeech: "noun",
       practiceFilter: {
-        levels: ["N3", "N5"],
-        verbGroups: ["godan", "ichidan"]
+        levels: ["N3", "N5"]
       },
       handlePracticeFilterChange
     });
@@ -129,41 +130,73 @@ describe("ModePicker basic composable filters (#789)", () => {
 
     expect(handlePracticeFilterChange).toHaveBeenCalledTimes(1);
     expect(handlePracticeFilterChange).toHaveBeenCalledWith({
-      levels: ["N3", "N4", "N5"],
-      verbGroups: ["godan", "ichidan"]
+      levels: ["N3", "N4", "N5"]
     });
   });
 
-  it("toggles multiple verb groups without collapsing to one scalar value", () => {
+  it("disables unsupported verb levels derived by the hook", async () => {
+    const user = userEvent.setup();
     const handlePracticeFilterChange = vi.fn();
+    renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "verb",
+      availableBasicLevels: ["N5"],
+      handlePracticeFilterChange
+    });
+
+    const levels = screen.getByRole("group", { name: "題庫範圍" });
+    for (const level of ["N1", "N2", "N3", "N4"]) {
+      expect(within(levels).getByRole("button", { name: level })).toBeDisabled();
+    }
+    expect(within(levels).getByRole("button", { name: "N5" })).toBeEnabled();
+
+    await user.click(within(levels).getByRole("button", { name: "N3" }));
+    expect(handlePracticeFilterChange).not.toHaveBeenCalled();
+  });
+
+  it("hides verb-group choices for mixed practice", () => {
+    renderPicker({
+      practiceMode: "basic",
+      showLevelRange: false,
+      partOfSpeech: "mixed",
+      selectedVerbGroups: ["godan"]
+    });
+
+    expect(screen.queryByRole("group", { name: "動詞類別" })).not.toBeInTheDocument();
+  });
+
+  it("toggles multiple verb groups without collapsing to one scalar value", () => {
+    const handleVerbGroupsChange = vi.fn();
     renderPicker({
       practiceMode: "basic",
       showLevelRange: false,
       partOfSpeech: "verb",
       practiceFilter: { levels: ["N5"], verbGroups: ["godan"] },
-      handlePracticeFilterChange
+      selectedVerbGroups: ["godan"],
+      handleVerbGroupsChange
     });
 
     const groups = screen.getByRole("group", { name: "動詞類別" });
     fireEvent.click(within(groups).getByRole("button", { name: "二類" }));
 
-    expect(handlePracticeFilterChange).toHaveBeenCalledWith({
-      levels: ["N5"],
-      verbGroups: ["godan", "ichidan"]
-    });
+    expect(handleVerbGroupsChange).toHaveBeenCalledWith(["godan", "ichidan"]);
   });
 
   it("uses All to remove each restriction without changing the other filter", () => {
     const handlePracticeFilterChange = vi.fn();
+    const handleVerbGroupsChange = vi.fn();
     renderPicker({
       practiceMode: "basic",
       showLevelRange: false,
       partOfSpeech: "verb",
       practiceFilter: {
-        levels: ["N3", "N4", "N5"],
+        levels: ["N5"],
         verbGroups: ["godan", "ichidan"]
       },
-      handlePracticeFilterChange
+      selectedVerbGroups: ["godan", "ichidan"],
+      handlePracticeFilterChange,
+      handleVerbGroupsChange
     });
 
     const levels = screen.getByRole("group", { name: "題庫範圍" });
@@ -175,27 +208,20 @@ describe("ModePicker basic composable filters (#789)", () => {
 
     const groups = screen.getByRole("group", { name: "動詞類別" });
     fireEvent.click(within(groups).getByRole("button", { name: "全部" }));
-    expect(handlePracticeFilterChange).toHaveBeenLastCalledWith({
-      levels: ["N3", "N4", "N5"],
-      verbGroups: undefined
-    });
+    expect(handleVerbGroupsChange).toHaveBeenLastCalledWith(undefined);
   });
 
-  it("keeps both compact multi-select rows available at a mobile viewport", () => {
-    const originalWidth = window.innerWidth;
-    Object.defineProperty(window, "innerWidth", { configurable: true, value: 360 });
-
+  it("keeps both multi-select rows and every control in the accessible DOM", () => {
     const { container } = renderPicker({
       practiceMode: "basic",
       showLevelRange: false,
       partOfSpeech: "verb",
+      availableBasicLevels: ["N5"],
       practiceFilter: {}
     });
 
     expect(container.querySelectorAll(".level-segmented")).toHaveLength(2);
     expect(screen.getByRole("group", { name: "題庫範圍" }).querySelectorAll("button")).toHaveLength(6);
     expect(screen.getByRole("group", { name: "動詞類別" }).querySelectorAll("button")).toHaveLength(4);
-
-    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth });
   });
 });

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -58,7 +58,8 @@ export function ModePicker({
   selectedForm,
   setTargetForm,
   compatibleForms,
-  isVerbCapable,
+  availableBasicLevels,
+  selectedVerbGroups,
   availableFocusOptions,
   focusSummary,
   reviewQueue,
@@ -67,6 +68,7 @@ export function ModePicker({
   handlePartOfSpeechChange,
   handlePracticeFocusChange,
   handlePracticeFilterChange,
+  handleVerbGroupsChange,
   applyModePreset,
   handleLevelRangeChange,
   resetSession
@@ -81,7 +83,8 @@ export function ModePicker({
   | "selectedForm"
   | "setTargetForm"
   | "compatibleForms"
-  | "isVerbCapable"
+  | "availableBasicLevels"
+  | "selectedVerbGroups"
   | "availableFocusOptions"
   | "focusSummary"
   | "reviewQueue"
@@ -90,6 +93,7 @@ export function ModePicker({
   | "handlePartOfSpeechChange"
   | "handlePracticeFocusChange"
   | "handlePracticeFilterChange"
+  | "handleVerbGroupsChange"
   | "applyModePreset"
   | "handleLevelRangeChange"
   | "resetSession"
@@ -205,6 +209,7 @@ export function ModePicker({
                     type="button"
                     className={selected ? "selected" : ""}
                     aria-pressed={selected}
+                    disabled={!availableBasicLevels.includes(level)}
                     onClick={() =>
                       handlePracticeFilterChange({
                         ...practiceFilter,
@@ -237,17 +242,15 @@ export function ModePicker({
             </fieldset>
           ) : null}
 
-          {isVerbCapable ? (
+          {partOfSpeech === "verb" ? (
             <fieldset>
               <legend>{t.verbGroup}</legend>
               <div className="segmented level-segmented">
                 <button
                   type="button"
-                  className={practiceFilter.verbGroups === undefined ? "selected" : ""}
-                  aria-pressed={practiceFilter.verbGroups === undefined}
-                  onClick={() =>
-                    handlePracticeFilterChange({ ...practiceFilter, verbGroups: undefined })
-                  }
+                  className={selectedVerbGroups === undefined ? "selected" : ""}
+                  aria-pressed={selectedVerbGroups === undefined}
+                  onClick={() => handleVerbGroupsChange(undefined)}
                 >
                   {t.verbGroups.all}
                 </button>
@@ -255,17 +258,12 @@ export function ModePicker({
                   <button
                     key={option}
                     type="button"
-                    className={practiceFilter.verbGroups?.includes(option) ? "selected" : ""}
-                    aria-pressed={practiceFilter.verbGroups?.includes(option) ?? false}
+                    className={selectedVerbGroups?.includes(option) ? "selected" : ""}
+                    aria-pressed={selectedVerbGroups?.includes(option) ?? false}
                     onClick={() =>
-                      handlePracticeFilterChange({
-                        ...practiceFilter,
-                        verbGroups: toggleSelection(
-                          verbGroupOptions,
-                          practiceFilter.verbGroups,
-                          option
-                        )
-                      })
+                      handleVerbGroupsChange(
+                        toggleSelection(verbGroupOptions, selectedVerbGroups, option)
+                      )
                     }
                   >
                     {t.verbGroups[option]}

--- a/src/components/challenge/ModePicker.tsx
+++ b/src/components/challenge/ModePicker.tsx
@@ -1,14 +1,24 @@
 import { RotateCcw } from "lucide-react";
 import { copy, type Language } from "../../i18n";
 import { JabikoMark } from "../JabikoMark";
-import type { PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
+import type { JlptLevel, PartOfSpeech, TargetForm, VerbGroup } from "../../domain/types";
 import { VOCAB_LEVEL_RANGE_OPTIONS } from "../../domain/levelRange";
 import { MODE_GROUPS } from "../../domain/practiceMode";
 import { type PracticeSession } from "../../hooks/usePracticeSession";
 
 const partOfSpeechOptions: Array<PartOfSpeech | "mixed"> = ["verb", "i_adjective", "na_adjective", "noun", "mixed"];
 
-const verbGroupOptions: Array<VerbGroup | "all"> = ["godan", "ichidan", "irregular", "all"];
+const jlptLevelOptions: JlptLevel[] = ["N1", "N2", "N3", "N4", "N5"];
+
+const verbGroupOptions: VerbGroup[] = ["godan", "ichidan", "irregular"];
+
+function toggleSelection<T>(options: readonly T[], selected: T[] | undefined, value: T): T[] {
+  if (selected === undefined) return [value];
+  const next = new Set(selected);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return options.filter((option) => next.has(option));
+}
 
 const formOptions: TargetForm[] = [
   "te",
@@ -40,13 +50,12 @@ const formOptions: TargetForm[] = [
 export function ModePicker({
   language,
   partOfSpeech,
-  verbGroup,
+  practiceFilter,
   practiceFocus,
   practiceMode,
   levelRange,
   showLevelRange,
   selectedForm,
-  setVerbGroup,
   setTargetForm,
   compatibleForms,
   isVerbCapable,
@@ -57,19 +66,19 @@ export function ModePicker({
   modeCounts,
   handlePartOfSpeechChange,
   handlePracticeFocusChange,
+  handlePracticeFilterChange,
   applyModePreset,
   handleLevelRangeChange,
   resetSession
 }: Pick<
   PracticeSession,
   | "partOfSpeech"
-  | "verbGroup"
+  | "practiceFilter"
   | "practiceFocus"
   | "practiceMode"
   | "levelRange"
   | "showLevelRange"
   | "selectedForm"
-  | "setVerbGroup"
   | "setTargetForm"
   | "compatibleForms"
   | "isVerbCapable"
@@ -80,6 +89,7 @@ export function ModePicker({
   | "modeCounts"
   | "handlePartOfSpeechChange"
   | "handlePracticeFocusChange"
+  | "handlePracticeFilterChange"
   | "applyModePreset"
   | "handleLevelRangeChange"
   | "resetSession"
@@ -174,6 +184,41 @@ export function ModePicker({
             </div>
           </fieldset>
 
+          <fieldset>
+            <legend>{t.levelRange}</legend>
+            <div className="segmented level-segmented">
+              <button
+                type="button"
+                className={practiceFilter.levels === undefined ? "selected" : ""}
+                aria-pressed={practiceFilter.levels === undefined}
+                onClick={() =>
+                  handlePracticeFilterChange({ ...practiceFilter, levels: undefined })
+                }
+              >
+                {t.levelRangeOptions.all}
+              </button>
+              {jlptLevelOptions.map((level) => {
+                const selected = practiceFilter.levels?.includes(level) ?? false;
+                return (
+                  <button
+                    key={level}
+                    type="button"
+                    className={selected ? "selected" : ""}
+                    aria-pressed={selected}
+                    onClick={() =>
+                      handlePracticeFilterChange({
+                        ...practiceFilter,
+                        levels: toggleSelection(jlptLevelOptions, practiceFilter.levels, level)
+                      })
+                    }
+                  >
+                    {level}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+
           {availableFocusOptions.length > 0 ? (
             <fieldset>
               <legend>{t.practiceFocus}</legend>
@@ -195,16 +240,33 @@ export function ModePicker({
           {isVerbCapable ? (
             <fieldset>
               <legend>{t.verbGroup}</legend>
-              <div className="segmented">
+              <div className="segmented level-segmented">
+                <button
+                  type="button"
+                  className={practiceFilter.verbGroups === undefined ? "selected" : ""}
+                  aria-pressed={practiceFilter.verbGroups === undefined}
+                  onClick={() =>
+                    handlePracticeFilterChange({ ...practiceFilter, verbGroups: undefined })
+                  }
+                >
+                  {t.verbGroups.all}
+                </button>
                 {verbGroupOptions.map((option) => (
                   <button
                     key={option}
                     type="button"
-                    className={verbGroup === option ? "selected" : ""}
-                    onClick={() => {
-                      setVerbGroup(option);
-                      resetSession();
-                    }}
+                    className={practiceFilter.verbGroups?.includes(option) ? "selected" : ""}
+                    aria-pressed={practiceFilter.verbGroups?.includes(option) ?? false}
+                    onClick={() =>
+                      handlePracticeFilterChange({
+                        ...practiceFilter,
+                        verbGroups: toggleSelection(
+                          verbGroupOptions,
+                          practiceFilter.verbGroups,
+                          option
+                        )
+                      })
+                    }
                   >
                     {t.verbGroups[option]}
                   </button>

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -13,6 +13,7 @@ import {
   buildModeCounts,
   buildPracticeQuestions,
   composeDailySet,
+  getAvailableBasicLevels,
   resolveBookmarkedQuestions,
   uniqueForms,
   type PracticePoolOptions
@@ -375,6 +376,23 @@ describe("buildPracticeQuestions", () => {
 });
 
 describe("buildPracticeQuestions basic composable filters (#789)", () => {
+  it("derives supported JLPT levels from the canonical basic vocabulary", () => {
+    expect(
+      getAvailableBasicLevels({
+        partOfSpeech: "verb",
+        verbGroup: "all",
+        targetForms: ["meaning"]
+      })
+    ).toEqual(["N5"]);
+    expect(
+      getAvailableBasicLevels({
+        partOfSpeech: "noun",
+        verbGroup: "all",
+        targetForms: ["meaning"]
+      })
+    ).toEqual(["N1", "N2", "N3", "N4", "N5"]);
+  });
+
   it("narrows the basic pool to one selected JLPT level", () => {
     const questions = buildPracticeQuestions(
       poolParams({
@@ -460,6 +478,57 @@ describe("buildPracticeQuestions basic composable filters (#789)", () => {
     );
 
     expect(questions).toEqual([]);
+  });
+
+  it("treats explicit verb groups as a verb-only filter in mixed practice", () => {
+    const selectedGroups = new Set(["godan", "ichidan"]);
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "mixed",
+        verbGroup: "irregular",
+        verbGroups: ["godan", "ichidan"],
+        targetForms: ["meaning"]
+      })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(
+      questions.every(
+        (question) =>
+          question.vocabulary.partOfSpeech === "verb" &&
+          question.vocabulary.group !== null &&
+          selectedGroups.has(question.vocabulary.group)
+      )
+    ).toBe(true);
+    expect(new Set(questions.map((question) => question.vocabulary.group))).toEqual(
+      new Set(["godan", "ichidan"])
+    );
+  });
+
+  it("keeps an explicitly empty verb-group selection empty in mixed practice", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "mixed", targetForms: ["meaning"], verbGroups: [] })
+    );
+
+    expect(questions).toEqual([]);
+  });
+
+  it("preserves legacy scalar mixed practice when no explicit group filter exists", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "mixed",
+        verbGroup: "godan",
+        verbGroups: undefined,
+        targetForms: ["meaning"]
+      })
+    );
+
+    expect(questions.some((question) => question.vocabulary.partOfSpeech !== "verb")).toBe(true);
+    expect(
+      questions
+        .filter((question) => question.vocabulary.partOfSpeech === "verb")
+        .every((question) => question.vocabulary.group === "godan")
+    ).toBe(true);
   });
 });
 

--- a/src/domain/sessionPools.test.ts
+++ b/src/domain/sessionPools.test.ts
@@ -374,6 +374,95 @@ describe("buildPracticeQuestions", () => {
   });
 });
 
+describe("buildPracticeQuestions basic composable filters (#789)", () => {
+  it("narrows the basic pool to one selected JLPT level", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "noun",
+        targetForms: ["meaning"],
+        levels: ["N4"]
+      })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((question) => question.vocabulary.level === "N4")).toBe(true);
+  });
+
+  it("unions selected JLPT levels within the basic pool", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "noun",
+        targetForms: ["meaning"],
+        levels: ["N3", "N4", "N5"]
+      })
+    );
+
+    expect(new Set(questions.map((question) => question.vocabulary.level))).toEqual(
+      new Set(["N3", "N4", "N5"])
+    );
+  });
+
+  it("unions selected verb groups and excludes unselected groups", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "verb",
+        verbGroup: "irregular",
+        verbGroups: ["godan", "ichidan"],
+        targetForms: ["meaning"]
+      })
+    );
+
+    expect(new Set(questions.map((question) => question.vocabulary.group))).toEqual(
+      new Set(["godan", "ichidan"])
+    );
+  });
+
+  it("intersects levels, part of speech, verb groups, and target forms", () => {
+    const selectedLevels = new Set(["N3", "N4", "N5"]);
+    const selectedGroups = new Set(["godan", "ichidan"]);
+    const questions = buildPracticeQuestions(
+      poolParams({
+        partOfSpeech: "verb",
+        verbGroups: ["godan", "ichidan"],
+        targetForms: ["meaning"],
+        levels: ["N3", "N4", "N5"]
+      })
+    );
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(new Set(questions.map((question) => question.vocabulary.group))).toEqual(
+      new Set(["godan", "ichidan"])
+    );
+    expect(
+      questions.every(
+        (question) =>
+          question.vocabulary.level !== undefined &&
+          selectedLevels.has(question.vocabulary.level) &&
+          question.vocabulary.partOfSpeech === "verb" &&
+          question.vocabulary.group !== null &&
+          selectedGroups.has(question.vocabulary.group) &&
+          question.targetForm === "meaning"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps an explicitly empty level selection empty", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "noun", targetForms: ["meaning"], levels: [] })
+    );
+
+    expect(questions).toEqual([]);
+  });
+
+  it("keeps an explicitly empty verb-group selection empty", () => {
+    const questions = buildPracticeQuestions(
+      poolParams({ partOfSpeech: "verb", targetForms: ["meaning"], verbGroups: [] })
+    );
+
+    expect(questions).toEqual([]);
+  });
+});
+
 describe("composeDailySet", () => {
   const makeDue = (n: number): PracticeQuestion[] => buildExamQuestionPool("N1").slice(0, n);
 

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -261,6 +261,56 @@ export type PracticePoolOptions = {
   attemptedIds?: Set<string>;
 };
 
+type BasicPracticePoolOptions = Pick<
+  PracticePoolOptions,
+  "partOfSpeech" | "levels" | "verbGroups" | "verbGroup" | "targetForms"
+>;
+
+const BASIC_JLPT_LEVEL_ORDER: readonly JlptLevel[] = ["N1", "N2", "N3", "N4", "N5"];
+
+function buildBasicQuestionPool({
+  partOfSpeech,
+  levels,
+  verbGroups,
+  verbGroup,
+  targetForms
+}: BasicPracticePoolOptions): PracticeQuestion[] {
+  const levelFiltered = vocabulary.filter(
+    (item) =>
+      levels === undefined ||
+      (item.level !== undefined && levels.includes(item.level))
+  );
+  // An explicit array is a canonical verb-only filter, including [] as an
+  // intentional zero state. Without one, preserve buildQuestionPool's legacy
+  // scalar semantics: mixed practice keeps non-verbs and narrows only verbs.
+  const source =
+    verbGroups === undefined
+      ? levelFiltered
+      : levelFiltered.filter(
+          (item) => item.group !== null && verbGroups.includes(item.group)
+        );
+
+  return buildQuestionPool(source, {
+    partOfSpeech,
+    verbGroup: verbGroups === undefined ? verbGroup : "all",
+    targetForms
+  });
+}
+
+// Derive the level picker's enabled choices from the exact canonical pool
+// predicate. This deliberately scans item.level metadata instead of encoding
+// today's verb-bank level as UI knowledge.
+export function getAvailableBasicLevels(
+  options: Omit<BasicPracticePoolOptions, "levels">
+): JlptLevel[] {
+  const available = new Set(
+    buildBasicQuestionPool({ ...options, levels: undefined })
+      .map((question) => question.vocabulary.level)
+      .filter((level): level is JlptLevel => level !== undefined)
+  );
+  return BASIC_JLPT_LEVEL_ORDER.filter((level) => available.has(level));
+}
+
 // Derives the active question pool for the current mode. This is the body
 // of usePracticeSession's `questions` memo, lifted out verbatim so every
 // mode/range branch (section-filtered exam, 綜合 level-range exam, cloze,
@@ -397,27 +447,9 @@ export function buildPracticeQuestions(options: PracticePoolOptions): PracticeQu
       return bookmarkedQuestions;
 
     case "basic": {
-      const selectedVerbGroups =
-        verbGroups ?? (verbGroup === "all" ? undefined : [verbGroup]);
-      const basicVocabulary = vocabulary
-        .filter(
-          (item) =>
-            levels === undefined ||
-            (item.level !== undefined && levels.includes(item.level))
-        )
-        .filter(
-          (item) =>
-            item.partOfSpeech !== "verb" ||
-            selectedVerbGroups === undefined ||
-            (item.group !== null && selectedVerbGroups.includes(item.group))
-        );
       return cap(
         shuffleQuestions(
-          buildQuestionPool(basicVocabulary, {
-            partOfSpeech,
-            verbGroup: "all",
-            targetForms
-          })
+          buildBasicQuestionPool({ partOfSpeech, levels, verbGroups, verbGroup, targetForms })
         )
       );
     }

--- a/src/domain/sessionPools.ts
+++ b/src/domain/sessionPools.ts
@@ -26,7 +26,7 @@ import {
   reduceAdjacentClusters,
   shuffleQuestions
 } from "./practice";
-import type { PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./types";
+import type { JlptLevel, PartOfSpeech, PracticeQuestion, TargetForm, VerbGroup } from "./types";
 import { prioritizeUnattempted } from "./unattempted";
 import { starterVocabulary } from "./starterVocabulary";
 import { vocabulary } from "./vocabulary";
@@ -233,6 +233,11 @@ export type PracticePoolOptions = {
   // Gojuon script for kana mode (#533); undefined -> hiragana.
   kanaScript?: KanaScript;
   partOfSpeech: PartOfSpeech | "mixed";
+  // Focused basic-practice filters. Undefined keeps every level / the
+  // legacy scalar verbGroup; an explicit empty array intentionally yields
+  // no matching basic questions.
+  levels?: JlptLevel[];
+  verbGroups?: VerbGroup[];
   verbGroup: VerbGroup | "all";
   targetForms: TargetForm[];
   levelRange: LevelRange;
@@ -268,6 +273,8 @@ export function buildPracticeQuestions(options: PracticePoolOptions): PracticeQu
     patternIds,
     kanaScript,
     partOfSpeech,
+    levels,
+    verbGroups,
     verbGroup,
     targetForms,
     levelRange,
@@ -389,16 +396,31 @@ export function buildPracticeQuestions(options: PracticePoolOptions): PracticeQu
       // review -- toggling a star mid-session doesn't reshuffle the live pass.
       return bookmarkedQuestions;
 
-    case "basic":
+    case "basic": {
+      const selectedVerbGroups =
+        verbGroups ?? (verbGroup === "all" ? undefined : [verbGroup]);
+      const basicVocabulary = vocabulary
+        .filter(
+          (item) =>
+            levels === undefined ||
+            (item.level !== undefined && levels.includes(item.level))
+        )
+        .filter(
+          (item) =>
+            item.partOfSpeech !== "verb" ||
+            selectedVerbGroups === undefined ||
+            (item.group !== null && selectedVerbGroups.includes(item.group))
+        );
       return cap(
         shuffleQuestions(
-          buildQuestionPool(vocabulary, {
+          buildQuestionPool(basicVocabulary, {
             partOfSpeech,
-            verbGroup,
+            verbGroup: "all",
             targetForms
           })
         )
       );
+    }
 
     default:
       return assertNever(mode);

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BOOKMARKS_KEY } from "../domain/bookmarks";
 import { buildAllKnownQuestions } from "../domain/sessionPools";
 import type { SentencePatternId } from "../domain/sentencePatterns";
-import type { Attempt, PracticeQuestion } from "../domain/types";
+import type { Attempt, JlptLevel, PracticeQuestion, VerbGroup } from "../domain/types";
 import {
   createPracticePoolSnapshot,
   initialLevelRange,
@@ -119,6 +119,31 @@ describe("usePracticeSession pool snapshot (#623)", () => {
     expect(n5Snapshot.examSection).toEqual({ level: "N5", promptLabel: "詞彙填空" });
   });
 
+  it("copies focused-practice level and verb-group arrays into the pass snapshot", () => {
+    const levels: JlptLevel[] = ["N3", "N4", "N5"];
+    const verbGroups: VerbGroup[] = ["godan", "ichidan"];
+    const snapshot = createPracticePoolSnapshot(
+      {
+        ...baseConfig,
+        filter: { levels, verbGroups },
+        targetForm: "meaning",
+        targetForms: ["meaning"]
+      },
+      liveInputs
+    );
+
+    expect(snapshot.levels).toEqual(["N3", "N4", "N5"]);
+    expect(snapshot.verbGroups).toEqual(["godan", "ichidan"]);
+    expect(snapshot.levels).not.toBe(levels);
+    expect(snapshot.verbGroups).not.toBe(verbGroups);
+
+    levels.splice(0, levels.length, "N1");
+    verbGroups.splice(0, verbGroups.length, "irregular");
+
+    expect(snapshot.levels).toEqual(["N3", "N4", "N5"]);
+    expect(snapshot.verbGroups).toEqual(["godan", "ichidan"]);
+  });
+
   // #679 — snapshot copy: the live inputs are captured by reference at pass
   // start; a later mutation of the caller's arrays must not corrupt the
   // stored pass (the hook hands in freshly-computed inputs each pass).
@@ -173,6 +198,101 @@ describe("usePracticeSession pool snapshot (#623)", () => {
     expect(result.current.bookmarksEmpty).toBe(true);
     expect(result.current.currentQuestion).toBeNull();
     expect(result.current.sessionTotal).toBe(0);
+  });
+});
+
+describe("usePracticeSession basic composable filters (#789)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("normalizes a legacy scalar verb-group launch when no filter is supplied", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          partOfSpeech: "verb",
+          verbGroup: "ichidan",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    expect(result.current.practiceFilter).toEqual({ verbGroups: ["ichidan"] });
+    expect(result.current.currentQuestion?.vocabulary.group).toBe("ichidan");
+  });
+
+  it("lets an explicit canonical filter override the legacy scalar launch field", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { verbGroups: ["godan"] },
+          partOfSpeech: "verb",
+          verbGroup: "ichidan",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    expect(result.current.currentQuestion?.vocabulary.group).toBe("godan");
+  });
+
+  it("keeps an explicit empty filter as a zero-question pass", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: [] },
+          partOfSpeech: "noun",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    expect(result.current.currentQuestion).toBeNull();
+    expect(result.current.sessionTotal).toBe(0);
+  });
+
+  it("starts a fresh pass and clears answer state when focused filters change", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: ["N5"], verbGroups: ["godan"] },
+          partOfSpeech: "verb",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    act(() => result.current.handleChoiceSubmit(result.current.choiceOptions[0]));
+    act(() => result.current.nextQuestion());
+    act(() => result.current.handleChoiceSubmit(result.current.choiceOptions[0]));
+    expect(result.current.attempts).toHaveLength(2);
+    expect(result.current.questionIndex).toBe(1);
+    expect(result.current.feedback).not.toBeNull();
+    expect(result.current.handlePracticeFilterChange).toBeTypeOf("function");
+
+    act(() =>
+      result.current.handlePracticeFilterChange({
+        levels: ["N5"],
+        verbGroups: ["ichidan"]
+      })
+    );
+
+    expect(result.current.practiceFilter).toEqual({
+      levels: ["N5"],
+      verbGroups: ["ichidan"]
+    });
+    expect(result.current.attempts).toEqual([]);
+    expect(result.current.questionIndex).toBe(0);
+    expect(result.current.feedback).toBeNull();
+    expect(result.current.currentQuestion?.vocabulary.group).toBe("ichidan");
   });
 });
 

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -365,6 +365,40 @@ describe("usePracticeSession basic composable filters (#789)", () => {
     expect(result.current.selectedVerbGroups).toBeUndefined();
   });
 
+  it("preserves basic filters across mode changes while clearing mode-specific filters", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: {
+            levels: ["N5"],
+            verbGroups: ["godan"],
+            kanaScript: "katakana"
+          },
+          partOfSpeech: "verb",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    act(() => result.current.applyModePreset("kana"));
+
+    expect(result.current.practiceFilter).toEqual({
+      levels: ["N5"],
+      verbGroups: ["godan"]
+    });
+
+    act(() => result.current.applyModePreset("basic"));
+
+    expect(result.current.practiceFilter).toEqual({
+      levels: ["N5"],
+      verbGroups: ["godan"]
+    });
+    expect(result.current.currentQuestion?.vocabulary.level).toBe("N5");
+    expect(result.current.currentQuestion?.vocabulary.group).toBe("godan");
+  });
+
   it("keeps an explicit empty filter as a zero-question pass", () => {
     const { result } = renderHook(() =>
       usePracticeSession({

--- a/src/hooks/usePracticeSession.test.ts
+++ b/src/hooks/usePracticeSession.test.ts
@@ -134,6 +134,7 @@ describe("usePracticeSession pool snapshot (#623)", () => {
 
     expect(snapshot.levels).toEqual(["N3", "N4", "N5"]);
     expect(snapshot.verbGroups).toEqual(["godan", "ichidan"]);
+    expect(snapshot.verbGroup).toBe("all");
     expect(snapshot.levels).not.toBe(levels);
     expect(snapshot.verbGroups).not.toBe(verbGroups);
 
@@ -142,6 +143,23 @@ describe("usePracticeSession pool snapshot (#623)", () => {
 
     expect(snapshot.levels).toEqual(["N3", "N4", "N5"]);
     expect(snapshot.verbGroups).toEqual(["godan", "ichidan"]);
+  });
+
+  it("preserves the legacy scalar in a snapshot when no explicit group array exists", () => {
+    const snapshot = createPracticePoolSnapshot(
+      {
+        ...baseConfig,
+        partOfSpeech: "mixed",
+        verbGroup: "ichidan",
+        filter: {},
+        targetForm: "meaning",
+        targetForms: ["meaning"]
+      },
+      liveInputs
+    );
+
+    expect(snapshot.verbGroups).toBeUndefined();
+    expect(snapshot.verbGroup).toBe("ichidan");
   });
 
   // #679 — snapshot copy: the live inputs are captured by reference at pass
@@ -206,7 +224,7 @@ describe("usePracticeSession basic composable filters (#789)", () => {
     window.localStorage.clear();
   });
 
-  it("normalizes a legacy scalar verb-group launch when no filter is supplied", () => {
+  it("preserves a legacy scalar verb-group launch when no explicit filter is supplied", () => {
     const { result } = renderHook(() =>
       usePracticeSession({
         ...baseHookArgs,
@@ -219,7 +237,9 @@ describe("usePracticeSession basic composable filters (#789)", () => {
       })
     );
 
-    expect(result.current.practiceFilter).toEqual({ verbGroups: ["ichidan"] });
+    expect(result.current.practiceFilter).toEqual({});
+    expect(result.current.selectedVerbGroups).toEqual(["ichidan"]);
+    expect(result.current.availableBasicLevels).toEqual(["N5"]);
     expect(result.current.currentQuestion?.vocabulary.group).toBe("ichidan");
   });
 
@@ -237,7 +257,112 @@ describe("usePracticeSession basic composable filters (#789)", () => {
       })
     );
 
+    expect(result.current.selectedVerbGroups).toEqual(["godan"]);
     expect(result.current.currentQuestion?.vocabulary.group).toBe("godan");
+  });
+
+  it("atomically prunes invalid selected levels when the part of speech changes", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: ["N3", "N5"] },
+          partOfSpeech: "mixed",
+          verbGroup: "godan",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    expect(result.current.availableBasicLevels).toEqual(["N1", "N2", "N3", "N4", "N5"]);
+
+    act(() => result.current.handlePartOfSpeechChange("verb"));
+
+    expect(result.current.practiceFilter.levels).toEqual(["N5"]);
+    expect(result.current.availableBasicLevels).toEqual(["N5"]);
+    expect(result.current.currentQuestion?.vocabulary.level).toBe("N5");
+  });
+
+  it("clears an explicit verb filter in the same pass when leaving verb practice", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: ["N5"], verbGroups: ["godan"] },
+          partOfSpeech: "verb",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    act(() => result.current.handlePartOfSpeechChange("noun"));
+
+    expect(result.current.practiceFilter.verbGroups).toBeUndefined();
+    expect(result.current.verbGroup).toBe("all");
+    expect(result.current.selectedVerbGroups).toBeUndefined();
+    expect(result.current.currentQuestion?.vocabulary.partOfSpeech).toBe("noun");
+  });
+
+  it("clears a newly invalid non-empty level selection but preserves an explicit empty one", () => {
+    const selected = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: ["N3"] },
+          partOfSpeech: "mixed",
+          targetForm: "meaning"
+        }
+      })
+    );
+    const empty = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          filter: { levels: [] },
+          partOfSpeech: "mixed",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    act(() => selected.result.current.handlePartOfSpeechChange("verb"));
+    act(() => empty.result.current.handlePartOfSpeechChange("verb"));
+
+    expect(selected.result.current.practiceFilter.levels).toBeUndefined();
+    expect(selected.result.current.currentQuestion?.vocabulary.level).toBe("N5");
+    expect(empty.result.current.practiceFilter.levels).toEqual([]);
+    expect(empty.result.current.currentQuestion).toBeNull();
+  });
+
+  it("makes explicit group changes authoritative and keeps All coherent with the scalar", () => {
+    const { result } = renderHook(() =>
+      usePracticeSession({
+        ...baseHookArgs,
+        init: {
+          mode: "basic",
+          partOfSpeech: "verb",
+          verbGroup: "ichidan",
+          targetForm: "meaning"
+        }
+      })
+    );
+
+    act(() => result.current.handleVerbGroupsChange(["godan"]));
+
+    expect(result.current.verbGroup).toBe("all");
+    expect(result.current.practiceFilter.verbGroups).toEqual(["godan"]);
+    expect(result.current.selectedVerbGroups).toEqual(["godan"]);
+    expect(result.current.currentQuestion?.vocabulary.group).toBe("godan");
+
+    act(() => result.current.handleVerbGroupsChange(undefined));
+
+    expect(result.current.verbGroup).toBe("all");
+    expect(result.current.practiceFilter.verbGroups).toBeUndefined();
+    expect(result.current.selectedVerbGroups).toBeUndefined();
   });
 
   it("keeps an explicit empty filter as a zero-question pass", () => {

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -22,7 +22,7 @@ import {
 } from "../domain/sessionPools";
 import { collectAttemptedIds } from "../domain/unattempted";
 import { getBookmarkedIds, toggleBookmark } from "../domain/bookmarks";
-import type { Attempt, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
+import type { Attempt, JlptLevel, PartOfSpeech, TargetForm, VerbGroup } from "../domain/types";
 import { readStored, writeStored } from "../domain/safeStorage";
 import { copy, type Language } from "../i18n";
 import { trackEvent } from "../lib/analytics";
@@ -50,6 +50,10 @@ export type PracticeFocus = "single" | "teTa" | "negative" | "plain" | "adverbia
 // many `import { PracticeMode } from "../hooks/usePracticeSession"` sites keep working.
 export type { PracticeMode };
 export type PracticeFilter = {
+  // Focused basic-practice filters. Undefined means no restriction; an
+  // explicit empty array intentionally produces a zero-question pass.
+  levels?: JlptLevel[];
+  verbGroups?: VerbGroup[];
   patternIds?: SentencePatternId[];
   // Narrows exam mode to one JLPT section (by level + promptLabel), set
   // when the learner taps a section card in the 模擬考 picker.
@@ -58,6 +62,25 @@ export type PracticeFilter = {
   // the 入門 chapter CTAs. Kana mode without it defaults to hiragana.
   kanaScript?: KanaScript;
 };
+
+function copyPracticeFilter(filter: PracticeFilter): PracticeFilter {
+  return {
+    ...filter,
+    levels: filter.levels === undefined ? undefined : [...filter.levels],
+    verbGroups: filter.verbGroups === undefined ? undefined : [...filter.verbGroups]
+  };
+}
+
+function legacyVerbGroupFilter(verbGroup: VerbGroup | "all"): PracticeFilter {
+  return verbGroup === "all" ? {} : { verbGroups: [verbGroup] };
+}
+
+function initialPracticeFilter(init: SessionInit | undefined): PracticeFilter {
+  if (init?.filter !== undefined) {
+    return copyPracticeFilter(init.filter);
+  }
+  return legacyVerbGroupFilter(init?.verbGroup ?? "godan");
+}
 
 // Initial configuration the challenge view is launched with. App sets
 // this (the "launch request") when the learner taps a learning-block
@@ -192,7 +215,7 @@ function makeInitialConfig(
 ): PracticeSessionConfig {
   const config = {
     mode: init?.mode ?? "daily",
-    filter: init?.filter ?? {},
+    filter: initialPracticeFilter(init),
     partOfSpeech: init?.partOfSpeech ?? "verb",
     verbGroup: init?.verbGroup ?? "godan",
     practiceFocus: init?.practiceFocus ?? "single",
@@ -216,8 +239,14 @@ export function createPracticePoolSnapshot(
     examSection: config.filter.examSection,
     patternIds: config.filter.patternIds,
     kanaScript: config.filter.kanaScript,
+    levels: config.filter.levels === undefined ? undefined : [...config.filter.levels],
+    verbGroups:
+      config.filter.verbGroups === undefined ? undefined : [...config.filter.verbGroups],
     partOfSpeech: config.partOfSpeech,
-    verbGroup: config.verbGroup,
+    // PracticePoolOptions keeps the scalar for direct legacy callers. Once a
+    // canonical filter exists, its arrays are authoritative; an omitted group
+    // array means all groups rather than falling back to an unrelated scalar.
+    verbGroup: config.filter.verbGroups === undefined ? "all" : config.verbGroup,
     targetForms: [...config.targetForms],
     levelRange: config.levelRange,
     sessionLength: config.sessionLength,
@@ -491,7 +520,11 @@ export function usePracticeSession({
   const updateConfig = (nextConfig: PracticeSessionConfig) => {
     // Resolve targetForms for the NEW config so a mode/focus/form change can
     // never carry a stale form set into the fresh pass (e.g. daily -> exam).
-    const next = { ...nextConfig, targetForms: resolveTargetForms(nextConfig) };
+    const next = {
+      ...nextConfig,
+      filter: copyPracticeFilter(nextConfig.filter),
+      targetForms: resolveTargetForms(nextConfig)
+    };
     configRef.current = next;
     setConfig(next);
     return next;
@@ -517,7 +550,14 @@ export function usePracticeSession({
   const setPartOfSpeech = (next: PartOfSpeech | "mixed") =>
     updateConfig({ ...configRef.current, partOfSpeech: next });
   const setVerbGroup = (next: VerbGroup | "all") =>
-    updateConfig({ ...configRef.current, verbGroup: next });
+    updateConfig({
+      ...configRef.current,
+      verbGroup: next,
+      filter: {
+        ...configRef.current.filter,
+        verbGroups: next === "all" ? undefined : [next]
+      }
+    });
   const setTargetForm = (next: TargetForm) =>
     updateConfig({ ...configRef.current, targetForm: next });
   const setPracticeFocus = (next: PracticeFocus) =>
@@ -526,6 +566,10 @@ export function usePracticeSession({
     updateConfig({ ...configRef.current, mode: next });
   const setPracticeFilter = (next: PracticeFilter) =>
     updateConfig({ ...configRef.current, filter: next });
+
+  const handlePracticeFilterChange = (nextFilter: PracticeFilter) => {
+    startNewPass({ ...configRef.current, filter: nextFilter });
+  };
 
   const handlePartOfSpeechChange = (nextPartOfSpeech: PartOfSpeech | "mixed") => {
     startNewPass({
@@ -551,7 +595,15 @@ export function usePracticeSession({
     // re-picked from the in-session picker -- not only on first mount (#199).
     const resolvedRange = nextRange ?? initialLevelRange({ mode: nextMode }, targetLevel);
     if (nextMode === practiceMode && resolvedRange === levelRange) return;
-    startNewPass({ ...configRef.current, mode: nextMode, levelRange: resolvedRange, filter: {} });
+    startNewPass({
+      ...configRef.current,
+      mode: nextMode,
+      levelRange: resolvedRange,
+      filter:
+        nextMode === "basic"
+          ? legacyVerbGroupFilter(configRef.current.verbGroup)
+          : {}
+    });
   };
 
   const handleLevelRangeChange = (nextRange: LevelRange) => {
@@ -684,6 +736,7 @@ export function usePracticeSession({
   return {
     partOfSpeech,
     verbGroup,
+    practiceFilter,
     practiceFocus,
     practiceMode,
     levelRange,
@@ -728,6 +781,7 @@ export function usePracticeSession({
     startedAtRef,
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
+    handlePracticeFilterChange,
     applyModePreset,
     handleLevelRangeChange,
     handleSessionLengthChange,

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -16,6 +16,7 @@ import {
   buildAllKnownQuestions,
   buildModeCounts,
   buildPracticeQuestions,
+  getAvailableBasicLevels,
   resolveBookmarkedQuestions,
   type PracticePoolOptions,
   uniqueForms
@@ -71,15 +72,11 @@ function copyPracticeFilter(filter: PracticeFilter): PracticeFilter {
   };
 }
 
-function legacyVerbGroupFilter(verbGroup: VerbGroup | "all"): PracticeFilter {
-  return verbGroup === "all" ? {} : { verbGroups: [verbGroup] };
-}
-
 function initialPracticeFilter(init: SessionInit | undefined): PracticeFilter {
   if (init?.filter !== undefined) {
     return copyPracticeFilter(init.filter);
   }
-  return legacyVerbGroupFilter(init?.verbGroup ?? "godan");
+  return {};
 }
 
 // Initial configuration the challenge view is launched with. App sets
@@ -209,6 +206,40 @@ export function resolveTargetForms(config: {
   return [...(focusOptions.find((option) => option.value === config.practiceFocus)?.targetForms ?? [selectedForm])];
 }
 
+function pruneUnavailableLevels(
+  levels: JlptLevel[] | undefined,
+  availableLevels: readonly JlptLevel[]
+): JlptLevel[] | undefined {
+  if (levels === undefined) return undefined;
+  if (levels.length === 0) return [];
+  const available = new Set(availableLevels);
+  const pruned = levels.filter((level) => available.has(level));
+  return pruned.length > 0 ? pruned : undefined;
+}
+
+function preparePracticeSessionConfig(
+  config: PracticeSessionConfig
+): PracticeSessionConfig {
+  const targetForms = resolveTargetForms(config);
+  const filter = copyPracticeFilter(config.filter);
+  if (config.mode !== "basic") return { ...config, filter, targetForms };
+
+  const availableLevels = getAvailableBasicLevels({
+    partOfSpeech: config.partOfSpeech,
+    verbGroups: filter.verbGroups,
+    verbGroup: config.verbGroup,
+    targetForms
+  });
+  return {
+    ...config,
+    filter: {
+      ...filter,
+      levels: pruneUnavailableLevels(filter.levels, availableLevels)
+    },
+    targetForms
+  };
+}
+
 function makeInitialConfig(
   init: SessionInit | undefined,
   targetLevel: LevelRange | null
@@ -223,7 +254,10 @@ function makeInitialConfig(
     levelRange: initialLevelRange(init, targetLevel),
     sessionLength: readSessionLength()
   };
-  return { ...config, targetForms: resolveTargetForms(config) };
+  return preparePracticeSessionConfig({
+    ...config,
+    targetForms: resolveTargetForms(config)
+  });
 }
 
 // Pure snapshot builder (#679): merges the static config with the live
@@ -243,10 +277,9 @@ export function createPracticePoolSnapshot(
     verbGroups:
       config.filter.verbGroups === undefined ? undefined : [...config.filter.verbGroups],
     partOfSpeech: config.partOfSpeech,
-    // PracticePoolOptions keeps the scalar for direct legacy callers. Once a
-    // canonical filter exists, its arrays are authoritative; an omitted group
-    // array means all groups rather than falling back to an unrelated scalar.
-    verbGroup: config.filter.verbGroups === undefined ? "all" : config.verbGroup,
+    // Explicit arrays are authoritative; without one, retain the scalar launch
+    // contract for legacy mixed/basic callers.
+    verbGroup: config.filter.verbGroups === undefined ? config.verbGroup : "all",
     targetForms: [...config.targetForms],
     levelRange: config.levelRange,
     sessionLength: config.sessionLength,
@@ -405,6 +438,25 @@ export function usePracticeSession({
   // the chosen word type / verb group / form), and "review" is dynamic
   // (the due count) so it's read from reviewQueue at render time.
   const modeCounts = useMemo(() => buildModeCounts(), []);
+  const selectedVerbGroups = useMemo(
+    () =>
+      practiceFilter.verbGroups === undefined
+        ? verbGroup === "all"
+          ? undefined
+          : [verbGroup]
+        : [...practiceFilter.verbGroups],
+    [practiceFilter.verbGroups, verbGroup]
+  );
+  const availableBasicLevels = useMemo(
+    () =>
+      getAvailableBasicLevels({
+        partOfSpeech,
+        verbGroups: practiceFilter.verbGroups,
+        verbGroup,
+        targetForms
+      }),
+    [partOfSpeech, practiceFilter.verbGroups, targetForms, verbGroup]
+  );
   const isVerbCapable = partOfSpeech === "verb" || partOfSpeech === "mixed";
   const availableFocusOptions = focusOptions.filter((option) => {
     if (option.verbOnly && !isVerbCapable) return false;
@@ -520,11 +572,7 @@ export function usePracticeSession({
   const updateConfig = (nextConfig: PracticeSessionConfig) => {
     // Resolve targetForms for the NEW config so a mode/focus/form change can
     // never carry a stale form set into the fresh pass (e.g. daily -> exam).
-    const next = {
-      ...nextConfig,
-      filter: copyPracticeFilter(nextConfig.filter),
-      targetForms: resolveTargetForms(nextConfig)
-    };
+    const next = preparePracticeSessionConfig(nextConfig);
     configRef.current = next;
     setConfig(next);
     return next;
@@ -555,7 +603,7 @@ export function usePracticeSession({
       verbGroup: next,
       filter: {
         ...configRef.current.filter,
-        verbGroups: next === "all" ? undefined : [next]
+        verbGroups: undefined
       }
     });
   const setTargetForm = (next: TargetForm) =>
@@ -571,10 +619,26 @@ export function usePracticeSession({
     startNewPass({ ...configRef.current, filter: nextFilter });
   };
 
+  const handleVerbGroupsChange = (nextVerbGroups: VerbGroup[] | undefined) => {
+    startNewPass({
+      ...configRef.current,
+      verbGroup: "all",
+      filter: {
+        ...configRef.current.filter,
+        verbGroups: nextVerbGroups === undefined ? undefined : [...nextVerbGroups]
+      }
+    });
+  };
+
   const handlePartOfSpeechChange = (nextPartOfSpeech: PartOfSpeech | "mixed") => {
+    const leavingVerbPractice = nextPartOfSpeech !== "verb";
     startNewPass({
       ...configRef.current,
       partOfSpeech: nextPartOfSpeech,
+      verbGroup: leavingVerbPractice ? "all" : configRef.current.verbGroup,
+      filter: leavingVerbPractice
+        ? { ...configRef.current.filter, verbGroups: undefined }
+        : configRef.current.filter,
       practiceFocus: "single",
       targetForm: nextPartOfSpeech === "verb" || nextPartOfSpeech === "mixed" ? "te" : "plainPresentNegative"
     });
@@ -599,10 +663,7 @@ export function usePracticeSession({
       ...configRef.current,
       mode: nextMode,
       levelRange: resolvedRange,
-      filter:
-        nextMode === "basic"
-          ? legacyVerbGroupFilter(configRef.current.verbGroup)
-          : {}
+      filter: {}
     });
   };
 
@@ -758,6 +819,8 @@ export function usePracticeSession({
     setPracticeFilter,
     compatibleForms,
     isVerbCapable,
+    availableBasicLevels,
+    selectedVerbGroups,
     availableFocusOptions,
     focusSummary,
     activeModeCopyKey,
@@ -782,6 +845,7 @@ export function usePracticeSession({
     handlePartOfSpeechChange,
     handlePracticeFocusChange,
     handlePracticeFilterChange,
+    handleVerbGroupsChange,
     applyModePreset,
     handleLevelRangeChange,
     handleSessionLengthChange,

--- a/src/hooks/usePracticeSession.ts
+++ b/src/hooks/usePracticeSession.ts
@@ -651,19 +651,24 @@ export function usePracticeSession({
   // The mode picker lists the exam pool as three side-by-side presets
   // (綜合 / N1 備考 / N2 備考), so picking one sets BOTH the mode and its
   // level range at once. Non-exam presets pass "all" (a no-op for the
-  // modes that ignore levelRange). Clearing the filter keeps the picker a
-  // "fresh mix" (a chapter drill button is what sets a patternIds filter).
+  // modes that ignore levelRange). Mode-specific filters are cleared so the
+  // picker starts a fresh mix, while focused-basic selections survive a
+  // round trip through another mode.
   const applyModePreset = (nextMode: PracticeMode, nextRange?: LevelRange) => {
     // An explicit range (the exam 綜合 / 備考 cards) wins; otherwise inherit
     // the global target preference, so daily / 単字 keep honouring it when
     // re-picked from the in-session picker -- not only on first mount (#199).
     const resolvedRange = nextRange ?? initialLevelRange({ mode: nextMode }, targetLevel);
     if (nextMode === practiceMode && resolvedRange === levelRange) return;
+    const { levels, verbGroups } = configRef.current.filter;
     startNewPass({
       ...configRef.current,
       mode: nextMode,
       levelRange: resolvedRange,
-      filter: {}
+      filter: {
+        ...(levels === undefined ? {} : { levels: [...levels] }),
+        ...(verbGroups === undefined ? {} : { verbGroups: [...verbGroups] })
+      }
     });
   };
 


### PR DESCRIPTION
## Summary

- add typed JLPT-level and multi-select verb-group filters to focused basic practice
- derive selectable levels from canonical pool eligibility and disable impossible combinations
- preserve legacy scalar launches while making explicit arrays authoritative, including explicit zero states
- start a fresh immutable pass for every configuration change without new persistence

## Validation

- RED: domain 62 pass / 3 fail; hook 36 pass / 5 fail plus a focused 41 pass / 1 fail; UI 6 pass / 4 fail
- GREEN: focused 118/118; affected 223/223
- `pnpm typecheck`
- `pnpm lint`
- `pnpm verify` (L1)
- `VITEST_MAX_WORKERS=1 pnpm verify:full` (L3: lint, full test, production build)
- `git diff --check`
- independent exact-HEAD review: Standards PASS, Spec PASS, Ready Yes; no blocking findings

Closes #789