### PR TITLE
fix(routes): canonicalize grammar level URLs

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -313,10 +313,9 @@ describe("App", () => {
 
       await user.click(screen.getByRole("button", { name: "瀏覽 N5" }));
       const breadcrumb = await screen.findByRole("navigation", { name: "目前位置" });
-      // In-app level navigation serializes the typed level (/grammar/N5);
-      // direct loads are lowercase (/grammar/n5). Both parse to the same route
-      // and render the identical Home > Grammar > N5 trail (#727 normalizes).
-      expect(window.location.pathname.toLowerCase()).toBe("/grammar/n5");
+      // In-app navigation uses the same lowercase canonical path as direct
+      // loads, sitemap, prerender, and SEO metadata (#805).
+      expect(window.location.pathname).toBe("/grammar/n5");
       expect(within(breadcrumb).getByRole("link", { name: "首頁" })).toHaveAttribute("href", "/");
       expect(within(breadcrumb).getByRole("link", { name: "文型" })).toHaveAttribute("href", "/grammar");
       expect(within(breadcrumb).getByText("N5")).toHaveAttribute("aria-current", "page");

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -234,6 +234,23 @@ describe("App", () => {
       expect(screen.queryByText("回到文型一覽")).not.toBeInTheDocument();
     });
 
+    it("replaces a legacy uppercase grammar-level URL instead of adding a history entry (#805)", async () => {
+      await import("./components/GrammarIndexPage");
+      window.history.replaceState({}, "", "/grammar/N5");
+      const replaceState = vi.spyOn(window.history, "replaceState");
+      const pushState = vi.spyOn(window.history, "pushState");
+
+      try {
+        render(<App />);
+        await waitFor(() => expect(window.location.pathname).toBe("/grammar/n5"));
+        expect(replaceState).toHaveBeenCalledWith({ view: "grammar" }, "", "/grammar/n5");
+        expect(pushState).not.toHaveBeenCalled();
+      } finally {
+        replaceState.mockRestore();
+        pushState.mockRestore();
+      }
+    });
+
     it("direct-load /grammar/<surface>: current crumb is the surface with lang=ja", async () => {
       await import("./components/GrammarPointPage");
       const { allGrammarSurfaces } = await import("./domain/grammarPoints");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ import { kanjiDefaultLevel, type LevelRange } from "./domain/levelRange";
 import { trackEvent } from "./lib/analytics";
 import {
   grammarRoute,
+  isEquivalentGrammarLevelPath,
   parseRoute,
   serializeRoute,
   staticRoute,
@@ -163,7 +164,12 @@ export default function App() {
   useEffect(() => {
     const target = serializeRoute(route);
     if (window.location.pathname !== target) {
-      window.history.pushState({ view: route.view }, "", target);
+      const state = { view: route.view };
+      if (isEquivalentGrammarLevelPath(window.location.pathname, route)) {
+        window.history.replaceState(state, "", target);
+      } else {
+        window.history.pushState(state, "", target);
+      }
     }
   }, [route]);
 

--- a/src/domain/routes.test.ts
+++ b/src/domain/routes.test.ts
@@ -47,6 +47,18 @@ describe("app route contract (#623)", () => {
     expect(parseRoute(serializeRoute(route))).toEqual(route);
   });
 
+  it("serializes JLPT grammar level hubs to their lowercase canonical paths (#805)", () => {
+    for (const level of ["N1", "N2", "N3", "N4", "N5"] as const) {
+      const canonicalPath = `/grammar/${level.toLowerCase()}`;
+      expect(serializeRoute(grammarRoute(level))).toBe(canonicalPath);
+      expect(serializeRoute(grammarRoute(level.toLowerCase()))).toBe(canonicalPath);
+    }
+  });
+
+  it("preserves non-level grammar surface spelling while serializing (#805)", () => {
+    expect(serializeRoute(grammarRoute("Nならでは"))).toBe("/grammar/N%E3%81%AA%E3%82%89%E3%81%A7%E3%81%AF");
+  });
+
   it("falls an unknown path back to the home route", () => {
     expect(parseRoute("/does-not-exist")).toEqual(staticRoute("home"));
   });

--- a/src/domain/routes.ts
+++ b/src/domain/routes.ts
@@ -70,3 +70,18 @@ export function serializeRoute(route: AppRoute): string {
   }
   return APP_VIEW_PATHS[route.view];
 }
+
+/**
+ * Whether pathname and route identify the same JLPT level hub even though the
+ * pathname still uses a legacy uppercase segment. App uses this to replace
+ * that history entry during canonicalization instead of creating a Back loop.
+ */
+export function isEquivalentGrammarLevelPath(pathname: string, route: AppRoute): boolean {
+  const current = parseRoute(pathname);
+  if (current.view !== "grammar" || route.view !== "grammar") return false;
+  if (!current.grammarSurface || !route.grammarSurface) return false;
+  if (!/^[Nn][1-5]$/.test(current.grammarSurface) || !/^[Nn][1-5]$/.test(route.grammarSurface)) {
+    return false;
+  }
+  return current.grammarSurface.toLowerCase() === route.grammarSurface.toLowerCase();
+}

--- a/src/domain/routes.ts
+++ b/src/domain/routes.ts
@@ -63,7 +63,10 @@ export function parseRoute(pathname: string): AppRoute {
 /** Serialize App route state back to its canonical pathname. */
 export function serializeRoute(route: AppRoute): string {
   if (route.view === "grammar" && route.grammarSurface) {
-    return `${APP_VIEW_PATHS.grammar}/${encodeURIComponent(route.grammarSurface)}`;
+    const surface = /^[Nn][1-5]$/.test(route.grammarSurface)
+      ? route.grammarSurface.toLowerCase()
+      : route.grammarSurface;
+    return `${APP_VIEW_PATHS.grammar}/${encodeURIComponent(surface)}`;
   }
   return APP_VIEW_PATHS[route.view];
 }


### PR DESCRIPTION
## Summary

- serialize JLPT grammar level hubs N1-N5 to the established lowercase canonical paths
- preserve non-level grammar surface spelling and encoding
- strengthen route and App regressions so direct and in-app navigation require the same exact pathname

## Browser finding

#803 Chromium acceptance reproduced /grammar/n5 on direct load but /grammar/N5 after in-app Browse N5 and Back/Forward. Sitemap, prerender, and SEO canonical authority all use lowercase. The browser assertion remains unchanged.

## TDD

- RED: routes test expected /grammar/n1 but received /grammar/N1; App flow expected /grammar/n5 but received /grammar/N5
- GREEN: focused routes test 9/9 and focused App test 1/1 passed

## Verification

- affected integration file scripts/gemini-correctness/red-stage-integration.test.ts passed 23/23 after an initial resource-contention timeout in the first parallel L3 attempt
- pnpm verify:full — pass (L3: lint, full tests, build)
- git diff --check — pass
- exact HEAD independent review: pending at PR creation

Closes #805