### PR TITLE
test(e2e): add navigation browser acceptance

### DIFF
--- a/.github/workflows/browser-acceptance.yml
+++ b/.github/workflows/browser-acceptance.yml
@@ -1,4 +1,4 @@
-name: Browser acceptance
+name: Chromium navigation acceptance
 
 on:
   pull_request:
@@ -10,6 +10,23 @@ on:
       - "package.json"
       - "playwright.config.ts"
       - "pnpm-lock.yaml"
+      - "tsconfig.playwright.json"
+      - "src/App.tsx"
+      - "src/components/AppBreadcrumbs.tsx"
+      - "src/components/AppNavigation.tsx"
+      - "src/components/GrammarIndexPage.tsx"
+      - "src/components/HomePanel.tsx"
+      - "src/components/LegalLinks.tsx"
+      - "src/components/MoreMenu.tsx"
+      - "src/domain/breadcrumbs.ts"
+      - "src/domain/legalLabels.ts"
+      - "src/domain/navigation.ts"
+      - "src/domain/routes.ts"
+      - "src/i18n.ts"
+      - "src/locales/zh-Hant.ts"
+      - "src/styles/breadcrumbs.css"
+      - "src/styles/layout.css"
+      - "src/styles/responsive.css"
   push:
     branches:
       - main
@@ -19,6 +36,23 @@ on:
       - "package.json"
       - "playwright.config.ts"
       - "pnpm-lock.yaml"
+      - "tsconfig.playwright.json"
+      - "src/App.tsx"
+      - "src/components/AppBreadcrumbs.tsx"
+      - "src/components/AppNavigation.tsx"
+      - "src/components/GrammarIndexPage.tsx"
+      - "src/components/HomePanel.tsx"
+      - "src/components/LegalLinks.tsx"
+      - "src/components/MoreMenu.tsx"
+      - "src/domain/breadcrumbs.ts"
+      - "src/domain/legalLabels.ts"
+      - "src/domain/navigation.ts"
+      - "src/domain/routes.ts"
+      - "src/i18n.ts"
+      - "src/locales/zh-Hant.ts"
+      - "src/styles/breadcrumbs.css"
+      - "src/styles/layout.css"
+      - "src/styles/responsive.css"
   workflow_dispatch:
 
 permissions:
@@ -26,7 +60,7 @@ permissions:
 
 jobs:
   navigation:
-    name: Navigation browser acceptance
+    name: Chromium navigation acceptance
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/browser-acceptance.yml
+++ b/.github/workflows/browser-acceptance.yml
@@ -1,0 +1,64 @@
+name: Browser acceptance
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/browser-acceptance.yml"
+      - "e2e/**"
+      - "package.json"
+      - "playwright.config.ts"
+      - "pnpm-lock.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/browser-acceptance.yml"
+      - "e2e/**"
+      - "package.json"
+      - "playwright.config.ts"
+      - "pnpm-lock.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  navigation:
+    name: Navigation browser acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run navigation browser acceptance
+        run: pnpm test:browser:navigation
+
+      - name: Upload browser acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: navigation-browser-report-${{ github.run_attempt }}
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/browser-acceptance.yml
+++ b/.github/workflows/browser-acceptance.yml
@@ -4,55 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/browser-acceptance.yml"
-      - "e2e/**"
-      - "package.json"
-      - "playwright.config.ts"
-      - "pnpm-lock.yaml"
-      - "tsconfig.playwright.json"
-      - "src/App.tsx"
-      - "src/components/AppBreadcrumbs.tsx"
-      - "src/components/AppNavigation.tsx"
-      - "src/components/GrammarIndexPage.tsx"
-      - "src/components/HomePanel.tsx"
-      - "src/components/LegalLinks.tsx"
-      - "src/components/MoreMenu.tsx"
-      - "src/domain/breadcrumbs.ts"
-      - "src/domain/legalLabels.ts"
-      - "src/domain/navigation.ts"
-      - "src/domain/routes.ts"
-      - "src/i18n.ts"
-      - "src/locales/zh-Hant.ts"
-      - "src/styles/breadcrumbs.css"
-      - "src/styles/layout.css"
-      - "src/styles/responsive.css"
   push:
     branches:
       - main
-    paths:
-      - ".github/workflows/browser-acceptance.yml"
-      - "e2e/**"
-      - "package.json"
-      - "playwright.config.ts"
-      - "pnpm-lock.yaml"
-      - "tsconfig.playwright.json"
-      - "src/App.tsx"
-      - "src/components/AppBreadcrumbs.tsx"
-      - "src/components/AppNavigation.tsx"
-      - "src/components/GrammarIndexPage.tsx"
-      - "src/components/HomePanel.tsx"
-      - "src/components/LegalLinks.tsx"
-      - "src/components/MoreMenu.tsx"
-      - "src/domain/breadcrumbs.ts"
-      - "src/domain/legalLabels.ts"
-      - "src/domain/navigation.ts"
-      - "src/domain/routes.ts"
-      - "src/i18n.ts"
-      - "src/locales/zh-Hant.ts"
-      - "src/styles/breadcrumbs.css"
-      - "src/styles/layout.css"
-      - "src/styles/responsive.css"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist/
 dev-dist/
 coverage/
 .vite/
+playwright-report/
+test-results/
 *.tsbuildinfo
 
 # Local environment

--- a/e2e/navigation.acceptance.spec.ts
+++ b/e2e/navigation.acceptance.spec.ts
@@ -1,0 +1,275 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const navigationName = "學習流程";
+const breadcrumbName = "目前位置";
+
+const viewportMatrix = [
+  { name: "320px", width: 320, foldedTrigger: "更多", hiddenTrigger: "資源" },
+  { name: "390px", width: 390, foldedTrigger: "更多", hiddenTrigger: "資源" },
+  { name: "768px", width: 768, foldedTrigger: "資源", hiddenTrigger: "更多" },
+  { name: "1280px", width: 1280, foldedTrigger: "資源", hiddenTrigger: "更多" }
+] as const;
+
+const representativeRoutes = ["/", "/grammar/n5", "/kana", "/privacy", "/terms"] as const;
+
+function appNavigation(page: Page) {
+  return page.getByRole("navigation", { name: navigationName });
+}
+
+async function expectNoPageOverflow(page: Page, context: string) {
+  const dimensions = await page.evaluate(() => ({
+    contentWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+    viewportWidth: window.innerWidth
+  }));
+  expect(
+    dimensions.contentWidth,
+    `${context}: page content must fit within the viewport`
+  ).toBeLessThanOrEqual(dimensions.viewportWidth);
+}
+
+async function openFoldedMenu(page: Page, triggerName: string) {
+  const trigger = appNavigation(page).getByRole("button", { name: triggerName });
+  await trigger.focus();
+  await trigger.press("ArrowDown");
+  const menu = page.getByRole("menu", { name: triggerName });
+  await expect(menu).toBeVisible();
+  return { menu, trigger };
+}
+
+async function menuItems(menu: Locator) {
+  const items = menu.locator('[role^="menuitem"]');
+  await expect(items.first()).toBeFocused();
+  return items;
+}
+
+async function selectKanaWithKeyboard(page: Page, triggerName: string) {
+  const { menu } = await openFoldedMenu(page, triggerName);
+  const items = await menuItems(menu);
+  const kanaIndex = await items.evaluateAll((nodes) =>
+    nodes.findIndex((node) => node.textContent?.includes("五十音表"))
+  );
+  expect(kanaIndex).toBeGreaterThanOrEqual(0);
+
+  await page.keyboard.press("Home");
+  for (let index = 0; index < kanaIndex; index += 1) {
+    await page.keyboard.press("ArrowDown");
+  }
+  await expect(menu.getByRole("menuitem", { name: "五十音表" })).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(page).toHaveURL(/\/kana$/);
+}
+
+async function breadcrumbSnapshot(page: Page) {
+  const breadcrumb = page.getByRole("navigation", { name: breadcrumbName });
+  await expect(breadcrumb).toBeVisible();
+  const crumbs = breadcrumb.locator('a, [aria-current="page"]');
+  return {
+    labels: (await crumbs.allTextContents()).map((label) => label.trim()),
+    parentPaths: await breadcrumb.getByRole("link").evaluateAll((links) =>
+      links.map((link) => new URL((link as HTMLAnchorElement).href).pathname)
+    ),
+    current: (await breadcrumb.locator('[aria-current="page"]').textContent())?.trim() ?? "",
+    currentCount: await breadcrumb.locator('[aria-current="page"]').count()
+  };
+}
+
+for (const viewport of viewportMatrix) {
+  test.describe(`navigation at ${viewport.name}`, () => {
+    test.use({ viewport: { width: viewport.width, height: 900 } });
+
+    test("keeps representative routes and the open navigation menu within the viewport", async ({ page }) => {
+      for (const route of representativeRoutes) {
+        await page.goto(route);
+        await expect(page).toHaveURL(new RegExp(`${route === "/" ? "/$" : `${route}$`}`));
+        await expectNoPageOverflow(page, `${viewport.name} ${route}`);
+      }
+
+      await page.goto("/");
+      const nav = appNavigation(page);
+      await expect(nav.getByRole("button", { name: viewport.foldedTrigger })).toBeVisible();
+      await expect(
+        nav.getByRole("button", { name: viewport.hiddenTrigger, includeHidden: true })
+      ).toBeHidden();
+      await openFoldedMenu(page, viewport.foldedTrigger);
+      await expectNoPageOverflow(page, `${viewport.name} open ${viewport.foldedTrigger} menu`);
+    });
+
+    test("supports keyboard traversal, focus return, selection, and exact current state", async ({ page }) => {
+      await page.goto("/");
+      const { menu, trigger } = await openFoldedMenu(page, viewport.foldedTrigger);
+      const items = await menuItems(menu);
+
+      await page.keyboard.press("End");
+      await expect(items.last()).toBeFocused();
+      await page.keyboard.press("Home");
+      await expect(items.first()).toBeFocused();
+      await page.keyboard.press("ArrowUp");
+      await expect(items.last()).toBeFocused();
+      await page.keyboard.press("Escape");
+      await expect(menu).toBeHidden();
+      await expect(trigger).toBeFocused();
+
+      await selectKanaWithKeyboard(page, viewport.foldedTrigger);
+      await expect(appNavigation(page).getByRole("button", { name: "學習" })).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+      await expect(page.getByRole("navigation", { name: breadcrumbName })).toContainText("五十音表");
+
+      const currentTrigger = appNavigation(page).getByRole("button", {
+        name: `${viewport.foldedTrigger}（目前：五十音表）`
+      });
+      await currentTrigger.focus();
+      await currentTrigger.press("ArrowDown");
+      await expect(page.getByRole("menuitem", { name: "五十音表" })).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+    });
+  });
+}
+
+test.describe("route, breadcrumb, link, and history acceptance", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("makes direct loads and in-app navigation produce the same deterministic breadcrumbs", async ({ page }) => {
+    const cases = [
+      {
+        path: "/grammar/n5",
+        expected: {
+          labels: ["首頁", "文型", "N5"],
+          parentPaths: ["/", "/grammar"],
+          current: "N5",
+          currentCount: 1
+        },
+        navigate: async () => {
+          await appNavigation(page).getByRole("button", { name: "文型" }).click();
+          await page.getByRole("button", { name: "瀏覽 N5" }).click();
+        }
+      },
+      {
+        path: "/kana",
+        expected: {
+          labels: ["首頁", "學習", "五十音表"],
+          parentPaths: ["/", "/learn"],
+          current: "五十音表",
+          currentCount: 1
+        },
+        navigate: async () => {
+          await appNavigation(page).getByRole("button", { name: "資源" }).click();
+          await page.getByRole("menuitem", { name: "五十音表" }).click();
+        }
+      },
+      {
+        path: "/privacy",
+        expected: {
+          labels: ["首頁", "關於", "隱私政策"],
+          parentPaths: ["/", "/about"],
+          current: "隱私政策",
+          currentCount: 1
+        },
+        navigate: async () => {
+          await page.getByRole("link", { name: "隱私政策" }).click();
+        }
+      },
+      {
+        path: "/terms",
+        expected: {
+          labels: ["首頁", "關於", "使用條款"],
+          parentPaths: ["/", "/about"],
+          current: "使用條款",
+          currentCount: 1
+        },
+        navigate: async () => {
+          await page.getByRole("link", { name: "使用條款" }).click();
+        }
+      }
+    ] as const;
+
+    for (const acceptanceCase of cases) {
+      await page.goto(acceptanceCase.path);
+      const direct = await breadcrumbSnapshot(page);
+      expect(direct).toEqual(acceptanceCase.expected);
+
+      await page.goto("/");
+      await acceptanceCase.navigate();
+      await expect(page).toHaveURL(new RegExp(`${acceptanceCase.path}$`));
+      expect(await breadcrumbSnapshot(page)).toEqual(direct);
+    }
+  });
+
+  test("preserves native modified and middle-click behavior while plain click stays in the SPA", async ({ context, page }) => {
+    await page.goto("/grammar/n5");
+    const grammarCrumb = page.getByRole("navigation", { name: breadcrumbName }).getByRole("link", {
+      name: "文型"
+    });
+
+    await page.evaluate(() => {
+      (window as unknown as { browserAcceptanceMarker?: string }).browserAcceptanceMarker = "same-document";
+    });
+    await grammarCrumb.click();
+    await expect(page).toHaveURL(/\/grammar$/);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { browserAcceptanceMarker?: string }).browserAcceptanceMarker
+      )
+    ).toBe("same-document");
+
+    const newTabModifier: "Meta" | "Control" = process.platform === "darwin" ? "Meta" : "Control";
+    for (const click of [
+      () => grammarCrumb.click({ modifiers: [newTabModifier] }),
+      () => grammarCrumb.click({ button: "middle" })
+    ]) {
+      await page.goto("/grammar/n5");
+      const [newPage] = await Promise.all([context.waitForEvent("page"), click()]);
+      await newPage.waitForLoadState("domcontentloaded");
+      expect(new URL(newPage.url()).pathname).toBe("/grammar");
+      await expect(page).toHaveURL(/\/grammar\/n5$/);
+      await newPage.close();
+    }
+  });
+
+  test("restores canonical navigation and breadcrumbs through Back and Forward without stale child state", async ({ page }) => {
+    await page.goto("/");
+    await appNavigation(page).getByRole("button", { name: "文型" }).click();
+    await page.getByRole("button", { name: "瀏覽 N5" }).click();
+    await appNavigation(page).getByRole("button", { name: "資源" }).click();
+    await page.getByRole("menuitem", { name: "五十音表" }).click();
+    await expect(page).toHaveURL(/\/kana$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/grammar\/n5$/);
+    await expect(appNavigation(page).getByRole("button", { name: "文型" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(await breadcrumbSnapshot(page)).toEqual({
+      labels: ["首頁", "文型", "N5"],
+      parentPaths: ["/", "/grammar"],
+      current: "N5",
+      currentCount: 1
+    });
+    await appNavigation(page).getByRole("button", { name: "資源" }).click();
+    await expect(page.getByRole("menu").locator('[aria-current="page"]')).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/kana$/);
+    await expect(appNavigation(page).getByRole("button", { name: "學習" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(await breadcrumbSnapshot(page)).toEqual({
+      labels: ["首頁", "學習", "五十音表"],
+      parentPaths: ["/", "/learn"],
+      current: "五十音表",
+      currentCount: 1
+    });
+    const resources = appNavigation(page).getByRole("button", { name: "資源（目前：五十音表）" });
+    await resources.click();
+    await expect(page.getByRole("menuitem", { name: "五十音表" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+  });
+});

--- a/e2e/navigation.acceptance.test.ts
+++ b/e2e/navigation.acceptance.test.ts
@@ -12,6 +12,20 @@ const viewportMatrix = [
 
 const representativeRoutes = ["/", "/grammar/n5", "/kana", "/privacy", "/terms"] as const;
 
+const grammarN5Breadcrumb = {
+  labels: ["首頁", "文型", "N5"],
+  parentPaths: ["/", "/grammar"],
+  current: "N5",
+  currentCount: 1
+} as const;
+
+const kanaBreadcrumb = {
+  labels: ["首頁", "學習", "五十音表"],
+  parentPaths: ["/", "/learn"],
+  current: "五十音表",
+  currentCount: 1
+} as const;
+
 function appNavigation(page: Page) {
   return page.getByRole("navigation", { name: navigationName });
 }
@@ -71,6 +85,19 @@ async function breadcrumbSnapshot(page: Page) {
     current: (await breadcrumb.locator('[aria-current="page"]').textContent())?.trim() ?? "",
     currentCount: await breadcrumb.locator('[aria-current="page"]').count()
   };
+}
+
+async function expectDesktopResourceCurrent(page: Page, itemName: string) {
+  const trigger = appNavigation(page).getByRole("button", {
+    name: `資源（目前：${itemName}）`
+  });
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  await expect(page.getByRole("menuitem", { name: itemName })).toHaveAttribute(
+    "aria-current",
+    "page"
+  );
+  await page.keyboard.press("Escape");
 }
 
 for (const viewport of viewportMatrix) {
@@ -136,28 +163,31 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
     const cases = [
       {
         path: "/grammar/n5",
-        expected: {
-          labels: ["首頁", "文型", "N5"],
-          parentPaths: ["/", "/grammar"],
-          current: "N5",
-          currentCount: 1
-        },
+        expected: grammarN5Breadcrumb,
         navigate: async () => {
           await appNavigation(page).getByRole("button", { name: "文型" }).click();
           await page.getByRole("button", { name: "瀏覽 N5" }).click();
+        },
+        assertCurrent: async () => {
+          await expect(appNavigation(page).getByRole("button", { name: "文型" })).toHaveAttribute(
+            "aria-current",
+            "page"
+          );
         }
       },
       {
         path: "/kana",
-        expected: {
-          labels: ["首頁", "學習", "五十音表"],
-          parentPaths: ["/", "/learn"],
-          current: "五十音表",
-          currentCount: 1
-        },
+        expected: kanaBreadcrumb,
         navigate: async () => {
           await appNavigation(page).getByRole("button", { name: "資源" }).click();
           await page.getByRole("menuitem", { name: "五十音表" }).click();
+        },
+        assertCurrent: async () => {
+          await expect(appNavigation(page).getByRole("button", { name: "學習" })).toHaveAttribute(
+            "aria-current",
+            "page"
+          );
+          await expectDesktopResourceCurrent(page, "五十音表");
         }
       },
       {
@@ -170,6 +200,9 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
         },
         navigate: async () => {
           await page.getByRole("link", { name: "隱私政策" }).click();
+        },
+        assertCurrent: async () => {
+          await expectDesktopResourceCurrent(page, "關於");
         }
       },
       {
@@ -182,6 +215,9 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
         },
         navigate: async () => {
           await page.getByRole("link", { name: "使用條款" }).click();
+        },
+        assertCurrent: async () => {
+          await expectDesktopResourceCurrent(page, "關於");
         }
       }
     ] as const;
@@ -190,11 +226,13 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
       await page.goto(acceptanceCase.path);
       const direct = await breadcrumbSnapshot(page);
       expect(direct).toEqual(acceptanceCase.expected);
+      await acceptanceCase.assertCurrent();
 
       await page.goto("/");
       await acceptanceCase.navigate();
       await expect(page).toHaveURL(new RegExp(`${acceptanceCase.path}$`));
       expect(await breadcrumbSnapshot(page)).toEqual(direct);
+      await acceptanceCase.assertCurrent();
     }
   });
 
@@ -215,7 +253,9 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
       )
     ).toBe("same-document");
 
-    const newTabModifier: "Meta" | "Control" = process.platform === "darwin" ? "Meta" : "Control";
+    const newTabModifier: "Meta" | "Control" = await page.evaluate(() =>
+      navigator.platform.startsWith("Mac") ? "Meta" : "Control"
+    );
     for (const click of [
       () => grammarCrumb.click({ modifiers: [newTabModifier] }),
       () => grammarCrumb.click({ button: "middle" })
@@ -243,12 +283,7 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
       "aria-current",
       "page"
     );
-    expect(await breadcrumbSnapshot(page)).toEqual({
-      labels: ["首頁", "文型", "N5"],
-      parentPaths: ["/", "/grammar"],
-      current: "N5",
-      currentCount: 1
-    });
+    expect(await breadcrumbSnapshot(page)).toEqual(grammarN5Breadcrumb);
     await appNavigation(page).getByRole("button", { name: "資源" }).click();
     await expect(page.getByRole("menu").locator('[aria-current="page"]')).toHaveCount(0);
     await page.keyboard.press("Escape");
@@ -259,12 +294,7 @@ test.describe("route, breadcrumb, link, and history acceptance", () => {
       "aria-current",
       "page"
     );
-    expect(await breadcrumbSnapshot(page)).toEqual({
-      labels: ["首頁", "學習", "五十音表"],
-      parentPaths: ["/", "/learn"],
-      current: "五十音表",
-      currentCount: 1
-    });
+    expect(await breadcrumbSnapshot(page)).toEqual(kanaBreadcrumb);
     const resources = appNavigation(page).getByRole("button", { name: "資源（目前：五十音表）" });
     await resources.click();
     await expect(page.getByRole("menuitem", { name: "五十音表" })).toHaveAttribute(

--- a/e2e/navigation.acceptance.test.ts
+++ b/e2e/navigation.acceptance.test.ts
@@ -41,6 +41,21 @@ async function expectNoPageOverflow(page: Page, context: string) {
   ).toBeLessThanOrEqual(dimensions.viewportWidth);
 }
 
+async function expectRepresentativeRouteReady(
+  page: Page,
+  route: (typeof representativeRoutes)[number]
+) {
+  const routeContent = {
+    "/": page.getByRole("region", { name: "首頁" }),
+    "/grammar/n5": page.getByRole("heading", { name: /JLPT N5/ }),
+    "/kana": page.getByRole("heading", { name: "五十音表" }),
+    "/privacy": page.getByRole("heading", { name: "隱私政策" }),
+    "/terms": page.getByRole("heading", { name: "使用條款" })
+  } satisfies Record<(typeof representativeRoutes)[number], Locator>;
+
+  await expect(routeContent[route]).toBeVisible();
+}
+
 async function openFoldedMenu(page: Page, triggerName: string) {
   const trigger = appNavigation(page).getByRole("button", { name: triggerName });
   await trigger.focus();
@@ -108,6 +123,7 @@ for (const viewport of viewportMatrix) {
       for (const route of representativeRoutes) {
         await page.goto(route);
         await expect(page).toHaveURL(new RegExp(`${route === "/" ? "/$" : `${route}$`}`));
+        await expectRepresentativeRouteReady(page, route);
         await expectNoPageOverflow(page, `${viewport.name} ${route}`);
       }
 

--- a/e2e/navigation.acceptance.test.ts
+++ b/e2e/navigation.acceptance.test.ts
@@ -30,6 +30,10 @@ function appNavigation(page: Page) {
   return page.getByRole("navigation", { name: navigationName });
 }
 
+function appShell(page: Page) {
+  return page.locator(".app-shell");
+}
+
 async function expectNoPageOverflow(page: Page, context: string) {
   const dimensions = await page.evaluate(() => ({
     contentWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
@@ -45,12 +49,13 @@ async function expectRepresentativeRouteReady(
   page: Page,
   route: (typeof representativeRoutes)[number]
 ) {
+  const shell = appShell(page);
   const routeContent = {
-    "/": page.getByRole("region", { name: "首頁" }),
-    "/grammar/n5": page.getByRole("heading", { name: /JLPT N5/ }),
-    "/kana": page.getByRole("heading", { name: "五十音表" }),
-    "/privacy": page.getByRole("heading", { name: "隱私政策" }),
-    "/terms": page.getByRole("heading", { name: "使用條款" })
+    "/": shell.getByRole("region", { name: "首頁" }),
+    "/grammar/n5": shell.getByRole("heading", { name: /JLPT N5/ }),
+    "/kana": shell.getByRole("heading", { name: "五十音表" }),
+    "/privacy": shell.getByRole("heading", { name: "隱私政策" }),
+    "/terms": shell.getByRole("heading", { name: "使用條款" })
   } satisfies Record<(typeof representativeRoutes)[number], Locator>;
 
   await expect(routeContent[route]).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings=0",
     "test": "vitest run",
+    "test:browser:navigation": "playwright test e2e/navigation.acceptance.spec.ts --project=chromium",
     "test:watch": "vitest",
     "verify": "node scripts/verify.mjs",
     "verify:dry-run": "node scripts/verify.mjs --dry-run",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@playwright/test": "^1.62.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --max-warnings=0",
     "test": "vitest run",
-    "test:browser:navigation": "playwright test e2e/navigation.acceptance.spec.ts --project=chromium",
+    "test:browser:navigation": "tsc --project tsconfig.playwright.json && playwright test e2e/navigation.acceptance.test.ts --project=chromium",
     "test:watch": "vitest",
     "verify": "node scripts/verify.mjs",
     "verify:dry-run": "node scripts/verify.mjs --dry-run",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,15 +2,18 @@ import { defineConfig, devices } from "@playwright/test";
 
 const port = 4173;
 const baseURL = `http://127.0.0.1:${port}`;
+const isCI = Boolean(
+  (globalThis as { process?: { env?: { CI?: string } } }).process?.env?.CI
+);
 
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
-  forbidOnly: Boolean(process.env.CI),
+  forbidOnly: isCI,
   retries: 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: isCI ? 1 : undefined,
   reporter: [
-    [process.env.CI ? "line" : "list"],
+    [isCI ? "line" : "list"],
     ["html", { outputFolder: "playwright-report", open: "never" }]
   ],
   outputDir: "test-results",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = 4173;
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    [process.env.CI ? "line" : "list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }]
+  ],
+  outputDir: "test-results",
+  use: {
+    baseURL,
+    locale: "zh-TW",
+    screenshot: "only-on-failure",
+    serviceWorkers: "block",
+    trace: "retain-on-failure"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], browserName: "chromium" }
+    }
+  ],
+  webServer: {
+    command: `pnpm build && pnpm preview --host 127.0.0.1 --port ${port} --strictPort`,
+    reuseExistingServer: false,
+    timeout: 180_000,
+    url: baseURL
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.5
         version: 9.39.5
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1134,6 +1137,11 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1962,6 +1970,11 @@ packages:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2438,6 +2451,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4138,6 +4161,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.4)':
@@ -5056,6 +5083,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5527,6 +5557,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/tsconfig.playwright.json
+++ b/tsconfig.playwright.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["e2e/**/*.test.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary\n\n- add the only new dependency, @playwright/test 1.62.1, with a stable Chromium-only navigation acceptance command\n- test the production Vite build/preview at 320, 390, 768, and 1280px\n- cover keyboard Resources/More behavior, focus return/selection, responsive overflow after lazy route content is visible, exact breadcrumbs/routes/current state, native modified/middle click, and Back/Forward stale-state behavior\n- add a separate bounded GitHub Actions workflow that installs supported Chromium and retains HTML report/traces/screenshots as a seven-day artifact\n- ignore only generated Playwright report/result directories; no production navigation code changes are in this PR\n\n## RED / GREEN\n\nInfrastructure RED on original main 689d37d:\n- pnpm test:browser:navigation failed because the command and harness did not exist\n\nFirst browser RED:\n- 7/11 cases passed\n- exact direct-vs-in-app canonical assertion found /grammar/n5 vs /grammar/N5 and Back/Forward mismatch\n- focused product defect #805 was opened, independently fixed through PR #807, reviewed, and merged; the assertion was not weakened\n- 768px classification was corrected to desktop Resources from the live 560px CSS breakpoint\n\nReview RED / GREEN:\n- strict TypeScript first failed because the new route-readiness helper was undefined\n- each representative route now waits for its page-specific lazy content before overflow is measured\n- Chromium remains GREEN: 11/11, zero retries\n\n## Verification\n\n- pnpm test:browser:navigation — pass (11/11)\n- pnpm verify:full — pass on 273cd88 (L3: lint, 2329 tests, build)\n- latest local L3 retry reached the same unrelated resource-contention timeout in scripts/gemini-correctness/red-stage-integration.test.ts; isolated rerun passed 23/23, build passed, and exact-HEAD GitHub Test and build remains the merge gate\n- git diff --check — pass\n- independent exact-HEAD Standards/Spec review — rerunning after review hardening\n\n## Dependency and CI scope\n\n@playwright/test is required by #803 and is the only package/lockfile addition. The separate Chromium workflow runs on every pull request to main and every push to main, plus manual dispatch. It has a 20-minute job timeout, one CI worker, no retries, Chromium only, and seven-day artifact retention. It does not replace or weaken the existing Test and build gate.\n\nCloses #803