### PR TITLE
feat(conversation): define deterministic feedback rubric

### DIFF
--- a/docs/conversation-feedback-authoring.md
+++ b/docs/conversation-feedback-authoring.md
@@ -15,7 +15,7 @@ Each `CuratedConversationResponse` needs:
 - one continuation category;
 - one register/context-fit category;
 - zero or more response-composition signals; and
-- optional developer-facing `authorRationale` by feedback dimension.
+- an `authorRationale` map by feedback dimension, which may be empty.
 
 `authorRationale` supports content review. It is not localized learner-facing copy and must not be
 rendered directly. A presentation layer must use the applicable localized content contract.

--- a/docs/conversation-feedback-authoring.md
+++ b/docs/conversation-feedback-authoring.md
@@ -1,0 +1,86 @@
+# Conversation feedback authoring
+
+This document defines how to annotate deterministic curated response cases for
+Conversation-first practice. The curriculum terms and canonical conversation-skill IDs remain
+owned by [`conversation-learning-model.md`](conversation-learning-model.md); this rubric does not
+create another skill taxonomy.
+
+## Author one context-bound case at a time
+
+Each `CuratedConversationResponse` needs:
+
+- a stable `id` and the Japanese response being annotated;
+- non-empty `situation`, `relationship`, and `discourse` context;
+- one language-quality stage;
+- one continuation category;
+- one register/context-fit category;
+- zero or more response-composition signals; and
+- optional developer-facing `authorRationale` by feedback dimension.
+
+`authorRationale` supports content review. It is not localized learner-facing copy and must not be
+rendered directly. A presentation layer must use the applicable localized content contract.
+
+Do not make one candidate sentence a universal answer. Author multiple context-bound cases when
+several responses are acceptable. Matching learner production to a case belongs to the curated
+exercise runtime; this rubric evaluates the selected case deterministically and does not impose
+exact-string-only scoring.
+
+## Language quality
+
+The stable stages are cumulative:
+
+| Stage | Result |
+| --- | --- |
+| `not_understandable` | The intended meaning is not reasonably recoverable. |
+| `understandable` | Meaning is recoverable, but grammar or wording still needs work. |
+| `correct` | Grammar and wording are acceptable for the task, but contextual naturalness can improve. |
+| `natural` | The wording is natural for the declared situation, relationship, and discourse context. |
+
+Never annotate `natural` without enough context to justify it. The same Japanese response may be
+`natural` in one discourse context and `correct` in another. `natural` is not a context-free rank
+across all possible sentences.
+
+## Continuation and register/context fit
+
+Continuation is independent from language quality:
+
+| Category | Meaning |
+| --- | --- |
+| `dead_end` | The response gives the partner no useful next conversational move. |
+| `opens_thread` | The response gives the partner a clear way to continue. |
+| `enriches_thread` | The response contributes relevant material and creates additional useful continuation paths. |
+
+A short direct answer can still open a thread. A longer response is not automatically richer.
+Annotate the conversational effect in the declared context, not character count.
+
+Register/context fit is either `fits` or `mismatch`. Judge it separately from grammatical
+correctness. A grammatically correct response can still mismatch the declared social distance or
+situation.
+
+## Response composition
+
+`answer`, `add`, and `ask` are optional composition features. They describe how this response is
+built; they are not canonical conversation-skill IDs and a good response does not need all three.
+
+Each feature references the canonical skill that expresses its function in this case. For example:
+
+- a direct personal `answer` can reference `share`;
+- an `ask` that follows up on the partner can reference `expand`;
+- an `ask` that returns responsibility to the partner can reference `bounce`; and
+- an `ask` that requests clarification can reference `repair`.
+
+The type is generic over the canonical skill ID so the scenario contract can supply that bounded
+type without this module duplicating it.
+
+## Determinism, analytics, and future evaluation
+
+`evaluateCuratedConversationResponse()` derives all five dimension statuses from the annotation;
+it performs no network or AI call. Re-evaluating the same case produces the same result.
+
+`toConversationFeedbackAnalytics()` returns only bounded source, quality, status, and composition
+identifiers. It excludes response IDs, Japanese response text, context, author rationale, and
+canonical skill references.
+
+`ConversationFeedbackEvaluator` is the extension seam for a future bounded evaluator. The current
+adapter remains deterministic and curated. Future AI evaluation must return the same explicit
+multidimensional result and must not replace this rubric with one opaque score.

--- a/src/domain/conversationFeedback.test.ts
+++ b/src/domain/conversationFeedback.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  createCuratedConversationFeedbackEvaluator,
   evaluateCuratedConversationResponse,
+  toConversationFeedbackAnalytics,
   type CuratedConversationResponse
 } from "./conversationFeedback";
 
@@ -19,7 +21,7 @@ describe("evaluateCuratedConversationResponse", () => {
         continuation: "opens_thread",
         registerContextFit: "fits",
         composition: [{ feature: "answer", canonicalSkillId: "share" }],
-        explanations: {
+        authorRationale: {
           understandable: "The intended activity and time are recoverable.",
           correct: "The companion marker and destination construction need work."
         }
@@ -39,5 +41,325 @@ describe("evaluateCuratedConversationResponse", () => {
       },
       composition: [{ feature: "answer", canonicalSkillId: "share" }]
     });
+  });
+
+  it("keeps dead-end, continuing, and enriching responses distinct without a numeric score", () => {
+    const context = {
+      situation: "A classmate has just shared a weekend trip to Kamakura.",
+      relationship: "classmates using polite casual conversation",
+      discourse: "The partner has offered a new experience for the learner to develop."
+    };
+    const cases = [
+      {
+        id: "kamakura-dead-end",
+        responseJapanese: "そうですか。",
+        context,
+        feedback: {
+          languageQuality: "natural",
+          continuation: "dead_end",
+          registerContextFit: "fits",
+          composition: [{ feature: "answer", canonicalSkillId: "react" }],
+          authorRationale: {
+            continuation: "The acknowledgement offers no next conversational move."
+          }
+        }
+      },
+      {
+        id: "kamakura-better",
+        responseJapanese: "いいですね。どうでした？",
+        context,
+        feedback: {
+          languageQuality: "natural",
+          continuation: "opens_thread",
+          registerContextFit: "fits",
+          composition: [{ feature: "ask", canonicalSkillId: "expand" }],
+          authorRationale: {
+            continuation: "The follow-up invites the partner to develop the trip."
+          }
+        }
+      },
+      {
+        id: "kamakura-richer",
+        responseJapanese: "いいですね！最近行ってないです。人多かったですか？",
+        context,
+        feedback: {
+          languageQuality: "natural",
+          continuation: "enriches_thread",
+          registerContextFit: "fits",
+          composition: [
+            { feature: "add", canonicalSkillId: "share" },
+            { feature: "ask", canonicalSkillId: "expand" }
+          ],
+          authorRationale: {
+            continuation: "The learner adds relevant material and invites a focused reply."
+          }
+        }
+      }
+    ] as const satisfies readonly CuratedConversationResponse<string>[];
+
+    expect(cases.map(evaluateCuratedConversationResponse)).toMatchObject([
+      { continuationQuality: "dead_end", dimensions: { continuation: "needs_work" } },
+      {
+        continuationQuality: "opens_thread",
+        dimensions: { continuation: "met" },
+        composition: [{ feature: "ask", canonicalSkillId: "expand" }]
+      },
+      {
+        continuationQuality: "enriches_thread",
+        dimensions: { continuation: "met" },
+        composition: [
+          { feature: "add", canonicalSkillId: "share" },
+          { feature: "ask", canonicalSkillId: "expand" }
+        ]
+      }
+    ]);
+  });
+
+  it("maps the Ask feature by conversational function rather than treating it as a skill", () => {
+    const followUp = {
+      id: "ask-follow-up",
+      responseJapanese: "どうでした？",
+      context: {
+        situation: "The partner has shared a trip.",
+        relationship: "classmates",
+        discourse: "The learner asks about the partner's contribution."
+      },
+      feedback: {
+        languageQuality: "correct",
+        continuation: "opens_thread",
+        registerContextFit: "fits",
+        composition: [{ feature: "ask", canonicalSkillId: "expand" }],
+        authorRationale: {}
+      }
+    } as const satisfies CuratedConversationResponse<"expand">;
+    const askBack = {
+      ...followUp,
+      id: "ask-back",
+      responseJapanese: "〇〇さんは何してました？",
+      context: {
+        ...followUp.context,
+        discourse: "The learner has answered and returns responsibility to the partner."
+      },
+      feedback: {
+        ...followUp.feedback,
+        composition: [{ feature: "ask", canonicalSkillId: "bounce" }]
+      }
+    } as const satisfies CuratedConversationResponse<"bounce">;
+
+    expect(evaluateCuratedConversationResponse(followUp).composition).toEqual([
+      { feature: "ask", canonicalSkillId: "expand" }
+    ]);
+    expect(evaluateCuratedConversationResponse(askBack).composition).toEqual([
+      { feature: "ask", canonicalSkillId: "bounce" }
+    ]);
+  });
+
+  it("reports register mismatch independently from other successful dimensions", () => {
+    const response = {
+      id: "teacher-register-mismatch",
+      responseJapanese: "週末何してた？",
+      context: {
+        situation: "The learner opens a weekend topic with a teacher.",
+        relationship: "student speaking to a teacher",
+        discourse: "This is the first topic after class."
+      },
+      feedback: {
+        languageQuality: "correct",
+        continuation: "opens_thread",
+        registerContextFit: "mismatch",
+        composition: [{ feature: "ask", canonicalSkillId: "open" }],
+        authorRationale: {
+          register_context_fit: "The plain form is too familiar for the declared relationship."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"open">;
+
+    expect(evaluateCuratedConversationResponse(response)).toMatchObject({
+      continuationQuality: "opens_thread",
+      registerContextFit: "mismatch",
+      dimensions: {
+        understandable: "met",
+        correct: "met",
+        natural: "needs_work",
+        continuation: "met",
+        register_context_fit: "needs_work"
+      }
+    });
+  });
+
+  it("can identify production that has not yet reached the understandable stage", () => {
+    const response = {
+      id: "not-yet-understandable",
+      responseJapanese: "昨日、友達。",
+      context: {
+        situation: "A classmate asks what the learner did yesterday.",
+        relationship: "classmates",
+        discourse: "The fragment does not communicate an activity."
+      },
+      feedback: {
+        languageQuality: "not_understandable",
+        continuation: "dead_end",
+        registerContextFit: "fits",
+        composition: [],
+        authorRationale: {
+          understandable: "The partner cannot recover what happened from the fragment."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<string>;
+
+    expect(evaluateCuratedConversationResponse(response).dimensions).toMatchObject({
+      understandable: "needs_work",
+      correct: "needs_work",
+      natural: "needs_work"
+    });
+  });
+
+  it("keeps naturalness relative to the declared discourse context", () => {
+    const responseJapanese = "昨日、友達と飲みに行ってたんです。";
+    const explanatory = {
+      id: "past-explanatory-context",
+      responseJapanese,
+      context: {
+        situation: "A classmate asks what the learner did yesterday.",
+        relationship: "classmates using polite casual conversation",
+        discourse: "The response explains the background to the partner's direct question."
+      },
+      feedback: {
+        languageQuality: "natural",
+        continuation: "opens_thread",
+        registerContextFit: "fits",
+        composition: [{ feature: "answer", canonicalSkillId: "share" }],
+        authorRationale: {
+          natural: "The explanatory form fits the prompted background explanation."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"share">;
+    const unpromptedAnnouncement = {
+      ...explanatory,
+      id: "past-unprompted-context",
+      context: {
+        ...explanatory.context,
+        discourse: "The learner volunteers a standalone factual announcement without an explanatory prompt."
+      },
+      feedback: {
+        ...explanatory.feedback,
+        languageQuality: "correct",
+        authorRationale: {
+          natural: "A plain past event report better fits this unprompted announcement."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"share">;
+
+    const naturalResult = evaluateCuratedConversationResponse(explanatory);
+    const contextSpecificResult = evaluateCuratedConversationResponse(unpromptedAnnouncement);
+
+    expect(naturalResult).toMatchObject({
+      context: explanatory.context,
+      languageQuality: "natural",
+      dimensions: { natural: "met" }
+    });
+    expect(contextSpecificResult).toMatchObject({
+      context: unpromptedAnnouncement.context,
+      languageQuality: "correct",
+      dimensions: { natural: "needs_work" }
+    });
+  });
+
+  it("rejects curated naturalness or pragmatic judgments without complete context", () => {
+    const incomplete = {
+      id: "missing-discourse",
+      responseJapanese: "昨日、友達と飲みに行ってたんです。",
+      context: {
+        situation: "A classmate asks about yesterday.",
+        relationship: "classmates",
+        discourse: "   "
+      },
+      feedback: {
+        languageQuality: "natural",
+        continuation: "opens_thread",
+        registerContextFit: "fits",
+        composition: [{ feature: "answer", canonicalSkillId: "share" }],
+        authorRationale: {}
+      }
+    } as const satisfies CuratedConversationResponse<"share">;
+
+    expect(() => evaluateCuratedConversationResponse(incomplete)).toThrow(
+      "Curated conversation feedback requires non-empty situation, relationship, and discourse context."
+    );
+  });
+
+  it("projects deterministic analytics categories without learner or author text", () => {
+    const response = {
+      id: "analytics-boundary-example",
+      responseJapanese: "いいですね！最近行ってないです。人多かったですか？",
+      context: {
+        situation: "A classmate has shared a weekend trip.",
+        relationship: "classmates",
+        discourse: "The learner develops the partner's contribution."
+      },
+      feedback: {
+        languageQuality: "natural",
+        continuation: "enriches_thread",
+        registerContextFit: "fits",
+        composition: [
+          { feature: "ask", canonicalSkillId: "expand" },
+          { feature: "add", canonicalSkillId: "share" },
+          { feature: "ask", canonicalSkillId: "expand" }
+        ],
+        authorRationale: {
+          continuation: "Free-form author rationale must stay out of analytics."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"expand" | "share">;
+
+    const firstEvaluation = evaluateCuratedConversationResponse(response);
+    const secondEvaluation = evaluateCuratedConversationResponse(response);
+    const analytics = toConversationFeedbackAnalytics(firstEvaluation);
+
+    expect(secondEvaluation).toEqual(firstEvaluation);
+    expect(analytics).toEqual({
+      source: "curated",
+      languageQuality: "natural",
+      continuationQuality: "enriches_thread",
+      registerContextFit: "fits",
+      understandable: "met",
+      correct: "met",
+      natural: "met",
+      continuation: "met",
+      register_context_fit: "met",
+      compositionFeatures: ["add", "ask"]
+    });
+    expect(JSON.stringify(analytics)).not.toContain(response.id);
+    expect(JSON.stringify(analytics)).not.toContain(response.responseJapanese);
+    expect(JSON.stringify(analytics)).not.toContain(response.context.situation);
+    expect(JSON.stringify(analytics)).not.toContain(
+      response.feedback.authorRationale.continuation
+    );
+    expect(JSON.stringify(analytics)).not.toContain("expand");
+    expect(JSON.stringify(analytics)).not.toContain("share");
+  });
+
+  it("exposes deterministic curated evaluation through the provider-neutral evaluator seam", async () => {
+    const response = {
+      id: "future-evaluator-seam",
+      responseJapanese: "いいですね。どうでした？",
+      context: {
+        situation: "A classmate has shared a weekend trip.",
+        relationship: "classmates",
+        discourse: "The learner follows up on the partner's contribution."
+      },
+      feedback: {
+        languageQuality: "natural",
+        continuation: "opens_thread",
+        registerContextFit: "fits",
+        composition: [{ feature: "ask", canonicalSkillId: "expand" }],
+        authorRationale: {}
+      }
+    } as const satisfies CuratedConversationResponse<"expand">;
+    const evaluator = createCuratedConversationFeedbackEvaluator<"expand">();
+
+    await expect(evaluator.evaluate(response)).resolves.toEqual(
+      evaluateCuratedConversationResponse(response)
+    );
   });
 });

--- a/src/domain/conversationFeedback.test.ts
+++ b/src/domain/conversationFeedback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateCuratedConversationResponse,
+  type CuratedConversationResponse
+} from "./conversationFeedback";
+
+describe("evaluateCuratedConversationResponse", () => {
+  it("preserves an understandable message while identifying grammar that still needs work", () => {
+    const response = {
+      id: "weekend-understandable-01",
+      responseJapanese: "昨日、友達、飲みました。",
+      context: {
+        situation: "A classmate asks what the learner did yesterday.",
+        relationship: "classmates using polite casual conversation",
+        discourse: "The learner is answering a direct question about yesterday."
+      },
+      feedback: {
+        languageQuality: "understandable",
+        continuation: "opens_thread",
+        registerContextFit: "fits",
+        composition: [{ feature: "answer", canonicalSkillId: "share" }],
+        explanations: {
+          understandable: "The intended activity and time are recoverable.",
+          correct: "The companion marker and destination construction need work."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"share">;
+
+    expect(evaluateCuratedConversationResponse(response)).toMatchObject({
+      source: "curated",
+      responseId: "weekend-understandable-01",
+      languageQuality: "understandable",
+      dimensions: {
+        understandable: "met",
+        correct: "needs_work",
+        natural: "needs_work",
+        continuation: "met",
+        register_context_fit: "met"
+      },
+      composition: [{ feature: "answer", canonicalSkillId: "share" }]
+    });
+  });
+});

--- a/src/domain/conversationFeedback.test.ts
+++ b/src/domain/conversationFeedback.test.ts
@@ -187,6 +187,31 @@ describe("evaluateCuratedConversationResponse", () => {
     });
   });
 
+  it("rejects Natural feedback that contradicts the declared register/context fit", () => {
+    const contradictory = {
+      id: "natural-register-contradiction",
+      responseJapanese: "週末何してた？",
+      context: {
+        situation: "The learner opens a weekend topic with a teacher.",
+        relationship: "student speaking to a teacher",
+        discourse: "This is the first topic after class."
+      },
+      feedback: {
+        languageQuality: "natural",
+        continuation: "opens_thread",
+        registerContextFit: "mismatch",
+        composition: [{ feature: "ask", canonicalSkillId: "open" }],
+        authorRationale: {
+          register_context_fit: "The plain form is too familiar for the declared relationship."
+        }
+      }
+    } as const satisfies CuratedConversationResponse<"open">;
+
+    expect(() => evaluateCuratedConversationResponse(contradictory)).toThrow(
+      "Natural conversation feedback requires register/context fit for the declared context."
+    );
+  });
+
   it("can identify production that has not yet reached the understandable stage", () => {
     const response = {
       id: "not-yet-understandable",

--- a/src/domain/conversationFeedback.ts
+++ b/src/domain/conversationFeedback.ts
@@ -1,0 +1,159 @@
+export const CONVERSATION_FEEDBACK_DIMENSIONS = [
+  "understandable",
+  "correct",
+  "natural",
+  "continuation",
+  "register_context_fit"
+] as const;
+
+export type ConversationFeedbackDimension =
+  (typeof CONVERSATION_FEEDBACK_DIMENSIONS)[number];
+export type ConversationFeedbackStatus = "met" | "needs_work";
+export type ConversationLanguageQuality =
+  | "not_understandable"
+  | "understandable"
+  | "correct"
+  | "natural";
+export type ConversationContinuationQuality =
+  | "dead_end"
+  | "opens_thread"
+  | "enriches_thread";
+export type ConversationRegisterContextFit = "fits" | "mismatch";
+export type ConversationFeedbackSource = "curated" | "bounded_ai";
+export const CONVERSATION_COMPOSITION_FEATURES = ["answer", "add", "ask"] as const;
+export type ConversationCompositionFeature =
+  (typeof CONVERSATION_COMPOSITION_FEATURES)[number];
+
+export interface ConversationFeedbackContext {
+  situation: string;
+  relationship: string;
+  discourse: string;
+}
+
+export interface ConversationCompositionSignal<CanonicalSkillId extends string> {
+  feature: ConversationCompositionFeature;
+  canonicalSkillId: CanonicalSkillId;
+}
+
+export interface CuratedConversationResponse<CanonicalSkillId extends string> {
+  id: string;
+  responseJapanese: string;
+  context: ConversationFeedbackContext;
+  feedback: {
+    languageQuality: ConversationLanguageQuality;
+    continuation: ConversationContinuationQuality;
+    registerContextFit: ConversationRegisterContextFit;
+    composition: readonly ConversationCompositionSignal<CanonicalSkillId>[];
+    authorRationale: Partial<Record<ConversationFeedbackDimension, string>>;
+  };
+}
+
+export interface ConversationFeedbackResult<
+  CanonicalSkillId extends string,
+  Source extends ConversationFeedbackSource = ConversationFeedbackSource
+> {
+  source: Source;
+  responseId: string;
+  context: ConversationFeedbackContext;
+  languageQuality: ConversationLanguageQuality;
+  continuationQuality: ConversationContinuationQuality;
+  registerContextFit: ConversationRegisterContextFit;
+  dimensions: Record<ConversationFeedbackDimension, ConversationFeedbackStatus>;
+  composition: readonly ConversationCompositionSignal<CanonicalSkillId>[];
+  authorRationale: Partial<Record<ConversationFeedbackDimension, string>>;
+}
+
+export interface ConversationFeedbackAnalytics {
+  source: ConversationFeedbackSource;
+  languageQuality: ConversationLanguageQuality;
+  continuationQuality: ConversationContinuationQuality;
+  registerContextFit: ConversationRegisterContextFit;
+  understandable: ConversationFeedbackStatus;
+  correct: ConversationFeedbackStatus;
+  natural: ConversationFeedbackStatus;
+  continuation: ConversationFeedbackStatus;
+  register_context_fit: ConversationFeedbackStatus;
+  compositionFeatures: readonly ConversationCompositionFeature[];
+}
+
+export interface ConversationFeedbackEvaluator<
+  Input,
+  CanonicalSkillId extends string,
+  Source extends ConversationFeedbackSource = ConversationFeedbackSource
+> {
+  evaluate(input: Input): Promise<ConversationFeedbackResult<CanonicalSkillId, Source>>;
+}
+
+const LANGUAGE_QUALITY_LEVEL = {
+  not_understandable: 0,
+  understandable: 1,
+  correct: 2,
+  natural: 3
+} as const satisfies Record<ConversationLanguageQuality, number>;
+
+export function evaluateCuratedConversationResponse<CanonicalSkillId extends string>(
+  response: CuratedConversationResponse<CanonicalSkillId>
+): ConversationFeedbackResult<CanonicalSkillId, "curated"> {
+  const { situation, relationship, discourse } = response.context;
+  if ([situation, relationship, discourse].some((value) => value.trim().length === 0)) {
+    throw new Error(
+      "Curated conversation feedback requires non-empty situation, relationship, and discourse context."
+    );
+  }
+
+  const attainedLanguageQuality = LANGUAGE_QUALITY_LEVEL[response.feedback.languageQuality];
+
+  return {
+    source: "curated",
+    responseId: response.id,
+    context: response.context,
+    languageQuality: response.feedback.languageQuality,
+    continuationQuality: response.feedback.continuation,
+    registerContextFit: response.feedback.registerContextFit,
+    dimensions: {
+      understandable: attainedLanguageQuality >= 1 ? "met" : "needs_work",
+      correct: attainedLanguageQuality >= 2 ? "met" : "needs_work",
+      natural: attainedLanguageQuality >= 3 ? "met" : "needs_work",
+      continuation:
+        response.feedback.continuation === "dead_end" ? "needs_work" : "met",
+      register_context_fit:
+        response.feedback.registerContextFit === "fits" ? "met" : "needs_work"
+    },
+    composition: response.feedback.composition,
+    authorRationale: response.feedback.authorRationale
+  };
+}
+
+export function toConversationFeedbackAnalytics<CanonicalSkillId extends string>(
+  feedback: ConversationFeedbackResult<CanonicalSkillId>
+): ConversationFeedbackAnalytics {
+  const presentFeatures = new Set(
+    feedback.composition.map(({ feature }) => feature)
+  );
+
+  return {
+    source: feedback.source,
+    languageQuality: feedback.languageQuality,
+    continuationQuality: feedback.continuationQuality,
+    registerContextFit: feedback.registerContextFit,
+    understandable: feedback.dimensions.understandable,
+    correct: feedback.dimensions.correct,
+    natural: feedback.dimensions.natural,
+    continuation: feedback.dimensions.continuation,
+    register_context_fit: feedback.dimensions.register_context_fit,
+    compositionFeatures: CONVERSATION_COMPOSITION_FEATURES.filter((feature) =>
+      presentFeatures.has(feature)
+    )
+  };
+}
+
+export function createCuratedConversationFeedbackEvaluator<CanonicalSkillId extends string>():
+  ConversationFeedbackEvaluator<
+    CuratedConversationResponse<CanonicalSkillId>,
+    CanonicalSkillId,
+    "curated"
+  > {
+  return {
+    evaluate: async (response) => evaluateCuratedConversationResponse(response)
+  };
+}

--- a/src/domain/conversationFeedback.ts
+++ b/src/domain/conversationFeedback.ts
@@ -100,6 +100,14 @@ export function evaluateCuratedConversationResponse<CanonicalSkillId extends str
       "Curated conversation feedback requires non-empty situation, relationship, and discourse context."
     );
   }
+  if (
+    response.feedback.languageQuality === "natural" &&
+    response.feedback.registerContextFit === "mismatch"
+  ) {
+    throw new Error(
+      "Natural conversation feedback requires register/context fit for the declared context."
+    );
+  }
 
   const attainedLanguageQuality = LANGUAGE_QUALITY_LEVEL[response.feedback.languageQuality];
 


### PR DESCRIPTION
## Summary

Add deterministic multidimensional conversation feedback for #813, with distinct language quality, continuation, and register/context fit. Answer/Add/Ask remain response-composition features with canonical-skill references, and the analytics projection excludes arbitrary response text. Keep a provider-neutral future evaluator seam without an LLM integration.

Natural Japanese may still be inappropriate for a relationship/register. The evaluator now represents `natural: met` with `register_context_fit: needs_work` instead of rejecting that valid combination. Minimal curriculum and authoring wording clarifies situation/discourse naturalness separately from relationship/register fit.

## Verification

Final HEAD: `905b48647ac637c1b354e21d37b5895c74732a23`, integrating `main` `672176638673de9de70551ca9763253d94545704`.

- Real semantic RED: casual natural Japanese used with a teacher threw under the old invariant (9 passed / 1 failed).
- `pnpm vitest run src/domain/conversationFeedback.test.ts`: PASS, 11 tests; existing discourse-relative naturalness coverage preserved.
- `VITEST_MAX_WORKERS=1 pnpm verify`: PASS, L1.
- Pinned pnpm 10.33.0, `VITEST_MAX_WORKERS=1 pnpm verify:full`: PASS, L3 lint/full tests/build.
- `git diff --check`: PASS.
- Exact-head hosted Test and build, Chromium navigation acceptance, Cloudflare Pages: SUCCESS.

The generated commit hook invoked an incorrect pnpm version and was bypassed for commit creation; its sole `pnpm build` check was executed successfully by final L3 with the pinned toolchain. No check coverage was omitted.

No UI, persistence, scenario runtime, pronunciation scoring, or content batch.

Closes #813

Canonical skill P2 is also repaired: every public feedback generic is constrained by the canonical `ConversationSkillId` from merged #812 through a type-only import. Negative `pnpm typecheck` RED produced TS2578 when misspelled `expnad` and composition-only `ask` were incorrectly accepted; final typecheck and 11 focused tests pass. No untyped ingestion or duplicate taxonomy was introduced.
