### PR TITLE
Harden Supabase Auth and synced-attempt access

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,22 +23,33 @@ export function useAuth() {
       .then((client) => {
         if (!client || !active) return;
 
+        // Do not trust the user object from getSession() as an authorization
+        // decision. getUser() validates the access token with Supabase Auth and
+        // gives this hook a server-confirmed identity for account-backed data.
         client.auth
-          .getSession()
-          .then(({ data: { session }, error: err }) => {
+          .getUser()
+          .then(({ data: { user }, error: err }) => {
+            if (!active) return;
             if (err) {
-              console.error("Supabase getSession error:", err);
+              console.error("Supabase getUser error:", err);
+              setUser(null);
               setError("sessionFetchFailed");
+              return;
             }
-            setUser(session?.user ?? null);
+            setUser(user ?? null);
+            setError(null);
           })
           .catch((e: unknown) => {
-            console.error("Supabase getSession exception:", e);
+            console.error("Supabase getUser exception:", e);
+            if (!active) return;
+            setUser(null);
+            setError("sessionFetchFailed");
           });
 
         const {
           data: { subscription }
         } = client.auth.onAuthStateChange((_event, session) => {
+          if (!active) return;
           setUser(session?.user ?? null);
           setError(null); // clear errors on successful auth change
         });
@@ -46,6 +57,9 @@ export function useAuth() {
       })
       .catch((e: unknown) => {
         console.error("Supabase load error:", e);
+        if (!active) return;
+        setUser(null);
+        setError("sessionFetchFailed");
       });
 
     return () => {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,37 +23,63 @@ export function useAuth() {
       .then((client) => {
         if (!client || !active) return;
 
-        // Do not trust the user object from getSession() as an authorization
-        // decision. getUser() validates the access token with Supabase Auth and
-        // gives this hook a server-confirmed identity for account-backed data.
-        client.auth
-          .getUser()
-          .then(({ data: { user }, error: err }) => {
-            if (!active) return;
-            if (err) {
-              console.error("Supabase getUser error:", err);
-              setUser(null);
-              setError("sessionFetchFailed");
-              return;
-            }
-            setUser(user ?? null);
-            setError(null);
-          })
-          .catch((e: unknown) => {
-            console.error("Supabase getUser exception:", e);
-            if (!active) return;
-            setUser(null);
-            setError("sessionFetchFailed");
-          });
-
+        // INITIAL_SESSION reflects locally persisted auth state. Ignore that
+        // event here because restored identities are validated below before
+        // they are exposed to account-backed features.
         const {
           data: { subscription }
-        } = client.auth.onAuthStateChange((_event, session) => {
-          if (!active) return;
+        } = client.auth.onAuthStateChange((event, session) => {
+          if (!active || event === "INITIAL_SESSION") return;
           setUser(session?.user ?? null);
           setError(null); // clear errors on successful auth change
         });
         unsubscribe = () => subscription.unsubscribe();
+
+        // A missing session is the normal signed-out state: Jabiko does not
+        // require login. If a persisted session exists, do not trust its user
+        // object for authorization. Ask Supabase Auth to validate it first.
+        client.auth
+          .getSession()
+          .then(({ data: { session }, error: sessionError }) => {
+            if (!active) return;
+            if (sessionError) {
+              console.error("Supabase getSession error:", sessionError);
+              setUser(null);
+              setError("sessionFetchFailed");
+              return;
+            }
+            if (!session) {
+              setUser(null);
+              setError(null);
+              return;
+            }
+
+            client.auth
+              .getUser()
+              .then(({ data: { user }, error: userError }) => {
+                if (!active) return;
+                if (userError) {
+                  console.error("Supabase getUser error:", userError);
+                  setUser(null);
+                  setError("sessionFetchFailed");
+                  return;
+                }
+                setUser(user ?? null);
+                setError(null);
+              })
+              .catch((e: unknown) => {
+                console.error("Supabase getUser exception:", e);
+                if (!active) return;
+                setUser(null);
+                setError("sessionFetchFailed");
+              });
+          })
+          .catch((e: unknown) => {
+            console.error("Supabase getSession exception:", e);
+            if (!active) return;
+            setUser(null);
+            setError("sessionFetchFailed");
+          });
       })
       .catch((e: unknown) => {
         console.error("Supabase load error:", e);

--- a/supabase/migrations/0005_attempts_authenticated.sql
+++ b/supabase/migrations/0005_attempts_authenticated.sql
@@ -1,0 +1,25 @@
+-- Auth hardening: authenticated account data stays account-only.
+--
+-- Sign-in is optional for Jabiko, but synced practice attempts are not public.
+-- RLS remains the authorization boundary: authenticated users may only read,
+-- insert, or delete rows whose user_id matches auth.uid().
+
+alter table public.attempts enable row level security;
+
+drop policy if exists "attempts_select_own" on public.attempts;
+create policy "attempts_select_own" on public.attempts
+  for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+drop policy if exists "attempts_insert_own" on public.attempts;
+create policy "attempts_insert_own" on public.attempts
+  for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+drop policy if exists "attempts_delete_own" on public.attempts;
+create policy "attempts_delete_own" on public.attempts
+  for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);


### PR DESCRIPTION
## Summary

Restore identities only after `supabase.auth.getUser()` validates them, including storage-backed `SIGNED_IN` events emitted by SDK startup. Ignore `INITIAL_SESSION`, validate other non-null auth events asynchronously, and prevent older validation results from overwriting a newer sign-in or sign-out event. Keep an already-validated matching user present during background revalidation so duplicate sign-in/token-refresh events do not interrupt sync. Restrict synced `attempts` policies to `authenticated` while retaining `auth.uid() = user_id` ownership checks.

Public learning remains available signed out, account sync stays optional, and anonymous feedback is unchanged.

## Regression evidence

Fifteen focused `useAuth` cases cover successful/failed restoration, missing sessions, rejected requests, SDK startup ordering, initial events, intervening sign-in/sign-out, duplicate same-user revalidation, different-account transitions, stale errors, and unmount cleanup. Existing behavior was honestly first-run green. The initial ordering regression produced 8 passed / 2 failed; SDK-startup regressions produced 9 passed / 2 failed; same-user continuity produced 12 passed / 1 failed before its repair. The final suite passes all fifteen cases. An additional ephemeral test using the actual installed SDK and rendered hook confirmed server-validated restoration without an Auth callback deadlock.

## Verification

Final HEAD: `98c216bedc74cc2738aeff8219376ef2c2e2f13b`, integrating `main` at `24657569f01e6e5303506e672ed5fa3075115c93`.

- `pnpm vitest run src/hooks/useAuth.test.tsx`: PASS, 15 tests.
- Pinned pnpm 10.33.0, `VITEST_MAX_WORKERS=1 pnpm verify:full`: PASS, L3 lint/full tests/build.
- `git diff --check` and `git diff --check origin/main...HEAD`: PASS.
- Earlier unrestricted-worker runs had unrelated Gemini/LearningPanel timeouts; final full single-worker verification passed.

## Production evidence boundary

The original PR reported that the RLS migration was already applied and verified in Jabiko. This run did not modify production and could not refresh that claim: the current Supabase connector does not expose the Jabiko project. Production verification remains an operator follow-up, separate from repository validation.
