### PR TITLE
feat(points): award one point per correct answer, shown on the home dashboard

### DIFF
--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -460,3 +460,25 @@ describe("HomePanel promotion placement", () => {
     expect(recommendation.compareDocumentPosition(heroHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });
+
+describe("HomePanel points cell (points economy foundation)", () => {
+  it("shows total earned points -- one per correct attempt -- in the stats strip", () => {
+    renderHome({
+      progressAttempts: [
+        sampleAttempt,
+        { ...sampleAttempt, isCorrect: false, timestamp: 2 },
+        { ...sampleAttempt, isCorrect: true, timestamp: 3 }
+      ]
+    });
+    const cell = screen.getByText("累積點數").closest(".home-stats-cell");
+    expect(cell).not.toBeNull();
+    expect(within(cell as HTMLElement).getByText("2")).toBeInTheDocument();
+  });
+
+  it("wrong answers earn nothing (points cell stays at zero)", () => {
+    renderHome({ progressAttempts: [{ ...sampleAttempt, isCorrect: false }] });
+    const cell = screen.getByText("累積點數").closest(".home-stats-cell");
+    expect(cell).not.toBeNull();
+    expect(within(cell as HTMLElement).getByText("0")).toBeInTheDocument();
+  });
+});

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -7,6 +7,7 @@ import { isLearningBlockComplete, learningBlocks } from "../domain/learningBlock
 import { localizeLearningBlock, type LearningBlockOverlays } from "../domain/learningBlockText";
 import { CONTENT_STATS } from "../domain/contentStats";
 import { computeProgressStats } from "../domain/stats";
+import { computeEarnedPoints } from "../domain/points";
 import { computeActivityTrend } from "../domain/analytics/trend";
 import { computeErrorsByQuestionType } from "../domain/analytics/weakness";
 import { AccuracyRing } from "./dashboard/AccuracyRing";
@@ -588,6 +589,13 @@ export function HomePanel({
             <div className="home-stats-cell">
               <strong>{progress.masteredCount}</strong>
               <small>{t.homeStatsMastered}</small>
+            </div>
+            {/* Points economy foundation: 1 point per correct answer, derived
+                from the same attempt history as the other tiles (points.ts).
+                A future shop spends against this via a separate spend ledger. */}
+            <div className="home-stats-cell">
+              <strong>{computeEarnedPoints(progressAttempts)}</strong>
+              <small>{t.homeStatsPoints}</small>
             </div>
           </div>
 

--- a/src/domain/points.test.ts
+++ b/src/domain/points.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Attempt } from "./types";
+import { computeEarnedPoints, POINTS_PER_CORRECT_ANSWER, pointsForAttempt } from "./points";
+
+function attempt(overrides: Partial<Attempt> = {}): Attempt {
+  return {
+    vocabularyId: "v1",
+    targetForm: "reading",
+    prompt: "prompt",
+    expectedAnswers: ["a"],
+    submittedAnswer: "a",
+    isCorrect: true,
+    timestamp: 1,
+    responseTimeMs: 100,
+    ...overrides
+  };
+}
+
+describe("points economy — answer-reward foundation", () => {
+  it("awards exactly one point for a correct attempt", () => {
+    expect(POINTS_PER_CORRECT_ANSWER).toBe(1);
+    expect(pointsForAttempt(attempt({ isCorrect: true }))).toBe(1);
+  });
+
+  it("awards nothing for a wrong attempt", () => {
+    expect(pointsForAttempt(attempt({ isCorrect: false }))).toBe(0);
+  });
+
+  it("earned total replays the whole attempt history", () => {
+    const history = [
+      attempt({ isCorrect: true }),
+      attempt({ isCorrect: false }),
+      attempt({ isCorrect: true }),
+      attempt({ isCorrect: true })
+    ];
+    expect(computeEarnedPoints(history)).toBe(3);
+  });
+
+  it("an empty history earns zero", () => {
+    expect(computeEarnedPoints([])).toBe(0);
+  });
+
+  it("re-deriving from the same history is stable (same attempts, same total)", () => {
+    const history = [attempt({ isCorrect: true }), attempt({ isCorrect: false })];
+    expect(computeEarnedPoints(history)).toBe(computeEarnedPoints([...history]));
+  });
+});

--- a/src/domain/points.ts
+++ b/src/domain/points.ts
@@ -1,0 +1,34 @@
+// Points economy — answer-reward foundation.
+//
+// Earning is a pure rule replayed over the attempt history (like srs.ts /
+// stats.ts): a correct attempt earns POINTS_PER_CORRECT_ANSWER, anything else
+// earns nothing. Deriving from attempts means points need no storage of their
+// own, ride the existing cross-device attempt sync (#151), and stay consistent
+// with the learner's visible stats by construction.
+//
+// Planned evolution (shop system): spending must NOT rewrite earning history.
+// A shop adds a separate spend ledger (its own storage + sync) and the balance
+// becomes `computeEarnedPoints(attempts) - totalSpent`. Richer earning rules
+// (streak multipliers, level bonuses) change only pointsForAttempt — the
+// replay-from-history design re-derives every learner's total under the new
+// rule with no migration.
+//
+// Imports only domain types: safe for the eager home bundle (never pulls the
+// exam bank; see the stats.ts header for the same constraint).
+import type { Attempt } from "./types";
+
+export const POINTS_PER_CORRECT_ANSWER = 1;
+
+/** Earning rule for a single attempt. The single seam future bonus rules extend. */
+export function pointsForAttempt(attempt: Attempt): number {
+  return attempt.isCorrect ? POINTS_PER_CORRECT_ANSWER : 0;
+}
+
+/** Total points earned over a full attempt history. */
+export function computeEarnedPoints(attempts: Attempt[]): number {
+  let total = 0;
+  for (const attempt of attempts) {
+    total += pointsForAttempt(attempt);
+  }
+  return total;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -135,6 +135,8 @@ export type Copy = {
   homeStatsStreak: string;
   homeStatsDue: string;
   homeStatsMastered: string;
+  /** Stats-strip label for total earned points (1 per correct answer; src/domain/points.ts). */
+  homeStatsPoints: string;
   homeLevelLabel: string;
   homeLevelAnswered: (count: number) => string;
   homeTrendTitle: string;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -135,6 +135,7 @@ export const en: Copy = {
   homeStatsStreak: "Day streak",
   homeStatsDue: "Due for review",
   homeStatsMastered: "Mastered",
+  homeStatsPoints: "Points earned",
   homeLevelLabel: "Accuracy by level",
   homeLevelAnswered: (count) => `${count} answered`,
   homeTrendTitle: "Daily practice volume",

--- a/src/locales/id.ts
+++ b/src/locales/id.ts
@@ -135,6 +135,7 @@ export const id: Copy = {
   homeStatsStreak: "Hari beruntun",
   homeStatsDue: "Perlu diulang",
   homeStatsMastered: "Sudah dikuasai",
+  homeStatsPoints: "Poin terkumpul",
   homeLevelLabel: "Akurasi tiap level",
   homeLevelAnswered: (count) => `${count} soal`,
   homeTrendTitle: "Jumlah latihan harian",

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -136,6 +136,7 @@ export const ja: Copy = {
   homeStatsStreak: "連続日数",
   homeStatsDue: "復習待ち",
   homeStatsMastered: "習得済み",
+  homeStatsPoints: "獲得ポイント",
   homeLevelLabel: "レベル別正答率",
   homeLevelAnswered: (count) => `${count} 問`,
   homeTrendTitle: "日々の練習量",

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -135,6 +135,7 @@ export const ko: Copy = {
   homeStatsStreak: "연속 일수",
   homeStatsDue: "복습 예정",
   homeStatsMastered: "마스터함",
+  homeStatsPoints: "획득 포인트",
   homeLevelLabel: "레벨별 정답률",
   homeLevelAnswered: (count) => `${count}문제 풀이`,
   homeTrendTitle: "일일 연습량",

--- a/src/locales/my.ts
+++ b/src/locales/my.ts
@@ -135,6 +135,7 @@ export const my: Copy = {
   homeStatsStreak: "ဆက်တိုက်ရက်",
   homeStatsDue: "ပြန်လေ့ကျင့်ရန်",
   homeStatsMastered: "ကျွမ်းကျင်ပြီး",
+  homeStatsPoints: "စုဆောင်းပွိုင့်",
   homeLevelLabel: "အဆင့်အလိုက် မှန်ကန်မှု",
   homeLevelAnswered: (count) => `${count} ဖြေဆိုပြီး`,
   homeTrendTitle: "နေ့စဉ် လေ့ကျင့်မှု ပမာဏ",

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -136,6 +136,7 @@ export const th: Copy = {
   homeStatsStreak: "จำนวนวันต่อเนื่อง",
   homeStatsDue: "รอทบทวน",
   homeStatsMastered: "เชี่ยวชาญแล้ว",
+  homeStatsPoints: "คะแนนสะสม",
   homeLevelLabel: "อัตราตอบถูกแต่ละระดับ",
   homeLevelAnswered: (count) => `${count} ข้อ`,
   homeTrendTitle: "ปริมาณฝึกรายวัน",

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -135,6 +135,7 @@ export const vi: Copy = {
   homeStatsStreak: "Chuỗi ngày liên tiếp",
   homeStatsDue: "Đến hạn ôn",
   homeStatsMastered: "Đã thành thạo",
+  homeStatsPoints: "Điểm thưởng",
   homeLevelLabel: "Độ chính xác theo cấp độ",
   homeLevelAnswered: (count) => `Đã trả lời ${count} câu`,
   homeTrendTitle: "Lượng luyện tập hằng ngày",

--- a/src/locales/zh-Hant.ts
+++ b/src/locales/zh-Hant.ts
@@ -135,6 +135,7 @@ export const zhHant: Copy = {
   homeStatsStreak: "連續天數",
   homeStatsDue: "待複習",
   homeStatsMastered: "已熟練",
+  homeStatsPoints: "累積點數",
   homeLevelLabel: "各級正答率",
   homeLevelAnswered: (count) => `${count} 題`,
   homeTrendTitle: "每日練習量",


### PR DESCRIPTION
## Summary

Points-economy foundation (**1 point per correct answer**) plus a home-dashboard presentation pass (the chosen direction for the profile question: optimize the home dashboard rather than adding a separate profile page).

概要:點數系統地基——答對一題 +1 點,顯示在首頁統計條(**累積點數**,以強調色呈現);並依討論方向優化首頁 dashboard 的資訊密度(寬螢幕雙欄圖卡)。點數直接從答題紀錄推導,不新增儲存、跨裝置同步免費;之後商店系統用獨立消費帳接上(餘額 = 獲得 − 消費)。

### Commit 1 — points foundation

- `src/domain/points.ts` — earning is a pure rule replayed over the attempt history (same pattern as `srs.ts`/`stats.ts`): `pointsForAttempt` (the single seam future bonus rules extend) and `computeEarnedPoints`. Imports only domain types → safe for the eager home bundle.
- **No new storage**: totals derive from `attempts`, riding the existing cross-device sync (#151); past correct answers count retroactively.
- **Shop-ready**: a future shop adds a separate spend ledger; `balance = earned − spent`. Rule changes re-derive all totals with no migration.
- UI: a sixth tile in the home stats strip; `homeStatsPoints` copy in all 8 locale files.

### Commit 2 — dashboard density + points accent

- The points tile's number renders in the accent (`--vermilion`) — the strip's one focal number.
- At ≥900px the two chart cards (practice trend + type strength) share one row (two-column grid); the title/metric strip/overview keep full width. Narrow screens unchanged.
- **Test-infra fixes surfaced along the way:**
  - `src/styles` was in **no** vitest project — `feedback.test.ts` (the #652 flex-wrap guard) never ran; and css `?raw` imports resolve to an empty stub under the runner, so it also failed once discovered. `src/styles/**/*.test.ts` now runs in the domain-node project, with the file switched to the `FocusBreakLayout` readFileSync trick (browser-only tsconfig).
  - `red-stage-integration.test.ts`'s "runRedStage integration" block spawns real git/vitest subprocesses and flaked over the 5s default timeout under full-suite load (observed twice locally); it now carries an explicit 30s timeout — headroom, not a behavioural change.

### TDD

Every change RED-first: `points.test.ts` (5), `HomePanel` points cases (3), `styles/home.test.ts` (2) — all observed failing before implementation.

## Verification (L3 full, Node 22)

- `pnpm verify:full` → lint ✓, test ✓ (2372+ tests incl. revived styles guards), build ✓, check:i18n ✓
- Live check against a seeded 127-attempt history: 6 tiles render, points = 89 (≈70% correct ✓), accent color applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)