### PR TITLE
refactor(home): dashboard density pass + points accent, revive orphaned CSS tests

### DIFF
--- a/scripts/gemini-correctness/red-stage-integration.test.ts
+++ b/scripts/gemini-correctness/red-stage-integration.test.ts
@@ -184,7 +184,10 @@ describe("runGuardedTargetedVitest", () => {
   });
 });
 
-describe("runRedStage integration", () => {
+// These cases spawn real git / vitest subprocesses, so wall time tracks
+// machine load; the default 5s per-test timeout flakes when the full suite
+// runs in parallel. 30s is headroom, not a behavioural change.
+describe("runRedStage integration", { timeout: 30_000 }, () => {
   beforeEach(() => initializeFixture());
   afterEach(() => {
     fs.rmSync(fixtureRoot, { recursive: true, force: true });

--- a/src/components/HomePanel.test.tsx
+++ b/src/components/HomePanel.test.tsx
@@ -475,6 +475,12 @@ describe("HomePanel points cell (points economy foundation)", () => {
     expect(within(cell as HTMLElement).getByText("2")).toBeInTheDocument();
   });
 
+  it("marks the points tile with the accent class (the strip's focal number)", () => {
+    renderHome({ progressAttempts: [sampleAttempt] });
+    const cell = screen.getByText("累積點數").closest(".home-stats-cell");
+    expect(cell).toHaveClass("home-stats-cell-points");
+  });
+
   it("wrong answers earn nothing (points cell stays at zero)", () => {
     renderHome({ progressAttempts: [{ ...sampleAttempt, isCorrect: false }] });
     const cell = screen.getByText("累積點數").closest(".home-stats-cell");

--- a/src/components/HomePanel.tsx
+++ b/src/components/HomePanel.tsx
@@ -593,7 +593,7 @@ export function HomePanel({
             {/* Points economy foundation: 1 point per correct answer, derived
                 from the same attempt history as the other tiles (points.ts).
                 A future shop spends against this via a separate spend ledger. */}
-            <div className="home-stats-cell">
+            <div className="home-stats-cell home-stats-cell-points">
               <strong>{computeEarnedPoints(progressAttempts)}</strong>
               <small>{t.homeStatsPoints}</small>
             </div>

--- a/src/styles/feedback.test.ts
+++ b/src/styles/feedback.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-// ?raw import (typed via vite/client), same trick as staticPages.test.ts.
-import css from "./feedback.css?raw";
+
+// The app tsconfig has browser-only types (no @types/node), so reach fs via a
+// computed dynamic specifier — same trick as FocusBreakLayout.test.ts. (This
+// test originally used a `?raw` import, which resolves to an empty stub under
+// the test runner — and no vitest project included src/styles anyway, so the
+// guard silently never ran.)
+const nodeFsSpecifier = ["node", "fs"].join(":");
+const { readFileSync } = (await import(/* @vite-ignore */ nodeFsSpecifier)) as {
+  readFileSync: (path: URL, encoding: "utf8") => string;
+};
+const css = readFileSync(new URL("./feedback.css", import.meta.url), "utf8");
 
 describe("choice-option layout (#652)", () => {
   it("wraps long furigana option sentences (flex-wrap) instead of overflowing", () => {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -679,6 +679,12 @@
   letter-spacing: 0.02em;
 }
 
+/* The points tile is the strip's one focal number (the balance a future shop
+   spends); every other tile stays in --ink so the accent reads. */
+.home-stats-cell-points strong {
+  color: var(--vermilion);
+}
+
 /* ── Home dashboard v1 (#243) ──────────────────────────────────────────
    Lightweight progress visuals layered into the existing .home-progress
    section: an overall-accuracy ring + per-level bars (one row) and a daily
@@ -698,8 +704,9 @@
   letter-spacing: 0.02em;
 }
 
-/* The merged lifetime+SRS metric strip carries 5 cells; auto-fit keeps them
-   even and wraps gracefully on narrow screens (vs the fixed 3-col default). */
+/* The merged lifetime+SRS+points metric strip carries 6 cells; auto-fit keeps
+   them even and wraps gracefully on narrow screens (vs the fixed 3-col
+   default). */
 .home-stats-strip.is-wrap {
   grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
 }
@@ -713,6 +720,23 @@
   background: var(--paper);
   border: 1px solid var(--rule);
   border-radius: var(--radius-lg);
+}
+
+/* Density pass: on wide screens the two self-contained chart cards (practice
+   trend + type strength) share one row; the title, metric strip and overview
+   row keep full width. Narrow screens keep the flex column above. */
+@media (min-width: 900px) {
+  .home-progress {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+
+  .home-progress-title,
+  .home-stats-strip,
+  .home-overview-row {
+    grid-column: 1 / -1;
+  }
 }
 
 /* Accuracy ring */

--- a/src/styles/home.test.ts
+++ b/src/styles/home.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+// The app tsconfig has browser-only types (no @types/node), so reach fs via a
+// computed dynamic specifier — same trick as FocusBreakLayout.test.ts. (A css
+// `?raw` import would resolve to an empty stub under the test runner.)
+const nodeFsSpecifier = ["node", "fs"].join(":");
+const { readFileSync } = (await import(/* @vite-ignore */ nodeFsSpecifier)) as {
+  readFileSync: (path: URL, encoding: "utf8") => string;
+};
+const css = readFileSync(new URL("./home.css", import.meta.url), "utf8");
+
+describe("home dashboard presentation (points economy foundation)", () => {
+  it("renders the points tile's number in the accent color", () => {
+    // The points tile is the strip's one focal number (the balance a future
+    // shop spends); every other tile stays in --ink so the accent reads.
+    const start = css.indexOf(".home-stats-cell-points strong {");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const rule = css.slice(start, css.indexOf("}", start));
+    expect(rule).toMatch(/color:\s*var\(--vermilion\)/);
+  });
+
+  it("pairs the trend and type charts side by side on wide screens", () => {
+    // Density pass: the two self-contained chart cards share one row once the
+    // column fits two readable halves; title/strip/overview keep full width.
+    const media = css.indexOf("@media (min-width: 900px)");
+    expect(media).toBeGreaterThanOrEqual(0);
+    const block = css.slice(media);
+    const progress = block.indexOf(".home-progress {");
+    expect(progress).toBeGreaterThanOrEqual(0);
+    const rule = block.slice(progress, block.indexOf("}", progress));
+    expect(rule).toMatch(/grid-template-columns:\s*1fr 1fr/);
+    expect(block).toMatch(/\.home-overview-row\s*\{[^}]*grid-column:\s*1 \/ -1/);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -84,6 +84,10 @@ export default defineConfig({
           include: [
             "src/domain/**/*.test.ts",
             "src/domain/**/*.test.mjs",
+            // CSS contract tests: plain text assertions over the stylesheet
+            // source (node env; no pattern covered src/styles before, which
+            // silently orphaned feedback.test.ts).
+            "src/styles/**/*.test.ts",
             "functions/**/*.test.mjs",
             "scripts/**/*.test.ts"
           ],


### PR DESCRIPTION
## Summary

Home-dashboard presentation follow-up to #826 (the chosen direction for the profile-page question: optimize the home dashboard rather than adding a separate page). The dashboard-polish commit was pushed to the #826 branch moments after that PR merged, so it lands here as its own PR.

概要:承接 #826 的首頁 dashboard 優化——累積點數改用強調色作為統計條的視覺焦點,寬螢幕(≥900px)時「近 14 天練習量」與「題型強弱」兩張圖卡並排以縮短滾動;順帶修復兩個測試基礎設施問題(styles 孤兒測試、整合測試逾時 flake)。

### Presentation

- The points tile's number renders in the accent (`--vermilion`) — the strip's one focal number (the balance a future shop spends). New `home-stats-cell-points` class + HomePanel case.
- At ≥900px `.home-progress` becomes a two-column grid: the two self-contained chart cards (practice trend + type strength) share one row; title/metric strip/overview keep full width. Narrow screens keep the flex column. Guarded by `src/styles/home.test.ts`.
- Stale "5 cells" comment updated (the strip carries 6 now).

### Test-infra fixes surfaced by TDD

- **`src/styles` was in no vitest project** — `feedback.test.ts` (the #652 flex-wrap guard) never ran; and a css `?raw` import resolves to an empty stub under the runner, so it also failed once discovered. `src/styles/**/*.test.ts` now runs in the domain-node project, and the file uses the `FocusBreakLayout` readFileSync trick (browser-only tsconfig has no `node:fs` types).
- **`red-stage-integration.test.ts`** "runRedStage integration" cases spawn real git/vitest subprocesses and flaked over the default 5s per-test timeout under full-suite load (observed twice locally, 5.3s vs 5s). The block now carries an explicit 30s timeout — headroom, not a behavioural change.

### TDD

RED-first throughout: the HomePanel accent-class case and both `home.test.ts` cases were observed failing before the CSS/JSX landed (and discovering the orphaned/broken styles tests was itself the RED step for the config fix).

## Verification (L3 full, Node 22, re-run after cherry-pick onto merged main)

- `pnpm verify:full` → lint ✓, test ✓, build ✓ (+ check:i18n ✓ on the pre-cherry-pick run)
- Live check with a seeded 127-attempt history: 6 tiles render, points 89, accent color `rgb(185,74,44)` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)